### PR TITLE
Thinking controls: /effort (deepseek+codegraff) and /fast (codex)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,6 @@ jobs:
 
       - name: SDK generation drift
         run: |
-          python3 sdk/generate.py --harness ./zig-out/bin/harness
+          python3 sdk/generate.py --harness ./zig-out/bin/graff
           git diff --exit-code sdk/ \
-            || (echo "::error::SDKs are stale — run: python3 sdk/generate.py --harness ./zig-out/bin/harness" && exit 1)
+            || (echo "::error::SDKs are stale — run: python3 sdk/generate.py --harness ./zig-out/bin/graff" && exit 1)

--- a/src/main.zig
+++ b/src/main.zig
@@ -1940,7 +1940,7 @@ fn loadOrCreateId(io: Io, gpa: Allocator, home: []const u8, fname: []const u8) [
 /// Reasoning depth for codex/responses (OpenAI Responses `reasoning.effort`).
 const ReasoningEffort = enum { low, medium, high };
 
-const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/plan", "/key", "/keepcontext", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
+const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/plan", "/key", "/keepcontext", "/effort", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
 
 /// Lifecycle hooks (codex/Claude-style), loaded once at startup from
 /// .harness/settings.json's "hooks" object. Three events:
@@ -4516,7 +4516,8 @@ const command_menu = [_]PickItem{
     .{ .name = "/yolo", .desc = "toggle permission prompts" },
     .{ .name = "/strict", .desc = "toggle every-message-is-a-tool mode" },
     .{ .name = "/keepcontext", .desc = "keep history across wire-format switches" },
-    .{ .name = "/reasoning", .desc = "codex/gpt-5 reasoning depth" },
+    .{ .name = "/effort", .desc = "thinking depth: low|medium|high (codex, deepseek, codegraff)" },
+    .{ .name = "/reasoning", .desc = "alias for /effort" },
     .{ .name = "/image", .desc = "attach an image to the next message" },
     .{ .name = "/paste", .desc = "attach the clipboard image" },
     .{ .name = "/trace", .desc = "toggle the JSONL event trace" },
@@ -4690,9 +4691,9 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             const disabled = skillDisabled(sk.name);
             const state: []const u8 = if (disabled) "disabled     " else if (inst) "installed    " else "not installed";
             try out.print("  {s}{s:<8}{s} {s}{s}{s}  {s}\n", .{
-                style.cyan,                                                       sk.name, style.reset,
-                if (disabled) style.yellow else if (inst) style.green else style.dim, state,
-                style.reset,                                                      sk.desc,
+                style.cyan,                                                           sk.name, style.reset,
+                if (disabled) style.yellow else if (inst) style.green else style.dim, state,   style.reset,
+                sk.desc,
             });
         }
         try out.writeAll("  install/enable: /skills add <name> · disable: /skills remove <name>\n");
@@ -4950,8 +4951,9 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         try out.flush();
         return;
     }
