### PR TITLE
gui: revert chat selection when snapshot has no conversation view

### DIFF
--- a/gui/src/app/SessionProvider.test.tsx
+++ b/gui/src/app/SessionProvider.test.tsx
@@ -31,6 +31,10 @@ let handoffChatImpl: (
   input: import("../services/desktop/types/contracts").HandoffChatInput,
 ) => Promise<SessionSnapshot>;
 let openWorkspaceImpl: (workspacePath: string) => Promise<SessionSnapshot>;
+let selectConversationImpl: (
+  workspacePath: string,
+  conversationId: string,
+) => Promise<SessionSnapshot>;
 let renameWorkspaceImpl: (
   workspacePath: string,
   displayName: string | null,
@@ -170,7 +174,7 @@ mock.module("../services/desktop/client", () => ({
   },
   selectConversation: async (workspacePath: string, conversationId: string) => {
     selectConversationCallCount += 1;
-    return createSnapshot(workspacePath, conversationId);
+    return await selectConversationImpl(workspacePath, conversationId);
   },
   sendPrompt: async (
     input: import("../services/desktop/types/contracts").SendPromptInput,
@@ -285,6 +289,10 @@ describe("SessionProvider", () => {
       );
     openWorkspaceImpl = async (workspacePath: string) =>
       createSnapshot(workspacePath, "chat-1");
+    selectConversationImpl = async (
+      workspacePath: string,
+      conversationId: string,
+    ) => createSnapshot(workspacePath, conversationId);
     renameWorkspaceImpl = async (
       workspacePath: string,
       displayName: string | null,
@@ -368,6 +376,96 @@ describe("SessionProvider", () => {
       },
       kind: "single-chat",
     });
+  });
+
+  test("failed conversation selection restores the previous board selection", async () => {
+    sessionStore.getState().setBoardSelection({
+      chat: {
+        conversationId: "chat-1",
+        workspacePath: "/workspace/codegraff-gui",
+      },
+      kind: "single-chat",
+    });
+    selectConversationImpl = async () => {
+      throw new Error("selection failed");
+    };
+
+    let capturedActions: SessionActionsContextValue | null = null;
+
+    function CaptureActions() {
+      capturedActions = useContext(SessionActionsContext);
+      return null;
+    }
+
+    renderToStaticMarkup(
+      <SessionProvider>
+        <CaptureActions />
+      </SessionProvider>,
+    );
+
+    if (capturedActions == null) {
+      throw new Error("Expected session actions to be available");
+    }
+
+    const actions = capturedActions as SessionActionsContextValue;
+
+    await actions.selectConversation("/workspace/other", "chat-9");
+
+    expect(sessionStore.getState().selection).toEqual({
+      chat: {
+        conversationId: "chat-1",
+        workspacePath: "/workspace/codegraff-gui",
+      },
+      kind: "single-chat",
+    });
+  });
+
+  test("stale conversation selection snapshots restore the previous board selection", async () => {
+    sessionStore.getState().setBoardSelection({
+      chat: {
+        conversationId: "chat-1",
+        workspacePath: "/workspace/codegraff-gui",
+      },
+      kind: "single-chat",
+    });
+    selectConversationImpl = async (workspacePath, conversationId) =>
+      createSnapshot(workspacePath, conversationId, {
+        conversationViews: [],
+      });
+
+    let capturedActions: SessionActionsContextValue | null = null;
+
+    function CaptureActions() {
+      capturedActions = useContext(SessionActionsContext);
+      return null;
+    }
+
+    renderToStaticMarkup(
+      <SessionProvider>
+        <CaptureActions />
+      </SessionProvider>,
+    );
+
+    if (capturedActions == null) {
+      throw new Error("Expected session actions to be available");
+    }
+
+    const actions = capturedActions as SessionActionsContextValue;
+
+    await actions.selectConversation("/workspace/other", "chat-9");
+
+    expect(sessionStore.getState().selection).toEqual({
+      chat: {
+        conversationId: "chat-1",
+        workspacePath: "/workspace/codegraff-gui",
+      },
+      kind: "single-chat",
+    });
+    expect(
+      sessionStore.getState().conversationViewsByKey[
+        "/workspace/other::chat-9"
+      ],
+    ).toBeUndefined();
   });
 
   test("stopPrompt targets the active binding", async () => {

--- a/gui/src/app/SessionProvider.test.tsx
+++ b/gui/src/app/SessionProvider.test.tsx
@@ -49,12 +49,14 @@ let lastStopPromptInput:
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
 
-  const promise = new Promise<T>((nextResolve) => {
+  const promise = new Promise<T>((nextResolve, nextReject) => {
     resolve = nextResolve;
+    reject = nextReject;
   });
 
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }
 
 function createSnapshot(
@@ -417,6 +419,61 @@ describe("SessionProvider", () => {
         workspacePath: "/workspace/codegraff-gui",
       },
       kind: "single-chat",
+    });
+  });
+
+  test("failed conversation selection does not overwrite newer navigation", async () => {
+    sessionStore.getState().setBoardSelection({
+      chat: {
+        conversationId: "chat-1",
+        workspacePath: "/workspace/codegraff-gui",
+      },
+      kind: "single-chat",
+    });
+    const selectionRequest = deferred<SessionSnapshot>();
+    selectConversationImpl = async () => await selectionRequest.promise;
+
+    let capturedActions: SessionActionsContextValue | null = null;
+
+    function CaptureActions() {
+      capturedActions = useContext(SessionActionsContext);
+      return null;
+    }
+
+    renderToStaticMarkup(
+      <SessionProvider>
+        <CaptureActions />
+      </SessionProvider>,
+    );
+
+    if (capturedActions == null) {
+      throw new Error("Expected session actions to be available");
+    }
+
+    const actions = capturedActions as SessionActionsContextValue;
+    const selectPromise = actions.selectConversation("/workspace/other", "chat-9");
+
+    expect(sessionStore.getState().selection).toEqual({
+      chat: {
+        conversationId: "chat-9",
+        workspacePath: "/workspace/other",
+      },
+      kind: "single-chat",
+    });
+
+    await actions.startNewChat();
+
+    expect(sessionStore.getState().selection).toEqual({
+      kind: "workspace-draft",
+      workspacePath: "/workspace/managed-chat",
+    });
+
+    selectionRequest.reject(new Error("selection failed"));
+    await selectPromise;
+
+    expect(sessionStore.getState().selection).toEqual({
+      kind: "workspace-draft",
+      workspacePath: "/workspace/managed-chat",
     });
   });
 

--- a/gui/src/app/SessionProvider.tsx
+++ b/gui/src/app/SessionProvider.tsx
@@ -17,6 +17,7 @@ import {
 } from "./sessionClientActions";
 import {
   beginConversationSelectionRequest,
+  areSelectionsEqual,
   ensureConversationViewLoaded,
   ensureWorkspacePromptSettingsLoaded,
   ensureWorkspaceRuntimeStatusLoaded,
@@ -421,13 +422,24 @@ export function SessionProvider({ children }: SessionProviderProps) {
         const previousSelection = sessionStore.getState().selection;
 
         const binding = { conversationId, workspacePath } satisfies ChatBinding;
+        const optimisticSelection = {
+          kind: "single-chat",
+          chat: binding,
+        } as const;
 
         ensureWorkspaceMeta(workspacePath);
 
-        sessionStore.getState().setBoardSelection({
-          kind: "single-chat",
-          chat: binding,
-        });
+        sessionStore.getState().setBoardSelection(optimisticSelection);
+
+        const revertOptimisticSelection = () => {
+          const store = sessionStore.getState();
+          if (
+            isLatestConversationSelectionRequest(requestId) &&
+            areSelectionsEqual(store.selection, optimisticSelection)
+          ) {
+            store.setBoardSelection(previousSelection);
+          }
+        };
 
         try {
           const snapshot = await desktopClient.selectConversation(
@@ -446,16 +458,14 @@ export function SessionProvider({ children }: SessionProviderProps) {
             snapshot.activeConversationId === conversationId &&
             !snapshotHasConversationView(snapshot, binding)
           ) {
-            sessionStore.getState().setBoardSelection(previousSelection);
+            revertOptimisticSelection();
             return;
           }
 
           applySessionSnapshot(snapshot);
           ensureWorkspaceMeta(workspacePath, { forceRuntimeStatus: true });
         } catch {
-          if (isLatestConversationSelectionRequest(requestId)) {
-            sessionStore.getState().setBoardSelection(previousSelection);
-          }
+          revertOptimisticSelection();
           return;
         }
       },

--- a/gui/src/app/SessionProvider.tsx
+++ b/gui/src/app/SessionProvider.tsx
@@ -40,6 +40,17 @@ import { appendAttachmentsToPrompt } from "@/components/attachments/attachmentTy
 import type { SessionProviderProps } from "./types/app";
 import { useSessionBootstrap } from "../hooks/useSessionBootstrap";
 
+function snapshotHasConversationView(
+  snapshot: SessionSnapshot,
+  binding: ChatBinding,
+) {
+  return snapshot.conversationViews.some(
+    (view) =>
+      view.workspacePath === binding.workspacePath &&
+      view.conversationId === binding.conversationId,
+  );
+}
+
 export function SessionProvider({ children }: SessionProviderProps) {
   const activeWorkspacePath = useStore(
     sessionStore,
@@ -407,6 +418,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
         conversationId: string,
       ) => {
         const requestId = beginConversationSelectionRequest();
+        const previousSelection = sessionStore.getState().selection;
 
         const binding = { conversationId, workspacePath } satisfies ChatBinding;
 
@@ -426,9 +438,24 @@ export function SessionProvider({ children }: SessionProviderProps) {
             return;
           }
 
+          // The harness can report the target as active without ever sending its
+          // conversation view (e.g. a draft that was discarded). Selecting it
+          // would leave the board pointing at an empty chat, so revert.
+          if (
+            snapshot.activeWorkspacePath === workspacePath &&
+            snapshot.activeConversationId === conversationId &&
+            !snapshotHasConversationView(snapshot, binding)
+          ) {
+            sessionStore.getState().setBoardSelection(previousSelection);
+            return;
+          }
+
           applySessionSnapshot(snapshot);
           ensureWorkspaceMeta(workspacePath, { forceRuntimeStatus: true });
         } catch {
+          if (isLatestConversationSelectionRequest(requestId)) {
+            sessionStore.getState().setBoardSelection(previousSelection);
+          }
           return;
         }
       },

--- a/gui/src/app/sessionStore.ts
+++ b/gui/src/app/sessionStore.ts
@@ -235,7 +235,7 @@ function buildConversationSummariesByKey(workspaces: WorkspaceSession[]) {
   return byKey;
 }
 
-function areSelectionsEqual(
+export function areSelectionsEqual(
   left: WorkspaceBoardSelection,
   right: WorkspaceBoardSelection,
 ): boolean {


### PR DESCRIPTION
Reverts the chat selection when an incoming snapshot has no conversation view, preventing the UI from getting stuck on a selection that no longer resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)