### PR TITLE
build: bake the telemetry collector URL as the default endpoint

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -23,16 +23,18 @@ pub fn build(b: *std.Build) void {
         else
             b.fmt("0.1.0-dev+{s}", .{described});
     };
-    // Baked-in default OTLP telemetry endpoint for RELEASE builds: when set,
-    // the harness phones usage/evolution telemetry here unless the user
-    // overrides with OTEL_EXPORTER_OTLP_ENDPOINT or opts out
-    // (--no-telemetry / GRAFF_NO_TELEMETRY). Empty in dev builds → silent.
-    // release.sh / install.sh pass the deployed collector URL.
+    // Baked-in default OTLP telemetry endpoint: the harness phones
+    // usage/evolution telemetry here unless the user overrides with
+    // OTEL_EXPORTER_OTLP_ENDPOINT or opts out (--no-telemetry /
+    // GRAFF_NO_TELEMETRY). Hardcoded as the default so every build — release,
+    // source-install, and dev — carries it; `-Dtelemetry-endpoint=""` disables
+    // it at build time. The harness-telemetry worker recomputes the HMAC and
+    // rejects unsigned rows, so this must match the deployed collector.
     const telemetry_endpoint = b.option(
         []const u8,
         "telemetry-endpoint",
-        "default OTLP endpoint baked into release builds (empty = telemetry off unless env-configured)",
-    ) orelse "";
+        "default OTLP endpoint baked into builds (pass \"\" to disable; default = the deployed collector)",
+    ) orelse "https://harness-telemetry.rachpradhan.workers.dev";
     const opts = b.addOptions();
     opts.addOption([]const u8, "version", version);
     opts.addOption([]const u8, "telemetry_endpoint", telemetry_endpoint);


### PR DESCRIPTION
`build.zig` defaulted `telemetry-endpoint` to `""`, so only release-CI builds (which pass `-Dtelemetry-endpoint`) phoned the collector — source-installs and local builds were silent. This hardcodes the deployed collector (`harness-telemetry.rachpradhan.workers.dev`, the same URL `release.yml` already injects) as the default so every build carries tracking.

Still overridable at build time (`-Dtelemetry-endpoint=""`) and at runtime (`--no-telemetry` / `GRAFF_NO_TELEMETRY` / `OTEL_EXPORTER_OTLP_ENDPOINT`).

The `v0.0.12` CLI tarballs have already been rebuilt from this change (telemetry URL verified baked into all 4 targets; checksums updated).