-    if (std.mem.startsWith(u8, line, "/reasoning")) {
-        const arg = std.mem.trim(u8, line["/reasoning".len..], " \t");
+    if (std.mem.startsWith(u8, line, "/effort") or std.mem.startsWith(u8, line, "/reasoning")) {
+        const prefix: []const u8 = if (std.mem.startsWith(u8, line, "/effort")) "/effort" else "/reasoning";
+        const arg = std.mem.trim(u8, line[prefix.len..], " \t");
         if (std.mem.eql(u8, arg, "low")) {
             root.reasoning = .low;
         } else if (std.mem.eql(u8, arg, "medium") or std.mem.eql(u8, arg, "med")) {
@@ -4959,13 +4961,13 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         } else if (std.mem.eql(u8, arg, "high")) {
             root.reasoning = .high;
         } else if (arg.len != 0) {
-            try out.writeAll("usage: /reasoning low|medium|high\n");
+            try out.writeAll("usage: /effort low|medium|high\n");
             try out.flush();
             return;
         }
         try out.print("reasoning effort: {s}{s}\n", .{
             @tagName(root.reasoning),
-            if (root.provider.kind != .responses) " (applies to codex/responses models — current model ignores it)" else "",
+            if (!root.effortApplies()) " (current model ignores it — applies to codex, deepseek, codegraff)" else "",
         });
         try out.flush();
         return;
@@ -5106,9 +5108,9 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             else
                 "abnormal";
             try out.print("  {s}{d:>3}{s}  {s}{s:<8}{s} {d:>7} unread B  {s}\n", .{
-                style.cyan,                                  job.id,  style.reset,
-                if (job.done) style.dim else style.green,    status,  style.reset,
-                job.buf.items.len - job.cursor,              utf8Prefix(job.cmd, 60),
+                style.cyan,                               job.id,                  style.reset,
+                if (job.done) style.dim else style.green, status,                  style.reset,
+                job.buf.items.len - job.cursor,           utf8Prefix(job.cmd, 60),
             });
         }
         try out.flush();
@@ -5127,7 +5129,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         if (c.unpriced_calls > 0) try out.print(" ({d} on unpriced models)", .{c.unpriced_calls});
         try out.print("\n  tokens:    {d} in ({d} cached) + {d} out\n", .{ c.in_tokens + c.cache_tokens, c.cache_tokens, c.out_tokens });
         try out.print("  cost:      {s}${d:.4}{s}{s}\n", .{
-            style.green, c.usd, style.reset,
+            style.green,                                                                                     c.usd, style.reset,
             if (c.sub_calls > 0 or c.unpriced_calls > 0) " (API-key calls with a known price only)" else "",
         });
         try out.flush();
@@ -5314,7 +5316,8 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         \\  /plan           toggle plan mode: read-only explore + propose; writes/edits denied
         \\  /key [prov key] show API-key status; /key <provider> <key> adds one live (+ Keychain)
         \\  /keepcontext    toggle keeping the conversation when /model switches wire format (default on)
-        \\  /reasoning      codex/gpt-5 reasoning depth: low|medium|high (default high)
+        \\  /effort         thinking depth: low|medium|high (codex, deepseek, codegraff; default medium)
+        \\  /reasoning      alias for /effort
         \\  /strict         toggle "every message is a tool" mode
         \\  /yolo           toggle bash auto-approval (skip permission prompts)
         \\  /trace          toggle the JSONL event trace (harness.trace.jsonl)
@@ -6342,7 +6345,7 @@ const Agent = struct {
     pending_image: ?PendingImage = null, // staged by /image, sent with the next turn
     home: []const u8 = "", // $HOME, for /key persistence (set by main)
     keep_context: bool = true, // carry the conversation across wire-format model switches (/keepcontext)
-    reasoning: ReasoningEffort = .high, // codex/responses reasoning depth (/reasoning)
+    reasoning: ReasoningEffort = .medium, // reasoning/thinking depth — codex, deepseek, codegraff (/effort, /reasoning)
     sys_strict: []const u8 = main_system_prompt_strict,
     tools_anthropic: []const u8 = tools_anthropic_sub,
     tools_openai: []const u8 = tools_openai_sub,
@@ -6428,6 +6431,16 @@ const Agent = struct {
     fn systemPrompt(self: *const Agent) []const u8 {
         if (self.sub) return self.sys_override orelse sub_system_prompt;
         return if (self.strict) self.sys_strict else self.sys_normal;
+    }
+
+    /// Whether the active provider honors a reasoning-effort hint: the
+    /// Responses API (codex) via reasoning.effort, and the OpenAI-compatible
+    /// providers we know normalize a top-level reasoning_effort — the
+    /// codegraff gateway and deepseek. Everything else ignores it.
+    fn effortApplies(self: *const Agent) bool {
+        return self.provider.kind == .responses or
+            std.mem.eql(u8, self.provider.id, "codegraff") or
+            std.mem.eql(u8, self.provider.id, "deepseek");
     }
 
     fn toolsJson(self: *const Agent) []const u8 {
@@ -7372,6 +7385,13 @@ const Agent = struct {
                 try s.endObject();
                 for (self.messages.items) |m| try s.write(m);
                 try s.endArray();
+                // Reasoning-effort hint for OpenAI-compatible providers that
+                // honor it (codegraff gateway, deepseek). Mirrors the
+                // Responses `reasoning.effort` set in the branch below.
+                if (self.effortApplies()) {
+                    try s.objectField("reasoning_effort");
+                    try s.write(@tagName(self.reasoning));
+                }
             },
             .responses => {
                 // Codex / ChatGPT Responses API. system prompt → instructions;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1940,7 +1940,7 @@ fn loadOrCreateId(io: Io, gpa: Allocator, home: []const u8, fname: []const u8) [
 /// Reasoning depth for codex/responses (OpenAI Responses `reasoning.effort`).
 const ReasoningEffort = enum { low, medium, high };
 
-const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/plan", "/key", "/keepcontext", "/effort", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
+const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/plan", "/key", "/keepcontext", "/effort", "/fast", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
 
 /// Lifecycle hooks (codex/Claude-style), loaded once at startup from
 /// .harness/settings.json's "hooks" object. Three events:
@@ -4518,6 +4518,7 @@ const command_menu = [_]PickItem{
     .{ .name = "/keepcontext", .desc = "keep history across wire-format switches" },
     .{ .name = "/effort", .desc = "thinking depth: low|medium|high (codex, deepseek, codegraff)" },
     .{ .name = "/reasoning", .desc = "alias for /effort" },
+    .{ .name = "/fast", .desc = "codex priority service tier — lower latency (gpt-5.5)" },
     .{ .name = "/image", .desc = "attach an image to the next message" },
     .{ .name = "/paste", .desc = "attach the clipboard image" },
     .{ .name = "/trace", .desc = "toggle the JSONL event trace" },
@@ -4951,6 +4952,15 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         try out.flush();
         return;
     }
+    if (std.mem.eql(u8, line, "/fast") or std.mem.eql(u8, line, "/fast on") or std.mem.eql(u8, line, "/fast off")) {
+        root.fast = if (std.mem.eql(u8, line, "/fast on")) true else if (std.mem.eql(u8, line, "/fast off")) false else !root.fast;
+        try out.print("fast mode: {s}{s}\n", .{
+            if (root.fast) "on" else "off",
+            if (root.provider.kind != .responses) " (codex only — current model ignores it)" else "",
+        });
+        try out.flush();
+        return;
+    }
     if (std.mem.startsWith(u8, line, "/effort") or std.mem.startsWith(u8, line, "/reasoning")) {
         const prefix: []const u8 = if (std.mem.startsWith(u8, line, "/effort")) "/effort" else "/reasoning";
         const arg = std.mem.trim(u8, line[prefix.len..], " \t");
@@ -5318,6 +5328,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         \\  /keepcontext    toggle keeping the conversation when /model switches wire format (default on)
         \\  /effort         thinking depth: low|medium|high (codex, deepseek, codegraff; default medium)
         \\  /reasoning      alias for /effort
+        \\  /fast           codex only: priority service tier for lower latency (toggle)
         \\  /strict         toggle "every message is a tool" mode
         \\  /yolo           toggle bash auto-approval (skip permission prompts)
         \\  /trace          toggle the JSONL event trace (harness.trace.jsonl)
@@ -6346,6 +6357,7 @@ const Agent = struct {
     home: []const u8 = "", // $HOME, for /key persistence (set by main)
     keep_context: bool = true, // carry the conversation across wire-format model switches (/keepcontext)
     reasoning: ReasoningEffort = .medium, // reasoning/thinking depth — codex, deepseek, codegraff (/effort, /reasoning)
+    fast: bool = false, // codex "fast" mode → priority service_tier (/fast)
     sys_strict: []const u8 = main_system_prompt_strict,
     tools_anthropic: []const u8 = tools_anthropic_sub,
     tools_openai: []const u8 = tools_openai_sub,
@@ -7409,6 +7421,13 @@ const Agent = struct {
                     try s.write(if (force_tool) "required" else "auto");
                     try s.objectField("parallel_tool_calls");
                     try s.write(true);
+                }
+                // Codex "fast" mode (/fast): request the priority service
+                // tier for lower latency. This branch is codex-only, so it is
+                // never emitted for other providers.
+                if (self.fast) {
+                    try s.objectField("service_tier");
+                    try s.write("priority");
                 }
                 try s.objectField("reasoning");
                 try s.beginObject();

--- a/src/main.zig
+++ b/src/main.zig
@@ -2437,6 +2437,65 @@ fn saveSkillSetting(io: Io, gpa: Allocator, name: []const u8, enabled: bool) boo
     return true;
 }
 
+/// Persist the thinking controls (/effort, /fast) to .harness/settings.json,
+/// preserving every other key. Default values (medium effort, fast off) are
+/// removed rather than written so the file stays clean. Best-effort.
+fn saveThinkingSettings(io: Io, gpa: Allocator, effort: ReasoningEffort, fast: bool) bool {
+    Io.Dir.cwd().createDir(io, Approvals.settings_dir, .default_dir) catch {}; // already-exists is fine
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var root_obj: std.json.ObjectMap = .empty;
+    if (Io.Dir.cwd().readFileAlloc(io, Approvals.settings_path, a, .limited(1 << 20))) |data| {
+        if (std.json.parseFromSliceLeaky(Value, a, data, .{ .allocate = .alloc_always })) |v| {
+            if (v == .object) root_obj = v.object;
+        } else |_| {}
+    } else |_| {}
+    if (effort == .medium) {
+        _ = root_obj.orderedRemove("effort");
+    } else {
+        root_obj.put(a, "effort", .{ .string = @tagName(effort) }) catch return false;
+    }
+    if (!fast) {
+        _ = root_obj.orderedRemove("fast");
+    } else {
+        root_obj.put(a, "fast", .{ .bool = true }) catch return false;
+    }
+    var aw: Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    var s: std.json.Stringify = .{ .writer = &aw.writer, .options = .{ .whitespace = .indent_2 } };
+    s.write(Value{ .object = root_obj }) catch return false;
+    const f = Io.Dir.cwd().createFile(io, Approvals.settings_path, .{}) catch return false;
+    defer f.close(io);
+    var wbuf: [4096]u8 = undefined;
+    var fw = f.writer(io, &wbuf);
+    fw.interface.writeAll(aw.writer.buffered()) catch return false;
+    fw.interface.writeAll("\n") catch return false;
+    fw.interface.flush() catch return false;
+    return true;
+}
+
+/// Load persisted thinking controls into the root agent at startup:
+/// {"effort": "low|medium|high"} and {"fast": true}. Best-effort — a missing
+/// or garbled file just leaves the defaults (medium, off).
+fn loadThinkingSettings(io: Io, arena: Allocator, root: *Agent) void {
+    const data = Io.Dir.cwd().readFileAlloc(io, Approvals.settings_path, arena, .limited(1 << 20)) catch return;
+    const v = std.json.parseFromSliceLeaky(Value, arena, data, .{ .allocate = .alloc_always }) catch return;
+    if (v != .object) return;
+    if (v.object.get("effort")) |e| if (e == .string) {
+        if (std.mem.eql(u8, e.string, "low")) {
+            root.reasoning = .low;
+        } else if (std.mem.eql(u8, e.string, "medium")) {
+            root.reasoning = .medium;
+        } else if (std.mem.eql(u8, e.string, "high")) {
+            root.reasoning = .high;
+        }
+    };
+    if (v.object.get("fast")) |fv| if (fv == .bool) {
+        root.fast = fv.bool;
+    };
+}
+
 /// Tab-completion candidates for the current input. After `/model ` →
 /// model names (deduped) + provider ids matching the partial; a bare `/word`
 /// → slash commands. Returns the byte offset of the word being completed
@@ -3829,6 +3888,7 @@ pub fn main(init: std.process.Init) !void {
         .tools_openai = try renderRootTools(arena, .openai, &root_specs, mcp_tools),
         .tools_responses = try renderRootTools(arena, .responses, &root_specs, mcp_tools),
     };
+    loadThinkingSettings(io, arena, &root); // {"effort":...,"fast":...} persisted by /effort and /fast
     tracer.note("session", root.provider.model);
 
     // One-shot print mode: run the single prompt to completion, print the
@@ -4954,6 +5014,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
     }
     if (std.mem.eql(u8, line, "/fast") or std.mem.eql(u8, line, "/fast on") or std.mem.eql(u8, line, "/fast off")) {
         root.fast = if (std.mem.eql(u8, line, "/fast on")) true else if (std.mem.eql(u8, line, "/fast off")) false else !root.fast;
+        _ = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast);
         try out.print("fast mode: {s}{s}\n", .{
             if (root.fast) "on" else "off",
             if (root.provider.kind != .responses) " (codex only — current model ignores it)" else "",
@@ -4975,6 +5036,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             try out.flush();
             return;
         }
+        _ = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast);
         try out.print("reasoning effort: {s}{s}\n", .{
             @tagName(root.reasoning),
             if (!root.effortApplies()) " (current model ignores it — applies to codex, deepseek, codegraff)" else "",
@@ -5326,9 +5388,9 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         \\  /plan           toggle plan mode: read-only explore + propose; writes/edits denied
         \\  /key [prov key] show API-key status; /key <provider> <key> adds one live (+ Keychain)
         \\  /keepcontext    toggle keeping the conversation when /model switches wire format (default on)
-        \\  /effort         thinking depth: low|medium|high (codex, deepseek, codegraff; default medium)
+        \\  /effort         thinking depth: low|medium|high (codex, deepseek, codegraff; default medium, persists)
         \\  /reasoning      alias for /effort
-        \\  /fast           codex only: priority service tier for lower latency (toggle)
+        \\  /fast           codex only: priority service tier for lower latency (toggle, persists)
         \\  /strict         toggle "every message is a tool" mode
         \\  /yolo           toggle bash auto-approval (skip permission prompts)
         \\  /trace          toggle the JSONL event trace (harness.trace.jsonl)


### PR DESCRIPTION
Unifies the thinking/latency controls across providers. Two commits of feature + a CI fix.

## 1. `/effort` — thinking depth on deepseek + codegraff
Reasoning effort was wired only to the Responses API (codex) via `reasoning.effort`. Extended to the OpenAI-compatible providers that honor a top-level `reasoning_effort` — the **codegraff gateway** and **deepseek**.
- `effortApplies()` gates emission to codex / codegraff / deepseek; everything else ignores it.
- `.openai` body now emits `reasoning_effort` (low|medium|high) for those providers.
- New `/effort` command; `/reasoning` kept as an alias. **Default is now `medium`** (was high).

## 2. `/fast` — codex priority service tier
Codex-only "fast" mode, mirroring codegraff2's `openai_responses` request (`fast_mode -> ServiceTier::Priority`).
- `Agent.fast` (bool), toggled with `/fast` (also `/fast on|off`).
- The `.responses` body emits `service_tier="priority"` when set; omitted otherwise. Lives in the codex-only branch, so other providers are unaffected (`/fast` on a non-codex model reports "codex only — current model ignores it").

Wire-verified:
```
/fast on  -> {"model":"gpt-5.5","service_tier":"priority","reasoning":{"effort":"medium"},...}
/fast off -> {"model":"gpt-5.5","reasoning":{"effort":"medium"},...}
```

## 3. CI fix (was red on every branch incl. main)
The SDK-drift step still invoked the generator against `./zig-out/bin/harness`, but the binary was renamed to `graff` — so it failed everywhere. Pointed it at `graff`; with the right binary the generator produces zero drift.

## Verified
`zig build` ✓ · `zig fmt --check` ✓ · `zig build test` ✓ · SDK drift ✓ (zero) · runtime smoke tests for `/effort` and `/fast` ✓