### PR TITLE
Kimi Code plan (k2.7, vision, OAuth) + GUI: harness-derived settings, image paste/thumbnails, motion

### DIFF
--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -351,6 +351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,10 +505,12 @@ version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "bstr",
  "bytes",
  "diesel",
  "futures",
+ "image",
  "log",
  "portable-pty",
  "pretty_assertions",
@@ -523,6 +531,12 @@ dependencies = [
  "urlencoding",
  "uuid",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -1084,7 +1098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1473,6 +1487,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -1911,7 +1935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2027,6 +2051,34 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -2435,6 +2487,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,7 +2511,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2995,6 +3057,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,6 +3233,18 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4439,7 +4526,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -5071,7 +5158,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -5558,6 +5645,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "widestring"
@@ -6335,3 +6428,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -46,6 +46,8 @@ url = { version = "2.5.8", features = ["serde"] }
 urlencoding = "2.1.3"
 uuid = { version = "1.23.0", features = ["v4", "serde"] }
 portable-pty = "0.9.0"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp"] }
+base64 = "0.22"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/gui/src-tauri/src/commands.rs
+++ b/gui/src-tauri/src/commands.rs
@@ -268,6 +268,29 @@ pub(crate) async fn save_pasted_image(data: Vec<u8>, ext: String) -> Result<Stri
     Ok(path.to_string_lossy().into_owned())
 }
 
