### PR TITLE
Fix install hang: flat-tarball handling + companion-suite recursion

### DIFF
--- a/docs/install-flow.md
+++ b/docs/install-flow.md
@@ -1,0 +1,99 @@
+# Install flow — diagnosis & fix
+
+Working notes for the `curl | sh` install path. Branch: `fix/install-flow`.
+
+## Symptom
+
+User runs the one-liner (`curl -fsSL https://codegraff.com/install-graff.sh | sh`)
+and sees:
+
+```
+install: /var/folders/.../graff-aarch64-macos/graff: No such file or directory
+  | download  ok (prebuilt release)
+  | install   ok
+  installed -> /Users/<u>/bin/graff
+  | graff            <- cursor sits here forever
+```
+
+i.e. an `install: No such file` error, a *false* "ok", and then a hang.
+It "worked before", so something changed — `install.sh` itself did **not**
+(byte-identical on `main`, the GUI branch, and the published release asset).
+
+## How the install actually works
+
+`curl | sh` runs `install.sh` -> `main()`, top to bottom:
+
+1. **`fetch_release`** — download the single `graff` tarball from GitHub
+   Releases, extract, drop the binary at `~/bin/graff`. **The only step that
+   makes graff work.** Falls back to a Zig **source build** on failure or
+   `HARNESS_BUILD=source`.
+2. Symlink `harness -> graff` (back-compat).
+3. **Companion suite** step — installs muonry + zigrep tools + codedb.
+4. **kuri** step (opt-in).
+5. PATH check, done.
+
+Only step 1 is required; the harness "works fine without it, premium paths just
+stay dormant."
+
+## The URLs (how hosting fits together — all live)
+
+zigrepper's Next.js frontend (deployed to codegraff.com) owns these routes:
+
+| URL | Route file | Serves |
+| --- | --- | --- |
+| `codegraff.com/install-graff.sh` | `app/install-graff.sh/route.ts` | proxies `github.com/justrach/codegraff/releases/latest/download/install.sh` = **the harness installer** (correct: this is the public "install graff" one-liner) |
+| `codegraff.com/install.sh` | `app/install.sh/route.ts` | **the companion/tools installer** (inline script: 8 zig tools + muonry + codedb, `BASE_URL=codegraff.com/v`) |
+| `codegraff.com/v/latest.json` | `app/v/[...path]/route.ts` | `{"version":"0.2.8"}` |
+| `codegraff.com/v/v<ver>/<tool>-<platform>` | same | the tool binaries (verified: muonry-darwin-arm64 -> 200, 2.3 MB) |
+
+All live and healthy. (Earlier I tested `get.codegraff.com/*` and saw 500/404 —
+that's a *different/stale* host; the real infra is `codegraff.com` + `/v`.)
+
+## Root causes
+
+### 1. Tarball layout mismatch -> `No such file` + false success
+`fetch_release` assumed `graff-<target>/graff` inside the tarball. CI
+(`release.yml`) packs it that way, but the **live macOS asset is flat**
+(`graff`/`README.md`/`LICENSE` at the root) because the macOS tarballs are
+repacked by hand in the local sign+notarize flow (CI has no mac signing
+target). So `install` failed. And because `fetch_release` runs inside
+`if ... fetch_release`, **`set -e` is suppressed** and it returned its last
+command's status (`rm -rf` -> 0) — printing `download ok / install ok`, never
+falling back to source, leaving `~/bin/graff` unwritten -> `command not found`.
+
+### 2. Companion step called the wrong URL -> recursion / hang
+The companion step ran `curl codegraff.com/install-graff.sh | sh`. But
+`install-graff.sh` proxies the **harness** release installer — so it reinstalled
+the harness, hit the same companion step, curled itself again -> infinite
+recursion. The `command -v muonry && zigpatch` guard never trips because the
+harness installer never installs those. **The companion installer is a
+different route: `codegraff.com/install.sh`** (the tools installer). One wrong
+URL was the entire hang.
+
+## Fix applied here (`install.sh`)
+
+1. **Robust binary location + fail-closed** in `fetch_release`: handle flat
+   *and* nested layouts, fall back to `find`, and `return 1` if the binary
+   didn't land so it falls through to a source build instead of lying.
+2. **Companion URL corrected** to `codegraff.com/install.sh` (the tools
+   installer) instead of the self-recursing `install-graff.sh`. Kept **default
+   ON / opt-out** via `HARNESS_NO_GRAFF=1` (product decision — restores prior
+   behavior), overridable via `GRAFF_SUITE_URL`, and now bounded by
+   `curl --max-time 120` so a slow network can never freeze the install.
+
+Verified: plain install lands a working `graff` in seconds; the companion step
+detects already-present tools and skips, or installs from the live endpoint, and
+never recurses/hangs.
+
+## Still TODO (other repos / nice-to-have)
+
+- **zigrepper `install.sh` / the `codegraff.com/install.sh` route** — the 9
+  tools download in a sequential `for` loop; parallelize (background curls +
+  `wait`) so the companion step is seconds, not ~a minute on a fresh machine.
+  This is the "make it parallel" piece — it lives in zigrepper, not here.
+- **Release packaging** — make the hand-repacked macOS tarball nest like CI (or
+  let CI own the mac sign+notarize) so the flat/nested split stops recurring.
+  The script now tolerates both, but artifacts should be consistent.
+- **(optional UX)** the companion `curl | sh` is silenced (`>/dev/null 2>&1`),
+  so on a fresh machine it looks idle while ~20 MB downloads. Once the downloads
+  are parallel this is a few seconds; otherwise consider a progress hint.

--- a/install.sh
+++ b/install.sh
@@ -105,11 +105,29 @@ fetch_release() {
   done
   [ -f "$tmpd/$asset" ] || { rm -rf "$tmpd"; return 1; }
   tar -xzf "$tmpd/$asset" -C "$tmpd" 2>/dev/null || { rm -rf "$tmpd"; return 1; }
-  place_bin "$tmpd/$stem-$target/$stem"
+  # Locate the extracted binary. CI (release.yml) nests it under
+  # graff-<target>/, but hand-repacked macOS tarballs (the local notarize
+  # flow) ship it flat at the root. Handle both, then fall back to a search
+  # so a future layout change can't silently break the install again.
+  local binpath=""
+  if [ -f "$tmpd/$stem" ]; then
+    binpath="$tmpd/$stem"
+  elif [ -f "$tmpd/$stem-$target/$stem" ]; then
+    binpath="$tmpd/$stem-$target/$stem"
+  else
+    binpath="$(find "$tmpd" -type f -name "$stem" 2>/dev/null | head -1)"
+  fi
+  [ -n "$binpath" ] && [ -f "$binpath" ] || { rm -rf "$tmpd"; return 1; }
+  place_bin "$binpath"
   if [ "$(uname -s)" = "Darwin" ]; then
     codesign -s - --force "$INSTALL_DIR/$BIN" >/dev/null 2>&1 || true
   fi
   rm -rf "$tmpd"
+  # Fail closed: if the binary didn't actually land, return non-zero so the
+  # caller falls back to a source build instead of falsely reporting success.
+  # (set -e is suppressed inside the `if fetch_release` guard, so the install
+  # error above does not abort on its own.)
+  [ -x "$INSTALL_DIR/$BIN" ] || return 1
 }
 
 build_from_source() {
@@ -164,18 +182,26 @@ main() {
 
   # The graff companion suite (muonry, zigrep/zigread/zigpatch, codedb):
   # the harness auto-upgrades to it when present — codedb backs the @ picker
-  # and the codedb tool, zigpatch does atomic edit_file splices. Installed
-  # by default; skip with HARNESS_NO_GRAFF=1 (the harness works fine
-  # without it, premium paths just stay dormant).
+  # and the codedb tool, zigpatch does atomic edit_file splices — but works
+  # fully without it, premium paths just stay dormant.
+  #
+  # Installed by default; skip with HARNESS_NO_GRAFF=1 (the harness works fine
+  # without it, premium paths just stay dormant). The companion installer is
+  # codegraff.com/install.sh (the tools installer). This step previously
+  # called codegraff.com/install-graff.sh, which proxies *this* harness
+  # installer (github releases/.../install.sh) — so it reinstalled the harness
+  # and recursed into itself, hanging at this line. Bounded by --max-time so a
+  # slow network can never freeze the install; override with GRAFF_SUITE_URL.
+  GRAFF_SUITE_URL="${GRAFF_SUITE_URL:-https://codegraff.com/install.sh}"
   if [ -z "${HARNESS_NO_GRAFF:-}" ]; then
     if command -v muonry >/dev/null 2>&1 && command -v zigpatch >/dev/null 2>&1; then
-      printf "  ${D}│${N} %-10s ${G}✓${N} (already present)\n" "graff"
+      printf "  ${D}│${N} %-10s ${G}✓${N} (already present)\n" "suite"
     else
-      printf "  ${D}│${N} %-10s " "graff"
-      if curl -fsSL https://codegraff.com/install-graff.sh | sh >/dev/null 2>&1; then
+      printf "  ${D}│${N} %-10s " "suite"
+      if curl -fsSL --max-time 120 "$GRAFF_SUITE_URL" | sh >/dev/null 2>&1; then
         printf "${G}✓${N} (muonry + zigrep suite)\n"
       else
-        printf "${Y}skipped${N} ${D}(install-graff.sh unavailable — harness still fully functional)${N}\n"
+        printf "${Y}skipped${N} ${D}(companion install unavailable — harness still fully functional)${N}\n"
       fi
     fi
   fi


### PR DESCRIPTION
## Symptom

`curl -fsSL https://codegraff.com/install-graff.sh | sh` printed `install: .../graff-aarch64-macos/graff: No such file or directory`, a *false* `download ✓ / install ✓`, then hung at the `graff`/`suite` line. The script itself was unchanged from when it worked — two separate regressions stacked up.

## Root causes

**1. Tarball layout mismatch → false success.** `fetch_release` assumed the binary lived at `graff-<target>/graff` inside the tarball. CI packs it nested, but the live macOS asset is **flat** (`graff` at the root) because the mac tarballs are repacked by hand in the local sign+notarize flow. So `install` failed — and because `fetch_release` runs inside `if … fetch_release`, `set -e` is suppressed and it returned `0` (from the trailing `rm -rf`), so it lied "✓", never fell back to a source build, and `~/bin/graff` was never written → `command not found`.

**2. Companion-suite recursion → the hang.** The companion step called `codegraff.com/install-graff.sh`, which **proxies this harness's own release `install.sh`**. So it reinstalled the harness, hit the same companion step, curled itself again → infinite recursion. The real companion installer is a different route, `codegraff.com/install.sh`.

## Fix

- `fetch_release`: locate the binary in flat **or** nested tarballs (with a `find` fallback) and **fail closed** — `return 1` if the binary didn't land, so it falls through to the source build instead of falsely succeeding.
- Companion step: point at `codegraff.com/install.sh` (the tools installer, verified live), keep it default-on/opt-out via `HARNESS_NO_GRAFF`, make the source overridable via `GRAFF_SUITE_URL`, and bound it with `curl --max-time` so a slow network can never freeze the install.

## Docs

`docs/install-flow.md` captures the full diagnosis, the `codegraff.com` route map, and the remaining packaging/zigrepper TODOs.

## Verified

Plain `curl … | sh` now lands a working `graff` in seconds; the companion step detects already-present tools and skips (or installs from the live endpoint); no recursion, no hang.