### PR TITLE
mcp: /mcp trust — connect skipped workspace servers in-session

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -3831,7 +3831,7 @@ pub fn main(init: std.process.Init) !void {
         if (g_telem) |t| t.errorEvent("mcp", @errorName(err));
         break :inner null;
     }) orelse mcp.Registry.empty(gpa, io)) else outer: {
-        if (mcp_count > 0) try out.print("{s}skipped {d} workspace MCP server(s) — re-run with --yolo to trust this workspace{s}\n", .{ style.dim, mcp_count, style.reset });
+        if (mcp_count > 0) try out.print("{s}skipped {d} workspace MCP server(s) — /mcp trust to connect them now (or re-run with --yolo){s}\n", .{ style.dim, mcp_count, style.reset });
         break :outer mcp.Registry.empty(gpa, io);
     };
     defer registry_storage.deinit();
@@ -4767,7 +4767,7 @@ const command_menu = [_]PickItem{
     .{ .name = "/jobs", .desc = "list background bash jobs (bash run_in_background)" },
     .{ .name = "/cost", .desc = "session usage: api calls, tokens, USD total" },
     .{ .name = "/animation", .desc = "pick the thinking animation (braille, matrix, pacman…)" },
-    .{ .name = "/mcp", .desc = "list/connect MCP servers" },
+    .{ .name = "/mcp", .desc = "list/add/trust MCP servers" },
     .{ .name = "/help", .desc = "list all commands" },
 };
 
@@ -5425,7 +5425,28 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             try out.flush();
             return;
         }
+        if (std.mem.eql(u8, arg, "trust")) {
+            // Connect workspace .mcp.json servers that were skipped at startup
+            // (consent declined / no --yolo), live, without a restart.
+            const n = reg.trustWorkspace(mcp_config_path) catch |err| {
+                try out.print("{s}✗ /mcp trust failed: {t}{s}\n", .{ style.red, err, style.reset });
+                try out.flush();
+                return;
+            };
+            if (n == 0) {
+                try out.writeAll("no untrusted workspace MCP server(s) to connect.\n");
+            } else {
+                // Re-render the tool lists so the new tools reach the model.
+                root.tools_anthropic = try renderRootTools(arena, .anthropic, &root_specs, reg.tools);
+                root.tools_openai = try renderRootTools(arena, .openai, &root_specs, reg.tools);
+                root.tools_responses = try renderRootTools(arena, .responses, &root_specs, reg.tools);
+                try out.print("{s}✓{s} trusted workspace — connected {d} MCP server(s); {d} tool(s) total\n", .{ style.green, style.reset, n, reg.tools.len });
+            }
+            try out.flush();
+            return;
+        }
         // Plain /mcp: list servers (with tool counts) then tools.
+        const pending = reg.pendingWorkspace(mcp_config_path);
         if (reg.servers.len == 0) {
             try out.writeAll("no MCP servers connected.\n  add one: /mcp add <name> <command> [args...]\n  e.g.   /mcp add fs npx -y @modelcontextprotocol/server-filesystem .\n");
         } else {
@@ -5436,6 +5457,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             for (reg.tools) |t| try out.print("    {s}{s}{s}\n", .{ style.dim, t.qualified_name, style.reset });
             try out.writeAll("  add more: /mcp add <name> <command> [args...]\n");
         }
+        if (pending > 0) try out.print("  {s}{d} workspace server(s) not connected — /mcp trust to connect them{s}\n", .{ style.dim, pending, style.reset });
         try out.flush();
         return;
     }
@@ -5586,7 +5608,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         \\  /todo           show the current task list
         \\  /animation      pick the thinking animation (braille/pulse/orbit-dots/block-wave/
         \\                  shimmer/matrix/pacman/starfield/random/off); persists to settings
-        \\  /mcp [add …]    list MCP servers/tools; /mcp add <name> <cmd> [args...] connects one live
+        \\  /mcp [add …]    list MCP servers/tools; /mcp add <name> <cmd> [args...] connects one live; /mcp trust connects skipped workspace servers
         \\  exit / /exit    quit (also: ctrl-d, or ctrl-c on an empty line)
         \\
         \\esc during a response interrupts the turn (what streamed stays in history).

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -149,6 +149,75 @@ pub const Registry = struct {
         return tools.items.len - before;
     }
 
