### PR TITLE
gui: add first-run onboarding

### DIFF
--- a/gui/src-tauri/src/dto/runtime.rs
+++ b/gui/src-tauri/src/dto/runtime.rs
@@ -359,6 +359,7 @@ pub struct ProviderUrlParamValueDto {
 pub enum ProviderAuthSessionKindDto {
     ApiKey,
     DeviceCode,
+    CliLogin,
     OAuthCode,
 }
 

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -334,15 +334,17 @@ impl RuntimeManager {
         input: CompleteProviderAuthInput,
     ) -> Result<ProviderSummaryDto> {
         let provider_id = provider_from_auth_session_id(&input.auth_session_id);
-        if let Some(api_key) = input
+        let submitted_api_key = input
             .api_key
             .as_deref()
             .map(str::trim)
-            .filter(|key| !key.is_empty())
-        {
+            .filter(|key| !key.is_empty());
+        if let Some(api_key) = submitted_api_key {
             run_codegraff_key_set(provider_id, api_key).await?;
         }
-        provider_summary(provider_id).await
+        let summary = provider_summary(provider_id).await?;
+        validate_provider_auth_completion(&summary, submitted_api_key.is_some())?;
+        Ok(summary)
     }
 
     /// Deletes a provider's stored credential from the same locations the CLI
@@ -2750,6 +2752,19 @@ fn provider_summary_with_key_list(
     }
 }
 
+fn validate_provider_auth_completion(
+    summary: &ProviderSummaryDto,
+    submitted_api_key: bool,
+) -> Result<()> {
+    if submitted_api_key || summary.configured {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "Provider login not detected yet. Complete the login flow in Terminal, then try Finish setup again."
+    )
+}
+
 /// Builds the env-override hint when a provider's `<PROVIDER>_API_KEY` is set,
 /// locating where it's defined so the UI can offer to open that file.
 fn provider_env_override(provider: &CodegraffProvider) -> Option<ProviderEnvOverrideDto> {
@@ -3349,6 +3364,43 @@ mod tests {
         let _ = std::fs::remove_dir_all(temp_dir);
 
         assert!(configured);
+    }
+
+    fn provider_summary_for_test(configured: bool) -> ProviderSummaryDto {
+        ProviderSummaryDto {
+            id: "codegraff".into(),
+            name: "Codegraff".into(),
+            configured,
+            auth_methods: vec![ProviderAuthMethodDto {
+                kind: ProviderAuthMethodKindDto::CodegraffDevice,
+                label: "Codegraff device login".into(),
+            }],
+            env_override: None,
+        }
+    }
+
+    #[test]
+    fn provider_completion_rejects_unfinished_cli_login() {
+        let error = validate_provider_auth_completion(&provider_summary_for_test(false), false)
+            .expect_err("unfinished login should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Provider login not detected yet")
+        );
+    }
+
+    #[test]
+    fn provider_completion_accepts_configured_cli_login() {
+        validate_provider_auth_completion(&provider_summary_for_test(true), false)
+            .expect("configured login should complete");
+    }
+
+    #[test]
+    fn provider_completion_allows_api_key_completion_to_report_summary() {
+        validate_provider_auth_completion(&provider_summary_for_test(false), true)
+            .expect("api-key completion is validated by graff key set");
     }
 
     fn model(provider: &str, name: &str) -> ModelOption {

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 #[cfg(target_os = "macos")]
 use std::os::unix::fs::PermissionsExt;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     process::Command,
     sync::Arc,
@@ -124,11 +124,6 @@ impl RuntimeManager {
         self.projects.add_project(Path::new(&workspace_path))?;
         let mut state = self.state.lock().await;
         set_active_workspace(&mut state, &workspace_path);
-        // Focus this workspace's own conversation (None for a fresh project).
-        // Otherwise active_conversation_id still points at the previously active
-        // workspace's chat, and the UI's (workspace, conversation) view lookup
-        // misses — leaving the panel stuck on an endless loading spinner.
-        state.active_conversation_id = state.selected_by_workspace.get(&workspace_path).cloned();
         drop(state);
         self.snapshot().await
     }
@@ -149,28 +144,7 @@ impl RuntimeManager {
     /// Returns the model picker, populated from `graff --schema`.
     pub async fn get_prompt_settings(&self, _: Option<String>) -> Result<PromptSettingsDto> {
         let catalog = self.ensure_model_catalog().await;
-        // Only surface models for providers the user has credentials for,
-        // ordered codex first, then codegraff, then the rest (stable within
-        // each group).
-        let catalog = {
-            let key_list = codegraff_key_list().await.unwrap_or_default();
-            let configured: std::collections::HashSet<String> = schema_providers()
-                .await
-                .iter()
-                .filter(|provider| provider_configured(provider, &key_list))
-                .map(|provider| provider.id.clone())
-                .collect();
-            let mut models: Vec<ModelOption> = catalog
-                .into_iter()
-                .filter(|model| configured.contains(model.provider.as_str()))
-                .collect();
-            models.sort_by_key(|model| match model.provider.as_str() {
-                "codex" => 0u8,
-                "codegraff" => 1,
-                _ => 2,
-            });
-            models
-        };
+        let configured_provider_ids = configured_provider_ids().await;
         let (selected_provider, selected_model, selected_effort, fast_enabled) = {
             let state = self.state.lock().await;
             (
@@ -181,81 +155,14 @@ impl RuntimeManager {
             )
         };
 
-        if catalog.is_empty() {
-            // Schema unavailable (e.g. binary missing): fall back to a single
-            // default so the picker still renders and sessions use the CLI default.
-            return Ok(PromptSettingsDto {
-                available_models: vec![PromptModelOptionDto {
-                    provider_id: "codegraff".into(),
-                    provider_name: "Codegraff".into(),
-                    model_id: "default".into(),
-                    model_name: Some("Default".into()),
-                    context_length: None,
-                    supports_reasoning: false,
-                    reasoning_efforts: vec![],
-                }],
-                selected_provider_id: Some("codegraff".into()),
-                selected_model_id: Some("default".into()),
-                selected_reasoning_effort: None,
-                fast_enabled: false,
-            });
-        }
-
-        let available_models = catalog
-            .iter()
-            .map(|model| {
-                // Effort-capable providers (mirrors the binary's effortApplies):
-                // codex takes reasoning.effort via the Responses API; codegraff
-                // and deepseek take a top-level reasoning_effort. But the
-                // gateway's gpt-* models go through /v1/chat/completions, which
-                // rejects reasoning_effort (they need the codex/Responses path),
-                // so don't advertise effort for them.
-                let effort_capable = match model.provider.as_str() {
-                    "codex" => true,
-                    "codegraff" | "deepseek" => !model.name.starts_with("gpt-"),
-                    "kimi" => true,
-                    _ => false,
-                };
-                let reasoning_efforts: Vec<String> = if effort_capable {
-                    vec!["low".into(), "medium".into(), "high".into()]
-                } else {
-                    vec![]
-                };
-                PromptModelOptionDto {
-                    provider_id: model.provider.clone(),
-                    provider_name: provider_display_name(&model.provider),
-                    model_id: model.name.clone(),
-                    model_name: Some(model.name.clone()),
-                    context_length: model.context,
-                    supports_reasoning: !reasoning_efforts.is_empty(),
-                    reasoning_efforts,
-                }
-            })
-            .collect();
-
-        // Default to the codegraff gateway's model, else the first advertised.
-        let default_model = catalog
-            .iter()
-            .find(|model| model.name == "deepseek-v4-pro")
-            .or_else(|| catalog.first());
-        let selected_model_id =
-            selected_model.or_else(|| default_model.map(|model| model.name.clone()));
-        let selected_provider_id = selected_provider.or_else(|| {
-            selected_model_id.as_ref().and_then(|name| {
-                catalog
-                    .iter()
-                    .find(|model| &model.name == name)
-                    .map(|model| model.provider.clone())
-            })
-        });
-
-        Ok(PromptSettingsDto {
-            available_models,
-            selected_provider_id,
-            selected_model_id,
-            selected_reasoning_effort: selected_effort,
+        Ok(build_prompt_settings_from_catalog(
+            &catalog,
+            &configured_provider_ids,
+            selected_provider.as_deref(),
+            selected_model.as_deref(),
+            selected_effort,
             fast_enabled,
-        })
+        ))
     }
 
     /// Generates a short chat title with the active model (a one-shot graff run)
@@ -319,10 +226,23 @@ impl RuntimeManager {
         &self,
         input: UpdatePromptSettingsInput,
     ) -> Result<PromptSettingsDto> {
+        let catalog = self.ensure_model_catalog().await;
+        let configured_provider_ids = configured_provider_ids().await;
+        let available_catalog = filtered_catalog_models(&catalog, &configured_provider_ids);
+        let selected_model = available_catalog
+            .iter()
+            .copied()
+            .find(|model| model.provider == input.provider_id && model.name == input.model_id)
+            .with_context(|| {
+                format!(
+                    "{} is not available for provider {}. Choose a configured provider/model from the picker.",
+                    input.model_id, input.provider_id
+                )
+            })?;
         let live_conversation_id = {
             let mut state = self.state.lock().await;
-            state.selected_provider = Some(input.provider_id.clone());
-            state.selected_model = Some(input.model_id.clone());
+            state.selected_provider = Some(selected_model.provider.clone());
+            state.selected_model = Some(selected_model.name.clone());
             if let Some(effort) = &input.reasoning_effort {
                 state.selected_effort = Some(effort.clone());
             }
@@ -334,7 +254,7 @@ impl RuntimeManager {
                     &conversation_id,
                     serde_json::json!({
                         "type": "set_model",
-                        "name": input.model_id,
+                        "name": selected_model.name,
                     }),
                 )
                 .await?;
@@ -441,14 +361,16 @@ impl RuntimeManager {
                     .filter(|value| !value.trim().is_empty())
                     .is_some()
                 {
-                    let location = match find_env_definition(&env_key) {
-                        Some((path, line)) => format!("{path}:{line}"),
-                        None => "your shell environment".into(),
-                    };
-                    anyhow::bail!(
-                        "Removed the stored {provider} credential, but ${env_key} is set in {location} and takes precedence. Open that file to remove the line, then restart to fully remove this provider.",
-                        provider = input.provider_id
-                    );
+                    match find_env_definition(&env_key) {
+                        Some((path, line)) => anyhow::bail!(
+                            "Stored {provider} credential removed. ${env_key} is still set in {path}:{line}, so it is still being used.",
+                            provider = input.provider_id
+                        ),
+                        None => anyhow::bail!(
+                            "Stored {provider} credential removed. ${env_key} is still inherited by the running Codegraff app, so it is still being used.",
+                            provider = input.provider_id
+                        ),
+                    }
                 }
             }
         }
@@ -502,6 +424,9 @@ impl RuntimeManager {
             conversation.plan_mode = plan_mode;
             conversation.updated_at = now_millis();
             is_first_turn = conversation.messages.is_empty();
+            if is_first_turn && is_placeholder_title(&conversation.title) {
+                conversation.title = title_from_prompt(&input.prompt);
+            }
             conversation.messages.push(SessionMessageDto::User {
                 id: format!("{request_id}-user"),
                 request_id: request_id.clone(),
@@ -694,16 +619,17 @@ impl RuntimeManager {
                     let rid = request_id.to_string();
                     let delta = delta.to_string();
                     self.mutate_conversation(conversation_id, move |conversation| {
-                        let existing = conversation.messages.iter_mut().rev().find_map(
-                            |message| match message {
-                                SessionMessageDto::Reasoning { id: mid, text, .. }
-                                    if *mid == id =>
-                                {
-                                    Some(text)
-                                }
-                                _ => None,
-                            },
-                        );
+                        let existing =
+                            conversation.messages.iter_mut().rev().find_map(
+                                |message| match message {
+                                    SessionMessageDto::Reasoning { id: mid, text, .. }
+                                        if *mid == id =>
+                                    {
+                                        Some(text)
+                                    }
+                                    _ => None,
+                                },
+                            );
                         match existing {
                             Some(text) => text.push_str(&delta),
                             None => conversation.messages.push(SessionMessageDto::Reasoning {
@@ -1432,10 +1358,20 @@ impl RuntimeManager {
     ) -> Result<SessionSnapshotDto> {
         let mut state = self.state.lock().await;
         set_active_workspace(&mut state, &workspace_path);
-        state.active_conversation_id = Some(conversation_id.clone());
-        state
-            .selected_by_workspace
-            .insert(workspace_path, conversation_id);
+        if state.conversations.contains_key(&conversation_id) {
+            state.active_conversation_id = Some(conversation_id.clone());
+            state
+                .selected_by_workspace
+                .insert(workspace_path, conversation_id);
+        } else if let Some(fallback_id) = first_workspace_conversation_id(&state, &workspace_path) {
+            state.active_conversation_id = Some(fallback_id.clone());
+            state
+                .selected_by_workspace
+                .insert(workspace_path, fallback_id);
+        } else {
+            state.active_conversation_id = None;
+            state.selected_by_workspace.remove(&workspace_path);
+        }
         drop(state);
         self.snapshot().await
     }
@@ -1560,15 +1496,27 @@ impl RuntimeManager {
     /// Archives a conversation from local state.
     pub async fn archive_conversation(
         &self,
-        _: String,
+        workspace_path: String,
         conversation_id: String,
     ) -> Result<SessionSnapshotDto> {
         self.drop_session(&conversation_id).await;
-        self.state
-            .lock()
-            .await
-            .conversations
-            .remove(&conversation_id);
+        let mut state = self.state.lock().await;
+        state.conversations.remove(&conversation_id);
+        if state.selected_by_workspace.get(&workspace_path) == Some(&conversation_id) {
+            state.selected_by_workspace.remove(&workspace_path);
+        }
+        state
+            .selected_by_workspace
+            .retain(|_, selected_id| selected_id != &conversation_id);
+        if state.active_conversation_id.as_deref() == Some(&conversation_id) {
+            if state.active_workspace_path.as_deref() == Some(&workspace_path) {
+                state.active_conversation_id =
+                    first_workspace_conversation_id(&state, &workspace_path);
+            } else {
+                state.active_conversation_id = None;
+            }
+        }
+        drop(state);
         self.persist_conversations().await;
         self.snapshot().await
     }
@@ -1774,6 +1722,7 @@ impl RuntimeManager {
                 )
             })
             .collect();
+        normalize_runtime_selection(&mut state);
         let active_conversation_id = state.active_conversation_id.clone();
         let pending_followups = state.pending_followups.clone();
         let visible_followup = active_conversation_id
@@ -1822,13 +1771,14 @@ impl RuntimeManager {
                     .get(path)
                     .cloned()
                     .unwrap_or((WorkspaceKindDto::Project, None));
+                let selected_conversation_id = selected_workspace_conversation_id(&state, path);
                 WorkspaceSessionDto {
                     kind,
                     workspace_path: path.clone(),
                     workspace_name: display_name.unwrap_or_else(|| workspace_name(path)),
                     configured: true,
                     configuration_error: None,
-                    selected_conversation_id: state.selected_by_workspace.get(path).cloned(),
+                    selected_conversation_id,
                     conversations,
                 }
             })
@@ -2018,8 +1968,11 @@ struct PersistedPromptSettings {
 
 /// Path to the persisted prompt selection (`~/.codegraff-gui/prompt-settings.json`).
 fn prompt_settings_store_path() -> Option<PathBuf> {
-    std::env::var_os("HOME")
-        .map(|home| PathBuf::from(home).join(".codegraff-gui").join("prompt-settings.json"))
+    std::env::var_os("HOME").map(|home| {
+        PathBuf::from(home)
+            .join(".codegraff-gui")
+            .join("prompt-settings.json")
+    })
 }
 
 /// Loads the last model/effort/fast selection so it survives app restarts.
@@ -2069,12 +2022,13 @@ fn load_persisted_conversations() -> HashMap<String, ConversationState> {
     items
         .into_iter()
         .map(|conversation| {
+            let title = recover_conversation_title(&conversation.title, &conversation.messages);
             (
                 conversation.conversation_id.clone(),
                 ConversationState {
                     workspace_path: conversation.workspace_path,
                     conversation_id: conversation.conversation_id,
-                    title: conversation.title,
+                    title,
                     messages: conversation.messages,
                     active_request_ids: vec![],
                     active_agent_id: conversation.active_agent_id,
@@ -2086,11 +2040,85 @@ fn load_persisted_conversations() -> HashMap<String, ConversationState> {
         .collect()
 }
 
+fn recover_conversation_title(title: &str, messages: &[SessionMessageDto]) -> String {
+    if !is_placeholder_title(title) {
+        return title.to_string();
+    }
+
+    first_user_message_text(messages)
+        .map(title_from_prompt)
+        .unwrap_or_else(|| title_from_prompt(""))
+}
+
+fn first_user_message_text(messages: &[SessionMessageDto]) -> Option<&str> {
+    messages.iter().find_map(|message| match message {
+        SessionMessageDto::User { text, .. } if !text.trim().is_empty() => Some(text.as_str()),
+        _ => None,
+    })
+}
+
 fn set_active_workspace(state: &mut RuntimeState, workspace_path: &str) {
     state.active_workspace_path = Some(workspace_path.into());
     if !state.workspaces.iter().any(|path| path == workspace_path) {
         state.workspaces.insert(0, workspace_path.into());
     }
+}
+
+fn normalize_runtime_selection(state: &mut RuntimeState) {
+    let conversations = &state.conversations;
+    state
+        .selected_by_workspace
+        .retain(|workspace_path, conversation_id| {
+            conversations
+                .get(conversation_id)
+                .is_some_and(|conversation| &conversation.workspace_path == workspace_path)
+        });
+
+    if let Some(active_conversation_id) = state.active_conversation_id.clone() {
+        let active_workspace_path = state.active_workspace_path.clone();
+        let is_valid_active = state
+            .conversations
+            .get(&active_conversation_id)
+            .is_some_and(|conversation| {
+                active_workspace_path
+                    .as_ref()
+                    .is_none_or(|path| &conversation.workspace_path == path)
+            });
+        if !is_valid_active {
+            state.active_conversation_id = active_workspace_path
+                .as_deref()
+                .and_then(|workspace_path| first_workspace_conversation_id(state, workspace_path));
+        }
+    }
+}
+
+fn selected_workspace_conversation_id(
+    state: &RuntimeState,
+    workspace_path: &str,
+) -> Option<String> {
+    state
+        .selected_by_workspace
+        .get(workspace_path)
+        .filter(|conversation_id| {
+            state
+                .conversations
+                .get(*conversation_id)
+                .is_some_and(|conversation| conversation.workspace_path == workspace_path)
+        })
+        .cloned()
+}
+
+fn first_workspace_conversation_id(state: &RuntimeState, workspace_path: &str) -> Option<String> {
+    state
+        .conversations
+        .values()
+        .filter(|conversation| conversation.workspace_path == workspace_path)
+        .max_by(|a, b| {
+            a.updated_at
+                .cmp(&b.updated_at)
+                .then_with(|| a.conversation_id.cmp(&b.conversation_id))
+        })
+        .map(|conversation| conversation.conversation_id.clone())
 }
 
 fn conversation_view(
@@ -2264,6 +2292,112 @@ fn provider_display_name(provider_id: &str) -> String {
         .find(|provider| provider.id == provider_id)
         .map(|provider| provider.name.to_string())
         .unwrap_or_else(|| provider_id.to_string())
+}
+
+fn filtered_catalog_models<'a>(
+    catalog: &'a [ModelOption],
+    configured_provider_ids: &HashSet<String>,
+) -> Vec<&'a ModelOption> {
+    catalog
+        .iter()
+        .filter(|model| configured_provider_ids.contains(&model.provider))
+        .collect()
+}
+
+fn prompt_model_option(model: &ModelOption) -> PromptModelOptionDto {
+    // Effort-capable providers (mirrors the binary's effortApplies):
+    // codex takes reasoning.effort via the Responses API; codegraff and
+    // deepseek take a top-level reasoning_effort. But the gateway's gpt-*
+    // models go through /v1/chat/completions, which rejects reasoning_effort.
+    let effort_capable = match model.provider.as_str() {
+        "codex" => true,
+        "codegraff" | "deepseek" => !model.name.starts_with("gpt-"),
+        "kimi" => true,
+        _ => false,
+    };
+    let reasoning_efforts: Vec<String> = if effort_capable {
+        vec!["low".into(), "medium".into(), "high".into()]
+    } else {
+        vec![]
+    };
+
+    PromptModelOptionDto {
+        provider_id: model.provider.clone(),
+        provider_name: provider_display_name(&model.provider),
+        model_id: model.name.clone(),
+        model_name: Some(model.name.clone()),
+        context_length: model.context,
+        supports_reasoning: !reasoning_efforts.is_empty(),
+        reasoning_efforts,
+    }
+}
+
+fn build_prompt_settings_from_catalog(
+    catalog: &[ModelOption],
+    configured_provider_ids: &HashSet<String>,
+    selected_provider: Option<&str>,
+    selected_model: Option<&str>,
+    selected_effort: Option<String>,
+    fast_enabled: bool,
+) -> PromptSettingsDto {
+    if catalog.is_empty() {
+        if configured_provider_ids.contains("codegraff") {
+            return PromptSettingsDto {
+                available_models: vec![PromptModelOptionDto {
+                    provider_id: "codegraff".into(),
+                    provider_name: "Codegraff".into(),
+                    model_id: "default".into(),
+                    model_name: Some("Default".into()),
+                    context_length: None,
+                    supports_reasoning: false,
+                    reasoning_efforts: vec![],
+                }],
+                selected_provider_id: Some("codegraff".into()),
+                selected_model_id: Some("default".into()),
+                selected_reasoning_effort: None,
+                fast_enabled,
+            };
+        }
+
+        return PromptSettingsDto {
+            available_models: vec![],
+            selected_provider_id: None,
+            selected_model_id: None,
+            selected_reasoning_effort: None,
+            fast_enabled,
+        };
+    }
+
+    let available_catalog = filtered_catalog_models(catalog, configured_provider_ids);
+    let available_models = available_catalog
+        .iter()
+        .map(|model| prompt_model_option(model))
+        .collect();
+
+    // Default to the codegraff gateway's model when configured, else the first
+    // configured provider model.
+    let default_model = available_catalog
+        .iter()
+        .find(|model| model.name == "deepseek-v4-pro")
+        .copied()
+        .or_else(|| available_catalog.first().copied());
+    let selected_pair = selected_provider
+        .zip(selected_model)
+        .and_then(|(provider, model)| {
+            available_catalog
+                .iter()
+                .find(|candidate| candidate.provider == provider && candidate.name == model)
+                .map(|candidate| (candidate.provider.clone(), candidate.name.clone()))
+        })
+        .or_else(|| default_model.map(|model| (model.provider.clone(), model.name.clone())));
+
+    PromptSettingsDto {
+        available_models,
+        selected_provider_id: selected_pair.as_ref().map(|(provider, _)| provider.clone()),
+        selected_model_id: selected_pair.as_ref().map(|(_, model)| model.clone()),
+        selected_reasoning_effort: selected_pair.and(selected_effort),
+        fast_enabled,
+    }
 }
 
 /// Writes one newline-delimited protocol request to a session's stdin. Locks
@@ -2468,7 +2602,12 @@ struct CodegraffProvider {
 /// see `schema_providers`.
 fn fallback_providers() -> Vec<CodegraffProvider> {
     use ProviderAuthMethodKindDto::*;
-    fn p(id: &str, name: &str, env: Option<&str>, auth: ProviderAuthMethodKindDto) -> CodegraffProvider {
+    fn p(
+        id: &str,
+        name: &str,
+        env: Option<&str>,
+        auth: ProviderAuthMethodKindDto,
+    ) -> CodegraffProvider {
         CodegraffProvider {
             id: id.into(),
             name: name.into(),
@@ -2477,7 +2616,12 @@ fn fallback_providers() -> Vec<CodegraffProvider> {
         }
     }
     vec![
-        p("codegraff", "Codegraff", Some("CODEGRAFF_API_KEY"), CodegraffDevice),
+        p(
+            "codegraff",
+            "Codegraff",
+            Some("CODEGRAFF_API_KEY"),
+            CodegraffDevice,
+        ),
         p("anthropic", "Anthropic", Some("ANTHROPIC_API_KEY"), ApiKey),
         p("deepseek", "DeepSeek", Some("DEEPSEEK_API_KEY"), ApiKey),
         p("openai", "OpenAI", Some("OPENAI_API_KEY"), ApiKey),
@@ -2536,7 +2680,12 @@ async fn schema_providers() -> Vec<CodegraffProvider> {
             } else {
                 None
             };
-            Some(CodegraffProvider { id, name, env_key, auth_method })
+            Some(CodegraffProvider {
+                id,
+                name,
+                env_key,
+                auth_method,
+            })
         })
         .collect();
     if providers.is_empty() {
@@ -2557,6 +2706,22 @@ async fn list_codegraff_providers() -> Result<Vec<ProviderSummaryDto>> {
         .iter()
         .map(|provider| provider_summary_with_key_list(provider, &key_list))
         .collect())
+}
+
+async fn configured_provider_ids() -> HashSet<String> {
+    let key_list = codegraff_key_list().await.unwrap_or_default();
+    configured_provider_ids_from_providers(&schema_providers().await, &key_list)
+}
+
+fn configured_provider_ids_from_providers(
+    providers: &[CodegraffProvider],
+    key_list: &str,
+) -> HashSet<String> {
+    providers
+        .iter()
+        .filter(|provider| provider_configured(provider, key_list))
+        .map(|provider| provider.id.clone())
+        .collect()
 }
 
 async fn provider_summary(provider_id: &str) -> Result<ProviderSummaryDto> {
@@ -2665,12 +2830,21 @@ fn provider_configured(provider: &CodegraffProvider, key_list: &str) -> bool {
         return true;
     }
 
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    provider_login_configured(provider, key_list, home.as_deref())
+}
+
+fn provider_login_configured(
+    provider: &CodegraffProvider,
+    key_list: &str,
+    home: Option<&Path>,
+) -> bool {
     match provider.id.as_str() {
         "codegraff" => {
-            home_file_exists("forge/.credentials.json")
+            home_file_exists(home, ".simple-harness-codegraff.json")
                 || key_list_mentions_provider(key_list, &provider.id)
         }
-        "codex" => home_file_exists(".codex/auth.json"),
+        "codex" => home_codex_auth_has_valid_token(home),
         _ => key_list_mentions_provider(key_list, &provider.id),
     }
 }
@@ -2687,10 +2861,33 @@ fn key_list_mentions_provider(key_list: &str, provider_id: &str) -> bool {
     })
 }
 
-fn home_file_exists(relative_path: &str) -> bool {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .map(|home| home.join(relative_path).exists())
+fn home_file_exists(home: Option<&Path>, relative_path: &str) -> bool {
+    home.map(|home| home.join(relative_path).exists())
+        .unwrap_or(false)
+}
+
+fn home_codex_auth_has_valid_token(home: Option<&Path>) -> bool {
+    home.map(|home| codex_auth_file_has_valid_token(&home.join(".codex/auth.json")))
+        .unwrap_or(false)
+}
+
+fn codex_auth_file_has_valid_token(path: &Path) -> bool {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    codex_auth_text_has_valid_token(&text)
+}
+
+fn codex_auth_text_has_valid_token(text: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
+        return false;
+    };
+    value
+        .get("tokens")
+        .and_then(|tokens| tokens.get("access_token"))
+        .or_else(|| value.get("access_token"))
+        .and_then(|token| token.as_str())
+        .map(|token| !token.trim().is_empty())
         .unwrap_or(false)
 }
 
@@ -2713,7 +2910,7 @@ fn provider_from_auth_session_id(auth_session_id: &str) -> &str {
 
 fn cli_login_session(provider_id: &str, message: &str) -> ProviderAuthSessionDto {
     ProviderAuthSessionDto {
-        kind: ProviderAuthSessionKindDto::DeviceCode,
+        kind: ProviderAuthSessionKindDto::CliLogin,
         auth_session_id: auth_session_id(provider_id),
         requires_api_key: false,
         api_key_hint: Some(message.into()),
@@ -2860,9 +3057,8 @@ fn shell_single_quote(value: &str) -> String {
 /// capped to a handful of words.
 fn clean_title(raw: &str) -> String {
     let first = raw.trim().lines().next().unwrap_or("").trim();
-    let trimmed = first.trim_matches(|c: char| {
-        c == '"' || c == '\'' || c == '.' || c == ':' || c.is_whitespace()
-    });
+    let trimmed = first
+        .trim_matches(|c: char| c == '"' || c == '\'' || c == '.' || c == ':' || c.is_whitespace());
     trimmed
         .split_whitespace()
         .take(8)
@@ -2891,6 +3087,11 @@ fn title_from_prompt(prompt: &str) -> String {
     } else {
         title
     }
+}
+
+fn is_placeholder_title(title: &str) -> bool {
+    let title = title.trim();
+    title.is_empty() || title.eq_ignore_ascii_case("New chat")
 }
 
 fn git_status_files(workspace_path: &str) -> Result<Vec<WorkspaceFileStatusDto>> {
@@ -3014,5 +3215,283 @@ mod tests {
             selected_option_ids: Some(vec!["option-0".to_string()]),
         };
         assert_eq!(followup_answer_line(&request, &response), "yes please");
+    }
+
+    #[test]
+    fn placeholder_title_detection_accepts_empty_and_new_chat() {
+        assert!(is_placeholder_title(""));
+        assert!(is_placeholder_title("  New chat  "));
+        assert!(is_placeholder_title("new CHAT"));
+        assert!(!is_placeholder_title("Investigate stale sidebar state"));
+    }
+
+    #[test]
+    fn recover_conversation_title_uses_first_user_message() {
+        let messages = vec![
+            SessionMessageDto::Assistant {
+                id: "assistant-1".into(),
+                request_id: "request-1".into(),
+                text: "Hello".into(),
+            },
+            SessionMessageDto::User {
+                id: "user-1".into(),
+                request_id: "request-1".into(),
+                text: "Fix the new chat title regression with deterministic fallback".into(),
+            },
+        ];
+
+        assert_eq!(
+            recover_conversation_title("New chat", &messages),
+            "Fix the new chat title regression with deterministic"
+        );
+        assert_eq!(
+            recover_conversation_title("Custom title", &messages),
+            "Custom title"
+        );
+    }
+
+    #[test]
+    fn selected_workspace_conversation_ignores_stale_ids() {
+        let mut state = RuntimeState::default();
+        state.conversations.insert(
+            "chat-1".into(),
+            ConversationState {
+                workspace_path: "/tmp/work".into(),
+                conversation_id: "chat-1".into(),
+                title: "Existing".into(),
+                messages: vec![],
+                active_request_ids: vec![],
+                active_agent_id: None,
+                plan_mode: false,
+                updated_at: 10,
+            },
+        );
+        state
+            .selected_by_workspace
+            .insert("/tmp/work".into(), "missing".into());
+
+        assert_eq!(
+            selected_workspace_conversation_id(&state, "/tmp/work"),
+            None
+        );
+
+        state
+            .selected_by_workspace
+            .insert("/tmp/work".into(), "chat-1".into());
+        assert_eq!(
+            selected_workspace_conversation_id(&state, "/tmp/work"),
+            Some("chat-1".into())
+        );
+    }
+
+    #[test]
+    fn provider_configured_detects_codegraff_login_file() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "codegraff-provider-test-{}",
+            Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        std::fs::write(temp_dir.join(".simple-harness-codegraff.json"), "{}")
+            .expect("write login file");
+
+        let configured = provider_login_configured(
+            &CodegraffProvider {
+                id: "codegraff".into(),
+                name: "Codegraff".into(),
+                env_key: None,
+                auth_method: ProviderAuthMethodKindDto::CodegraffDevice,
+            },
+            "",
+            Some(&temp_dir),
+        );
+        let _ = std::fs::remove_dir_all(temp_dir);
+
+        assert!(configured);
+    }
+
+    #[test]
+    fn codex_auth_text_requires_nonempty_access_token() {
+        assert!(codex_auth_text_has_valid_token(
+            r#"{"tokens":{"access_token":"token"}}"#
+        ));
+        assert!(codex_auth_text_has_valid_token(
+            r#"{"access_token":"legacy-token"}"#
+        ));
+        assert!(!codex_auth_text_has_valid_token(
+            r#"{"tokens":{"access_token":" "}}"#
+        ));
+        assert!(!codex_auth_text_has_valid_token("{}"));
+        assert!(!codex_auth_text_has_valid_token("not json"));
+    }
+
+    #[test]
+    fn provider_configured_detects_codex_auth_file_token() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("codex-provider-test-{}", Uuid::new_v4().simple()));
+        let codex_dir = temp_dir.join(".codex");
+        std::fs::create_dir_all(&codex_dir).expect("create codex dir");
+        std::fs::write(
+            codex_dir.join("auth.json"),
+            r#"{"tokens":{"access_token":"token"}}"#,
+        )
+        .expect("write codex auth file");
+
+        let configured = provider_login_configured(
+            &CodegraffProvider {
+                id: "codex".into(),
+                name: "Codex / ChatGPT".into(),
+                env_key: None,
+                auth_method: ProviderAuthMethodKindDto::CodexDevice,
+            },
+            "",
+            Some(&temp_dir),
+        );
+        let _ = std::fs::remove_dir_all(temp_dir);
+
+        assert!(configured);
+    }
+
+    fn model(provider: &str, name: &str) -> ModelOption {
+        ModelOption {
+            provider: provider.into(),
+            name: name.into(),
+            context: None,
+        }
+    }
+
+    fn provider_ids(ids: &[&str]) -> HashSet<String> {
+        ids.iter().map(|id| (*id).to_string()).collect()
+    }
+
+    #[test]
+    fn prompt_settings_returns_no_models_without_configured_providers() {
+        let settings = build_prompt_settings_from_catalog(
+            &[
+                model("codegraff", "deepseek-v4-pro"),
+                model("codex", "gpt-5.5"),
+            ],
+            &HashSet::new(),
+            None,
+            None,
+            Some("high".into()),
+            true,
+        );
+
+        assert!(settings.available_models.is_empty());
+        assert_eq!(settings.selected_provider_id, None);
+        assert_eq!(settings.selected_model_id, None);
+        assert_eq!(settings.selected_reasoning_effort, None);
+        assert!(settings.fast_enabled);
+    }
+
+    #[test]
+    fn prompt_settings_filters_models_to_configured_providers() {
+        let settings = build_prompt_settings_from_catalog(
+            &[
+                model("codegraff", "deepseek-v4-pro"),
+                model("codex", "gpt-5.5"),
+                model("openai", "gpt-4.1"),
+            ],
+            &provider_ids(&["codex"]),
+            None,
+            None,
+            None,
+            false,
+        );
+
+        assert_eq!(settings.available_models.len(), 1);
+        assert_eq!(settings.available_models[0].provider_id, "codex");
+        assert_eq!(settings.available_models[0].model_id, "gpt-5.5");
+        assert_eq!(settings.selected_provider_id.as_deref(), Some("codex"));
+        assert_eq!(settings.selected_model_id.as_deref(), Some("gpt-5.5"));
+    }
+
+    #[test]
+    fn prompt_settings_ignores_persisted_unconfigured_model() {
+        let settings = build_prompt_settings_from_catalog(
+            &[
+                model("codegraff", "deepseek-v4-pro"),
+                model("codex", "gpt-5.5"),
+            ],
+            &provider_ids(&["codegraff"]),
+            Some("codex"),
+            Some("gpt-5.5"),
+            Some("medium".into()),
+            false,
+        );
+
+        assert_eq!(settings.available_models.len(), 1);
+        assert_eq!(settings.selected_provider_id.as_deref(), Some("codegraff"));
+        assert_eq!(
+            settings.selected_model_id.as_deref(),
+            Some("deepseek-v4-pro")
+        );
+        assert_eq!(
+            settings.selected_reasoning_effort.as_deref(),
+            Some("medium")
+        );
+    }
+
+    #[test]
+    fn prompt_settings_schema_fallback_requires_configured_codegraff() {
+        let unavailable =
+            build_prompt_settings_from_catalog(&[], &HashSet::new(), None, None, None, false);
+        assert!(unavailable.available_models.is_empty());
+
+        let available = build_prompt_settings_from_catalog(
+            &[],
+            &provider_ids(&["codegraff"]),
+            None,
+            None,
+            None,
+            true,
+        );
+        assert_eq!(available.available_models.len(), 1);
+        assert_eq!(available.selected_provider_id.as_deref(), Some("codegraff"));
+        assert_eq!(available.selected_model_id.as_deref(), Some("default"));
+        assert!(available.fast_enabled);
+    }
+
+    #[test]
+    fn normalize_runtime_selection_falls_back_to_existing_conversation() {
+        let mut state = RuntimeState {
+            active_workspace_path: Some("/tmp/work".into()),
+            active_conversation_id: Some("missing".into()),
+            ..RuntimeState::default()
+        };
+        state.conversations.insert(
+            "chat-old".into(),
+            ConversationState {
+                workspace_path: "/tmp/work".into(),
+                conversation_id: "chat-old".into(),
+                title: "Old".into(),
+                messages: vec![],
+                active_request_ids: vec![],
+                active_agent_id: None,
+                plan_mode: false,
+                updated_at: 10,
+            },
+        );
+        state.conversations.insert(
+            "chat-new".into(),
+            ConversationState {
+                workspace_path: "/tmp/work".into(),
+                conversation_id: "chat-new".into(),
+                title: "New".into(),
+                messages: vec![],
+                active_request_ids: vec![],
+                active_agent_id: None,
+                plan_mode: false,
+                updated_at: 20,
+            },
+        );
+        state
+            .selected_by_workspace
+            .insert("/tmp/work".into(), "missing".into());
+
+        normalize_runtime_selection(&mut state);
+
+        assert_eq!(state.active_conversation_id, Some("chat-new".into()));
+        assert_eq!(state.selected_by_workspace.get("/tmp/work"), None);
     }
 }

--- a/gui/src/app/SessionProvider.test.tsx
+++ b/gui/src/app/SessionProvider.test.tsx
@@ -130,6 +130,8 @@ mock.module("../hooks/useSessionBootstrap", () => ({
 
 mock.module("../services/desktop/client", () => ({
   setFast: async () => {},
+  savePastedImage: async () => "/tmp/pasted-image.png",
+  imageThumbnail: async () => "data:image/jpeg;base64,",
   openExternalUrl: async () => {},
   openPathInTarget: async () => {},
   ensureConversationView: async () => {

--- a/gui/src/app/sessionStore.test.ts
+++ b/gui/src/app/sessionStore.test.ts
@@ -99,6 +99,8 @@ function createSnapshot(
 
 mock.module("../services/desktop/client", () => ({
   setFast: async () => {},
+  savePastedImage: async () => "/tmp/pasted-image.png",
+  imageThumbnail: async () => "data:image/jpeg;base64,",
   openExternalUrl: async () => {},
   openPathInTarget: async () => {},
   ensureConversationView: async (workspacePath: string, conversationId: string) => {

--- a/gui/src/components/PromptInputCard.tsx
+++ b/gui/src/components/PromptInputCard.tsx
@@ -53,6 +53,7 @@ export function PromptInputCard({
   placeholder = "Ask about this workspace…",
   promptSettings,
   promptDraft,
+  focusSignal,
   isInputDisabled = false,
   binding,
   workspacePath,
@@ -134,6 +135,13 @@ export function PromptInputCard({
 
   useAutosizeTextarea(textareaRef, promptDraft);
 
+  useEffect(() => {
+    if (focusSignal == null || isControlDisabled) {
+      return;
+    }
+    textareaRef.current?.focus();
+  }, [focusSignal, isControlDisabled]);
+
   // Highlight a leading slash-command token so the user sees they're issuing a
   // command. Only active in command mode, so normal prose typing is untouched.
   const commandMatch = /^(\/[A-Za-z][\w-]*)([\s\S]*)$/.exec(promptDraft);
@@ -208,7 +216,7 @@ export function PromptInputCard({
       ) : null}
       <Card
         className={cn(
-          "relative gap-0 rounded-2xl border border-border bg-background/50 p-2 transition-colors transition-shadow ring-0",
+          "relative gap-0 rounded-2xl border border-foreground/5 bg-background/50 p-2 transition-colors transition-shadow ring-0",
           isPlanningMode &&
             "border-[color:var(--accent)] ring-5 ring-[color:color-mix(in_oklab,var(--accent)_14%,transparent)] border-dashed",
         )}

--- a/gui/src/components/new-chat-screen/NewChatPromptSection.tsx
+++ b/gui/src/components/new-chat-screen/NewChatPromptSection.tsx
@@ -1,10 +1,8 @@
 import { useCallback, useState } from "react";
 
-import { useSettingsNavigation } from "@/app/settingsNavigationContext";
 import { getUiActiveBinding, sessionStore } from "@/app/sessionStore";
 import { CommandResultDialog } from "@/components/CommandResultDialog";
 import { FollowupComposer } from "@/components/FollowupComposer";
-import { PromptActionAlert } from "@/components/PromptActionAlert";
 import { PromptInputCard } from "@/components/PromptInputCard";
 import { PlanDecisionCard } from "@/components/conversation-panel/PlanDecisionCard";
 import {
@@ -22,9 +20,11 @@ import type {
 
 export function NewChatPromptSection({
   binding,
+  focusSignal,
   onCommandResult,
 }: {
   binding?: ChatBinding | null;
+  focusSignal?: number;
   onCommandResult?: (result: CommandRunResult) => void;
 }) {
   const {
@@ -47,7 +47,6 @@ export function NewChatPromptSection({
     submitPrompt,
     updatePromptSettings,
   } = usePrompt(binding);
-  const { openProviderSettings } = useSettingsNavigation();
   const [dismissedPlanDecisionId, setDismissedPlanDecisionId] = useState<
     string | null
   >(null);
@@ -100,11 +99,6 @@ export function NewChatPromptSection({
       setDismissedPlanDecisionId(lastAssistant.id);
     }
   }, [lastAssistant]);
-  const showProviderSetupPrompt =
-    hasCurrentWorkspace &&
-    promptSettings != null &&
-    promptSettings.availableModels.length === 0;
-
   if (followupRequest != null) {
     return (
       <FollowupComposer
@@ -123,16 +117,9 @@ export function NewChatPromptSection({
           onContinue={handleContinuePlanning}
         />
       ) : null}
-      {showProviderSetupPrompt ? (
-        <PromptActionAlert
-          title="No provider is configured"
-          description="Configure at least one provider to start chatting."
-          actionLabel="Configure"
-          onAction={openProviderSettings}
-        />
-      ) : null}
       <PromptInputCard
         canCompose={canCompose}
+        focusSignal={focusSignal}
         isRequestActive={isRequestActive}
         isSendingPrompt={isSendingPrompt}
         placeholder={
@@ -145,7 +132,7 @@ export function NewChatPromptSection({
         isPlanningMode={isPlanningMode}
         promptDraft={promptDraft}
         promptSettings={promptSettings}
-        isInputDisabled={showProviderSetupPrompt}
+        isInputDisabled={!hasCurrentWorkspace}
         binding={binding}
         workspacePath={workspacePath}
         onCommandSelect={handleCommandSelect}

--- a/gui/src/components/new-chat-screen/NewChatScreen.tsx
+++ b/gui/src/components/new-chat-screen/NewChatScreen.tsx
@@ -1,17 +1,33 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { ChatThread } from "@/components/chat/ChatThread";
 import { useConversationSession } from "@/hooks/useSession";
 import { ConversationSurface } from "@/components/conversation-panel/ConversationSurface";
 import type { RequestTimingInfo } from "@/app/types/sessionContext";
 import type { CommandRunResult } from "@/services/desktop/types/contracts";
+import { useSettingsNavigation } from "@/app/settingsNavigationContext";
+import { ProviderSetupDialog } from "@/components/providers-settings/ProviderSetupDialog";
+import { useProviderSetup } from "@/components/providers-settings/useProviderSetup";
 
 import { CloneRepositoryDialog } from "./CloneRepositoryDialog";
 import { useNewChatScreenController } from "./hooks/useNewChatScreenController";
 import { NewChatLaunchActions } from "./NewChatLaunchActions";
 import { NewChatPromptSection } from "./NewChatPromptSection";
+import { OnboardingPanel } from "./OnboardingPanel";
 import { QuickStartProjectDialog } from "./QuickStartProjectDialog";
 import type { NewChatScreenProps } from "./types/newChatScreen";
+import {
+  hasConfiguredProvider,
+  readOnboardingStorage,
+  shouldShowOnboardingPanel,
+  writeOnboardingCompleted,
+} from "./utils/onboarding";
+
+function initialOnboardingCompleted() {
+  return readOnboardingStorage(
+    typeof window === "undefined" ? null : window.localStorage,
+  ).completed;
+}
 
 export function NewChatScreen({
   binding,
@@ -46,6 +62,7 @@ export function NewChatScreen({
       ? localCommandResultState.results
       : [];
   const visibleCommandResults = commandResults ?? localCommandResults;
+  const [focusSignal, setFocusSignal] = useState(0);
   const appendLocalCommandResult = useCallback(
     (result: CommandRunResult) => {
       if (onCommandResult != null) {
@@ -71,6 +88,10 @@ export function NewChatScreen({
       onOpenClone={controller.openCloneDialog}
       onOpenFolder={() => void controller.handleOpenWorkspacePicker()}
       onOpenQuickStart={controller.openQuickStartDialog}
+      onRequestPromptFocus={() => {
+        setFocusSignal((current) => current + 1);
+      }}
+      promptFocusSignal={focusSignal}
       requestTimingsById={requestTimingsById}
       visibleError={controller.visibleError}
       workspaceLabel={activeWorkspaceLabel}
@@ -132,6 +153,8 @@ function NewChatScreenContent({
   onOpenClone,
   onOpenFolder,
   onOpenQuickStart,
+  onRequestPromptFocus,
+  promptFocusSignal,
   requestTimingsById,
   visibleError,
   workspaceLabel,
@@ -145,6 +168,8 @@ function NewChatScreenContent({
   onOpenClone: () => void;
   onOpenFolder: () => void;
   onOpenQuickStart: () => void;
+  onRequestPromptFocus: () => void;
+  promptFocusSignal: number;
   requestTimingsById: Record<string, RequestTimingInfo>;
   visibleError: string | null;
   workspaceLabel: string;
@@ -154,12 +179,43 @@ function NewChatScreenContent({
     hasCurrentWorkspace,
     workspaceKind,
   } = useConversationSession(binding);
+  const providerSetup = useProviderSetup(workspacePath);
+  const { openProviderSettings } = useSettingsNavigation();
+  const [onboardingCompleted, setOnboardingCompleted] = useState(
+    initialOnboardingCompleted,
+  );
   const heading = hasCurrentWorkspace
     ? workspaceKind === "managed_chat"
       ? "Ask anything"
       : `Ask anything about ${workspaceLabel}`
     : "Ask anything";
   const hasCommandResults = commandResults.length > 0;
+  const hasProvider = hasConfiguredProvider(providerSetup.providers);
+  const showOnboarding =
+    !hasCommandResults &&
+    shouldShowOnboardingPanel({
+      completed: onboardingCompleted,
+      hasProvider,
+      hasWorkspace: hasCurrentWorkspace,
+    });
+
+  useEffect(() => {
+    if (onboardingCompleted || !hasProvider || !hasCurrentWorkspace) {
+      return;
+    }
+
+    setOnboardingCompleted(true);
+    writeOnboardingCompleted(
+      typeof window === "undefined" ? null : window.localStorage,
+    );
+  }, [hasCurrentWorkspace, hasProvider, onboardingCompleted]);
+
+  function completeOnboarding() {
+    setOnboardingCompleted(true);
+    writeOnboardingCompleted(
+      typeof window === "undefined" ? null : window.localStorage,
+    );
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-6 py-8">
@@ -200,9 +256,29 @@ function NewChatScreenContent({
           </div>
         ) : null}
 
+        {showOnboarding ? (
+          <div className="w-full max-w-3xl self-center text-left">
+            <OnboardingPanel
+              hasProvider={hasProvider}
+              hasWorkspace={hasCurrentWorkspace}
+              isBusy={isBusy}
+              isLoadingProviders={providerSetup.isLoadingProviders}
+              onCollapse={completeOnboarding}
+              onFocusPrompt={onRequestPromptFocus}
+              onOpenClone={onOpenClone}
+              onOpenFolder={onOpenFolder}
+              onOpenProviderSetup={providerSetup.openProviderSetup}
+              onOpenQuickStart={onOpenQuickStart}
+              onOpenSettings={openProviderSettings}
+              providers={providerSetup.providers}
+            />
+          </div>
+        ) : null}
+
         <div className="w-full max-w-3xl self-center">
           <NewChatPromptSection
             binding={binding}
+            focusSignal={promptFocusSignal}
             onCommandResult={onCommandResult}
           />
         </div>
@@ -217,6 +293,14 @@ function NewChatScreenContent({
           />
         ) : null}
       </div>
+      <ProviderSetupDialog
+        initialAuthMethod={providerSetup.initialAuthMethod}
+        isOpen={providerSetup.selectedProvider != null}
+        onClose={providerSetup.closeProviderSetup}
+        onProviderUpdated={providerSetup.applyProviderUpdate}
+        provider={providerSetup.selectedProvider}
+        workspacePath={workspacePath}
+      />
     </div>
   );
 }

--- a/gui/src/components/new-chat-screen/OnboardingPanel.tsx
+++ b/gui/src/components/new-chat-screen/OnboardingPanel.tsx
@@ -1,0 +1,243 @@
+import {
+  CheckCircle2,
+  Circle,
+  FolderOpen,
+  GitBranchPlus,
+  KeyRound,
+  MessageSquareText,
+  Rocket,
+  XIcon,
+} from "lucide-react";
+import type { ComponentType, ReactNode } from "react";
+
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent } from "@/components/ui/Card";
+import type {
+  ProviderAuthMethodKind,
+  ProviderSummary,
+} from "@/services/desktop/types/contracts";
+import { cn } from "@/utils/cn";
+
+import { findApiKeyProvider } from "./utils/onboarding";
+
+interface OnboardingPanelProps {
+  hasProvider: boolean;
+  hasWorkspace: boolean;
+  isBusy: boolean;
+  isLoadingProviders: boolean;
+  onCollapse: () => void;
+  onFocusPrompt: () => void;
+  onOpenClone: () => void;
+  onOpenFolder: () => void;
+  onOpenProviderSetup: (
+    providerIdOrProvider: string | ProviderSummary,
+    authMethod?: ProviderAuthMethodKind,
+  ) => boolean;
+  onOpenQuickStart: () => void;
+  onOpenSettings: () => void;
+  providers: ProviderSummary[];
+}
+
+export function OnboardingPanel({
+  hasProvider,
+  hasWorkspace,
+  isBusy,
+  isLoadingProviders,
+  onCollapse,
+  onFocusPrompt,
+  onOpenClone,
+  onOpenFolder,
+  onOpenProviderSetup,
+  onOpenQuickStart,
+  onOpenSettings,
+  providers,
+}: OnboardingPanelProps) {
+  const isComplete = hasProvider && hasWorkspace;
+  const apiKeyProvider = findApiKeyProvider(providers);
+
+  return (
+    <Card className="w-full border border-border/80 bg-card/95 shadow-sm">
+      <CardContent className="flex flex-col gap-4 px-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-foreground">
+              Set up the fastest path
+            </div>
+            <p className="mt-1 max-w-2xl text-xs/relaxed text-muted-foreground">
+              Start with a free Codegraff login. Codex login is also picked up,
+              and API keys can be added manually.
+            </p>
+          </div>
+          {isComplete ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Collapse onboarding"
+              onClick={onCollapse}
+            >
+              <XIcon className="size-3.5" />
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onOpenSettings}
+            >
+              Settings
+            </Button>
+          )}
+        </div>
+
+        <div className="grid gap-3">
+          <ChecklistItem
+            complete={hasProvider}
+            description={
+              hasProvider
+                ? "Provider credentials are ready."
+                : "Use Codegraff first, or connect Codex/API-key providers."
+            }
+            icon={KeyRound}
+            title="Connect provider"
+          >
+            {!hasProvider ? (
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  disabled={isLoadingProviders}
+                  onClick={() => {
+                    onOpenProviderSetup("codegraff", "codegraff_device");
+                  }}
+                >
+                  Connect Codegraff
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={isLoadingProviders}
+                  onClick={() => {
+                    onOpenProviderSetup("codex", "codex_device");
+                  }}
+                >
+                  Use Codex
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={apiKeyProvider == null || isLoadingProviders}
+                  onClick={() => {
+                    if (apiKeyProvider != null) {
+                      onOpenProviderSetup(apiKeyProvider, "api_key");
+                    }
+                  }}
+                >
+                  Use API key
+                </Button>
+              </div>
+            ) : null}
+          </ChecklistItem>
+
+          <ChecklistItem
+            complete={hasWorkspace}
+            description={
+              hasWorkspace
+                ? "Workspace selected."
+                : "Open a local folder, clone a repository, or create a project."
+            }
+            icon={FolderOpen}
+            title="Choose workspace"
+          >
+            {!hasWorkspace ? (
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={isBusy}
+                  onClick={onOpenFolder}
+                >
+                  <FolderOpen data-icon="inline-start" />
+                  Open folder
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={isBusy}
+                  onClick={onOpenClone}
+                >
+                  <GitBranchPlus data-icon="inline-start" />
+                  Clone from Git
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={isBusy}
+                  onClick={onOpenQuickStart}
+                >
+                  <Rocket data-icon="inline-start" />
+                  Quick start
+                </Button>
+              </div>
+            ) : null}
+          </ChecklistItem>
+
+          <ChecklistItem
+            complete={isComplete}
+            description={
+              isComplete
+                ? "Composer is ready."
+                : "Ready after provider and workspace are set."
+            }
+            icon={MessageSquareText}
+            title="Start chat"
+          >
+            {isComplete ? (
+              <Button type="button" onClick={onFocusPrompt}>
+                Focus prompt
+              </Button>
+            ) : null}
+          </ChecklistItem>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ChecklistItem({
+  children,
+  complete,
+  description,
+  icon: Icon,
+  title,
+}: {
+  children?: ReactNode;
+  complete: boolean;
+  description: string;
+  icon: ComponentType<{ className?: string }>;
+  title: string;
+}) {
+  const StatusIcon = complete ? CheckCircle2 : Circle;
+
+  return (
+    <div
+      className={cn(
+        "grid gap-3 rounded-lg border border-border/70 bg-background/60 p-3 sm:grid-cols-[auto_1fr]",
+        complete ? "border-accent/30" : null,
+      )}
+    >
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <StatusIcon
+          className={cn("size-4", complete ? "text-accent" : null)}
+        />
+        <Icon className="size-4" />
+      </div>
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-foreground">{title}</div>
+        <p className="mt-0.5 text-xs/relaxed text-muted-foreground">
+          {description}
+        </p>
+        {children ? <div className="mt-3">{children}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/gui/src/components/new-chat-screen/utils/onboarding.test.ts
+++ b/gui/src/components/new-chat-screen/utils/onboarding.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ProviderSummary } from "@/services/desktop/types/contracts";
+
+import {
+  findApiKeyProvider,
+  hasConfiguredProvider,
+  readOnboardingStorage,
+  shouldShowOnboardingPanel,
+  writeOnboardingCompleted,
+} from "./onboarding";
+
+function provider(
+  id: string,
+  configured: boolean,
+  kind: ProviderSummary["authMethods"][number]["kind"] = "api_key",
+): ProviderSummary {
+  return {
+    authMethods: [{ kind, label: kind }],
+    configured,
+    envOverride: null,
+    id,
+    name: id,
+  };
+}
+
+describe("onboarding helpers", () => {
+  test("detects configured providers", () => {
+    expect(hasConfiguredProvider([])).toBe(false);
+    expect(hasConfiguredProvider([provider("openai", false)])).toBe(false);
+    expect(hasConfiguredProvider([provider("codegraff", true)])).toBe(true);
+  });
+
+  test("shows only during incomplete first setup", () => {
+    expect(
+      shouldShowOnboardingPanel({
+        completed: false,
+        hasProvider: false,
+        hasWorkspace: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowOnboardingPanel({
+        completed: false,
+        hasProvider: true,
+        hasWorkspace: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowOnboardingPanel({
+        completed: false,
+        hasProvider: true,
+        hasWorkspace: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowOnboardingPanel({
+        completed: true,
+        hasProvider: false,
+        hasWorkspace: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("prefers OpenAI for manual API key setup", () => {
+    expect(
+      findApiKeyProvider([
+        provider("anthropic", false),
+        provider("openai", false),
+      ])?.id,
+    ).toBe("openai");
+  });
+
+  test("ignores malformed localStorage payloads", () => {
+    expect(
+      readOnboardingStorage({
+        getItem: () => "{",
+      }).completed,
+    ).toBe(false);
+    expect(
+      readOnboardingStorage({
+        getItem: () => JSON.stringify({ completed: true }),
+      }).completed,
+    ).toBe(true);
+    expect(
+      readOnboardingStorage({
+        getItem: () => JSON.stringify({ collapsed: true }),
+      }).completed,
+    ).toBe(true);
+  });
+
+  test("writes completion state to storage", () => {
+    let storedValue = "";
+    writeOnboardingCompleted({
+      setItem: (_key, value) => {
+        storedValue = value;
+      },
+    });
+
+    expect(JSON.parse(storedValue)).toEqual({ completed: true });
+  });
+});

--- a/gui/src/components/new-chat-screen/utils/onboarding.ts
+++ b/gui/src/components/new-chat-screen/utils/onboarding.ts
@@ -1,0 +1,76 @@
+import type { ProviderSummary } from "@/services/desktop/types/contracts";
+
+export const ONBOARDING_STORAGE_KEY = "codegraff:onboarding";
+
+export interface OnboardingStorageState {
+  completed: boolean;
+}
+
+export function getConfiguredProviderCount(providers: ProviderSummary[]) {
+  return providers.filter((provider) => provider.configured).length;
+}
+
+export function hasConfiguredProvider(providers: ProviderSummary[]) {
+  return getConfiguredProviderCount(providers) > 0;
+}
+
+export function shouldShowOnboardingPanel({
+  completed,
+  hasProvider,
+  hasWorkspace,
+}: {
+  completed: boolean;
+  hasProvider: boolean;
+  hasWorkspace: boolean;
+}) {
+  return !completed && (!hasProvider || !hasWorkspace);
+}
+
+export function findApiKeyProvider(providers: ProviderSummary[]) {
+  return (
+    providers.find((provider) => provider.id === "openai") ??
+    providers.find((provider) =>
+      provider.authMethods.some((method) => method.kind === "api_key"),
+    ) ??
+    null
+  );
+}
+
+export function readOnboardingStorage(
+  storage: Pick<Storage, "getItem"> | null | undefined,
+): OnboardingStorageState {
+  if (storage == null) {
+    return { completed: false };
+  }
+
+  try {
+    const rawValue = storage.getItem(ONBOARDING_STORAGE_KEY);
+    if (rawValue == null) {
+      return { completed: false };
+    }
+
+    const value = JSON.parse(rawValue) as Partial<
+      OnboardingStorageState & { collapsed: boolean }
+    >;
+    return { completed: value.completed === true || value.collapsed === true };
+  } catch {
+    return { completed: false };
+  }
+}
+
+export function writeOnboardingCompleted(
+  storage: Pick<Storage, "setItem"> | null | undefined,
+) {
+  if (storage == null) {
+    return;
+  }
+
+  try {
+    storage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({ completed: true }),
+    );
+  } catch {
+    // localStorage can be unavailable in restricted browser contexts.
+  }
+}

--- a/gui/src/components/providers-settings/ProviderSetupDialog.tsx
+++ b/gui/src/components/providers-settings/ProviderSetupDialog.tsx
@@ -1,0 +1,598 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ExternalLinkIcon,
+  LoaderCircle,
+} from "lucide-react";
+
+import { ensureWorkspacePromptSettingsLoaded } from "@/app/sessionStore";
+import { Button } from "@/components/ui/Button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/Dialog";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/Select";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
+import {
+  completeProviderAuth,
+  listenProviderOAuthCallback,
+  openExternalUrl,
+  startProviderAuth,
+} from "@/services/desktop/client";
+import type {
+  ProviderAuthMethodKind,
+  ProviderAuthSession,
+  ProviderOAuthCallback,
+  ProviderSummary,
+} from "@/services/desktop/types/contracts";
+
+import {
+  createUrlParameterValues,
+  formatAuthMethods,
+  getProviderButtonLabel,
+  getSortedAuthMethods,
+  normalizeProviderError,
+} from "./utils/providerAuth";
+
+export function ProviderSetupDialog({
+  initialAuthMethod,
+  isOpen,
+  onClose,
+  onProviderUpdated,
+  provider,
+  workspacePath,
+}: {
+  initialAuthMethod: ProviderAuthMethodKind | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onProviderUpdated: (provider: ProviderSummary) => void;
+  provider: ProviderSummary | null;
+  workspacePath: string | null;
+}) {
+  const startRequestVersionRef = useRef(0);
+  const [pendingAutoStartMethod, setPendingAutoStartMethod] =
+    useState<ProviderAuthMethodKind | null>(null);
+  const [selectedAuthMethod, setSelectedAuthMethod] =
+    useState<ProviderAuthMethodKind | null>(null);
+  const [authFlow, setAuthFlow] = useState<ProviderAuthSession | null>(null);
+  const [apiKeyDraft, setApiKeyDraft] = useState("");
+  const [authorizationCodeDraft, setAuthorizationCodeDraft] = useState("");
+  const [urlParameterValues, setUrlParameterValues] = useState<
+    Record<string, string>
+  >({});
+  const [isStartingAuth, setIsStartingAuth] = useState(false);
+  const [isSubmittingAuth, setIsSubmittingAuth] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const providerId = provider?.id ?? null;
+
+  const defaultAuthMethod = useMemo(() => {
+    if (provider == null) {
+      return null;
+    }
+    const authMethods = getSortedAuthMethods(provider);
+    return authMethods.length === 1 ? (authMethods[0]?.kind ?? null) : null;
+  }, [provider]);
+
+  function resetSetupState(nextAuthMethod: ProviderAuthMethodKind | null) {
+    startRequestVersionRef.current += 1;
+    setSelectedAuthMethod(nextAuthMethod);
+    setAuthFlow(null);
+    setApiKeyDraft("");
+    setAuthorizationCodeDraft("");
+    setUrlParameterValues({});
+    setIsStartingAuth(false);
+    setIsSubmittingAuth(false);
+    setActionError(null);
+  }
+
+  useEffect(() => {
+    if (!isOpen || provider == null) {
+      return;
+    }
+
+    const nextAuthMethod = initialAuthMethod ?? defaultAuthMethod;
+    resetSetupState(nextAuthMethod);
+    setPendingAutoStartMethod(nextAuthMethod);
+  }, [defaultAuthMethod, initialAuthMethod, isOpen, provider]);
+
+  async function refreshPromptSettings() {
+    await ensureWorkspacePromptSettingsLoaded(workspacePath, { force: true });
+  }
+
+  async function beginProviderSetup(
+    selectedProvider: ProviderSummary,
+    authMethod: ProviderAuthMethodKind,
+  ) {
+    const requestVersion = startRequestVersionRef.current + 1;
+    startRequestVersionRef.current = requestVersion;
+    setIsStartingAuth(true);
+    setActionError(null);
+
+    try {
+      const nextAuthFlow = await startProviderAuth({
+        workspacePath,
+        providerId: selectedProvider.id,
+        authMethod,
+      });
+      if (startRequestVersionRef.current !== requestVersion) {
+        return;
+      }
+
+      setAuthFlow(nextAuthFlow);
+      setUrlParameterValues(
+        createUrlParameterValues(nextAuthFlow.urlParameters),
+      );
+      setApiKeyDraft("");
+      setAuthorizationCodeDraft("");
+    } catch (error) {
+      if (startRequestVersionRef.current !== requestVersion) {
+        return;
+      }
+
+      setAuthFlow(null);
+      setActionError(normalizeProviderError(error));
+    } finally {
+      if (startRequestVersionRef.current === requestVersion) {
+        setIsStartingAuth(false);
+      }
+    }
+  }
+
+  useEffect(() => {
+    let isDisposed = false;
+    let unlisten: (() => void) | null = null;
+
+    async function subscribeToOAuthCallbacks() {
+      unlisten = await listenProviderOAuthCallback(
+        (payload: ProviderOAuthCallback) => {
+          if (isDisposed) {
+            return;
+          }
+
+          if (
+            authFlow?.kind !== "o_auth_code" ||
+            payload.authSessionId !== authFlow.authSessionId ||
+            payload.providerId !== providerId
+          ) {
+            return;
+          }
+
+          if (payload.errorMessage) {
+            setActionError(payload.errorMessage);
+            return;
+          }
+
+          if (payload.authorizationCode) {
+            setAuthorizationCodeDraft(payload.authorizationCode);
+            setActionError(null);
+          }
+        },
+      );
+    }
+
+    void subscribeToOAuthCallbacks();
+
+    return () => {
+      isDisposed = true;
+      if (unlisten) {
+        void unlisten();
+      }
+    };
+  }, [authFlow, providerId]);
+
+  function closeSetupDialog() {
+    setPendingAutoStartMethod(null);
+    resetSetupState(null);
+    onClose();
+  }
+
+  async function handleContinueSetup() {
+    if (provider == null || selectedAuthMethod == null) {
+      return;
+    }
+
+    await beginProviderSetup(provider, selectedAuthMethod);
+  }
+
+  async function handleOpenUrl(url: string | null | undefined) {
+    if (url == null || url.length === 0) {
+      return;
+    }
+
+    try {
+      await openExternalUrl(url);
+    } catch (error) {
+      setActionError(normalizeProviderError(error));
+    }
+  }
+
+  async function handleSubmitSetup() {
+    if (authFlow == null || provider == null) {
+      return;
+    }
+
+    setIsSubmittingAuth(true);
+    setActionError(null);
+
+    try {
+      const updatedProvider = await completeProviderAuth({
+        authSessionId: authFlow.authSessionId,
+        apiKey: authFlow.requiresApiKey ? apiKeyDraft.trim() : null,
+        authorizationCode: authorizationCodeDraft.trim() || null,
+        urlParameters: authFlow.urlParameters.map((parameter) => ({
+          name: parameter.name,
+          value: urlParameterValues[parameter.name] ?? "",
+        })),
+      });
+
+      onProviderUpdated(updatedProvider);
+      await refreshPromptSettings();
+      closeSetupDialog();
+    } catch (error) {
+      setActionError(normalizeProviderError(error));
+      setIsSubmittingAuth(false);
+    }
+  }
+
+  const requiresUrlParameters =
+    authFlow?.urlParameters.every(
+      (parameter) =>
+        (urlParameterValues[parameter.name] ?? "").trim().length > 0,
+    ) ?? false;
+  const canSubmitApiKeyFlow =
+    authFlow != null &&
+    authFlow.kind === "api_key" &&
+    (!authFlow.requiresApiKey || apiKeyDraft.trim().length > 0) &&
+    requiresUrlParameters;
+  const canSubmitCodeFlow =
+    authFlow != null &&
+    authFlow.kind === "o_auth_code" &&
+    authorizationCodeDraft.trim().length > 0;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          closeSetupDialog();
+        }
+      }}
+      onOpenChangeComplete={(open) => {
+        if (open && provider != null && pendingAutoStartMethod != null) {
+          void beginProviderSetup(provider, pendingAutoStartMethod);
+          setPendingAutoStartMethod(null);
+        }
+      }}
+    >
+      {provider ? (
+        <DialogContent className="max-w-lg" showCloseButton={!isSubmittingAuth}>
+          <DialogHeader>
+            <DialogTitle>{getProviderButtonLabel(provider)} provider</DialogTitle>
+            <DialogDescription>
+              {provider.name}
+              {" · "}
+              {formatAuthMethods(provider)}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-4">
+            {provider.authMethods.length > 1 ? (
+              <div className="flex flex-col gap-2">
+                <Label>Authentication method</Label>
+                <ToggleGroup
+                  variant="outline"
+                  size="sm"
+                  spacing={1}
+                  value={selectedAuthMethod ? [selectedAuthMethod] : []}
+                  onValueChange={(value) => {
+                    const nextAuthMethod =
+                      (value[0] as ProviderAuthMethodKind | undefined) ?? null;
+                    setPendingAutoStartMethod(null);
+                    resetSetupState(nextAuthMethod);
+                  }}
+                >
+                  {getSortedAuthMethods(provider).map((method) => (
+                    <ToggleGroupItem
+                      key={method.kind}
+                      value={method.kind}
+                      aria-label={`Use ${method.label}`}
+                      disabled={isStartingAuth || isSubmittingAuth}
+                    >
+                      {method.label}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
+              </div>
+            ) : null}
+
+            {isStartingAuth && authFlow == null ? (
+              <div className="flex items-center gap-2 rounded-lg border border-border/60 px-3 py-3 text-sm text-muted-foreground">
+                <LoaderCircle className="size-4 animate-spin" strokeWidth={2} />
+                Preparing provider setup...
+              </div>
+            ) : null}
+
+            {provider.authMethods.length > 1 && authFlow == null && !isStartingAuth ? (
+              <div className="rounded-lg border border-border/60 px-3 py-3 text-sm text-muted-foreground">
+                Choose how you want to authenticate, then continue.
+              </div>
+            ) : null}
+
+            {authFlow?.kind === "api_key" ? (
+              <div className="flex flex-col gap-4">
+                {!authFlow.requiresApiKey ? (
+                  <p className="text-sm text-muted-foreground">
+                    Forge will use Google Application Default Credentials from
+                    your local machine.
+                  </p>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="provider-api-key">API key</Label>
+                    <Input
+                      id="provider-api-key"
+                      type="password"
+                      value={apiKeyDraft}
+                      placeholder={authFlow.apiKeyHint ?? "Paste a key"}
+                      onChange={(event) => {
+                        setApiKeyDraft(event.target.value);
+                      }}
+                      disabled={isSubmittingAuth}
+                    />
+                  </div>
+                )}
+
+                {authFlow.urlParameters.length > 0 ? (
+                  <div className="flex flex-col gap-3">
+                    {authFlow.urlParameters.map((parameter) => (
+                      <div key={parameter.name} className="flex flex-col gap-2">
+                        <Label htmlFor={`provider-param-${parameter.name}`}>
+                          {parameter.name}
+                        </Label>
+                        {parameter.options && parameter.options.length > 0 ? (
+                          <Select
+                            value={urlParameterValues[parameter.name] || null}
+                            onValueChange={(value) => {
+                              setUrlParameterValues((current) => ({
+                                ...current,
+                                [parameter.name]: value ?? "",
+                              }));
+                            }}
+                          >
+                            <SelectTrigger
+                              id={`provider-param-${parameter.name}`}
+                              className="w-full"
+                            >
+                              <SelectValue placeholder="Select a value" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectGroup>
+                                {parameter.options.map((option) => (
+                                  <SelectItem key={option} value={option}>
+                                    {option}
+                                  </SelectItem>
+                                ))}
+                              </SelectGroup>
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <Input
+                            id={`provider-param-${parameter.name}`}
+                            value={urlParameterValues[parameter.name] ?? ""}
+                            onChange={(event) => {
+                              setUrlParameterValues((current) => ({
+                                ...current,
+                                [parameter.name]: event.target.value,
+                              }));
+                            }}
+                            disabled={isSubmittingAuth}
+                          />
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+
+            {authFlow?.kind === "device_code" ? (
+              <div className="flex flex-col gap-4">
+                <p className="text-sm text-muted-foreground">
+                  Open the verification page, enter the device code, then
+                  finish setup here.
+                </p>
+                {authFlow.userCode ? (
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="provider-user-code">Device code</Label>
+                    <Input
+                      id="provider-user-code"
+                      readOnly
+                      value={authFlow.userCode}
+                    />
+                  </div>
+                ) : null}
+                {authFlow.verificationUri ? (
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="provider-verification-uri">
+                      Verification URL
+                    </Label>
+                    <Input
+                      id="provider-verification-uri"
+                      readOnly
+                      value={
+                        authFlow.verificationUriComplete ??
+                        authFlow.verificationUri
+                      }
+                    />
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+
+            {authFlow?.kind === "cli_login" ? (
+              <div className="flex flex-col gap-4">
+                <p className="rounded-lg border border-border/60 px-3 py-3 text-sm text-muted-foreground">
+                  {authFlow.apiKeyHint ??
+                    "Login launched in Terminal. Complete the CLI flow there, then finish setup here."}
+                  </p>
+              </div>
+            ) : null}
+
+            {authFlow?.kind === "o_auth_code" ? (
+              <div className="flex flex-col gap-4">
+                <p className="text-sm text-muted-foreground">
+                  Open the auth page. Codegraff will capture the callback and
+                  fill the authorization code automatically. If that does not
+                  happen, paste the returned code here.
+                </p>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="provider-authorization-code">
+                    Authorization code
+                  </Label>
+                  <Input
+                    id="provider-authorization-code"
+                    value={authorizationCodeDraft}
+                    placeholder="Paste the returned code"
+                    onChange={(event) => {
+                      setAuthorizationCodeDraft(event.target.value);
+                    }}
+                    disabled={isSubmittingAuth}
+                  />
+                </div>
+              </div>
+            ) : null}
+
+            {actionError ? (
+              <p className="text-sm text-destructive">{actionError}</p>
+            ) : null}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={closeSetupDialog}
+              disabled={isSubmittingAuth}
+            >
+              Cancel
+            </Button>
+
+            {authFlow?.kind === "device_code" && authFlow.verificationUri ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  void handleOpenUrl(
+                    authFlow.verificationUriComplete ??
+                      authFlow.verificationUri,
+                  );
+                }}
+                disabled={isSubmittingAuth}
+              >
+                <ExternalLinkIcon data-icon="inline-start" />
+                Open browser
+              </Button>
+            ) : null}
+
+            {authFlow?.kind === "o_auth_code" ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  void handleOpenUrl(authFlow.authorizationUrl);
+                }}
+                disabled={isSubmittingAuth}
+              >
+                <ExternalLinkIcon data-icon="inline-start" />
+                Open browser
+              </Button>
+            ) : null}
+
+            {authFlow == null ? (
+              <Button
+                type="button"
+                disabled={selectedAuthMethod == null || isStartingAuth}
+                onClick={() => {
+                  void handleContinueSetup();
+                }}
+              >
+                {isStartingAuth ? (
+                  <LoaderCircle
+                    data-icon="inline-start"
+                    className="animate-spin"
+                  />
+                ) : null}
+                Continue
+              </Button>
+            ) : null}
+
+            {authFlow?.kind === "api_key" ? (
+              <Button
+                type="button"
+                disabled={!canSubmitApiKeyFlow || isSubmittingAuth}
+                onClick={() => {
+                  void handleSubmitSetup();
+                }}
+              >
+                {isSubmittingAuth ? (
+                  <LoaderCircle
+                    data-icon="inline-start"
+                    className="animate-spin"
+                  />
+                ) : null}
+                Save provider
+              </Button>
+            ) : null}
+
+            {authFlow?.kind === "device_code" || authFlow?.kind === "cli_login" ? (
+              <Button
+                type="button"
+                disabled={isSubmittingAuth}
+                onClick={() => {
+                  void handleSubmitSetup();
+                }}
+              >
+                {isSubmittingAuth ? (
+                  <LoaderCircle
+                    data-icon="inline-start"
+                    className="animate-spin"
+                  />
+                ) : null}
+                Finish setup
+              </Button>
+            ) : null}
+
+            {authFlow?.kind === "o_auth_code" ? (
+              <Button
+                type="button"
+                disabled={!canSubmitCodeFlow || isSubmittingAuth}
+                onClick={() => {
+                  void handleSubmitSetup();
+                }}
+              >
+                {isSubmittingAuth ? (
+                  <LoaderCircle
+                    data-icon="inline-start"
+                    className="animate-spin"
+                  />
+                ) : null}
+                Finish setup
+              </Button>
+            ) : null}
+          </DialogFooter>
+        </DialogContent>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/gui/src/components/providers-settings/ProvidersSettingsPane.tsx
+++ b/gui/src/components/providers-settings/ProvidersSettingsPane.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import {
-  ExternalLinkIcon,
   LoaderCircle,
+  RotateCcwIcon,
   SquarePenIcon,
+  TerminalIcon,
   Trash2Icon,
 } from "lucide-react";
 
@@ -12,47 +13,20 @@ import {
 } from "@/app/sessionStore";
 import { useSessionStore } from "@/hooks/useSession";
 import {
-  completeProviderAuth,
-  listProviders,
-  listenProviderOAuthCallback,
-  openExternalUrl,
   openPathForEdit,
   removeProvider,
-  startProviderAuth,
 } from "@/services/desktop/client";
-import type {
-  ProviderAuthMethodKind,
-  ProviderAuthSession,
-  ProviderOAuthCallback,
-  ProviderSummary,
-} from "@/services/desktop/types/contracts";
+import type { ProviderSummary } from "@/services/desktop/types/contracts";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent } from "@/components/ui/Card";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/Dialog";
 import { Input } from "@/components/ui/Input";
-import { Label } from "@/components/ui/Label";
 import { PaneSurface } from "@/components/ui/PaneSurface";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/Select";
 import { Separator } from "@/components/ui/Separator";
 import { Skeleton } from "@/components/ui/Skeleton";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
 
+import { ProviderSetupDialog } from "./ProviderSetupDialog";
+import { useProviderSetup } from "./useProviderSetup";
 import {
-  createUrlParameterValues,
   formatAuthMethods,
   getProviderButtonLabel,
   getSortedAuthMethods,
@@ -65,48 +39,42 @@ function basename(path: string): string {
   return index >= 0 ? path.slice(index + 1) : path;
 }
 
+function envOverrideRemovalError(message: string | null) {
+  if (message == null || !message.includes("credential removed")) {
+    return null;
+  }
+
+  const envKey = message.match(/\$([A-Z0-9_]+_API_KEY)\b/)?.[1] ?? null;
+  if (envKey == null) {
+    return null;
+  }
+
+  const fileMatch = message.match(
+    /still set in ([^,]+), so it is still being used\./,
+  );
+  return {
+    envKey,
+    fileLocation: fileMatch?.[1] ?? null,
+    inheritedByApp: message.includes("inherited by the running Codegraff app"),
+  };
+}
+
 export function ProvidersSettingsPane() {
   const workspacePath = useSessionStore((state) =>
     getUiActiveWorkspacePath(state),
   );
-  const startRequestVersionRef = useRef(0);
-
-  const [providers, setProviders] = useState<ProviderSummary[]>([]);
-  const [providersError, setProvidersError] = useState<string | null>(null);
-  const [isLoadingProviders, setIsLoadingProviders] = useState(true);
+  const providerSetup = useProviderSetup(workspacePath);
   const [searchQuery, setSearchQuery] = useState("");
-
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [dialogProviderId, setDialogProviderId] = useState<string | null>(null);
-  const [pendingAutoStartMethod, setPendingAutoStartMethod] =
-    useState<ProviderAuthMethodKind | null>(null);
-  const [selectedAuthMethod, setSelectedAuthMethod] =
-    useState<ProviderAuthMethodKind | null>(null);
-  const [authFlow, setAuthFlow] = useState<ProviderAuthSession | null>(null);
-  const [apiKeyDraft, setApiKeyDraft] = useState("");
-  const [authorizationCodeDraft, setAuthorizationCodeDraft] = useState("");
-  const [urlParameterValues, setUrlParameterValues] = useState<
-    Record<string, string>
-  >({});
-  const [isStartingAuth, setIsStartingAuth] = useState(false);
-  const [isSubmittingAuth, setIsSubmittingAuth] = useState(false);
   const [removingProviderId, setRemovingProviderId] = useState<string | null>(
     null,
-  );
-  const [actionError, setActionError] = useState<string | null>(null);
-
-  const selectedProvider = useMemo(
-    () =>
-      providers.find((provider) => provider.id === dialogProviderId) ?? null,
-    [dialogProviderId, providers],
   );
   const visibleProviders = useMemo(() => {
     const normalizedQuery = searchQuery.trim().toLowerCase();
     if (normalizedQuery.length === 0) {
-      return providers;
+      return providerSetup.providers;
     }
 
-    return providers.filter((provider) => {
+    return providerSetup.providers.filter((provider) => {
       const searchableText = [
         provider.name,
         provider.id,
@@ -117,230 +85,28 @@ export function ProvidersSettingsPane() {
 
       return searchableText.includes(normalizedQuery);
     });
-  }, [providers, searchQuery]);
-
-  useEffect(() => {
-    let isCancelled = false;
-
-    async function loadProviders() {
-      setIsLoadingProviders(true);
-      setProvidersError(null);
-
-      try {
-        const nextProviders = sortProviders(await listProviders(workspacePath));
-        if (isCancelled) {
-          return;
-        }
-
-        setProviders(nextProviders);
-        setDialogProviderId((current) =>
-          current != null &&
-          nextProviders.some((provider) => provider.id === current)
-            ? current
-            : null,
-        );
-      } catch (error) {
-        if (isCancelled) {
-          return;
-        }
-
-        setProviders([]);
-        setProvidersError(normalizeProviderError(error));
-      } finally {
-        if (!isCancelled) {
-          setIsLoadingProviders(false);
-        }
-      }
-    }
-
-    void loadProviders();
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [workspacePath]);
-
-  function resetSetupState(nextAuthMethod: ProviderAuthMethodKind | null) {
-    startRequestVersionRef.current += 1;
-    setSelectedAuthMethod(nextAuthMethod);
-    setAuthFlow(null);
-    setApiKeyDraft("");
-    setAuthorizationCodeDraft("");
-    setUrlParameterValues({});
-    setIsStartingAuth(false);
-    setIsSubmittingAuth(false);
-    setActionError(null);
-  }
+  }, [providerSetup.providers, searchQuery]);
+  const envRemovalError = useMemo(
+    () => envOverrideRemovalError(providerSetup.providersError),
+    [providerSetup.providersError],
+  );
 
   async function refreshPromptSettings() {
     await ensureWorkspacePromptSettingsLoaded(workspacePath, { force: true });
   }
 
-  async function beginProviderSetup(
-    provider: ProviderSummary,
-    authMethod: ProviderAuthMethodKind,
-  ) {
-    const requestVersion = startRequestVersionRef.current + 1;
-    startRequestVersionRef.current = requestVersion;
-    setIsStartingAuth(true);
-    setActionError(null);
-
-    try {
-      const nextAuthFlow = await startProviderAuth({
-        workspacePath,
-        providerId: provider.id,
-        authMethod,
-      });
-      if (startRequestVersionRef.current !== requestVersion) {
-        return;
-      }
-
-      setAuthFlow(nextAuthFlow);
-      setUrlParameterValues(
-        createUrlParameterValues(nextAuthFlow.urlParameters),
-      );
-      setApiKeyDraft("");
-      setAuthorizationCodeDraft("");
-    } catch (error) {
-      if (startRequestVersionRef.current !== requestVersion) {
-        return;
-      }
-
-      setAuthFlow(null);
-      setActionError(normalizeProviderError(error));
-    } finally {
-      if (startRequestVersionRef.current === requestVersion) {
-        setIsStartingAuth(false);
-      }
-    }
-  }
-
-  useEffect(() => {
-    let isDisposed = false;
-    let unlisten: (() => void) | null = null;
-
-    async function subscribeToOAuthCallbacks() {
-      unlisten = await listenProviderOAuthCallback(
-        (payload: ProviderOAuthCallback) => {
-          if (isDisposed) {
-            return;
-          }
-
-          if (
-            authFlow?.kind !== "o_auth_code" ||
-            payload.authSessionId !== authFlow.authSessionId ||
-            payload.providerId !== dialogProviderId
-          ) {
-            return;
-          }
-
-          if (payload.errorMessage) {
-            setActionError(payload.errorMessage);
-            return;
-          }
-
-          if (payload.authorizationCode) {
-            setAuthorizationCodeDraft(payload.authorizationCode);
-            setActionError(null);
-          }
-        },
-      );
-    }
-
-    void subscribeToOAuthCallbacks();
-
-    return () => {
-      isDisposed = true;
-      if (unlisten) {
-        void unlisten();
-      }
-    };
-  }, [authFlow, dialogProviderId]);
-
-  function closeSetupDialog() {
-    setIsDialogOpen(false);
-    setDialogProviderId(null);
-    setPendingAutoStartMethod(null);
-    resetSetupState(null);
-  }
-
-  function openSetupDialog(provider: ProviderSummary) {
-    const authMethods = getSortedAuthMethods(provider);
-    const nextAuthMethod =
-      authMethods.length === 1 ? (authMethods[0]?.kind ?? null) : null;
-
-    setDialogProviderId(provider.id);
-    setIsDialogOpen(true);
-    setPendingAutoStartMethod(nextAuthMethod);
-    resetSetupState(nextAuthMethod);
-  }
-
-  async function handleContinueSetup() {
-    if (selectedProvider == null || selectedAuthMethod == null) {
-      return;
-    }
-
-    await beginProviderSetup(selectedProvider, selectedAuthMethod);
-  }
-
-  async function handleOpenUrl(url: string | null | undefined) {
-    if (url == null || url.length === 0) {
-      return;
-    }
-
-    try {
-      await openExternalUrl(url);
-    } catch (error) {
-      setActionError(normalizeProviderError(error));
-    }
-  }
-
-  async function handleSubmitSetup() {
-    if (authFlow == null || selectedProvider == null) {
-      return;
-    }
-
-    setIsSubmittingAuth(true);
-    setActionError(null);
-
-    try {
-      const updatedProvider = await completeProviderAuth({
-        authSessionId: authFlow.authSessionId,
-        apiKey: authFlow.requiresApiKey ? apiKeyDraft.trim() : null,
-        authorizationCode: authorizationCodeDraft.trim() || null,
-        urlParameters: authFlow.urlParameters.map((parameter) => ({
-          name: parameter.name,
-          value: urlParameterValues[parameter.name] ?? "",
-        })),
-      });
-
-      setProviders((current) =>
-        sortProviders(
-          current.map((provider) =>
-            provider.id === updatedProvider.id ? updatedProvider : provider,
-          ),
-        ),
-      );
-      await refreshPromptSettings();
-      closeSetupDialog();
-    } catch (error) {
-      setActionError(normalizeProviderError(error));
-      setIsSubmittingAuth(false);
-    }
-  }
-
   async function handleOpenEnvFile(filePath: string) {
-    setProvidersError(null);
+    providerSetup.setProvidersError(null);
     try {
       await openPathForEdit(filePath);
     } catch (error) {
-      setProvidersError(normalizeProviderError(error));
+      providerSetup.setProvidersError(normalizeProviderError(error));
     }
   }
 
   async function handleRemoveProvider(provider: ProviderSummary) {
     setRemovingProviderId(provider.id);
-    setProvidersError(null);
+    providerSetup.setProvidersError(null);
 
     try {
       const updatedProvider = await removeProvider({
@@ -348,7 +114,7 @@ export function ProvidersSettingsPane() {
         providerId: provider.id,
       });
 
-      setProviders((current) =>
+      providerSetup.setProviders((current) =>
         sortProviders(
           current.map((currentProvider) =>
             currentProvider.id === updatedProvider.id
@@ -358,31 +124,12 @@ export function ProvidersSettingsPane() {
         ),
       );
       await refreshPromptSettings();
-
-      if (dialogProviderId === provider.id) {
-        closeSetupDialog();
-      }
     } catch (error) {
-      setProvidersError(normalizeProviderError(error));
+      providerSetup.setProvidersError(normalizeProviderError(error));
     } finally {
       setRemovingProviderId(null);
     }
   }
-
-  const requiresUrlParameters =
-    authFlow?.urlParameters.every(
-      (parameter) =>
-        (urlParameterValues[parameter.name] ?? "").trim().length > 0,
-    ) ?? false;
-  const canSubmitApiKeyFlow =
-    authFlow != null &&
-    authFlow.kind === "api_key" &&
-    (!authFlow.requiresApiKey || apiKeyDraft.trim().length > 0) &&
-    requiresUrlParameters;
-  const canSubmitCodeFlow =
-    authFlow != null &&
-    authFlow.kind === "o_auth_code" &&
-    authorizationCodeDraft.trim().length > 0;
 
   return (
     <PaneSurface className="flex-1" aria-label="Providers settings">
@@ -407,7 +154,7 @@ export function ProvidersSettingsPane() {
                 }}
               />
             </div>
-            {isLoadingProviders ? (
+            {providerSetup.isLoadingProviders ? (
               <div className="flex flex-col gap-0">
                 {[0, 1, 2, 3].map((index) => (
                   <div key={index}>
@@ -422,10 +169,54 @@ export function ProvidersSettingsPane() {
                   </div>
                 ))}
               </div>
-            ) : providersError ? (
-              <div className="px-4 py-4 text-sm text-destructive">
-                {providersError}
-              </div>
+            ) : providerSetup.providersError ? (
+              envRemovalError ? (
+                <div className="px-4 py-4">
+                  <div className="rounded-lg border border-destructive/25 bg-destructive/5 p-4">
+                    <div className="flex items-start gap-3">
+                      <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md bg-background text-destructive shadow-sm">
+                        <RotateCcwIcon className="size-4" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-medium text-foreground">
+                          Restart required
+                        </div>
+                        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+                          Stored credential removed.{" "}
+                          <code className="rounded bg-background px-1 py-0.5 font-mono text-xs text-foreground">
+                            {envRemovalError.envKey}
+                          </code>{" "}
+                          is still active because it was{" "}
+                          {envRemovalError.fileLocation
+                            ? "found in your shell config"
+                            : "inherited when Codegraff started"}
+                          .
+                        </p>
+                        <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                          <span className="inline-flex items-center gap-1.5 rounded-md border border-border/70 bg-background px-2 py-1">
+                            <TerminalIcon className="size-3.5" />
+                            Clear the variable
+                          </span>
+                          <span className="text-muted-foreground/60">then</span>
+                          <span className="inline-flex items-center gap-1.5 rounded-md border border-border/70 bg-background px-2 py-1">
+                            <RotateCcwIcon className="size-3.5" />
+                            Fully quit and reopen Codegraff
+                          </span>
+                        </div>
+                        {envRemovalError.fileLocation ? (
+                          <p className="mt-2 text-xs text-muted-foreground">
+                            Source: {envRemovalError.fileLocation}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="px-4 py-4 text-sm text-destructive">
+                  {providerSetup.providersError}
+                </div>
+              )
             ) : visibleProviders.length === 0 ? (
               <div className="px-4 py-4 text-sm text-muted-foreground">
                 No providers match your search.
@@ -449,7 +240,9 @@ export function ProvidersSettingsPane() {
                         </span>
                         {provider.envOverride ? (
                           <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                            via ${provider.envOverride.envKey}
+                            {provider.envOverride.filePath
+                              ? `via $${provider.envOverride.envKey}`
+                              : `via $${provider.envOverride.envKey} inherited by the running app`}
                             {provider.envOverride.filePath ? (
                               <button
                                 type="button"
@@ -471,7 +264,11 @@ export function ProvidersSettingsPane() {
                                   ? `:${provider.envOverride.line}`
                                   : ""}
                               </button>
-                            ) : null}
+                            ) : (
+                              <span title="No shell startup file currently defines this variable. It was inherited from the terminal or launcher that started Codegraff. Clear that environment variable there, then fully quit and restart Codegraff.">
+                                (source file not found)
+                              </span>
+                            )}
                           </span>
                         ) : null}
                       </div>
@@ -483,7 +280,7 @@ export function ProvidersSettingsPane() {
                           className="shrink-0"
                           disabled={removingProviderId === provider.id}
                           onClick={() => {
-                            openSetupDialog(provider);
+                            providerSetup.openProviderSetup(provider);
                           }}
                         >
                           {getProviderButtonLabel(provider)}
@@ -520,348 +317,14 @@ export function ProvidersSettingsPane() {
           </CardContent>
         </Card>
       </div>
-
-      <Dialog
-        open={isDialogOpen}
-        onOpenChange={(open) => {
-          if (!open) {
-            closeSetupDialog();
-          }
-        }}
-        onOpenChangeComplete={(open) => {
-          if (
-            open &&
-            selectedProvider != null &&
-            pendingAutoStartMethod != null
-          ) {
-            void beginProviderSetup(selectedProvider, pendingAutoStartMethod);
-            setPendingAutoStartMethod(null);
-          }
-        }}
-      >
-        {selectedProvider ? (
-          <DialogContent
-            className="max-w-lg"
-            showCloseButton={!isSubmittingAuth}
-          >
-            <DialogHeader>
-              <DialogTitle>
-                {getProviderButtonLabel(selectedProvider)} provider
-              </DialogTitle>
-              <DialogDescription>
-                {selectedProvider.name}
-                {" · "}
-                {formatAuthMethods(selectedProvider)}
-              </DialogDescription>
-            </DialogHeader>
-
-            <div className="flex flex-col gap-4">
-              {selectedProvider.authMethods.length > 1 ? (
-                <div className="flex flex-col gap-2">
-                  <Label>Authentication method</Label>
-                  <ToggleGroup
-                    variant="outline"
-                    size="sm"
-                    spacing={1}
-                    value={selectedAuthMethod ? [selectedAuthMethod] : []}
-                    onValueChange={(value) => {
-                      const nextAuthMethod =
-                        (value[0] as ProviderAuthMethodKind | undefined) ??
-                        null;
-                      setPendingAutoStartMethod(null);
-                      resetSetupState(nextAuthMethod);
-                    }}
-                  >
-                    {getSortedAuthMethods(selectedProvider).map((method) => (
-                      <ToggleGroupItem
-                        key={method.kind}
-                        value={method.kind}
-                        aria-label={`Use ${method.label}`}
-                        disabled={isStartingAuth || isSubmittingAuth}
-                      >
-                        {method.label}
-                      </ToggleGroupItem>
-                    ))}
-                  </ToggleGroup>
-                </div>
-              ) : null}
-
-              {isStartingAuth && authFlow == null ? (
-                <div className="flex items-center gap-2 rounded-lg border border-border/60 px-3 py-3 text-sm text-muted-foreground">
-                  <LoaderCircle
-                    className="size-4 animate-spin"
-                    strokeWidth={2}
-                  />
-                  Preparing provider setup...
-                </div>
-              ) : null}
-
-              {selectedProvider.authMethods.length > 1 &&
-              authFlow == null &&
-              !isStartingAuth ? (
-                <div className="rounded-lg border border-border/60 px-3 py-3 text-sm text-muted-foreground">
-                  Choose how you want to authenticate, then continue.
-                </div>
-              ) : null}
-
-              {authFlow?.kind === "api_key" ? (
-                <div className="flex flex-col gap-4">
-                  {!authFlow.requiresApiKey ? (
-                    <p className="text-sm text-muted-foreground">
-                      Forge will use Google Application Default Credentials from
-                      your local machine.
-                    </p>
-                  ) : (
-                    <div className="flex flex-col gap-2">
-                      <Label htmlFor="provider-api-key">API key</Label>
-                      <Input
-                        id="provider-api-key"
-                        type="password"
-                        value={apiKeyDraft}
-                        placeholder={authFlow.apiKeyHint ?? "Paste a key"}
-                        onChange={(event) => {
-                          setApiKeyDraft(event.target.value);
-                        }}
-                        disabled={isSubmittingAuth}
-                      />
-                    </div>
-                  )}
-
-                  {authFlow.urlParameters.length > 0 ? (
-                    <div className="flex flex-col gap-3">
-                      {authFlow.urlParameters.map((parameter) => (
-                        <div
-                          key={parameter.name}
-                          className="flex flex-col gap-2"
-                        >
-                          <Label htmlFor={`provider-param-${parameter.name}`}>
-                            {parameter.name}
-                          </Label>
-                          {parameter.options && parameter.options.length > 0 ? (
-                            <Select
-                              value={urlParameterValues[parameter.name] || null}
-                              onValueChange={(value) => {
-                                setUrlParameterValues((current) => ({
-                                  ...current,
-                                  [parameter.name]: value ?? "",
-                                }));
-                              }}
-                            >
-                              <SelectTrigger
-                                id={`provider-param-${parameter.name}`}
-                                className="w-full"
-                              >
-                                <SelectValue placeholder="Select a value" />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectGroup>
-                                  {parameter.options.map((option) => (
-                                    <SelectItem key={option} value={option}>
-                                      {option}
-                                    </SelectItem>
-                                  ))}
-                                </SelectGroup>
-                              </SelectContent>
-                            </Select>
-                          ) : (
-                            <Input
-                              id={`provider-param-${parameter.name}`}
-                              value={urlParameterValues[parameter.name] ?? ""}
-                              onChange={(event) => {
-                                setUrlParameterValues((current) => ({
-                                  ...current,
-                                  [parameter.name]: event.target.value,
-                                }));
-                              }}
-                              disabled={isSubmittingAuth}
-                            />
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
-
-              {authFlow?.kind === "device_code" ? (
-                <div className="flex flex-col gap-4">
-                  <p className="text-sm text-muted-foreground">
-                    Open the verification page, enter the device code, then
-                    finish setup here.
-                  </p>
-                  {authFlow.userCode ? (
-                    <div className="flex flex-col gap-2">
-                      <Label htmlFor="provider-user-code">Device code</Label>
-                      <Input
-                        id="provider-user-code"
-                        readOnly
-                        value={authFlow.userCode}
-                      />
-                    </div>
-                  ) : null}
-                  {authFlow.verificationUri ? (
-                    <div className="flex flex-col gap-2">
-                      <Label htmlFor="provider-verification-uri">
-                        Verification URL
-                      </Label>
-                      <Input
-                        id="provider-verification-uri"
-                        readOnly
-                        value={
-                          authFlow.verificationUriComplete ??
-                          authFlow.verificationUri
-                        }
-                      />
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
-
-              {authFlow?.kind === "o_auth_code" ? (
-                <div className="flex flex-col gap-4">
-                  <p className="text-sm text-muted-foreground">
-                    Open the auth page. Codegraff will capture the callback and
-                    fill the authorization code automatically. If that does not
-                    happen, paste the returned code here.
-                  </p>
-                  <div className="flex flex-col gap-2">
-                    <Label htmlFor="provider-authorization-code">
-                      Authorization code
-                    </Label>
-                    <Input
-                      id="provider-authorization-code"
-                      value={authorizationCodeDraft}
-                      placeholder="Paste the returned code"
-                      onChange={(event) => {
-                        setAuthorizationCodeDraft(event.target.value);
-                      }}
-                      disabled={isSubmittingAuth}
-                    />
-                  </div>
-                </div>
-              ) : null}
-
-              {actionError ? (
-                <p className="text-sm text-destructive">{actionError}</p>
-              ) : null}
-            </div>
-
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={closeSetupDialog}
-                disabled={isSubmittingAuth}
-              >
-                Cancel
-              </Button>
-
-              {authFlow?.kind === "device_code" ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => {
-                    void handleOpenUrl(
-                      authFlow.verificationUriComplete ??
-                        authFlow.verificationUri,
-                    );
-                  }}
-                  disabled={isSubmittingAuth}
-                >
-                  <ExternalLinkIcon data-icon="inline-start" />
-                  Open browser
-                </Button>
-              ) : null}
-
-              {authFlow?.kind === "o_auth_code" ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => {
-                    void handleOpenUrl(authFlow.authorizationUrl);
-                  }}
-                  disabled={isSubmittingAuth}
-                >
-                  <ExternalLinkIcon data-icon="inline-start" />
-                  Open browser
-                </Button>
-              ) : null}
-
-              {authFlow == null ? (
-                <Button
-                  type="button"
-                  disabled={selectedAuthMethod == null || isStartingAuth}
-                  onClick={() => {
-                    void handleContinueSetup();
-                  }}
-                >
-                  {isStartingAuth ? (
-                    <LoaderCircle
-                      data-icon="inline-start"
-                      className="animate-spin"
-                    />
-                  ) : null}
-                  Continue
-                </Button>
-              ) : null}
-
-              {authFlow?.kind === "api_key" ? (
-                <Button
-                  type="button"
-                  disabled={!canSubmitApiKeyFlow || isSubmittingAuth}
-                  onClick={() => {
-                    void handleSubmitSetup();
-                  }}
-                >
-                  {isSubmittingAuth ? (
-                    <LoaderCircle
-                      data-icon="inline-start"
-                      className="animate-spin"
-                    />
-                  ) : null}
-                  Save provider
-                </Button>
-              ) : null}
-
-              {authFlow?.kind === "device_code" ? (
-                <Button
-                  type="button"
-                  disabled={isSubmittingAuth}
-                  onClick={() => {
-                    void handleSubmitSetup();
-                  }}
-                >
-                  {isSubmittingAuth ? (
-                    <LoaderCircle
-                      data-icon="inline-start"
-                      className="animate-spin"
-                    />
-                  ) : null}
-                  Finish setup
-                </Button>
-              ) : null}
-
-              {authFlow?.kind === "o_auth_code" ? (
-                <Button
-                  type="button"
-                  disabled={!canSubmitCodeFlow || isSubmittingAuth}
-                  onClick={() => {
-                    void handleSubmitSetup();
-                  }}
-                >
-                  {isSubmittingAuth ? (
-                    <LoaderCircle
-                      data-icon="inline-start"
-                      className="animate-spin"
-                    />
-                  ) : null}
-                  Finish setup
-                </Button>
-              ) : null}
-            </DialogFooter>
-          </DialogContent>
-        ) : null}
-      </Dialog>
+      <ProviderSetupDialog
+        initialAuthMethod={providerSetup.initialAuthMethod}
+        isOpen={providerSetup.selectedProvider != null}
+        onClose={providerSetup.closeProviderSetup}
+        onProviderUpdated={providerSetup.applyProviderUpdate}
+        provider={providerSetup.selectedProvider}
+        workspacePath={workspacePath}
+      />
     </PaneSurface>
   );
 }

--- a/gui/src/components/providers-settings/useProviderSetup.ts
+++ b/gui/src/components/providers-settings/useProviderSetup.ts
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { listProviders } from "@/services/desktop/client";
+import type {
+  ProviderAuthMethodKind,
+  ProviderSummary,
+} from "@/services/desktop/types/contracts";
+
+import {
+  getSortedAuthMethods,
+  normalizeProviderError,
+  sortProviders,
+} from "./utils/providerAuth";
+
+export function useProviderSetup(workspacePath: string | null) {
+  const [providers, setProviders] = useState<ProviderSummary[]>([]);
+  const [providersError, setProvidersError] = useState<string | null>(null);
+  const [isLoadingProviders, setIsLoadingProviders] = useState(true);
+  const [dialogProviderId, setDialogProviderId] = useState<string | null>(null);
+  const [initialAuthMethod, setInitialAuthMethod] =
+    useState<ProviderAuthMethodKind | null>(null);
+
+  const selectedProvider = useMemo(
+    () =>
+      providers.find((provider) => provider.id === dialogProviderId) ?? null,
+    [dialogProviderId, providers],
+  );
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    async function loadProviders() {
+      setIsLoadingProviders(true);
+      setProvidersError(null);
+
+      try {
+        const nextProviders = sortProviders(await listProviders(workspacePath));
+        if (isCancelled) {
+          return;
+        }
+
+        setProviders(nextProviders);
+        setDialogProviderId((current) =>
+          current != null &&
+          nextProviders.some((provider) => provider.id === current)
+            ? current
+            : null,
+        );
+      } catch (error) {
+        if (isCancelled) {
+          return;
+        }
+
+        setProviders([]);
+        setProvidersError(normalizeProviderError(error));
+      } finally {
+        if (!isCancelled) {
+          setIsLoadingProviders(false);
+        }
+      }
+    }
+
+    void loadProviders();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [workspacePath]);
+
+  function openProviderSetup(
+    providerIdOrProvider: string | ProviderSummary,
+    authMethod?: ProviderAuthMethodKind,
+  ) {
+    const provider =
+      typeof providerIdOrProvider === "string"
+        ? providers.find((item) => item.id === providerIdOrProvider)
+        : providerIdOrProvider;
+    if (provider == null) {
+      return false;
+    }
+
+    const availableAuthMethods = getSortedAuthMethods(provider).map(
+      (method) => method.kind,
+    );
+    const nextAuthMethod =
+      authMethod != null && availableAuthMethods.includes(authMethod)
+        ? authMethod
+        : null;
+
+    setDialogProviderId(provider.id);
+    setInitialAuthMethod(nextAuthMethod);
+    return true;
+  }
+
+  function closeProviderSetup() {
+    setDialogProviderId(null);
+    setInitialAuthMethod(null);
+  }
+
+  function applyProviderUpdate(updatedProvider: ProviderSummary) {
+    setProviders((current) =>
+      sortProviders(
+        current.map((provider) =>
+          provider.id === updatedProvider.id ? updatedProvider : provider,
+        ),
+      ),
+    );
+  }
+
+  return {
+    applyProviderUpdate,
+    closeProviderSetup,
+    initialAuthMethod,
+    isLoadingProviders,
+    openProviderSetup,
+    providers,
+    providersError,
+    selectedProvider,
+    setProviders,
+    setProvidersError,
+  };
+}

--- a/gui/src/components/types/prompt.ts
+++ b/gui/src/components/types/prompt.ts
@@ -33,6 +33,7 @@ export interface PromptInputCardProps {
   placeholder?: string;
   promptSettings: PromptSettings | null;
   promptDraft: string;
+  focusSignal?: number;
   isInputDisabled?: boolean;
   binding?: ChatBinding | null;
   workspacePath?: string | null;

--- a/gui/src/services/desktop/types/contracts.generated.ts
+++ b/gui/src/services/desktop/types/contracts.generated.ts
@@ -76,7 +76,7 @@ export type ProviderUrlParam = { name: string, value: string | null, options: Ar
 
 export type ProviderUrlParamValue = { name: string, value: string, };
 
-export type ProviderAuthSessionKind = "api_key" | "device_code" | "o_auth_code";
+export type ProviderAuthSessionKind = "api_key" | "device_code" | "cli_login" | "o_auth_code";
 
 export type ProviderAuthSession = { kind: ProviderAuthSessionKind, authSessionId: string, requiresApiKey: boolean, apiKeyHint: string | null, urlParameters: Array<ProviderUrlParam>, verificationUri: string | null, verificationUriComplete: string | null, userCode: string | null, expiresInSeconds: bigint | null, authorizationUrl: string | null, };
 


### PR DESCRIPTION
## Summary
- add a first-run onboarding checklist for provider/workspace setup on the new-chat screen
- share provider setup dialog behavior between onboarding and provider settings
- make provider detection and model picker state reflect configured providers only
- persist onboarding completion so the setup card does not appear on every startup

## Verification
- bun test *(clean worktree: source tests passed except two Bun runner module-resolution errors around existing imageThumbnail exports; production build passed)*
- bun run build
- cargo check --no-default-features
- cargo test --no-default-features