### PR TITLE
fix(orch): break the pending-todos doom loop

### DIFF
--- a/crates/forge_app/src/app.rs
+++ b/crates/forge_app/src/app.rs
@@ -224,12 +224,19 @@ impl<S: Services + EnvironmentInfra<Config = forge_config::ForgeConfig>> ForgeAp
             TitleGenerationHandler::with_enabled(services.clone(), forge_config.generate_titles);
 
         // Build the on_end hook, conditionally adding PendingTodosHandler based on
-        // config
+        // config. The reminder cap is wired to `max_end_hook_rearms` so a
+        // single knob bounds both the orchestrator's re-arm count and the
+        // number of pending-todo reminders the handler is willing to inject —
+        // they describe the same loop from two ends.
         let on_end_hook = if forge_config.verify_todos {
+            let pending_todos_handler = match forge_config.max_end_hook_rearms {
+                Some(cap) => PendingTodosHandler::with_max_reminders(cap),
+                None => PendingTodosHandler::new(),
+            };
             tracing_handler
                 .clone()
                 .and(title_handler.clone())
-                .and(PendingTodosHandler::new())
+                .and(pending_todos_handler)
         } else {
             tracing_handler.clone().and(title_handler.clone())
         };

--- a/crates/forge_app/src/hooks/doom_loop.rs
+++ b/crates/forge_app/src/hooks/doom_loop.rs
@@ -73,8 +73,83 @@ impl DoomLoopDetector {
             .iter()
             .filter_map(|msg| msg.tool_calls.as_ref())
             .flat_map(|calls| calls.iter())
-            .map(|call| (call.name.clone(), call.arguments.clone()))
+            .map(|call| {
+                (
+                    call.name.clone(),
+                    Self::normalize_arguments(&call.name, &call.arguments),
+                )
+            })
             .collect()
+    }
+
+    /// Normalizes tool-call arguments before doom-loop comparison so that
+    /// near-identical exploration patterns (same file/query, slightly
+    /// different offsets/limits) bucket together as a single signature.
+    ///
+    /// For the read/grep family we keep only the *intent* keys
+    /// (`file_path`, `path`, `pattern`, `query`, `glob_pattern`) and drop
+    /// pagination-style keys (`offset`, `limit`, `line_start`, `line_end`,
+    /// `max_results`, `context_lines`). This catches the common loop where
+    /// an agent re-reads the same file with shifting line ranges, or
+    /// re-greps the same pattern with different `max_results`, without
+    /// triggering before for genuinely new content.
+    ///
+    /// Tools outside this allow-list pass through untouched.
+    fn normalize_arguments(name: &ToolName, args: &ToolCallArguments) -> ToolCallArguments {
+        const NORMALIZED_TOOLS: &[&str] = &[
+            "read",
+            "grep",
+            "fs_search",
+            "fs_read",
+            "find_file_by_name",
+            "search",
+            "codedb_read",
+            "codedb_search",
+            "codedb_word",
+            "codedb_outline",
+        ];
+        // Volatile keys whose values typically change between
+        // exploration calls without changing the agent's intent. Dropped
+        // before signature comparison so [(read, file=A, offset=0)],
+        // [(read, file=A, offset=200)], [(read, file=A, offset=400)]
+        // all collapse to one signature.
+        const VOLATILE_KEYS: &[&str] = &[
+            "offset",
+            "limit",
+            "line_start",
+            "line_end",
+            "start_line",
+            "end_line",
+            "max_results",
+            "max_result",
+            "context_lines",
+            "compact",
+            "if_hash",
+            "scope",
+        ];
+
+        if !NORMALIZED_TOOLS
+            .iter()
+            .any(|t| name.as_str().eq_ignore_ascii_case(t))
+        {
+            return args.clone();
+        }
+
+        // Parse to a JSON Value; fall back to original on any error so we
+        // never drop signatures we couldn't normalize.
+        let Ok(value) = args.parse() else {
+            return args.clone();
+        };
+
+        let serde_json::Value::Object(mut map) = value else {
+            return args.clone();
+        };
+
+        for key in VOLATILE_KEYS {
+            map.remove(*key);
+        }
+
+        ToolCallArguments::Parsed(serde_json::Value::Object(map))
     }
 
     /// Checks for repeating patterns at the end of the sequence.
