### PR TITLE
gui: add elevation shadow tokens and unify card borders

### DIFF
--- a/gui/src/components/PromptInputCard.tsx
+++ b/gui/src/components/PromptInputCard.tsx
@@ -208,7 +208,7 @@ export function PromptInputCard({
       ) : null}
       <Card
         className={cn(
-          "relative gap-0 rounded-2xl border border-foreground/5 bg-background/50 p-2 transition-colors transition-shadow ring-0",
+          "relative gap-0 rounded-2xl border border-border bg-background/50 p-2 transition-colors transition-shadow ring-0",
           isPlanningMode &&
             "border-[color:var(--accent)] ring-5 ring-[color:color-mix(in_oklab,var(--accent)_14%,transparent)] border-dashed",
         )}

--- a/gui/src/components/chat/activity-results/ActivityResultCard.tsx
+++ b/gui/src/components/chat/activity-results/ActivityResultCard.tsx
@@ -12,7 +12,7 @@ export function ActivityResultPreformattedBody({
   text,
 }: ActivityResultPreformattedBodyProps) {
   return (
-    <pre className={`block max-h-72 w-full max-w-full overflow-x-auto overflow-y-auto whitespace-pre px-3 py-2.5 ${CHAT_BODY_TEXT_CLASS} text-foreground`}>
+    <pre className={`block max-h-72 w-full max-w-full overflow-x-auto overflow-y-auto whitespace-pre px-3.5 py-2.5 ${CHAT_BODY_TEXT_CLASS} text-foreground`}>
       <code className="inline-block min-w-full w-max align-top whitespace-pre">
         {text}
       </code>
@@ -30,8 +30,8 @@ export function ActivityResultCard({
   const canCopy = copyText != null && copyText.length > 0;
 
   return (
-    <div className="min-w-0 max-w-full overflow-hidden rounded-2xl border border-border bg-card">
-      <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-xs/relaxed text-foreground">
+    <div className="min-w-0 max-w-full overflow-hidden rounded-2xl border border-border bg-card shadow-[var(--elevation-sm)]">
+      <div className="flex items-center gap-2 border-b border-border px-3.5 py-2.5 text-xs/relaxed text-foreground">
         <div className="min-w-0 flex-1 truncate text-foreground">
           {title}
         </div>
@@ -50,7 +50,7 @@ export function ActivityResultCard({
         ) : null}
       </div>
       {children}
-      <div className="flex items-center justify-between gap-3 border-t border-border px-3 py-2 text-xs/relaxed text-foreground">
+      <div className="flex items-center justify-between gap-3 border-t border-border px-3.5 py-2.5 text-xs/relaxed text-foreground">
         <span className="min-w-0 flex-1 truncate">{footer.leading}</span>
         <span className="shrink-0">{footer.trailing}</span>
       </div>

--- a/gui/src/components/conversation-panel/ConversationPanelHeader.tsx
+++ b/gui/src/components/conversation-panel/ConversationPanelHeader.tsx
@@ -81,7 +81,7 @@ export function ConversationPanelHeader({
     <>
       <header
         className={cn(
-          "flex h-9.5 items-center gap-3 border-b border-black/5 pr-11 select-none dark:border-white/5",
+          "flex h-9.5 items-center gap-3 border-b border-border pr-11 select-none",
           reserveTitlebarInset ? "pl-34" : "pl-3",
         )}
       >

--- a/gui/src/components/ui/Card.tsx
+++ b/gui/src/components/ui/Card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden rounded-lg bg-card py-4 text-xs/relaxed text-card-foreground ring-1 ring-foreground/10 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg",
+        "group/card flex flex-col gap-4 overflow-hidden rounded-lg bg-card py-4 text-xs/relaxed text-card-foreground shadow-[var(--elevation-sm)] ring-1 ring-foreground/10 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg",
         className
       )}
       {...props}

--- a/gui/src/styles/index.css
+++ b/gui/src/styles/index.css
@@ -220,6 +220,9 @@
     --pane-surface: var(--background);
     --pane-border: var(--border);
     --pane-shadow: rgb(26 24 19 / 12%);
+    --elevation-xs: 0 1px 2px rgb(0 0 0 / 5%);
+    --elevation-sm: 0 1px 2px rgb(0 0 0 / 5%), 0 2px 6px -1px rgb(0 0 0 / 6%);
+    --elevation-md: 0 2px 4px rgb(0 0 0 / 6%), 0 6px 16px -2px rgb(0 0 0 / 10%);
 }
 
 .dark {
@@ -263,6 +266,9 @@
     --pane-surface: var(--background);
     --pane-border: var(--border);
     --pane-shadow: rgb(0 0 0 / 30%);
+    --elevation-xs: 0 1px 2px rgb(0 0 0 / 30%);
+    --elevation-sm: 0 1px 2px rgb(0 0 0 / 35%), 0 2px 6px -1px rgb(0 0 0 / 30%);
+    --elevation-md: 0 2px 4px rgb(0 0 0 / 35%), 0 8px 20px -3px rgb(0 0 0 / 45%);
 }
 
 /* ── Theme presets ──────────────────────────────────────────────


### PR DESCRIPTION
Adds reusable `--elevation-xs/sm/md` shadow tokens (light + dark) to `index.css` and switches the card surfaces to a unified border + elevation treatment.

Touches:
- `gui/src/styles/index.css` — new elevation tokens
- `PromptInputCard.tsx`, `ActivityResultCard.tsx`, `ConversationPanelHeader.tsx`, `ui/Card.tsx` — unified card border/shadow usage

This is the one piece of unique work salvaged from the now-deleted `gui-live-json-controls-review` branch (everything else there was already squash-merged into main via #11–#17).