+    /// Connect any workspace `.mcp.json` servers not already running — the
+    /// in-session equivalent of having started with `--yolo`, so a user who
+    /// declined the startup consent prompt can opt in later without a restart.
+    /// Replays the `init` connect path (so per-server `env` is preserved, which
+    /// `addServer` drops), skipping servers already in the registry by name
+    /// (idempotent: won't double-spawn an auto-activated muonry). Returns the
+    /// number of servers newly connected. Caller must re-render its tool list.
+    /// Run between turns only (no tool calls in flight).
+    pub fn trustWorkspace(reg: *Registry, config_path: []const u8) !usize {
+        const a = reg.arena();
+        const text = Io.Dir.cwd().readFileAlloc(reg.io, config_path, a, .limited(1 << 20)) catch |err| switch (err) {
+            error.FileNotFound => return 0,
+            else => return err,
+        };
+        const parsed = try std.json.parseFromSliceLeaky(Value, a, text, .{ .allocate = .alloc_always });
+        if (parsed != .object) return 0;
+        const servers_v = parsed.object.get("mcpServers") orelse return 0;
+        if (servers_v != .object) return 0;
+
+        var servers: std.ArrayList(*Server) = .empty;
+        try servers.appendSlice(a, reg.servers);
+        var tools: std.ArrayList(Tool) = .empty;
+        try tools.appendSlice(a, reg.tools);
+        const before = servers.items.len;
+
+        var it = servers_v.object.iterator();
+        while (it.next()) |entry| {
+            const name = entry.key_ptr.*;
+            if (entry.value_ptr.* != .object) continue;
+            // Already connected (auto-activated muonry, or a prior /mcp trust)? skip.
+            var present = false;
+            for (reg.servers) |s| if (std.mem.eql(u8, s.name, name)) {
+                present = true;
+                break;
+            };
+            if (present) continue;
+            reg.startServer(a, &servers, &tools, try a.dupe(u8, name), entry.value_ptr.*.object) catch |err| {
+                std.debug.print("  [mcp:{s}] failed to start: {t}\n", .{ name, err });
+            };
+        }
+        reg.servers = try a.dupe(*Server, servers.items);
+        reg.tools = try a.dupe(Tool, tools.items);
+        return servers.items.len - before;
+    }
+
+    /// How many workspace `.mcp.json` servers are NOT yet connected — drives
+    /// the `/mcp trust` discoverability hint. Mirrors `trustWorkspace`'s
+    /// skip-by-name logic; best-effort (any read/parse failure → 0).
+    pub fn pendingWorkspace(reg: *Registry, config_path: []const u8) usize {
+        const a = reg.arena();
+        const text = Io.Dir.cwd().readFileAlloc(reg.io, config_path, a, .limited(1 << 20)) catch return 0;
+        const parsed = std.json.parseFromSliceLeaky(Value, a, text, .{ .allocate = .alloc_always }) catch return 0;
+        if (parsed != .object) return 0;
+        const servers_v = parsed.object.get("mcpServers") orelse return 0;
+        if (servers_v != .object) return 0;
+        var n: usize = 0;
+        var it = servers_v.object.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.* != .object) continue;
+            var present = false;
+            for (reg.servers) |s| if (std.mem.eql(u8, s.name, entry.key_ptr.*)) {
+                present = true;
+                break;
+            };
+            if (!present) n += 1;
+        }
+        return n;
+    }
+
     /// Number of tools a given server (by index) contributed — for `/mcp`.
     pub fn toolCount(reg: *Registry, server_index: usize) usize {
         var n: usize = 0;


### PR DESCRIPTION
Declining the startup `.mcp.json` consent prompt left workspace MCP servers skipped, with the only recovery being a full restart with `--yolo`. This adds an in-session `/mcp trust` that re-reads `.mcp.json` and connects the skipped servers live.

## Changes
- **`mcp.zig`** — `Registry.trustWorkspace()` replays the `init` connect path (preserving per-server `env`, which `addServer` drops), idempotent by name so it won't double-spawn an auto-activated muonry. `pendingWorkspace()` counts not-yet-connected entries to drive a hint.
- **`main.zig`** — `/mcp trust` subcommand (re-renders the root tool lists like `/mcp add`); startup skip message, `/mcp` list, and `/help` now point at `/mcp trust`.

## Verification
`zig fmt` clean, `zig build` passes. Drove the REPL end-to-end: decline consent → `/mcp trust` spawns + handshakes codedb (`mcp 2025-06-18`) → `connected 1 MCP server(s); 23 tool(s)`, tools live to the model, no restart.