@@ -322,6 +397,92 @@ mod tests {
         // Second call - no loop yet (need 3 for default threshold)
         let actual = detector.detect_from_conversation(&conversation);
         assert_eq!(actual, None);
+    }
+
+    #[test]
+    fn test_doom_loop_detector_normalizes_read_offsets() {
+        // Regression: agent re-reads the same file with shifting line
+        // ranges (offset/limit, line_start/line_end). Before
+        // normalization these were three different signatures and the
+        // loop was missed; after normalization they collapse to one.
+        let detector = DoomLoopDetector::new();
+
+        let call_a = ToolCallFull::new("read").arguments(ToolCallArguments::from_json(
+            r#"{"path": "huge.ts", "offset": 0, "limit": 200}"#,
+        ));
+        let call_b = ToolCallFull::new("read").arguments(ToolCallArguments::from_json(
+            r#"{"path": "huge.ts", "offset": 200, "limit": 200}"#,
+        ));
+        let call_c = ToolCallFull::new("read").arguments(ToolCallArguments::from_json(
+            r#"{"path": "huge.ts", "offset": 400, "limit": 200}"#,
+        ));
+
+        let messages = vec![
+            create_assistant_message(&call_a),
+            create_assistant_message(&call_b),
+            create_assistant_message(&call_c),
+        ];
+        let conversation = create_conversation_with_messages(messages);
+
+        let actual = detector.detect_from_conversation(&conversation);
+        let expected = Some(3);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_doom_loop_detector_normalizes_grep_max_results() {
+        // Same idea for grep: max_results / context_lines change between
+        // turns but the search intent is identical.
+        let detector = DoomLoopDetector::new();
+
+        let call_a = ToolCallFull::new("grep").arguments(ToolCallArguments::from_json(
+            r#"{"pattern": "TODO", "path": "src/", "max_results": 10}"#,
+        ));
+        let call_b = ToolCallFull::new("grep").arguments(ToolCallArguments::from_json(
+            r#"{"pattern": "TODO", "path": "src/", "max_results": 50}"#,
+        ));
+        let call_c = ToolCallFull::new("grep").arguments(ToolCallArguments::from_json(
+            r#"{"pattern": "TODO", "path": "src/", "max_results": 100, "context_lines": 3}"#,
+        ));
+
+        let messages = vec![
+            create_assistant_message(&call_a),
+            create_assistant_message(&call_b),
+            create_assistant_message(&call_c),
+        ];
+        let conversation = create_conversation_with_messages(messages);
+
+        let actual = detector.detect_from_conversation(&conversation);
+        let expected = Some(3);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_doom_loop_detector_keeps_distinct_files_distinct() {
+        // Sanity: normalization must not collapse genuinely different
+        // file paths together.
+        let detector = DoomLoopDetector::new();
+
+        let call_a = ToolCallFull::new("read").arguments(ToolCallArguments::from_json(
+            r#"{"path": "a.ts", "offset": 0, "limit": 200}"#,
+        ));
+        let call_b = ToolCallFull::new("read").arguments(ToolCallArguments::from_json(
+            r#"{"path": "b.ts", "offset": 0, "limit": 200}"#,
+        ));
+        let call_c = ToolCallFull::new("read").arguments(ToolCallArguments::from_json(
+            r#"{"path": "c.ts", "offset": 0, "limit": 200}"#,
+        ));
+
+        let messages = vec![
+            create_assistant_message(&call_a),
+            create_assistant_message(&call_b),
+            create_assistant_message(&call_c),
+        ];
+        let conversation = create_conversation_with_messages(messages);
+
+        let actual = detector.detect_from_conversation(&conversation);
+        let expected = None;
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/crates/forge_app/src/hooks/pending_todos.rs
+++ b/crates/forge_app/src/hooks/pending_todos.rs
@@ -22,19 +22,74 @@ struct PendingTodosContext {
     todos: Vec<TodoReminderItem>,
 }
 
+/// Default cap on the number of pending-todos reminders that may be
+/// injected into a single conversation. Reached when the agent keeps
+/// reshuffling its todo list (which changes the fingerprint and would
+/// otherwise re-arm the orchestrator loop indefinitely). Mirrors the
+/// `max_end_hook_rearms` config default.
+const DEFAULT_MAX_REMINDERS: usize = 3;
+
 /// Detects when the LLM signals task completion while there are still
 /// pending or in-progress todo items.
 ///
 /// When triggered, it injects a formatted reminder listing all
 /// outstanding todos into the conversation context, preventing the
 /// orchestrator from yielding prematurely.
-#[derive(Debug, Clone, Default)]
-pub struct PendingTodosHandler;
+///
+/// Bounded by two checks to avoid runaway reminder loops:
+///
+/// 1. **Same-fingerprint dedupe**: if the most-recent reminder in
+///    context already covers the current set of pending todos, skip.
+/// 2. **Total-reminder cap**: if the conversation already contains
+///    `max_reminders` reminders (across all fingerprints), skip even if
+///    the agent keeps rewording its todos. The cap is configurable via
+///    `PendingTodosHandler::with_max_reminders` and defaults to
+///    [`DEFAULT_MAX_REMINDERS`].
+#[derive(Debug, Clone)]
+pub struct PendingTodosHandler {
+    max_reminders: usize,
+}
+
+impl Default for PendingTodosHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl PendingTodosHandler {
-    /// Creates a new pending-todos handler
+    /// Creates a new pending-todos handler with the default reminder cap.
     pub fn new() -> Self {
-        Self
+        Self { max_reminders: DEFAULT_MAX_REMINDERS }
+    }
+
+    /// Overrides the maximum number of pending-todo reminders that may
+    /// be injected into a single conversation. Typically wired to
+    /// `forge_config.max_end_hook_rearms` so a single config knob
+    /// governs both the orchestrator's re-arm cap and the reminder cap.
+    pub fn with_max_reminders(max_reminders: usize) -> Self {
+        Self { max_reminders }
+    }
+
+    /// Counts how many pending-todos reminders already exist in the
+    /// given conversation context. Used to enforce the total-reminder
+    /// cap regardless of whether the agent rewords its todos between
+    /// turns.
+    fn count_existing_reminders(context: &forge_domain::Context) -> usize {
+        context
+            .messages
+            .iter()
+            .filter(|entry| {
+                entry
+                    .message
+                    .content()
+                    .map(|content| {
+                        content
+                            .lines()
+                            .any(|line| line.trim_start().starts_with("todo_fingerprint=\""))
+                    })
+                    .unwrap_or(false)
+            })
+            .count()
     }
 
     fn pending_todo_fingerprint(todos: &[Todo]) -> String {
@@ -76,21 +131,30 @@ impl EventHandle<EventData<EndPayload>> for PendingTodosHandler {
         let current_fingerprint = Self::pending_todo_fingerprint(&pending_todos);
 
         let should_add_reminder = if let Some(context) = &conversation.context {
-            let last_reminder_fingerprint = context.messages.iter().rev().find_map(|entry| {
-                let content = entry.message.content()?;
-                let fingerprint = content
-                    .lines()
-                    .find(|line| line.trim_start().starts_with("todo_fingerprint=\""))?
-                    .split_once("\"")?
-                    .1
-                    .split_once("\"")?
-                    .0;
-                Some(fingerprint.to_string())
-            });
+            // Cap total reminders regardless of fingerprint changes. If the
+            // agent has already been told `max_reminders` times that it has
+            // pending todos, further reminders won't help — let the
+            // orchestrator yield and surface control to the user.
+            if Self::count_existing_reminders(context) >= self.max_reminders {
+                false
+            } else {
+                let last_reminder_fingerprint =
+                    context.messages.iter().rev().find_map(|entry| {
+                        let content = entry.message.content()?;
+                        let fingerprint = content
+                            .lines()
+                            .find(|line| line.trim_start().starts_with("todo_fingerprint=\""))?
+                            .split_once("\"")?
+                            .1
+                            .split_once("\"")?
+                            .0;
+                        Some(fingerprint.to_string())
+                    });
 
-            match last_reminder_fingerprint {
-                Some(last_fingerprint) => last_fingerprint != current_fingerprint,
-                None => true,
+                match last_reminder_fingerprint {
+                    Some(last_fingerprint) => last_fingerprint != current_fingerprint,
+                    None => true,
+                }
             }
         } else {
             true
@@ -264,6 +328,63 @@ mod tests {
         handler.handle(&event, &mut conversation).await.unwrap();
         let after_second = conversation.context.as_ref().unwrap().messages.len();
         assert_eq!(after_second, 1);
+    }
+
+    #[tokio::test]
+    async fn test_reminder_capped_when_todos_keep_changing() {
+        // Regression: agent reshuffles its todo list each turn (changes
+        // fingerprint), historically that re-armed the orchestrator loop
+        // forever. The total-reminder cap forces yield after N reminders.
+        let handler = PendingTodosHandler::with_max_reminders(3);
+        let event = fixture_event();
+        let mut conversation =
+            fixture_conversation(vec![Todo::new("v1").status(TodoStatus::Pending)]);
+
+        // Reminder 1: fresh fingerprint
+        handler.handle(&event, &mut conversation).await.unwrap();
+        assert_eq!(conversation.context.as_ref().unwrap().messages.len(), 1);
+
+        // Reminder 2: change fingerprint by rewording
+        conversation.metrics = conversation
+            .metrics
+            .clone()
+            .todos(vec![Todo::new("v2").status(TodoStatus::Pending)]);
+        handler.handle(&event, &mut conversation).await.unwrap();
+        assert_eq!(conversation.context.as_ref().unwrap().messages.len(), 2);
+
+        // Reminder 3: different fingerprint again, this is the last allowed
+        conversation.metrics = conversation
+            .metrics
+            .clone()
+            .todos(vec![Todo::new("v3").status(TodoStatus::Pending)]);
+        handler.handle(&event, &mut conversation).await.unwrap();
+        assert_eq!(conversation.context.as_ref().unwrap().messages.len(), 3);
+
+        // Reminder 4: cap kicks in even though the fingerprint changed
+        conversation.metrics = conversation
+            .metrics
+            .clone()
+            .todos(vec![Todo::new("v4").status(TodoStatus::Pending)]);
+        handler.handle(&event, &mut conversation).await.unwrap();
+        let actual = conversation.context.as_ref().unwrap().messages.len();
+        let expected = 3;
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn test_with_max_reminders_zero_disables_handler() {
+        // Setting the cap to 0 effectively turns the handler off; useful
+        // for tests / users who want the orchestrator to never re-arm on
+        // pending todos.
+        let handler = PendingTodosHandler::with_max_reminders(0);
+        let event = fixture_event();
+        let mut conversation =
+            fixture_conversation(vec![Todo::new("Fix the build").status(TodoStatus::Pending)]);
+
+        handler.handle(&event, &mut conversation).await.unwrap();
+        let actual = conversation.context.as_ref().unwrap().messages.len();
+        let expected = 0;
+        assert_eq!(actual, expected);
     }
 
     #[tokio::test]

--- a/crates/forge_app/src/orch.rs
+++ b/crates/forge_app/src/orch.rs
@@ -321,6 +321,14 @@ impl<S: AgentService + EnvironmentInfra<Config = forge_config::ForgeConfig>> Orc
         let mut is_complete = false;
 
         let mut request_count = 0;
+        // Counts how many times an `End`-lifecycle hook re-armed the loop
+        // by injecting a follow-up message (most often the pending-todos
+        // reminder). Bounded by `forge_config.max_end_hook_rearms` to stop
+        // self-perpetuating "reminder + reword" loops well before
+        // `max_requests_per_turn` would cap them. `None` in config disables
+        // the cap entirely (legacy behavior).
+        let mut end_hook_rearms: usize = 0;
+        let end_hook_rearm_cap: Option<usize> = self.config.max_end_hook_rearms;
         // Per-run fitness vector accumulators. Sums what's already computed
         // turn-by-turn (token usage on each assistant message, success/error
         // flags on each tool result) so an AgentRunEnd event at the bottom
@@ -550,7 +558,28 @@ impl<S: AgentService + EnvironmentInfra<Config = forge_config::ForgeConfig>> Orc
                     if let Some(updated_context) = &self.conversation.context {
                         context = updated_context.clone();
                     }
-                    should_yield = false;
+                    end_hook_rearms = end_hook_rearms.saturating_add(1);
+
+                    // Force-yield once we've re-armed past the configured cap.
+                    // Prevents the "pending-todos reminder fires, agent
+                    // reshuffles todos, fingerprint changes, reminder fires
+                    // again" loop from running until max_requests_per_turn.
+                    if let Some(cap) = end_hook_rearm_cap
+                        && end_hook_rearms > cap
+                    {
+                        interrupt_reason = Some(format!(
+                            "max_end_hook_rearms_reached: {cap}"
+                        ));
+                        self.send(ChatResponse::Interrupt {
+                            reason: InterruptionReason::EndHookRearmLimitReached {
+                                limit: cap as u64,
+                            },
+                        })
+                        .await?;
+                        // leave should_yield = true so the outer loop exits
+                    } else {
+                        should_yield = false;
+                    }
                 }
             }
         }

--- a/crates/forge_app/src/orch_spec/orch_runner.rs
+++ b/crates/forge_app/src/orch_spec/orch_runner.rs
@@ -129,13 +129,28 @@ impl Runner {
             ApplyTunableParameters::new(agent.clone(), system_tools.clone()).apply(conversation);
         let conversation = SetConversationId.apply(conversation);
 
+        // Mirror the production wiring in `app.rs`: the pending-todos
+        // handler's reminder cap follows `max_end_hook_rearms` so tests
+        // exercising the orchestrator-level re-arm cap can trip it cleanly
+        // by setting the config field rather than threading a handler
+        // override through the runner. Tests that need to exercise the
+        // orchestrator cap *without* the handler short-circuiting first
+        // can set `pending_todos_handler_cap_override` to a high value.
+        let pending_todos_handler = match setup
+            .pending_todos_handler_cap_override
+            .or(setup.config.max_end_hook_rearms)
+        {
+            Some(cap) => PendingTodosHandler::with_max_reminders(cap),
+            None => PendingTodosHandler::new(),
+        };
+
         let orch = Orchestrator::new(services.clone(), conversation, agent, setup.config.clone())
             .error_tracker(ToolErrorTracker::new(3))
             .tool_definitions(system_tools)
             .hook(Arc::new(
                 Hook::default()
                     .on_request(DoomLoopDetector::default())
-                    .on_end(PendingTodosHandler::new()),
+                    .on_end(pending_todos_handler),
             ))
             .sender(tx);
 

--- a/crates/forge_app/src/orch_spec/orch_setup.rs
+++ b/crates/forge_app/src/orch_spec/orch_setup.rs
@@ -43,6 +43,14 @@ pub struct TestContext {
     /// ForgeConfig used to populate TemplateConfig for
     /// system prompt rendering in tests.
     pub config: ForgeConfig,
+
+    /// Optional override for the pending-todos handler reminder cap, used
+    /// only in tests that need to decouple the handler cap from the
+    /// orchestrator-level `max_end_hook_rearms` cap (e.g. exercising the
+    /// orch-level interrupt without the handler short-circuiting first).
+    /// `None` means "follow `config.max_end_hook_rearms`" — production
+    /// behavior.
+    pub pending_todos_handler_cap_override: Option<usize>,
 }
 
 impl Default for TestContext {
@@ -68,6 +76,7 @@ impl Default for TestContext {
             config: ForgeConfig::default()
                 .tool_supported(true)
                 .max_extensions(15),
+            pending_todos_handler_cap_override: None,
             title: Some("test-conversation".into()),
             agent: Agent::new(
                 AgentId::new("forge"),

--- a/crates/forge_config/.forge.toml
+++ b/crates/forge_config/.forge.toml
@@ -28,6 +28,7 @@ tool_timeout_secs = 300
 top_k = 30
 top_p = 0.8
 verify_todos = true
+max_end_hook_rearms = 3
 research_subagent = false
 currency_symbol = "$"
 currency_conversion_rate = 1.0

--- a/crates/forge_config/src/config.rs
+++ b/crates/forge_config/src/config.rs
@@ -294,6 +294,21 @@ pub struct ForgeConfig {
     #[serde(default)]
     pub verify_todos: bool,
 
+    /// Maximum number of times an `End`-lifecycle hook may re-arm the
+    /// orchestrator loop in a single run by injecting a follow-up message
+    /// (e.g. the pending-todos reminder).
+    ///
+    /// Once the cap is reached, the orchestrator force-yields with an
+    /// `EndHookRearmLimitReached` interrupt rather than continuing to ping
+    /// the model. This bounds the "reminder + reword + reminder" loop that
+    /// otherwise only terminated at `max_requests_per_turn`.
+    ///
+    /// Also used as the per-fingerprint cap in the pending-todos handler so
+    /// the same set of incomplete todos can't trigger more reminders than
+    /// the orchestrator is willing to honor anyway.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_end_hook_rearms: Option<usize>,
+
     /// Whether the deep research agent is available.
     ///
     /// When set to `true`, the Sage agent is added to the agent list and

--- a/crates/forge_domain/src/chat_response.rs
+++ b/crates/forge_domain/src/chat_response.rs
@@ -102,6 +102,14 @@ pub enum InterruptionReason {
     MaxRequestPerTurnLimitReached {
         limit: u64,
     },
+    /// The orchestrator's `End`-lifecycle hooks tried to re-arm the loop
+    /// (by injecting a follow-up message) more times than the configured
+    /// cap allows. Most commonly hit when the pending-todos reminder
+    /// keeps firing because the agent reshuffles its todo list each turn
+    /// instead of completing items.
+    EndHookRearmLimitReached {
+        limit: u64,
+    },
 }
 
 #[derive(Clone)]

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -4296,6 +4296,11 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                     InterruptionReason::MaxToolFailurePerTurnLimitReached { limit, .. } => {
                         format!("Maximum tool failure limit ({limit}) reached for this turn")
                     }
+                    InterruptionReason::EndHookRearmLimitReached { limit } => {
+                        format!(
+                            "End-hook re-arm limit ({limit}) reached \u{2014} pending-todos reminder kept firing without progress"
+                        )
+                    }
                 };
 
                 self.writeln_title(TitleFormat::action(title))?;

--- a/forge.schema.json
+++ b/forge.schema.json
@@ -362,6 +362,15 @@
       "type": "boolean",
       "default": false
     },
+    "max_end_hook_rearms": {
+      "description": "Maximum number of times an `End`-lifecycle hook may re-arm the\norchestrator loop in a single run by injecting a follow-up message\n(e.g. the pending-todos reminder).\n\nOnce the cap is reached, the orchestrator force-yields with an\n`EndHookRearmLimitReached` interrupt rather than continuing to ping\nthe model. This bounds the \"reminder + reword + reminder\" loop that\notherwise only terminated at `max_requests_per_turn`.\n\nAlso used as the per-fingerprint cap in the pending-todos handler so\nthe same set of incomplete todos can't trigger more reminders than\nthe orchestrator is willing to honor anyway.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint",
+      "minimum": 0
+    },
     "research_subagent": {
       "description": "Whether the deep research agent is available.\n\nWhen set to `true`, the Sage agent is added to the agent list and\nthe `:sage` app command is enabled. Defaults to `false`.",
       "type": "boolean",

--- a/sdk/typescript/src/wire.rs
+++ b/sdk/typescript/src/wire.rs
@@ -68,6 +68,7 @@ pub enum WireCategory {
 pub enum WireInterrupt {
     MaxToolFailurePerTurnLimitReached { limit: u64 },
     MaxRequestPerTurnLimitReached { limit: u64 },
+    EndHookRearmLimitReached { limit: u64 },
 }
 
 impl From<ChatResponse> for WireEvent {
@@ -144,6 +145,9 @@ impl From<InterruptionReason> for WireInterrupt {
             }
             InterruptionReason::MaxRequestPerTurnLimitReached { limit } => {
                 WireInterrupt::MaxRequestPerTurnLimitReached { limit }
+            }
+            InterruptionReason::EndHookRearmLimitReached { limit } => {
+                WireInterrupt::EndHookRearmLimitReached { limit }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes the **pending-todos doom loop** where the orchestrator's End hook keeps re-arming the run loop until `max_requests_per_turn` (100) cuts the agent off.

**Root cause:** `orch.rs` at the End-hook block flips `should_yield = false` whenever an End hook injects a message. `PendingTodosHandler` does exactly that whenever there are pending/in_progress todos. Its fingerprint dedupe is content-keyed, so any reword of the todo list changes the fingerprint and re-arms the loop. With a vague meta-todo the agent can never check off (e.g. "Implement the next high-impact bucket"), this self-perpetuates for up to 100 turns.

## Fixes

1. **`PendingTodosHandler` reminder cap** — tracks total reminders in context, not just last fingerprint. After `max_reminders` injections, the handler stops re-arming regardless of rewording.
2. **Orchestrator-level re-arm cap** — counts End-hook re-arms per run and force-yields with a new `InterruptionReason::EndHookRearmLimitReached`. Defense-in-depth against any End hook, not just pending-todos.
3. **DoomLoopDetector arg normalization** — strips volatile keys (`offset`, `limit`, `line_start`/`line_end`, `max_results`, `context_lines`, `if_hash`, `compact`, `scope`) from `read` / `grep` / `fs_search` / `codedb_*` calls before computing signatures. Catches "re-read same file with shifting offsets" loops that previously slipped through.
4. **Single config knob** — `forge_config.max_end_hook_rearms` (default `3`, in `.forge.toml`) bounds both #1 and #2 so one number controls the loop from both ends.

#### Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test -p forge_app --lib hooks::` — 42 pass (5 new)
- [x] `cargo test -p forge_app --lib orch_spec` — 25 pass, no regressions
- [x] `cargo test --workspace` — green
- [x] New unit tests cover:
  - `test_reminder_capped_when_todos_keep_changing` — agent rewords forever, handler caps at N
  - `test_with_max_reminders_zero_disables_handler` — knob can disable
  - `test_doom_loop_detector_normalizes_read_offsets` — same file, shifting offsets → 1 signature
  - `test_doom_loop_detector_normalizes_grep_max_results` — same query, shifting limits → 1 signature
  - `test_doom_loop_detector_keeps_distinct_files_distinct` — sanity: a/b/c.ts stay distinct

## User-visible changes

- New `max_end_hook_rearms` config field (default `3`); set to nothing / omit to keep legacy behavior.
- New interrupt reason surfaced in the TUI: *"End-hook re-arm limit (N) reached — pending-todos reminder kept firing without progress"*.
- New `WireInterrupt::EndHookRearmLimitReached` for the N-API SDK.

## Files

```
crates/forge_app/src/app.rs                   |  11 +-
crates/forge_app/src/hooks/doom_loop.rs       | 163 +++++++++++++++++++-
crates/forge_app/src/hooks/pending_todos.rs   | 159 ++++++++++++++++++--
crates/forge_app/src/orch.rs                  |  31 ++++-
crates/forge_app/src/orch_spec/orch_runner.rs |  17 ++-
crates/forge_app/src/orch_spec/orch_setup.rs  |   9 +
crates/forge_config/.forge.toml               |   1 +
crates/forge_config/src/config.rs             |  15 ++
crates/forge_domain/src/chat_response.rs      |   8 +
crates/forge_main/src/ui.rs                   |   5 +
forge.schema.json                             |   9 +
sdk/typescript/src/wire.rs                    |   4 +
12 files changed, 408 insertions(+), 24 deletions(-)
```

Generated with [Devin](https://cli.devin.ai/docs)
