### PR TITLE
GUI: clean spinner for activity rows

### DIFF
--- a/gui/src/components/chat/ChatActivityRow.tsx
+++ b/gui/src/components/chat/ChatActivityRow.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   Globe,
   ListTodo,
+  Loader2,
   Map,
   MessageCircle,
   Pencil,
@@ -20,7 +21,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "../ui/Collapsible";
-import { Throbber } from "../ui/Throbber";
 import { cn } from "@/utils/cn";
 
 import {
@@ -181,7 +181,7 @@ export function ChatActivityRow({ item, workspacePath }: ChatActivityRowProps) {
         <article className="grid min-w-0 max-w-3xl gap-1">
           <CollapsibleTrigger className={activityTriggerClassName}>
             {item.isRunning ? (
-              <Throbber variant="thinking" className="text-muted-foreground" />
+              <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
             ) : null}
             <ChatStatusLabel text={item.summary} />
             <ActivityChevron
@@ -206,7 +206,7 @@ export function ChatActivityRow({ item, workspacePath }: ChatActivityRowProps) {
       <article className="grid min-w-0 max-w-3xl gap-1">
         <CollapsibleTrigger className={activityTriggerClassName}>
           {item.isRunning ? (
-            <Throbber variant="spinner" className="text-muted-foreground" />
+            <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
           ) : null}
           <ChatStatusLabel text={item.summary} />
           <ActivityChevron

--- a/gui/src/components/chat/ChatWorkRow.tsx
+++ b/gui/src/components/chat/ChatWorkRow.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 
-import { Throbber } from "../ui/Throbber";
 import { CHAT_MUTED_TEXT_CLASS } from "./constants/chatStyles";
 import { useRunningNow } from "./hooks/useRunningNow";
 import { ChatActivityRow } from "./ChatActivityRow";
@@ -28,7 +27,7 @@ function WorkHeaderLabel({
   return (
     <span className="inline-flex min-w-0 items-center gap-1.5">
       {isRunning ? (
-        <Throbber variant="spinner" className="text-muted-foreground" />
+        <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
       ) : null}
       <ChatStatusLabel text={label} />
     </span>


### PR DESCRIPTION
Replace the braille throbbers (read like drag handles) with a single small spinning Loader2 across the Working header, running tool steps, and the streaming Thinking block. tsc + 70 bun tests pass.