+/// Decodes an image, downscales it to fit `max_dim` (default 96px, aspect
+/// preserved), and re-encodes it as a compressed JPEG returned as a data URL —
+/// so the composer can show a real thumbnail without loading the full file into
+/// the webview. Runs the CPU-bound work off the async runtime.
+#[tauri::command]
+pub(crate) async fn image_thumbnail(path: String, max_dim: Option<u32>) -> Result<String, String> {
+    let max = max_dim.unwrap_or(96).clamp(16, 512);
+    tokio::task::spawn_blocking(move || {
+        use base64::Engine as _;
+        let img = image::open(&path).map_err(|error| error.to_string())?;
+        // `thumbnail` is a fast box filter that preserves aspect ratio.
+        let rgb = img.thumbnail(max, max).to_rgb8();
+        let mut buf = std::io::Cursor::new(Vec::new());
+        image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, 70)
+            .encode_image(&rgb)
+            .map_err(|error| error.to_string())?;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(buf.get_ref());
+        Ok::<String, String>(format!("data:image/jpeg;base64,{b64}"))
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
 #[tauri::command]
 pub(crate) async fn set_active_agent(
     agent_id: String,

--- a/gui/src-tauri/src/commands.rs
+++ b/gui/src-tauri/src/commands.rs
@@ -249,6 +249,25 @@ pub(crate) async fn set_fast(
         .map_err(map_command_error)
 }
 
+/// Persists a clipboard-pasted image to a temp file and returns its path, so it
+/// can flow through the same attachment pipeline as drag-dropped files (the
+/// harness reads image attachments by path). Used by Cmd/Ctrl+V in the composer.
+#[tauri::command]
+pub(crate) async fn save_pasted_image(data: Vec<u8>, ext: String) -> Result<String, String> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let safe_ext = match ext.to_lowercase().as_str() {
+        "png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "avif" => ext.to_lowercase(),
+        _ => "png".to_string(),
+    };
+    let dir = std::env::temp_dir().join("codegraff-pasted");
+    std::fs::create_dir_all(&dir).map_err(|error| error.to_string())?;
+    let path = dir.join(format!("paste-{}-{n}.{safe_ext}", std::process::id()));
+    std::fs::write(&path, &data).map_err(|error| error.to_string())?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
 #[tauri::command]
 pub(crate) async fn set_active_agent(
     agent_id: String,

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -35,7 +35,7 @@ use commands::{
     pick_directory, pick_workspace, push_git_branch, quick_start_project, reload_mcp_servers,
     remove_mcp_server, remove_provider, rename_saved_workspace, rename_workspace, respond_followup,
     run_slash_command, save_conversation_layout, select_conversation, send_prompt,
-    set_active_agent, set_effort, set_fast, start_new_chat, start_provider_auth, stop_prompt, terminal_close,
+    save_pasted_image, set_active_agent, set_effort, set_fast, start_new_chat, start_provider_auth, stop_prompt, terminal_close,
     terminal_open, terminal_resize, terminal_write, update_prompt_settings,
     update_saved_workspace_layout, workspace_query, workspace_sync,
 };
@@ -103,6 +103,7 @@ pub fn run() {
             set_active_agent,
             set_effort,
             set_fast,
+            save_pasted_image,
             list_mcp_servers,
             import_mcp_config,
             remove_mcp_server,

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -35,7 +35,7 @@ use commands::{
     pick_directory, pick_workspace, push_git_branch, quick_start_project, reload_mcp_servers,
     remove_mcp_server, remove_provider, rename_saved_workspace, rename_workspace, respond_followup,
     run_slash_command, save_conversation_layout, select_conversation, send_prompt,
-    save_pasted_image, set_active_agent, set_effort, set_fast, start_new_chat, start_provider_auth, stop_prompt, terminal_close,
+    image_thumbnail, save_pasted_image, set_active_agent, set_effort, set_fast, start_new_chat, start_provider_auth, stop_prompt, terminal_close,
     terminal_open, terminal_resize, terminal_write, update_prompt_settings,
     update_saved_workspace_layout, workspace_query, workspace_sync,
 };
@@ -104,6 +104,7 @@ pub fn run() {
             set_effort,
             set_fast,
             save_pasted_image,
+            image_thumbnail,
             list_mcp_servers,
             import_mcp_config,
             remove_mcp_server,

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -2328,6 +2328,15 @@ fn tool_call_detail(name: &str, input: Option<&serde_json::Value>) -> ToolCallDe
             agent_id: String::new(),
             label: "workflow".to_string(),
         },
+        // Surface codedb's query like a command chip (e.g. "codedb search foo")
+        // instead of a bare "Ran codedb", mirroring how bash renders.
+        "codedb" => ToolCallDetailDto::Shell {
+            command: format!("codedb {}", str_field("command").unwrap_or_default())
+                .trim()
+                .to_string(),
+            cwd: None,
+            description: None,
+        },
         other => ToolCallDetailDto::Unknown {
             name: other.to_string(),
         },

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -149,10 +149,11 @@ impl RuntimeManager {
         // each group).
         let catalog = {
             let key_list = codegraff_key_list().await.unwrap_or_default();
-            let configured: std::collections::HashSet<&str> = CODEGRAFF_PROVIDERS
+            let configured: std::collections::HashSet<String> = schema_providers()
+                .await
                 .iter()
                 .filter(|provider| provider_configured(provider, &key_list))
-                .map(|provider| provider.id)
+                .map(|provider| provider.id.clone())
                 .collect();
             let mut models: Vec<ModelOption> = catalog
                 .into_iter()
@@ -429,12 +430,12 @@ impl RuntimeManager {
         // overriding it — surface that instead of appearing to do nothing.
         if summary.configured {
             if let Some(env_key) = provider_env_key(&input.provider_id) {
-                if std::env::var(env_key)
+                if std::env::var(&env_key)
                     .ok()
                     .filter(|value| !value.trim().is_empty())
                     .is_some()
                 {
-                    let location = match find_env_definition(env_key) {
+                    let location = match find_env_definition(&env_key) {
                         Some((path, line)) => format!("{path}:{line}"),
                         None => "your shell environment".into(),
                     };
@@ -2252,7 +2253,7 @@ fn read_mcp_servers(workspace_path: &str) -> Vec<McpServerSummaryDto> {
 
 /// Human-readable provider name, reusing the adapter's provider table.
 fn provider_display_name(provider_id: &str) -> String {
-    CODEGRAFF_PROVIDERS
+    fallback_providers()
         .iter()
         .find(|provider| provider.id == provider_id)
         .map(|provider| provider.name.to_string())
@@ -2441,78 +2442,103 @@ fn codegraff_binary() -> String {
 
 #[derive(Debug, Clone)]
 struct CodegraffProvider {
-    id: &'static str,
-    name: &'static str,
-    env_key: Option<&'static str>,
+    id: String,
+    name: String,
+    env_key: Option<String>,
     auth_method: ProviderAuthMethodKindDto,
 }
 
-const CODEGRAFF_PROVIDERS: &[CodegraffProvider] = &[
-    CodegraffProvider {
-        id: "codegraff",
-        name: "Codegraff",
-        env_key: Some("CODEGRAFF_API_KEY"),
-        auth_method: ProviderAuthMethodKindDto::CodegraffDevice,
-    },
-    CodegraffProvider {
-        id: "anthropic",
-        name: "Anthropic",
-        env_key: Some("ANTHROPIC_API_KEY"),
-        auth_method: ProviderAuthMethodKindDto::ApiKey,
-    },
-    CodegraffProvider {
-        id: "deepseek",
-        name: "DeepSeek",
-        env_key: Some("DEEPSEEK_API_KEY"),
-        auth_method: ProviderAuthMethodKindDto::ApiKey,
-    },
-    CodegraffProvider {
-        id: "openai",
-        name: "OpenAI",
-        env_key: Some("OPENAI_API_KEY"),
-        auth_method: ProviderAuthMethodKindDto::ApiKey,
-    },
-    CodegraffProvider {
-        id: "minimax",
-        name: "MiniMax",
-        env_key: Some("MINIMAX_API_KEY"),
-        auth_method: ProviderAuthMethodKindDto::ApiKey,
-    },
-    CodegraffProvider {
-        id: "xiaomi",
-        name: "Xiaomi",
-        env_key: Some("XIAOMI_API_KEY"),
-        auth_method: ProviderAuthMethodKindDto::ApiKey,
-    },
-    CodegraffProvider {
-        id: "kimi",
-        name: "Kimi",
-        env_key: Some("KIMI_API_KEY"),
-        auth_method: ProviderAuthMethodKindDto::ApiKey,
-    },
-    CodegraffProvider {
-        id: "xai",
-        name: "xAI",
-        env_key: Some("XAI_API_KEY"),
-        auth_method: ProviderAuthMethodKindDto::ApiKey,
-    },
-    CodegraffProvider {
-        id: "zai",
-        name: "Z.ai",
-        env_key: Some("ZAI_API_KEY"),
-        auth_method: ProviderAuthMethodKindDto::ApiKey,
-    },
-    CodegraffProvider {
-        id: "codex",
-        name: "Codex / ChatGPT",
-        env_key: None,
-        auth_method: ProviderAuthMethodKindDto::CodexDevice,
-    },
-];
+/// Static fallback list, used only when `graff --schema` can't be read (e.g.
+/// the binary is missing or too old). The live list comes from the harness —
+/// see `schema_providers`.
+fn fallback_providers() -> Vec<CodegraffProvider> {
+    use ProviderAuthMethodKindDto::*;
+    fn p(id: &str, name: &str, env: Option<&str>, auth: ProviderAuthMethodKindDto) -> CodegraffProvider {
+        CodegraffProvider {
+            id: id.into(),
+            name: name.into(),
+            env_key: env.map(Into::into),
+            auth_method: auth,
+        }
+    }
+    vec![
+        p("codegraff", "Codegraff", Some("CODEGRAFF_API_KEY"), CodegraffDevice),
+        p("anthropic", "Anthropic", Some("ANTHROPIC_API_KEY"), ApiKey),
+        p("deepseek", "DeepSeek", Some("DEEPSEEK_API_KEY"), ApiKey),
+        p("openai", "OpenAI", Some("OPENAI_API_KEY"), ApiKey),
+        p("minimax", "MiniMax", Some("MINIMAX_API_KEY"), ApiKey),
+        p("xiaomi", "Xiaomi", Some("XIAOMI_API_KEY"), ApiKey),
+        p("kimi", "Kimi", Some("KIMI_API_KEY"), ApiKey),
+        p("xai", "xAI", Some("XAI_API_KEY"), ApiKey),
+        p("zai", "Z.AI", Some("ZAI_API_KEY"), ApiKey),
+        p("codex", "Codex / ChatGPT", None, CodexDevice),
+    ]
+}
+
+/// The provider list the settings page renders, derived live from the harness's
+/// `graff --schema` so adding a provider in the Zig binary makes it appear here
+/// automatically — names, env vars, and login method all come from the harness.
+/// codegraff (primary login) is pinned first and codex last; otherwise harness
+/// order is preserved. Falls back to `fallback_providers` if the schema can't
+/// be read.
+async fn schema_providers() -> Vec<CodegraffProvider> {
+    let output = match tokio::process::Command::new(codegraff_binary())
+        .arg("--schema")
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return fallback_providers(),
+    };
+    let Ok(schema) = serde_json::from_slice::<serde_json::Value>(&output.stdout) else {
+        return fallback_providers();
+    };
+    let Some(entries) = schema.get("providers").and_then(|value| value.as_array()) else {
+        return fallback_providers();
+    };
+    let mut providers: Vec<CodegraffProvider> = entries
+        .iter()
+        .filter_map(|entry| {
+            let id = entry.get("id")?.as_str()?.to_string();
+            let name = entry
+                .get("name")
+                .and_then(|value| value.as_str())
+                .unwrap_or(&id)
+                .to_string();
+            let auth_method = match entry.get("login").and_then(|value| value.as_str()) {
+                Some("codegraff_device") => ProviderAuthMethodKindDto::CodegraffDevice,
+                Some("codex_device") => ProviderAuthMethodKindDto::CodexDevice,
+                _ => ProviderAuthMethodKindDto::ApiKey,
+            };
+            // Only api-key providers surface an env var; login providers carry a
+            // placeholder env_key in the schema that the UI must not show.
+            let env_key = if matches!(auth_method, ProviderAuthMethodKindDto::ApiKey) {
+                entry
+                    .get("env_key")
+                    .and_then(|value| value.as_str())
+                    .filter(|value| !value.is_empty())
+                    .map(|value| value.to_string())
+            } else {
+                None
+            };
+            Some(CodegraffProvider { id, name, env_key, auth_method })
+        })
+        .collect();
+    if providers.is_empty() {
+        return fallback_providers();
+    }
+    providers.sort_by_key(|provider| match provider.id.as_str() {
+        "codegraff" => 0u8,
+        "codex" => 2,
+        _ => 1,
+    });
+    providers
+}
 
 async fn list_codegraff_providers() -> Result<Vec<ProviderSummaryDto>> {
     let key_list = codegraff_key_list().await.unwrap_or_default();
-    Ok(CODEGRAFF_PROVIDERS
+    Ok(schema_providers()
+        .await
         .iter()
         .map(|provider| provider_summary_with_key_list(provider, &key_list))
         .collect())
@@ -2520,7 +2546,8 @@ async fn list_codegraff_providers() -> Result<Vec<ProviderSummaryDto>> {
 
 async fn provider_summary(provider_id: &str) -> Result<ProviderSummaryDto> {
     let key_list = codegraff_key_list().await.unwrap_or_default();
-    let provider = CODEGRAFF_PROVIDERS
+    let providers = schema_providers().await;
+    let provider = providers
         .iter()
         .find(|provider| provider.id == provider_id)
         .with_context(|| format!("Unknown provider {provider_id}"))?;
@@ -2532,8 +2559,8 @@ fn provider_summary_with_key_list(
     key_list: &str,
 ) -> ProviderSummaryDto {
     ProviderSummaryDto {
-        id: provider.id.into(),
-        name: provider.name.into(),
+        id: provider.id.clone(),
+        name: provider.name.clone(),
         configured: provider_configured(provider, key_list),
         auth_methods: vec![ProviderAuthMethodDto {
             kind: provider.auth_method.clone(),
@@ -2546,7 +2573,7 @@ fn provider_summary_with_key_list(
 /// Builds the env-override hint when a provider's `<PROVIDER>_API_KEY` is set,
 /// locating where it's defined so the UI can offer to open that file.
 fn provider_env_override(provider: &CodegraffProvider) -> Option<ProviderEnvOverrideDto> {
-    let env_key = provider.env_key?;
+    let env_key = provider.env_key.as_deref()?;
     let is_set = std::env::var(env_key)
         .ok()
         .filter(|value| !value.trim().is_empty())
@@ -2603,6 +2630,7 @@ fn provider_auth_label(provider: &CodegraffProvider) -> String {
     match provider.auth_method {
         ProviderAuthMethodKindDto::ApiKey => provider
             .env_key
+            .as_deref()
             .map(|env_key| format!("API key ({env_key} or graff key set {})", provider.id))
             .unwrap_or_else(|| "API key".into()),
         ProviderAuthMethodKindDto::CodegraffDevice => "Codegraff device login".into(),
@@ -2614,6 +2642,7 @@ fn provider_auth_label(provider: &CodegraffProvider) -> String {
 fn provider_configured(provider: &CodegraffProvider, key_list: &str) -> bool {
     if provider
         .env_key
+        .as_deref()
         .and_then(|env_key| std::env::var(env_key).ok())
         .filter(|value| !value.trim().is_empty())
         .is_some()
@@ -2621,13 +2650,13 @@ fn provider_configured(provider: &CodegraffProvider, key_list: &str) -> bool {
         return true;
     }
 
-    match provider.id {
+    match provider.id.as_str() {
         "codegraff" => {
             home_file_exists("forge/.credentials.json")
-                || key_list_mentions_provider(key_list, provider.id)
+                || key_list_mentions_provider(key_list, &provider.id)
         }
         "codex" => home_file_exists(".codex/auth.json"),
-        _ => key_list_mentions_provider(key_list, provider.id),
+        _ => key_list_mentions_provider(key_list, &provider.id),
     }
 }
 
@@ -2650,9 +2679,9 @@ fn home_file_exists(relative_path: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn provider_env_key(provider_id: &str) -> Option<&'static str> {
-    CODEGRAFF_PROVIDERS
-        .iter()
+fn provider_env_key(provider_id: &str) -> Option<String> {
+    fallback_providers()
+        .into_iter()
         .find(|provider| provider.id == provider_id)
         .and_then(|provider| provider.env_key)
 }

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -208,6 +208,7 @@ impl RuntimeManager {
                 let effort_capable = match model.provider.as_str() {
                     "codex" => true,
                     "codegraff" | "deepseek" => !model.name.starts_with("gpt-"),
+                    "kimi" => true,
                     _ => false,
                 };
                 let reasoning_efforts: Vec<String> = if effort_capable {

--- a/gui/src/app/SessionProvider.tsx
+++ b/gui/src/app/SessionProvider.tsx
@@ -517,6 +517,10 @@ export function SessionProvider({ children }: SessionProviderProps) {
         // submit path in useConversationActions.
         const attachments = getAttachments(promptDraftKey);
         const prompt = appendAttachmentsToPrompt(trimmedPrompt, attachments);
+        // Clear the welcome composer immediately on send (prompt already
+        // captured) so the draft + attachment don't linger while the turn runs.
+        sessionStore.getState().clearPromptDraft(promptDraftKey);
+        sessionStore.getState().clearAttachments(promptDraftKey);
 
         let nextPromptDraftKey: string | null = promptDraftKey;
         sessionStore.getState().setPromptDraftPending(promptDraftKey, true);

--- a/gui/src/components/PromptInputCard.tsx
+++ b/gui/src/components/PromptInputCard.tsx
@@ -37,7 +37,7 @@ import { useAttachments } from "@/hooks/useSession";
 import { useCommandAutocomplete } from "@/hooks/useCommandAutocomplete";
 import { useDropZone } from "@/hooks/useFileDrop";
 import { usePromptModelPicker } from "@/hooks/usePromptModelPicker";
-import { setFast } from "@/services/desktop/client";
+import { savePastedImage, setFast } from "@/services/desktop/client";
 import { cn } from "@/utils/cn";
 import {
   formatPlanningThinkingLabel,
@@ -162,6 +162,39 @@ export function PromptInputCard({
     setPlanningMode(!isPlanningMode);
   }
 
+  // Cmd/Ctrl+V of an image: persist the clipboard bytes to a temp file and add
+  // it through the same attachment pipeline as a drag-dropped file.
+  async function handlePaste(
+    event: React.ClipboardEvent<HTMLTextAreaElement>,
+  ) {
+    const items = event.clipboardData?.items;
+    if (!items) {
+      return;
+    }
+    for (const item of items) {
+      if (item.kind !== "file" || !item.type.startsWith("image/")) {
+        continue;
+      }
+      const file = item.getAsFile();
+      if (!file) {
+        continue;
+      }
+      event.preventDefault();
+      try {
+        const bytes = Array.from(new Uint8Array(await file.arrayBuffer()));
+        const ext = item.type.split("/")[1] ?? "png";
+        const path = await savePastedImage(bytes, ext);
+        const attachment = classifyPath(path);
+        if (attachment) {
+          addAttachments([attachment]);
+        }
+      } catch (error) {
+        console.error("Failed to attach pasted image", error);
+      }
+      return;
+    }
+  }
+
   return (
     <div ref={dropZoneRef} className="relative mx-auto w-full max-w-3xl">
       {isDropActive ? <DropOverlay /> : null}
@@ -214,6 +247,7 @@ export function PromptInputCard({
               placeholder={placeholder}
               value={promptDraft}
               onChange={(event) => setPromptDraft(event.target.value)}
+              onPaste={handlePaste}
               onKeyDown={(event) => {
                 // The command menu consumes Enter/Tab/arrows while open, so a
                 // command is completed rather than sent.

--- a/gui/src/components/attachments/AttachmentCard.tsx
+++ b/gui/src/components/attachments/AttachmentCard.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from "react";
 import { FileIcon, FileTextIcon, ImageIcon, XIcon } from "lucide-react";
-import { convertFileSrc } from "@tauri-apps/api/core";
+
+import { imageThumbnail } from "@/services/desktop/client";
 
 import { cn } from "@/utils/cn";
 import type { Attachment } from "./attachmentTypes";
@@ -24,17 +26,27 @@ export function AttachmentCard({
   onOpen?: (path: string) => void;
 }) {
   const isInteractive = onOpen != null;
+  const [thumbnail, setThumbnail] = useState<string | null>(null);
+  useEffect(() => {
+    if (attachment.kind !== "image") return;
+    let cancelled = false;
+    imageThumbnail(attachment.path).then(
+      (url) => {
+        if (!cancelled) setThumbnail(url);
+      },
+      () => {},
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [attachment.kind, attachment.path]);
   const subtitle = attachment.ext ? attachment.ext.toUpperCase() : "FILE";
 
   const content = (
     <>
       <div className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
-        {attachment.kind === "image" ? (
-          <img
-            src={convertFileSrc(attachment.path)}
-            alt=""
-            className="size-full object-cover"
-          />
+        {attachment.kind === "image" && thumbnail ? (
+          <img src={thumbnail} alt="" className="size-full object-cover" />
         ) : (
           <KindIcon kind={attachment.kind} />
         )}

--- a/gui/src/components/chat/ChatMessageRow.tsx
+++ b/gui/src/components/chat/ChatMessageRow.tsx
@@ -33,7 +33,7 @@ function UserChatMessage({ text, workspacePath }: UserChatMessageProps) {
     .filter((item): item is NonNullable<typeof item> => item != null);
 
   return (
-    <article className="flex w-full flex-col items-end gap-2 select-text">
+    <article className="cg-message-in flex w-full flex-col items-end gap-2 select-text">
       {attachments.length > 0 ? (
         <AttachmentTray
           attachments={attachments}
@@ -62,7 +62,7 @@ function MarkdownChatMessage({
     <article className="max-w-3xl">
       <ChatMarkdown
         text={text}
-        className={toneClassName}
+        className={`cg-stream-in ${toneClassName ?? ""}`}
         workspacePath={workspacePath}
       />
     </article>

--- a/gui/src/hooks/useConversationActions.ts
+++ b/gui/src/hooks/useConversationActions.ts
@@ -103,6 +103,11 @@ export function useConversationActions(binding?: ChatBinding | null) {
         const attachments = getAttachments(promptDraftKey);
         const prompt = appendAttachmentsToPrompt(trimmedPrompt, attachments);
 
+        // Clear the composer immediately on send so the draft + any attachment
+        // don't linger in the bar while the turn runs (the prompt is already
+        // captured above).
+        sessionStore.getState().clearPromptDraft(promptDraftKey);
+        sessionStore.getState().clearAttachments(promptDraftKey);
         sessionStore.getState().setPromptDraftPending(promptDraftKey, true);
         try {
           const snapshot = await desktopClient.sendPrompt({
@@ -112,8 +117,6 @@ export function useConversationActions(binding?: ChatBinding | null) {
             workspacePath,
           });
           sessionStore.getState().applySessionSnapshot(snapshot);
-          sessionStore.getState().clearPromptDraft(promptDraftKey);
-          sessionStore.getState().clearAttachments(promptDraftKey);
         } catch {
           return;
         } finally {

--- a/gui/src/services/desktop/client.ts
+++ b/gui/src/services/desktop/client.ts
@@ -491,6 +491,14 @@ export function savePastedImage(
   return invokeCommand("save_pasted_image", { data, ext });
 }
 
+/** Returns a compressed JPEG thumbnail of an image file as a data URL. */
+export function imageThumbnail(
+  path: string,
+  maxDim?: number,
+): Promise<string> {
+  return invokeCommand("image_thumbnail", { path, maxDim: maxDim ?? null });
+}
+
 export function listMcpServers(
   workspacePath?: string | null,
 ): Promise<McpSettingsPayload> {

--- a/gui/src/services/desktop/client.ts
+++ b/gui/src/services/desktop/client.ts
@@ -483,6 +483,14 @@ export function setFast(
   });
 }
 
+/** Writes a clipboard-pasted image to a temp file and returns its path. */
+export function savePastedImage(
+  data: number[],
+  ext: string,
+): Promise<string> {
+  return invokeCommand("save_pasted_image", { data, ext });
+}
+
 export function listMcpServers(
   workspacePath?: string | null,
 ): Promise<McpSettingsPayload> {

--- a/gui/src/styles/index.css
+++ b/gui/src/styles/index.css
@@ -670,3 +670,46 @@
     > .dv-sash::after {
     background: rgb(255 255 255 / 5%);
 }
+
+/* --- Chat entrance + streaming motion (transitions.dev-style easings) --- */
+
+/* Message slides up + fades in as it lands in the thread. */
+@keyframes cg-message-in {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.cg-message-in {
+    /* easeOutExpo — a soft, fast-settling deceleration */
+    animation: cg-message-in 0.45s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* Streaming assistant text: each freshly rendered block fades up gently so the
+   answer "flows in" rather than snapping token-by-token. */
+@keyframes cg-stream-in {
+    from {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.cg-stream-in > * {
+    animation: cg-stream-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .cg-message-in,
+    .cg-stream-in > * {
+        animation: none;
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -372,7 +372,9 @@ const main_system_prompt =
     \\user's machine. Use the provided tools to inspect and modify the current
     \\working directory and to run commands. read_file before editing; prefer
     \\edit_file for changes to existing files and write_file only for new
-    \\files or full rewrites. Some bash commands need user approval — if one
+    \\files or full rewrites. To navigate code — finding symbols, callers,
+    \\definitions, or where logic lives — prefer the codedb tool (it's indexed
+    \\and structural) over bash grep/find/ls. Some bash commands need user approval — if one
     \\is declined, try another approach or ask. For independent,
     \\self-contained chunks of work — exploring several directories, running
     \\unrelated checks, summarizing multiple files — fan out: call the
@@ -6780,7 +6782,8 @@ const Agent = struct {
     fn effortApplies(self: *const Agent) bool {
         return self.provider.kind == .responses or
             std.mem.eql(u8, self.provider.id, "codegraff") or
-            std.mem.eql(u8, self.provider.id, "deepseek");
+            std.mem.eql(u8, self.provider.id, "deepseek") or
+            std.mem.eql(u8, self.provider.id, "kimi");
     }
 
     fn toolsJson(self: *const Agent) []const u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3446,6 +3446,7 @@ const usage_text =
     \\  graff [-p] "prompt"              one-shot: run the prompt, print the answer, exit
     \\  graff login                      get a codegraff key (device-code OAuth)
     \\  graff login codex [--refresh]    ChatGPT/Codex OAuth login (PKCE)
+    \\  graff login kimi                 Kimi Code OAuth login (device-code)
     \\  graff key set <provider> <key>   store a key (macOS Keychain, else 0600 file)
     \\  graff key list                   show which providers have keys
     \\  graff --schema                   print the machine-readable interface (SDK codegen)
@@ -3490,6 +3491,7 @@ pub fn main(init: std.process.Init) !void {
     var login_flag = false;
     var refresh_flag = false;
     var codex_login = false;
+    var kimi_login = false;
     var help_flag = false;
     var version_flag = false;
     var print_flag = false;
@@ -3553,6 +3555,7 @@ pub fn main(init: std.process.Init) !void {
         }
         if (positionals.items.len > 0 and std.mem.eql(u8, positionals.items[0], "login")) login_flag = true;
         if (positionals.items.len > 1 and std.mem.eql(u8, positionals.items[1], "codex")) codex_login = true;
+        if (positionals.items.len > 1 and std.mem.eql(u8, positionals.items[1], "kimi")) kimi_login = true;
     }
 
     // One-shot print mode: `harness -p "prompt"` or a bare positional prompt
@@ -3589,7 +3592,7 @@ pub fn main(init: std.process.Init) !void {
     // `codex` (or --refresh) runs the ChatGPT PKCE/refresh flow → ~/.codex/auth.json.
     if (login_flag) {
         const home = init.environ_map.get("HOME") orelse std.process.fatal("no HOME", .{});
-        if (codex_login or refresh_flag) try codexLogin(io, gpa, arena, home, refresh_flag) else try codegraffLogin(io, gpa, arena, home);
+        if (kimi_login) try kimiLogin(io, gpa, arena, home) else if (codex_login or refresh_flag) try codexLogin(io, gpa, arena, home, refresh_flag) else try codegraffLogin(io, gpa, arena, home);
         return;
     }
 
@@ -3644,6 +3647,15 @@ pub fn main(init: std.process.Init) !void {
             }
             keys.codex_account = auth.account;
             codex_account = auth.account;
+        }
+    }
+    // Kimi "login": OAuth device-flow token from `graff login kimi`
+    // (~/.kimi/credentials/graff-oauth.json), refreshed in place when near
+    // expiry. Same on-disk-credential pattern as codex/codegraff; env wins.
+    if (init.environ_map.get("HOME")) |home| {
+        for (provider_specs, &keys.values) |spec, *value| {
+            if (std.mem.eql(u8, spec.id, "kimi") and value.* == null)
+                value.* = loadKimiOAuth(io, gpa, arena, home);
         }
     }
     // Stored keys (macOS Keychain / 0600 file via `harness key set`): fill any
@@ -5805,6 +5817,136 @@ fn openBrowser(io: Io, url: []const u8) void {
         &.{ "xdg-open", url };
     var child = std.process.spawn(io, .{ .argv = argv, .stdin = .ignore, .stdout = .ignore, .stderr = .ignore }) catch return;
     _ = child.wait(io) catch {};
+}
+
+// Kimi Code OAuth — device-code flow, same client + endpoints the Kimi CLI
+// uses (auth.kimi.com). `graff login kimi` runs the flow and writes the token
+// to ~/.kimi/credentials/graff-oauth.json; loadKimiOAuth reads it at startup
+// and refreshes in place when near expiry.
+const kimi_oauth_host = "https://auth.kimi.com";
+const kimi_device_auth_url = kimi_oauth_host ++ "/api/oauth/device_authorization";
+const kimi_token_url = kimi_oauth_host ++ "/api/oauth/token";
+const kimi_client_id = "17e5f671-d194-4dfb-9706-5516cb48c098";
+
+/// POST a form body to a Kimi OAuth endpoint; return the parsed JSON object.
+fn kimiOAuthPost(io: Io, gpa: Allocator, arena: Allocator, url: []const u8, body: []const u8) !std.json.ObjectMap {
+    var client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer client.deinit();
+    var aw: Io.Writer.Allocating = .init(arena);
+    _ = try client.fetch(.{
+        .location = .{ .url = url },
+        .method = .POST,
+        .payload = body,
+        .response_writer = &aw.writer,
+        .headers = .{ .content_type = .{ .override = "application/x-www-form-urlencoded" } },
+    });
+    const v = try std.json.parseFromSliceLeaky(Value, arena, aw.writer.buffered(), .{ .allocate = .alloc_always });
+    if (v != .object) return error.BadOAuthResponse;
+    return v.object;
+}
+
+fn kimiAuthPath(arena: Allocator, home: []const u8) []const u8 {
+    return std.fmt.allocPrint(arena, "{s}/.kimi/credentials/graff-oauth.json", .{home}) catch "";
+}
+
+fn writeKimiAuth(io: Io, arena: Allocator, home: []const u8, access: []const u8, refresh: []const u8, expires_at: i64) !void {
+    // createDir is one level, so make ~/.kimi then ~/.kimi/credentials.
+    Io.Dir.cwd().createDir(io, try std.fmt.allocPrint(arena, "{s}/.kimi", .{home}), .default_dir) catch {};
+    Io.Dir.cwd().createDir(io, try std.fmt.allocPrint(arena, "{s}/.kimi/credentials", .{home}), .default_dir) catch {};
+    var obj: std.json.ObjectMap = .empty;
+    try obj.put(arena, "access_token", .{ .string = access });
+    try obj.put(arena, "refresh_token", .{ .string = refresh });
+    try obj.put(arena, "expires_at", .{ .integer = expires_at });
+    var aw: Io.Writer.Allocating = .init(arena);
+    var s: std.json.Stringify = .{ .writer = &aw.writer };
+    try s.write(Value{ .object = obj });
+    const f = try Io.Dir.cwd().createFile(io, kimiAuthPath(arena, home), .{});
+    defer f.close(io);
+    var wbuf: [4096]u8 = undefined;
+    var fw = f.writer(io, &wbuf);
+    try fw.interface.writeAll(aw.writer.buffered());
+    try fw.interface.flush();
+}
+
+/// `graff login kimi`: Kimi Code device-code OAuth. Prints a verification URL +
+/// user code, opens the browser, polls until the user authorizes, then stores
+/// the access/refresh token.
+fn kimiLogin(io: Io, gpa: Allocator, arena: Allocator, home: []const u8) !void {
+    var obuf: [4096]u8 = undefined;
+    var ow = Io.File.stdout().writer(io, &obuf);
+    const out = &ow.interface;
+
+    const da_body = try std.fmt.allocPrint(arena, "client_id={s}", .{kimi_client_id});
+    const da = kimiOAuthPost(io, gpa, arena, kimi_device_auth_url, da_body) catch |err| {
+        try out.print("✗ Kimi device authorization failed: {t}\n", .{err});
+        try out.flush();
+        return;
+    };
+    if (da.get("error")) |e| {
+        try out.print("✗ {s}\n", .{if (e == .string) e.string else "device authorization error"});
+        try out.flush();
+        return;
+    }
+    const device_code = strFieldObj(da, "device_code") orelse return error.BadOAuthResponse;
+    const user_code = strFieldObj(da, "user_code") orelse "";
+    const verify = strFieldObj(da, "verification_uri_complete") orelse strFieldObj(da, "verification_uri") orelse "";
+    const interval: i64 = if (da.get("interval")) |iv| (if (iv == .integer) @max(iv.integer, 1) else 5) else 5;
+
+    try out.print("\nTo log in to Kimi, open this URL (browser should open automatically):\n\n  {s}\n\nand confirm the code:  {s}\n\nwaiting for authorization…\n", .{ verify, user_code });
+    try out.flush();
+    openBrowser(io, verify);
+
+    const poll_body = try std.fmt.allocPrint(arena, "client_id={s}&device_code={s}&grant_type=urn:ietf:params:oauth:grant-type:device_code", .{ kimi_client_id, device_code });
+    var attempts: usize = 0;
+    while (attempts < 360) : (attempts += 1) {
+        io.sleep(Io.Duration.fromSeconds(interval), .awake) catch {};
+        const resp = kimiOAuthPost(io, gpa, arena, kimi_token_url, poll_body) catch continue;
+        if (resp.get("access_token")) |a| if (a == .string and a.string.len > 0) {
+            const refresh = strFieldObj(resp, "refresh_token") orelse "";
+            const expires_in: i64 = if (resp.get("expires_in")) |ei| (if (ei == .integer) ei.integer else 900) else 900;
+            try writeKimiAuth(io, arena, home, a.string, refresh, @divTrunc(unixMs(io), 1000) + expires_in);
+            try out.print("✓ logged into Kimi — wrote {s}. /model kimi-k2.7\n", .{kimiAuthPath(arena, home)});
+            try out.flush();
+            return;
+        };
+        const msg = if (resp.get("error")) |e| (if (e == .string) e.string else "") else "";
+        if (std.mem.eql(u8, msg, "authorization_pending") or std.mem.eql(u8, msg, "slow_down")) continue;
+        if (std.mem.eql(u8, msg, "expired_token")) {
+            try out.writeAll("✗ the code expired — run `graff login kimi` again\n");
+            try out.flush();
+            return;
+        }
+        if (msg.len > 0) {
+            try out.print("✗ {s}\n", .{msg});
+            try out.flush();
+            return;
+        }
+    }
+    try out.writeAll("✗ timed out waiting for authorization\n");
+    try out.flush();
+}
+
+/// Reads the stored Kimi OAuth access token, refreshing it in place when within
+/// 60s of expiry. Returns null if not logged in. Mirrors loadCodexAuth.
+fn loadKimiOAuth(io: Io, gpa: Allocator, arena: Allocator, home: []const u8) ?[]const u8 {
+    const data = Io.Dir.cwd().readFileAlloc(io, kimiAuthPath(arena, home), arena, .limited(64 * 1024)) catch return null;
+    const v = std.json.parseFromSliceLeaky(Value, arena, data, .{ .allocate = .alloc_always }) catch return null;
+    if (v != .object) return null;
+    const access = strFieldObj(v.object, "access_token") orelse return null;
+    const expires_at: i64 = if (v.object.get("expires_at")) |e| (if (e == .integer) e.integer else 0) else 0;
+    if (expires_at != 0 and @divTrunc(unixMs(io), 1000) >= expires_at - 60) {
+        if (strFieldObj(v.object, "refresh_token")) |refresh| {
+            const body = std.fmt.allocPrint(arena, "client_id={s}&grant_type=refresh_token&refresh_token={s}", .{ kimi_client_id, refresh }) catch return access;
+            const resp = kimiOAuthPost(io, gpa, arena, kimi_token_url, body) catch return access;
+            if (resp.get("access_token")) |a| if (a == .string and a.string.len > 0) {
+                const new_refresh = strFieldObj(resp, "refresh_token") orelse refresh;
+                const expires_in: i64 = if (resp.get("expires_in")) |ei| (if (ei == .integer) ei.integer else 900) else 900;
+                writeKimiAuth(io, arena, home, a.string, new_refresh, @divTrunc(unixMs(io), 1000) + expires_in) catch {};
+                return a.string;
+            };
+        }
+    }
+    return access;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main.zig
+++ b/src/main.zig
@@ -4192,6 +4192,10 @@ pub fn main(init: std.process.Init) !void {
             \\gate will deny them. The user toggles execution back on with /plan.]
         , .{base_msg});
 
+        // Promote a GUI `@[image]` attachment to a native vision block when the
+        // model can see (otherwise it only gets the path and resorts to OCR).
+        stageGuiImageAttachment(&root, msg);
+
         // "ultracode" codeword: opt this turn into multi-agent workflow mode.
         if (std.ascii.indexOfIgnoreCase(msg, "ultracode") != null) {
             if (!json_mode) {
@@ -9441,6 +9445,26 @@ fn stageImagePath(root: *Agent, path: []const u8) StageResult {
     _ = enc.encode(b64, data);
     root.pending_image = .{ .media_type = imageMediaType(path), .b64 = b64, .label = arena.dupe(u8, path) catch path };
     return .ok;
+}
+
+/// GUI image attachments arrive inline as `@[path]` markers in the prompt text
+/// (see the desktop AttachmentTray / appendAttachmentsToPrompt). Stage the first
+/// image one as a real vision block so a vision model sees it natively instead
+/// of receiving only a path to OCR. The marker is left in the text — harmless
+/// once the image is visible — so non-image `@[path]` entries the agent should
+/// open with its tools are untouched. No-op for non-vision providers, when an
+/// image is already staged (e.g. via /image), or when no image marker is found.
+fn stageGuiImageAttachment(root: *Agent, msg: []const u8) void {
+    if (root.pending_image != null) return;
+    if (!visionCapable(root.provider)) return;
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, msg, search, "@[")) |open| {
+        const rest = msg[open + 2 ..];
+        const close = std.mem.indexOfScalar(u8, rest, ']') orelse break;
+        const path = rest[0..close];
+        if (isImagePath(path) and stageImagePath(root, path) == .ok) return;
+        search = open + 2 + close + 1;
+    }
 }
 
 /// macOS: dump the clipboard image (if any) to a temp PNG via osascript and

--- a/src/main.zig
+++ b/src/main.zig
@@ -152,6 +152,7 @@ const price_table = [_]ModelPrice{
     .{ .name = "minimax-m3", .in = 0.3, .out = 1.2, .cache = 0.06 },
     .{ .name = "mimo-v2.5-pro", .in = 0.435, .out = 0.87, .cache = 0.0036 },
     .{ .name = "mimo-v2.5", .in = 0.14, .out = 0.28, .cache = 0.0028 },
+    .{ .name = "kimi-for-coding", .in = 0.95, .out = 4, .cache = 0.1 },
     .{ .name = "kimi-k2.6", .in = 0.95, .out = 4, .cache = 0.1 },
     .{ .name = "kimi-k2-thinking", .in = 0.6, .out = 2.5, .cache = 0.06 },
     .{ .name = "kimi-k2.5", .in = 0.6, .out = 3, .cache = 0.06 },
@@ -258,7 +259,7 @@ const provider_specs = [_]ProviderSpec{
     .{ .id = "minimax", .kind = .anthropic, .auth = .bearer, .url = "https://api.minimax.io/anthropic/v1/messages", .env_key = "MINIMAX_API_KEY", .default_model = "MiniMax-M3" },
     .{ .id = "xiaomi", .kind = .openai, .auth = .bearer, .url = "https://api.xiaomimimo.com/v1/chat/completions", .env_key = "XIAOMI_API_KEY", .default_model = "mimo-v2.5-pro" },
     // OpenAI-format direct providers (matched to graff's provider.json).
-    .{ .id = "kimi", .kind = .openai, .auth = .bearer, .url = "https://api.kimi.com/coding/v1/chat/completions", .env_key = "KIMI_API_KEY", .default_model = "kimi-k2.6" },
+    .{ .id = "kimi", .kind = .openai, .auth = .bearer, .url = "https://api.kimi.com/coding/v1/chat/completions", .env_key = "KIMI_API_KEY", .default_model = "kimi-for-coding" },
     .{ .id = "xai", .kind = .openai, .auth = .bearer, .url = "https://api.x.ai/v1/chat/completions", .env_key = "XAI_API_KEY", .default_model = "grok-4.3" },
     .{ .id = "zai", .kind = .openai, .auth = .bearer, .url = "https://api.z.ai/api/paas/v4/chat/completions", .env_key = "ZAI_API_KEY", .default_model = "glm-5" },
     // codex: ChatGPT login via the Responses API. Its "key" isn't an env var
@@ -319,10 +320,10 @@ const model_table = [_]ModelInfo{
     .{ .provider = "codegraff", .name = "grok-build", .context = 256_000 },
     .{ .provider = "codegraff", .name = "mimo-v2.5", .context = 128_000 },
     .{ .provider = "codegraff", .name = "mimo-v2.5-pro", .context = 128_000 },
-    // kimi / xai / zai direct providers (contexts from models.dev 2026-06-10)
-    .{ .provider = "kimi", .name = "kimi-k2.6", .context = 262_144 },
-    .{ .provider = "kimi", .name = "kimi-k2-thinking", .context = 262_144 },
-    .{ .provider = "kimi", .name = "kimi-k2.5", .context = 262_144 },
+    // kimi: the Kimi for Coding plan endpoint serves a single alias model
+    // (`kimi-for-coding`, which tracks their latest coding model) — not the
+    // versioned ids; confirmed via GET /coding/v1/models 2026-06-16.
+    .{ .provider = "kimi", .name = "kimi-for-coding", .context = 262_144 },
     .{ .provider = "xai", .name = "grok-4.3", .context = 1_000_000 },
     .{ .provider = "xai", .name = "grok-build", .context = 256_000 },
     .{ .provider = "zai", .name = "glm-5", .context = 204_800 },
@@ -7921,7 +7922,10 @@ const Agent = struct {
         };
         var req = try self.client.request(.POST, try std.Uri.parse(provider.url), .{
             .redirect_behavior = .unhandled,
-            .headers = .{ .content_type = .{ .override = "application/json" } },
+            .headers = .{
+                .content_type = .{ .override = "application/json" },
+                .user_agent = providerUserAgent(provider),
+            },
             .extra_headers = extra,
         });
         defer req.deinit();
@@ -9476,6 +9480,18 @@ fn grabClipboardImage(io: Io) ?[]const u8 {
     return null;
 }
 /// Auth + provider-specific headers shared by post() and Agent.postStream().
+/// User-Agent for an outbound provider call. The Kimi for Coding plan gates
+/// access to recognized coding-agent clients by User-Agent (a graff/* or bare
+/// UA gets `access_terminated`), so graff identifies as one — a user's Kimi
+/// Code key then works here the same as in Kimi CLI or Claude Code. Every
+/// other provider keeps the http client default.
+const kimi_user_agent = "claude-code/1.0.0";
+fn providerUserAgent(provider: Provider) std.http.Client.Request.Headers.Value {
+    if (std.mem.eql(u8, provider.id, "kimi")) {
+        return .{ .override = kimi_user_agent };
+    }
+    return .default;
+}
 fn providerHeaders(provider: Provider, bearer: []const u8, buf: *[6]std.http.Header) []const std.http.Header {
     var n: usize = 0;
     switch (provider.auth) {
@@ -9530,7 +9546,10 @@ fn post(gpa: Allocator, client: *std.http.Client, provider: Provider, body: []co
         .method = .POST,
         .payload = body,
         .response_writer = &aw.writer,
-        .headers = .{ .content_type = .{ .override = "application/json" } },
+        .headers = .{
+            .content_type = .{ .override = "application/json" },
+            .user_agent = providerUserAgent(provider),
+        },
         .extra_headers = extra,
     });
     const code = @intFromEnum(res.status);
@@ -10903,7 +10922,7 @@ test "imageMediaType from extension" {
 }
 
 test "contextFor known model and default fallback" {
-    try std.testing.expectEqual(@as(u64, 262_144), contextFor("kimi", "kimi-k2.6"));
+    try std.testing.expectEqual(@as(u64, 262_144), contextFor("kimi", "kimi-for-coding"));
     try std.testing.expectEqual(@as(u64, default_context), contextFor("nope", "unknown-xyz"));
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -152,7 +152,7 @@ const price_table = [_]ModelPrice{
     .{ .name = "minimax-m3", .in = 0.3, .out = 1.2, .cache = 0.06 },
     .{ .name = "mimo-v2.5-pro", .in = 0.435, .out = 0.87, .cache = 0.0036 },
     .{ .name = "mimo-v2.5", .in = 0.14, .out = 0.28, .cache = 0.0028 },
-    .{ .name = "kimi-for-coding", .in = 0.95, .out = 4, .cache = 0.1 },
+    .{ .name = "kimi-k2.7", .in = 0.95, .out = 4, .cache = 0.1 },
     .{ .name = "kimi-k2.6", .in = 0.95, .out = 4, .cache = 0.1 },
     .{ .name = "kimi-k2-thinking", .in = 0.6, .out = 2.5, .cache = 0.06 },
     .{ .name = "kimi-k2.5", .in = 0.6, .out = 3, .cache = 0.06 },
@@ -259,7 +259,7 @@ const provider_specs = [_]ProviderSpec{
     .{ .id = "minimax", .kind = .anthropic, .auth = .bearer, .url = "https://api.minimax.io/anthropic/v1/messages", .env_key = "MINIMAX_API_KEY", .default_model = "MiniMax-M3" },
     .{ .id = "xiaomi", .kind = .openai, .auth = .bearer, .url = "https://api.xiaomimimo.com/v1/chat/completions", .env_key = "XIAOMI_API_KEY", .default_model = "mimo-v2.5-pro" },
     // OpenAI-format direct providers (matched to graff's provider.json).
-    .{ .id = "kimi", .kind = .openai, .auth = .bearer, .url = "https://api.kimi.com/coding/v1/chat/completions", .env_key = "KIMI_API_KEY", .default_model = "kimi-for-coding" },
+    .{ .id = "kimi", .kind = .openai, .auth = .bearer, .url = "https://api.kimi.com/coding/v1/chat/completions", .env_key = "KIMI_API_KEY", .default_model = "kimi-k2.7" },
     .{ .id = "xai", .kind = .openai, .auth = .bearer, .url = "https://api.x.ai/v1/chat/completions", .env_key = "XAI_API_KEY", .default_model = "grok-4.3" },
     .{ .id = "zai", .kind = .openai, .auth = .bearer, .url = "https://api.z.ai/api/paas/v4/chat/completions", .env_key = "ZAI_API_KEY", .default_model = "glm-5" },
     // codex: ChatGPT login via the Responses API. Its "key" isn't an env var
@@ -320,10 +320,10 @@ const model_table = [_]ModelInfo{
     .{ .provider = "codegraff", .name = "grok-build", .context = 256_000 },
     .{ .provider = "codegraff", .name = "mimo-v2.5", .context = 128_000 },
     .{ .provider = "codegraff", .name = "mimo-v2.5-pro", .context = 128_000 },
-    // kimi: the Kimi for Coding plan endpoint serves a single alias model
-    // (`kimi-for-coding`, which tracks their latest coding model) — not the
-    // versioned ids; confirmed via GET /coding/v1/models 2026-06-16.
-    .{ .provider = "kimi", .name = "kimi-for-coding", .context = 262_144 },
+    // kimi: the Kimi for Coding plan endpoint accepts versioned ids (and the
+    // `kimi-for-coding` alias), all routed to the latest coding model. We expose
+    // `kimi-k2.7` — its current release. Verified via /coding/v1 2026-06-16.
+    .{ .provider = "kimi", .name = "kimi-k2.7", .context = 262_144 },
     .{ .provider = "xai", .name = "grok-4.3", .context = 1_000_000 },
     .{ .provider = "xai", .name = "grok-build", .context = 256_000 },
     .{ .provider = "zai", .name = "glm-5", .context = 204_800 },
@@ -10946,7 +10946,7 @@ test "imageMediaType from extension" {
 }
 
 test "contextFor known model and default fallback" {
-    try std.testing.expectEqual(@as(u64, 262_144), contextFor("kimi", "kimi-for-coding"));
+    try std.testing.expectEqual(@as(u64, 262_144), contextFor("kimi", "kimi-k2.7"));
     try std.testing.expectEqual(@as(u64, default_context), contextFor("nope", "unknown-xyz"));
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -9380,6 +9380,7 @@ fn visionModel(m: []const u8) bool {
         std.mem.startsWith(u8, m, "gpt-5") or
         std.mem.startsWith(u8, m, "gpt-4") or
         std.mem.startsWith(u8, m, "grok-4") or
+        std.mem.startsWith(u8, m, "kimi") or // kimi-k2.7+ see images (Kimi for Coding endpoint, verified 2026-06-16)
         std.mem.startsWith(u8, m, "gemini");
 }
 
@@ -10965,7 +10966,8 @@ test "visionCapable allowlist" {
     try std.testing.expect(visionCapable(mk("claude-opus-4-8")));
     try std.testing.expect(visionCapable(mk("gpt-5.5")));
     try std.testing.expect(!visionCapable(mk("deepseek-v4-pro")));
-    try std.testing.expect(!visionCapable(mk("kimi-k2.6")));
+    try std.testing.expect(visionCapable(mk("kimi-k2.7"))); // Kimi for Coding sees images
+    try std.testing.expect(!visionCapable(mk("minimax-m3")));
 }
 
 test "binaryFileExt flags binaries, passes text" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -672,6 +672,31 @@ const schema_version = "0.4";
 /// providers, models, built-in tools (name/description/parameters), and the
 /// --json protocol contract. This is the single source of truth that SDK
 /// codegen consumes. Comptime data only — no keys, network, or MCP needed.
+/// Human-facing provider name for the `--schema` providers array (consumed by
+/// the GUI settings page so its provider list stays tied to the harness).
+fn providerDisplayName(id: []const u8) []const u8 {
+    const names = .{
+        .{ "codegraff", "Codegraff" }, .{ "anthropic", "Anthropic" },
+        .{ "deepseek", "DeepSeek" },   .{ "openai", "OpenAI" },
+        .{ "minimax", "MiniMax" },     .{ "xiaomi", "Xiaomi" },
+        .{ "kimi", "Kimi" },           .{ "xai", "xAI" },
+        .{ "zai", "Z.AI" },            .{ "codex", "Codex (ChatGPT)" },
+    };
+    inline for (names) |n| {
+        if (std.mem.eql(u8, id, n[0])) return n[1];
+    }
+    return id;
+}
+
+/// How a provider's credential is acquired, for the GUI settings page:
+/// `codegraff`/`codex` use device/OAuth login flows; everything else is a
+/// drop-in API key (env var or `graff key set <id>`).
+fn providerLoginKind(id: []const u8) []const u8 {
+    if (std.mem.eql(u8, id, "codegraff")) return "codegraff_device";
+    if (std.mem.eql(u8, id, "codex")) return "codex_device";
+    return "api_key";
+}
+
 fn emitSchema(w: *Io.Writer) !void {
     var s: std.json.Stringify = .{ .writer = w, .options = .{ .whitespace = .indent_2 } };
     try s.beginObject();
@@ -685,10 +710,16 @@ fn emitSchema(w: *Io.Writer) !void {
         try s.beginObject();
         try s.objectField("id");
         try s.write(p.id);
+        try s.objectField("name");
+        try s.write(providerDisplayName(p.id));
         try s.objectField("kind");
         try s.write(@tagName(p.kind));
         try s.objectField("auth");
         try s.write(@tagName(p.auth));
+        try s.objectField("env_key");
+        try s.write(p.env_key);
+        try s.objectField("login");
+        try s.write(providerLoginKind(p.id));
         try s.objectField("default_model");
         try s.write(p.default_model);
         try s.endObject();


### PR DESCRIPTION
A branch you can run as-is — Kimi Code plan support end-to-end, plus a batch of GUI/harness UX upgrades. **Not merged to main**; build from `feat/kimi-code-plan-settings`.

## Kimi Code plan
- **`kimi-k2.7`** is the exposed model (the coding endpoint accepts versioned ids and echoes them; `/models` only advertises the `kimi-for-coding` alias, but every id routes to the latest coding model).
- **User-Agent gate**: the endpoint returns `access_terminated` for a missing / `graff/*` UA — only `claude-code/*` is accepted. graff sends `claude-code/1.0.0` for the kimi provider, so a paid key works like Kimi CLI / Claude Code.
- **Vision**: kimi-k2.7 reads images (verified against the API + through graff). Added to `visionModel()`.
- **Reasoning levels**: the endpoint accepts `reasoning_effort`; kimi added to `effortApplies()` + the GUI advertisement, so the Reasoning dropdown enables.
- **OAuth login**: `graff login kimi` runs the Kimi Code device-code flow (auth.kimi.com) → stores/refreshes a token at `~/.kimi/credentials/graff-oauth.json`. `KIMI_API_KEY` still wins. After a one-time login the GUI uses the plan automatically.

## GUI
- **Settings provider list derived from `graff --schema`** (name / env_key / login) instead of a hardcoded copy — add a provider in the binary and it appears automatically.
- **Paste images** into the composer (Cmd/Ctrl+V) → native temp-file + the harness stages `@[image]` as a real vision block (not OCR'd text).
- **Image thumbnails** in the attachment card via a native `image` crate command (decode → downscale → JPEG-compress → data URL).
- **Composer clears** the draft + attachment immediately on send.
- **codedb**: steered in the system prompt (over raw bash) and its query shown as a command chip (Codex-style) instead of a bare "Ran codedb".
- **Motion**: transitions.dev-style easeOutExpo — user messages slide up, assistant text flows in block-by-block as it streams (respects reduced-motion).

## Commits
```
c9f1f3f  kimi: Kimi Code OAuth device-flow login (graff login kimi)
cf00a08  GUI: entrance + streaming motion for chat messages
d9bdb9d  GUI: show codedb's query as a command chip
4e238fe  GUI/harness UX: image thumbnails, clear-on-send, kimi reasoning, codedb steer
f112492  kimi: mark as vision-capable (kimi-k2.7 reads images)
58df503  kimi: expose the model as kimi-k2.7
ccb6b58  GUI: paste images into the composer with Cmd/Ctrl+V (native vision)
bb0021b  kimi: real kimi-for-coding model + coding-agent User-Agent
ae2ed4b  GUI settings: derive the provider list from the harness
```

## Verification
`zig build` ✓ · harness tests ✓ · JSON-controls 15/15 ✓ · `cargo check` ✓ · `tsc` ✓ — plus live GUI drive-throughs (kimi-k2.7 swarm, image paste + vision, thumbnails).