### PR TITLE
gui: release 0.0.11 — notarized desktop app + bundled codegraff CLI

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codegraff-gui",
   "private": true,
-  "version": "0.2.16",
+  "version": "0.0.11",
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.10",
   "type": "module",

--- a/gui/src-tauri/.gitignore
+++ b/gui/src-tauri/.gitignore
@@ -2,3 +2,6 @@
 # will have compiled files and executables
 /target/
 /gen/schemas
+
+# Staged CLI binary bundled into the app at build time (local artifact)
+binaries/

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "codegraff-gui"
-version = "0.2.16"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "codegraff-gui"
-version = "0.2.16"
+version = "0.0.11"
 description = "Desktop coding agent interface powered by Codegraff"
 authors = ["Codegraff contributors"]
 license = "Apache-2.0"

--- a/gui/src-tauri/src/cli_install.rs
+++ b/gui/src-tauri/src/cli_install.rs
@@ -1,0 +1,66 @@
+//! First-run install of the bundled `codegraff` CLI onto the user's PATH.
+//!
+//! The app bundles the Zig-native harness binary at
+//! `Codegraff.app/Contents/Resources/codegraff`. On macOS we expose it as a
+//! `codegraff` terminal command by symlinking it into a PATH directory the
+//! first time the app launches (VS Code `code`-style).
+//!
+//! Best-effort by design: it never fails app startup. In dev the bundled
+//! resource does not exist, so this is a natural no-op. When `/usr/local/bin`
+//! is not writable (common on stock macOS without Homebrew) it falls back to
+//! `~/.local/bin`.
+
+#[cfg(target_os = "macos")]
+pub fn ensure_cli_symlink(app: &tauri::App) {
+    use std::os::unix::fs::symlink;
+    use std::path::PathBuf;
+    use tauri::Manager;
+
+    let resource = match app.path().resource_dir() {
+        Ok(dir) => dir.join("codegraff"),
+        Err(_) => return,
+    };
+    // Only present in a bundled .app — absent in dev, so this returns quietly.
+    if !resource.exists() {
+        return;
+    }
+
+    // Preferred PATH dirs, in order. /usr/local/bin matches the VS Code `code`
+    // convention; ~/.local/bin is the no-admin fallback.
+    let mut targets: Vec<PathBuf> = vec![PathBuf::from("/usr/local/bin")];
+    if let Ok(home) = app.path().home_dir() {
+        targets.push(home.join(".local").join("bin"));
+    }
+
+    for dir in targets {
+        let link = dir.join("codegraff");
+        // Already linked to this exact build -> nothing to do.
+        if let Ok(existing) = std::fs::read_link(&link) {
+            if existing == resource {
+                log::info!("codegraff CLI already linked at {}", link.display());
+                return;
+            }
+        }
+        if std::fs::create_dir_all(&dir).is_err() {
+            continue;
+        }
+        // Clear any stale link/file we own before relinking.
+        let _ = std::fs::remove_file(&link);
+        match symlink(&resource, &link) {
+            Ok(()) => {
+                log::info!(
+                    "codegraff CLI linked: {} -> {}",
+                    link.display(),
+                    resource.display()
+                );
+                return;
+            }
+            Err(err) => {
+                log::warn!("could not link codegraff into {}: {err}", dir.display());
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn ensure_cli_symlink(_app: &tauri::App) {}

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod cli_install;
 mod desktop_open;
 pub mod dto;
 mod forge_config_home;
@@ -69,6 +70,8 @@ pub fn run() {
                 app_dir.join("managed-chats"),
             )?);
             app.manage(DesktopState::new(emitter, projects));
+            // First run: expose the bundled `codegraff` CLI on PATH (macOS).
+            cli_install::ensure_cli_symlink(app);
             Ok(())
         })
         .on_window_event(|window, event| {

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Codegraff",
-  "version": "0.2.16",
+  "version": "0.0.11",
   "identifier": "dev.codegraff.gui",
   "build": {
     "frontendDist": "../dist",
@@ -41,6 +41,13 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "resources": {
+      "binaries/codegraff": "codegraff"
+    },
+    "macOS": {
+      "signingIdentity": "Developer ID Application: Rachit Pradhan (WWP9DLJ27P)",
+      "hardenedRuntime": true
+    }
   }
 }


### PR DESCRIPTION
## What

- Bumps the desktop app to **0.0.11** (`tauri.conf.json`, `package.json`, `Cargo.toml`).
- Bundles the Zig-native harness binary into the app at `Contents/Resources/codegraff` and, on first macOS launch, symlinks it onto PATH (`/usr/local/bin`, falling back to `~/.local/bin`) so **`codegraff`** is available as a terminal command (VS Code `code`-style). Best-effort: never fails app startup; a no-op in dev.
- The bundled binary is Developer ID signed (hardened runtime + secure timestamp) before bundling, so the app notarizes cleanly.

## Release artifact

`Codegraff_0.0.11_aarch64.dmg` — Developer ID signed, **Apple-notarized and stapled** (verified `spctl: accepted / Notarized Developer ID`). Published as a non-latest GitHub release so it doesn't disturb the CLI's `install.sh` latest-release flow.

## Notes

- macOS arm64 only (matches the local toolchain).
- First-run symlink verified live: lands at `~/.local/bin/codegraff` when `/usr/local/bin` isn't writable.