### PR TITLE
Fix install.sh self-recursion hang and false-success on flat release tarball

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,18 @@ fetch_release() {
   done
   [ -f "$tmpd/$asset" ] || { rm -rf "$tmpd"; return 1; }
   tar -xzf "$tmpd/$asset" -C "$tmpd" 2>/dev/null || { rm -rf "$tmpd"; return 1; }
-  place_bin "$tmpd/$stem-$target/$stem"
+  # Current release tarballs are flat ($stem at the root); older ones nested
+  # the binary under a $stem-$target/ dir. Accept either, and fail (so we fall
+  # back to source) instead of handing place_bin a path that doesn't exist.
+  local binsrc
+  if [ -f "$tmpd/$stem" ]; then
+    binsrc="$tmpd/$stem"
+  elif [ -f "$tmpd/$stem-$target/$stem" ]; then
+    binsrc="$tmpd/$stem-$target/$stem"
+  else
+    rm -rf "$tmpd"; return 1
+  fi
+  place_bin "$binsrc"
   if [ "$(uname -s)" = "Darwin" ]; then
     codesign -s - --force "$INSTALL_DIR/$BIN" >/dev/null 2>&1 || true
   fi
@@ -171,12 +182,14 @@ main() {
     if command -v muonry >/dev/null 2>&1 && command -v zigpatch >/dev/null 2>&1; then
       printf "  ${D}│${N} %-10s ${G}✓${N} (already present)\n" "graff"
     else
-      printf "  ${D}│${N} %-10s " "graff"
-      if curl -fsSL https://codegraff.com/install-graff.sh | sh >/dev/null 2>&1; then
-        printf "${G}✓${N} (muonry + zigrep suite)\n"
-      else
-        printf "${Y}skipped${N} ${D}(install-graff.sh unavailable — harness still fully functional)${N}\n"
-      fi
+      # Do NOT auto-curl https://codegraff.com/install-graff.sh here: that URL
+      # currently serves *this* installer, not a muonry/zigpatch suite
+      # installer. Piping it into sh re-runs us — and since this branch can
+      # never make muonry/zigpatch present, every nested run re-enters here and
+      # recurses forever (the installer hangs and never returns; a nested run
+      # could also rm-then-fail the binary we just placed). Until a dedicated
+      # suite-installer URL exists, point the user at it instead of recursing.
+      printf "  ${D}│${N} %-10s ${Y}skipped${N} ${D}(install muonry + zigrep/zigpatch suite separately; premium paths stay dormant)${N}\n" "graff"
     fi
   fi
 


### PR DESCRIPTION
Fixes #4.

`curl -fsSL https://codegraff.com/install-graff.sh | sh` hung forever on a fresh machine; bypassing the hang then installed nothing while reporting success. Two independent bugs in `install.sh`, both fixed here.

## Bug 1 — infinite self-recursion (the hang)
The companion-suite step ran `curl -fsSL https://codegraff.com/install-graff.sh | sh`, but that URL serves **this same installer**. The guarding branch (`muonry`/`zigpatch` present) can never be satisfied by re-running the graff installer, so every nested invocation re-enters the step and recurses forever — the installer never returns. (A nested run can also `rm` the just-placed binary and then fail to reinstall, leaving a dangling `harness` symlink and no `graff`.)

**Fix:** replaced the recursive `curl … | sh` with a clear `skipped` message + guidance. The step never actually installed the suite from that URL, so removing the recursion loses no working behavior. Left a comment so a real suite-installer URL can be wired in later.

## Bug 2 — wrong tarball layout, false success
`fetch_release` assumed the release tarball nested the binary under `$stem-$target/` (e.g. `graff-aarch64-macos/graff`). Current release tarballs are **flat**:

```
$ tar -tzf graff-aarch64-macos.tar.gz
graff
README.md
LICENSE
```

So `install` received a nonexistent path and failed — yet the script still printed `installed`. **Fix:** locate the binary in either the flat or nested layout, and `return 1` (fall back to source build) when it isn't found, instead of reporting a false success.

## Verification (macOS, darwin-arm64)
- `bash -n install.sh` — clean.
- Fresh run with a hard 60s alarm now **terminates immediately**, downloads the prebuilt release, installs a working `graff` (+ valid `harness` symlink), and the companion step prints `skipped`:
  ```
  │ download   ✓ (prebuilt release)
  │ install    ✓
  installed → .../graff
  │ graff      skipped (install muonry + zigrep/zigpatch suite separately; ...)
  ```
- `graff --version` → `simple-harness 0.0.1`.