### PR TITLE
Add `graff update` self-update command

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -3606,7 +3606,10 @@ fn updateCommand(
 
     // Delegate download/codesign/atomic swap to install.sh. Inherit our stdio
     // so its progress (and any sudo prompt) reaches the terminal directly.
-    const cmd = try std.fmt.allocPrint(arena, "curl -fsSL {s} | HARNESS_NO_GRAFF=1 sh", .{install_url});
+    // "set -o pipefail" is required: without it, a failed "curl" is masked
+    // by the right-hand "sh" exiting 0 on EOF, and the pipeline reports
+    // success while installing nothing — silently.
+    const cmd = try std.fmt.allocPrint(arena, "set -o pipefail; curl -fsSL {s} | HARNESS_NO_GRAFF=1 sh", .{install_url});
     var child = std.process.spawn(io, .{ .argv = &.{ "/bin/sh", "-c", cmd } }) catch |err|
         std.process.fatal("update: could not launch installer: {t}", .{err});
     const term = child.wait(io) catch std.process.fatal("update: installer did not exit cleanly", .{});

--- a/src/main.zig
+++ b/src/main.zig
@@ -3764,6 +3764,10 @@ pub fn main(init: std.process.Init) !void {
     // release. Version-checked (skips if already current), reuses install.sh
     // for the actual download/codesign/atomic swap. Exits after.
     if (positionals.items.len > 0 and std.mem.eql(u8, positionals.items[0], "update")) {
+        // --check never installs, so --force has no effect on it — reject the
+        // contradictory combination up front rather than silently ignoring one.
+        if (update_force and update_check)
+            std.process.fatal("--force and --check are mutually exclusive — use `graff update` (without --check) to install", .{});
         try updateCommand(io, gpa, arena, init.environ_map, update_force, update_check);
         return;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -3531,6 +3531,59 @@ const usage_text =
     \\
 ;
 
+/// A parsed `MAJOR.MINOR.PATCH` (no pre-release/build suffix). Used to compare
+/// the running version against a GitHub release tag without the exact-string
+/// mismatch that `git describe` suffixes ("-3-gabc", "-dirty", "-dev") cause.
+const Version = struct {
+    major: u32,
+    minor: u32,
+    patch: u32,
+
+    fn eql(self: Version, other: Version) bool {
+        return self.major == other.major and self.minor == other.minor and self.patch == other.patch;
+    }
+
+    fn order(self: Version, other: Version) std.math.Order {
+        if (self.major != other.major) return std.math.order(self.major, other.major);
+        if (self.minor != other.minor) return std.math.order(self.minor, other.minor);
+        return std.math.order(self.patch, other.patch);
+    }
+};
+
+/// Parse a leading `MAJOR.MINOR.PATCH` from `s` (after any leading 'v' is
+/// stripped by the caller). Returns null if the numeric triple isn't present.
+fn parseVersion(s: []const u8) ?Version {
+    var it = std.mem.splitScalar(u8, s, '.');
+    const major_s = it.next() orelse return null;
+    const minor_s = it.next() orelse return null;
+    const patch_s = it.next() orelse return null;
+    // Each component must be all digits up to the next '.' (or end). `patch`
+    // may trail a pre-release suffix ("-3-gabc", "-dev"); take only the leading
+    // digits so "0.0.14-3-gabc" parses as 0.0.14.
+    const major = std.fmt.parseInt(u32, major_s, 10) catch return null;
+    const minor = std.fmt.parseInt(u32, minor_s, 10) catch return null;
+    const patch_digits = std.mem.indexOfAny(u8, patch_s, "-+") orelse patch_s.len;
+    const patch = std.fmt.parseInt(u32, patch_s[0..patch_digits], 10) catch return null;
+    return .{ .major = major, .minor = minor, .patch = patch };
+}
+
+/// True when `s` is a bare release version with no `git describe` suffix — i.e.
+/// exactly `MAJOR.MINOR.PATCH` (optionally 'v'-prefixed), no "-N-gHASH",
+/// "-dirty", "-dev", or "+build". A dev/dirty/commit-ahead build is not a clean
+/// release and shouldn't be silently "updated" (downgraded) to an older tag.
+fn isCleanReleaseVersion(s: []const u8) bool {
+    if (s.len == 0) return false;
+    var dots: u8 = 0;
+    for (s) |c| {
+        switch (c) {
+            '0'...'9' => {},
+            '.' => dots += 1,
+            else => return false, // any '-','+','g',... means it's not a bare tag
+        }
+    }
+    return dots == 2;
+}
+
 /// `graff update [--force|--check]` — bring the installed binary up to the
 /// latest GitHub release. Checks the release tag first and skips when already
 /// current (unless --force); --check only reports, never installs. The actual
@@ -3554,8 +3607,19 @@ fn updateCommand(
     var ow = Io.File.stdout().writer(io, &obuf);
     const out = &ow.interface;
 
-    // current version, leading 'v' stripped so the comparison ignores tag style
-    const cur = std.mem.trimStart(u8, harness_version, "v");
+    // current version, leading 'v' stripped so the comparison ignores tag style.
+    const cur_raw = if (std.mem.startsWith(u8, harness_version, "v")) harness_version[1..] else harness_version;
+
+    // A release tag is a bare "MAJOR.MINOR.PATCH". A dev/dirty/commit-ahead
+    // build (from `git describe --tags --always --dirty`) carries a suffix
+    // ("-3-gabc", "-dirty", "-dev+hash", "0.1.0-dev") and is NOT a clean
+    // release version. Comparing such a string against a release tag with exact
+    // equality always mismatched, so `graff update` would "update" (downgrade)
+    // a newer dev build to an older release, and `--check` always reported an
+    // update available. Parse the leading numeric triple instead, and refuse to
+    // act on a non-release local build rather than silently downgrading it.
+    const cur = parseVersion(cur_raw);
+    const cur_is_release = cur != null and isCleanReleaseVersion(cur_raw);
 
     // Query the latest release tag. GitHub's API requires a User-Agent; the
     // Accept header pins the v3 JSON response. Any failure → null, handled below.
@@ -3563,6 +3627,7 @@ fn updateCommand(
         var client: std.http.Client = .{ .allocator = gpa, .io = io };
         defer client.deinit();
         var aw: Io.Writer.Allocating = .init(arena);
+        defer aw.deinit();
         const extra = [_]std.http.Header{.{ .name = "Accept", .value = "application/vnd.github+json" }};
         const res = client.fetch(.{
             .location = .{ .url = repo_api },
@@ -3572,29 +3637,65 @@ fn updateCommand(
             .extra_headers = &extra,
         }) catch break :blk null;
         if (@intFromEnum(res.status) != 200) break :blk null;
+        // Cap the response before parsing: the endpoint is pinned to GitHub's
+        // API (normally a small JSON blob), but a captive-portal redirect or a
+        // TLS MITM could stream an unbounded body and exhaust memory. 64 KiB is
+        // far above any legitimate /releases/latest payload.
+        if (aw.writer.buffered().len > 64 * 1024) break :blk null;
         const v = std.json.parseFromSliceLeaky(Value, arena, aw.writer.buffered(), .{ .allocate = .alloc_always }) catch break :blk null;
         if (v != .object) break :blk null;
         const t = v.object.get("tag_name") orelse break :blk null;
         break :blk if (t == .string) t.string else null;
     };
 
-    if (latest_tag) |tag| {
-        const latest = std.mem.trimStart(u8, tag, "v");
-        const up_to_date = std.mem.eql(u8, cur, latest);
+    // `latest` is a release tag from GitHub, so it parses to a clean triple.
+    const latest_raw = if (latest_tag) |tag| (if (std.mem.startsWith(u8, tag, "v")) tag[1..] else tag) else null;
+    const latest = if (latest_raw) |r| parseVersion(r) else null;
+
+    if (latest_tag != null and latest == null) {
+        // The release endpoint returned a tag we couldn't parse — treat like a
+        // failed check rather than guessing.
+        if (check_only) std.process.fatal("update check failed — unparseable release tag '{s}'", .{latest_tag.?});
+        try out.print("could not parse latest release tag '{s}'; running installer anyway…\n", .{latest_tag.?});
+    } else if (latest != null) {
+        const up_to_date = cur != null and cur.?.eql(latest.?);
+        const cur_newer = cur != null and cur.?.order(latest.?) == .gt;
+
         if (check_only) {
-            if (up_to_date)
-                try out.print("graff is up to date (v{s})\n", .{cur})
-            else
-                try out.print("update available: v{s} → v{s}  (run `graff update`)\n", .{ cur, latest });
+            if (cur_is_release and up_to_date) {
+                try out.print("graff is up to date (v{s})\n", .{cur_raw});
+            } else if (cur_is_release and cur_newer) {
+                try out.print("graff v{s} is newer than latest release v{s} — not downgrading\n", .{ cur_raw, latest_raw.? });
+            } else if (cur_is_release) {
+                // Release build older than latest.
+                try out.print("update available: v{s} → v{s}  (run `graff update`)\n", .{ cur_raw, latest_raw.? });
+            } else if (cur_newer) {
+                // Dev/dirty build whose base version is ahead of the latest release.
+                try out.print("local build v{s} is newer than latest release v{s} — not a release build; no update needed\n", .{ cur_raw, latest_raw.? });
+            } else {
+                // Dev/dirty build at or below the release version: installing the
+                // release is reasonable if the user wants it.
+                try out.print("update available: v{s} → v{s}  (local build {s} is not a release; run `graff update` to install the release)\n", .{ cur_raw, latest_raw.?, cur_raw });
+            }
             try out.flush();
             return;
         }
-        if (up_to_date and !force) {
-            try out.print("graff is already up to date (v{s})\n", .{cur});
+
+        // Install path.
+        if (up_to_date and cur_is_release and !force) {
+            try out.print("graff is already up to date (v{s})\n", .{cur_raw});
             try out.flush();
             return;
         }
-        try out.print("updating graff v{s} → v{s}…\n", .{ cur, latest });
+        // Refuse to downgrade a build whose version is strictly ahead of the
+        // latest release without --force (applies to both release and dev builds
+        // — installing would replace a newer version with an older one).
+        if (cur_newer and !force) {
+            try out.print("graff v{s} is newer than latest release v{s} — not downgrading (use --force to override)\n", .{ cur_raw, latest_raw.? });
+            try out.flush();
+            return;
+        }
+        try out.print("updating graff v{s} → v{s}…\n", .{ cur_raw, latest_raw.? });
     } else {
         // Version check failed (offline / rate-limited / bad response). For
         // --check that's a hard error; otherwise fall through to the installer,
@@ -3609,12 +3710,18 @@ fn updateCommand(
     // "set -o pipefail" is required: without it, a failed "curl" is masked
     // by the right-hand "sh" exiting 0 on EOF, and the pipeline reports
     // success while installing nothing — silently.
-    const cmd = try std.fmt.allocPrint(arena, "set -o pipefail; curl -fsSL {s} | HARNESS_NO_GRAFF=1 sh", .{install_url});
-    var child = std.process.spawn(io, .{ .argv = &.{ "/bin/sh", "-c", cmd } }) catch |err|
+    //
+    // `install_url` is user-controllable via GRAFF_INSTALL_URL / HARNESS_INSTALL_URL,
+    // so it MUST NOT be interpolated into the sh -c string (shell injection).
+    // Pass it as positional $1 instead — the shell never re-parses it and curl
+    // receives it verbatim.
+    var child = std.process.spawn(io, .{
+        .argv = &.{ "/bin/sh", "-c", "set -o pipefail; curl -fsSL \"$1\" | HARNESS_NO_GRAFF=1 sh", "sh", install_url },
+    }) catch |err|
         std.process.fatal("update: could not launch installer: {t}", .{err});
     const term = child.wait(io) catch std.process.fatal("update: installer did not exit cleanly", .{});
     if (term != .exited or term.exited != 0)
-        std.process.fatal("update: installer failed — re-run: curl -fsSL {s} | sh", .{install_url});
+        std.process.fatal("update: installer failed — try again or download manually from https://github.com/justrach/codegraff/releases/latest", .{});
 }
 
 pub fn main(init: std.process.Init) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3504,6 +3504,7 @@ const usage_text =
     \\  graff --schema                   print the machine-readable interface (SDK codegen)
     \\  graff serve                      HTTP/NDJSON bridge over the --json protocol
     \\                                   (--host/--port/--token; sessions are --json children)
+    \\  graff update [--force|--check]   update graff to the latest GitHub release
     \\
     \\flags:
     \\  --model <name>   start on this model (same fuzzy resolution as /model)
@@ -3530,6 +3531,89 @@ const usage_text =
     \\
 ;
 
+/// `graff update [--force|--check]` — bring the installed binary up to the
+/// latest GitHub release. Checks the release tag first and skips when already
+/// current (unless --force); --check only reports, never installs. The actual
+/// download, codesign, and atomic binary swap are delegated to install.sh
+/// (curl | sh) — that platform-specific logic already lives there, so we don't
+/// reimplement it. HARNESS_NO_GRAFF=1 keeps the installer from also pulling in
+/// the companion suite: an update touches only graff itself.
+fn updateCommand(
+    io: Io,
+    gpa: Allocator,
+    arena: Allocator,
+    environ: *const std.process.Environ.Map,
+    force: bool,
+    check_only: bool,
+) !void {
+    const repo_api = "https://api.github.com/repos/justrach/codegraff/releases/latest";
+    const install_url = environ.get("GRAFF_INSTALL_URL") orelse environ.get("HARNESS_INSTALL_URL") orelse
+        "https://github.com/justrach/codegraff/releases/latest/download/install.sh";
+
+    var obuf: [4096]u8 = undefined;
+    var ow = Io.File.stdout().writer(io, &obuf);
+    const out = &ow.interface;
+
+    // current version, leading 'v' stripped so the comparison ignores tag style
+    const cur = std.mem.trimStart(u8, harness_version, "v");
+
+    // Query the latest release tag. GitHub's API requires a User-Agent; the
+    // Accept header pins the v3 JSON response. Any failure → null, handled below.
+    const latest_tag: ?[]const u8 = blk: {
+        var client: std.http.Client = .{ .allocator = gpa, .io = io };
+        defer client.deinit();
+        var aw: Io.Writer.Allocating = .init(arena);
+        const extra = [_]std.http.Header{.{ .name = "Accept", .value = "application/vnd.github+json" }};
+        const res = client.fetch(.{
+            .location = .{ .url = repo_api },
+            .method = .GET,
+            .response_writer = &aw.writer,
+            .headers = .{ .user_agent = .{ .override = "simple-harness/" ++ harness_version } },
+            .extra_headers = &extra,
+        }) catch break :blk null;
+        if (@intFromEnum(res.status) != 200) break :blk null;
+        const v = std.json.parseFromSliceLeaky(Value, arena, aw.writer.buffered(), .{ .allocate = .alloc_always }) catch break :blk null;
+        if (v != .object) break :blk null;
+        const t = v.object.get("tag_name") orelse break :blk null;
+        break :blk if (t == .string) t.string else null;
+    };
+
+    if (latest_tag) |tag| {
+        const latest = std.mem.trimStart(u8, tag, "v");
+        const up_to_date = std.mem.eql(u8, cur, latest);
+        if (check_only) {
+            if (up_to_date)
+                try out.print("graff is up to date (v{s})\n", .{cur})
+            else
+                try out.print("update available: v{s} → v{s}  (run `graff update`)\n", .{ cur, latest });
+            try out.flush();
+            return;
+        }
+        if (up_to_date and !force) {
+            try out.print("graff is already up to date (v{s})\n", .{cur});
+            try out.flush();
+            return;
+        }
+        try out.print("updating graff v{s} → v{s}…\n", .{ cur, latest });
+    } else {
+        // Version check failed (offline / rate-limited / bad response). For
+        // --check that's a hard error; otherwise fall through to the installer,
+        // which fetches the latest release on its own.
+        if (check_only) std.process.fatal("update check failed — could not reach GitHub", .{});
+        try out.writeAll("could not determine latest version; running installer anyway…\n");
+    }
+    try out.flush();
+
+    // Delegate download/codesign/atomic swap to install.sh. Inherit our stdio
+    // so its progress (and any sudo prompt) reaches the terminal directly.
+    const cmd = try std.fmt.allocPrint(arena, "curl -fsSL {s} | HARNESS_NO_GRAFF=1 sh", .{install_url});
+    var child = std.process.spawn(io, .{ .argv = &.{ "/bin/sh", "-c", cmd } }) catch |err|
+        std.process.fatal("update: could not launch installer: {t}", .{err});
+    const term = child.wait(io) catch std.process.fatal("update: installer did not exit cleanly", .{});
+    if (term != .exited or term.exited != 0)
+        std.process.fatal("update: installer failed — re-run: curl -fsSL {s} | sh", .{install_url});
+}
+
 pub fn main(init: std.process.Init) !void {
     const gpa = init.gpa;
     const io = init.io;
@@ -3547,6 +3631,8 @@ pub fn main(init: std.process.Init) !void {
     var help_flag = false;
     var version_flag = false;
     var print_flag = false;
+    var update_force = false; // graff update --force
+    var update_check = false; // graff update --check
     var model_flag: ?[]const u8 = null;
     var system_prompt_flag: ?[]const u8 = null;
     var append_system_flag: ?[]const u8 = null;
@@ -3580,6 +3666,10 @@ pub fn main(init: std.process.Init) !void {
                     version_flag = true;
                 } else if (std.mem.eql(u8, arg, "--print") or std.mem.eql(u8, arg, "-p")) {
                     print_flag = true;
+                } else if (std.mem.eql(u8, arg, "--force")) {
+                    update_force = true;
+                } else if (std.mem.eql(u8, arg, "--check")) {
+                    update_check = true;
                 } else if (std.mem.eql(u8, arg, "--model")) {
                     const mv = it.next() orelse std.process.fatal("--model needs a value — harness --help", .{});
                     model_flag = try arena.dupe(u8, mv);
@@ -3614,7 +3704,7 @@ pub fn main(init: std.process.Init) !void {
     // (`harness "say hi"`). Subcommands (login/key) are not prompts.
     const is_subcommand = positionals.items.len > 0 and
         (std.mem.eql(u8, positionals.items[0], "login") or std.mem.eql(u8, positionals.items[0], "key") or
-            std.mem.eql(u8, positionals.items[0], "serve"));
+            std.mem.eql(u8, positionals.items[0], "serve") or std.mem.eql(u8, positionals.items[0], "update"));
     var oneshot_prompt: ?[]const u8 = null;
     if (!is_subcommand and positionals.items.len > 0) {
         oneshot_prompt = try std.mem.join(arena, " ", positionals.items);
@@ -3664,6 +3754,14 @@ pub fn main(init: std.process.Init) !void {
             .system_prompt = system_prompt_flag,
             .append_system_prompt = append_system_flag,
         }, exe);
+        return;
+    }
+
+    // `harness update [--force|--check]`: self-update to the latest GitHub
+    // release. Version-checked (skips if already current), reuses install.sh
+    // for the actual download/codesign/atomic swap. Exits after.
+    if (positionals.items.len > 0 and std.mem.eql(u8, positionals.items[0], "update")) {
+        try updateCommand(io, gpa, arena, init.environ_map, update_force, update_check);
         return;
     }
 


### PR DESCRIPTION
## What

Adds a version-checked `graff update` subcommand that upgrades the installed binary from the latest GitHub release.

- `graff update` — queries the GitHub releases API, compares the latest tag to the running version, and **skips with "already up to date" when current**. Otherwise it delegates the download/codesign/atomic binary swap to the existing `install.sh` (`curl … | sh`) rather than reimplementing that platform-specific logic. Runs the installer with `HARNESS_NO_GRAFF=1` so an update touches only `graff`, not the companion suite.
- `graff update --force` — reinstall even if already current.
- `graff update --check` — report availability only; install nothing.
- Install URL overridable via `GRAFF_INSTALL_URL` / `HARNESS_INSTALL_URL`.

Follows standard CLI self-update conventions (`deno upgrade` / `bun upgrade` / `rustup update`): explicit command, version-checked, no silent startup auto-update.

## Implementation

~99 lines in `src/main.zig`: a new `updateCommand` function plus dispatch/flag/usage wiring. Reuses existing patterns — the GET-with-User-Agent from `rawFetch`, the JSON parse from `oauthTokenPost`, and the spawn+wait from the skill installer.

## Verification

- `zig build` clean.
- `graff --help` shows the new `update` line.
- `graff update --check` (dev build) → `update available: v0.0.12… → v0.0.13`, exit 0, nothing installed.
- Version-pinned build (`-Dversion=0.0.13`) → `graff update` prints "already up to date" and does **not** spawn the installer; `--check` agrees. Exit 0.

Not exercised live: the actual `--force` install (would replace the running binary) and the offline-failure path (network couldn't be cut here; code catches fetch/parse errors → `--check` exits via `fatal`, plain `update` warns and falls through to the installer).

## Note for reviewers

The version compare is exact-string equality after stripping a leading `v` — it answers "is this exactly the latest release," not semver ordering. Matches intended usage; a true "only upgrade, never downgrade" check would need semver comparison.