### PR TITLE
Add /bash and show current folder in prompt

### DIFF
--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -403,6 +403,7 @@ impl RuntimeManager {
         Ok(vec![
             command("help", "Show available commands.", false),
             command("agent", "Show active agent.", false),
+            command("pwd", "Show current workspace path.", true),
             command("compact", "Compact current conversation.", true),
             command("workspace-status", "Show git status.", true),
         ])
@@ -1067,6 +1068,20 @@ impl RuntimeManager {
                 result_kind: CommandResultKindDto::Snapshot,
                 payload: None,
             }),
+            "pwd" => {
+                let workspace = self
+                    .resolve_workspace(workspace_path)
+                    .await
+                    .context("Missing workspace")?;
+                Ok(CommandRunResultDto {
+                    title: "/pwd".into(),
+                    body: Some(workspace),
+                    snapshot: None,
+                    saved_path: None,
+                    result_kind: CommandResultKindDto::Text,
+                    payload: None,
+                })
+            }
             "workspace-status" => {
                 let workspace = workspace_path.unwrap_or_default();
                 Ok(CommandRunResultDto {
@@ -1086,7 +1101,7 @@ impl RuntimeManager {
             _ => Ok(CommandRunResultDto {
                 title: format!("/{name}"),
                 body: Some(format!(
-                    "Available MVP commands: /help, /agent, /compact, /workspace-status. Args: {}",
+                    "Available MVP commands: /help, /agent, /pwd, /compact, /workspace-status. Args: {}",
                     args.join(" ")
                 )),
                 snapshot: None,
@@ -2674,7 +2689,11 @@ fn codegraff_binary() -> String {
             }
         }
     }
-    for abs in ["/opt/homebrew/bin/graff", "/usr/local/bin/graff", "/usr/bin/graff"] {
+    for abs in [
+        "/opt/homebrew/bin/graff",
+        "/usr/local/bin/graff",
+        "/usr/bin/graff",
+    ] {
         if Path::new(abs).is_file() {
             return abs.to_string();
         }

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -403,7 +403,7 @@ impl RuntimeManager {
         Ok(vec![
             command("help", "Show available commands.", false),
             command("agent", "Show active agent.", false),
-            command("pwd", "Show current workspace path.", true),
+            bash_command(),
             command("compact", "Compact current conversation.", true),
             command("workspace-status", "Show git status.", true),
         ])
@@ -1068,14 +1068,25 @@ impl RuntimeManager {
                 result_kind: CommandResultKindDto::Snapshot,
                 payload: None,
             }),
-            "pwd" => {
+            "bash" => {
                 let workspace = self
                     .resolve_workspace(workspace_path)
                     .await
                     .context("Missing workspace")?;
+                let shell_command = args.join(" ").trim().to_string();
+                if shell_command.is_empty() {
+                    return Ok(CommandRunResultDto {
+                        title: "/bash".into(),
+                        body: Some("usage: /bash <command>".into()),
+                        snapshot: None,
+                        saved_path: None,
+                        result_kind: CommandResultKindDto::Text,
+                        payload: None,
+                    });
+                }
                 Ok(CommandRunResultDto {
-                    title: "/pwd".into(),
-                    body: Some(workspace),
+                    title: format!("/bash {shell_command}"),
+                    body: Some(run_shell_command(&workspace, &shell_command)?),
                     snapshot: None,
                     saved_path: None,
                     result_kind: CommandResultKindDto::Text,
@@ -1101,7 +1112,7 @@ impl RuntimeManager {
             _ => Ok(CommandRunResultDto {
                 title: format!("/{name}"),
                 body: Some(format!(
-                    "Available MVP commands: /help, /agent, /pwd, /compact, /workspace-status. Args: {}",
+                    "Available MVP commands: /help, /agent, /bash <command>, /compact, /workspace-status. Args: {}",
                     args.join(" ")
                 )),
                 snapshot: None,
@@ -2187,6 +2198,13 @@ fn command(name: &str, usage: &str, requires_workspace: bool) -> CommandDescript
     }
 }
 
+fn bash_command() -> CommandDescriptorDto {
+    CommandDescriptorDto {
+        argument_hint: Some("<command>".into()),
+        ..command("bash", "Run a shell command in the workspace.", true)
+    }
+}
+
 /// Spawns a persistent `graff --json` child for a conversation. `--yolo` skips
 /// permission prompts (the GUI has no approval surface yet); stderr is discarded
 /// since the protocol carries errors as `error` events on stdout.
@@ -3218,6 +3236,51 @@ fn title_from_prompt(prompt: &str) -> String {
 fn is_placeholder_title(title: &str) -> bool {
     let title = title.trim();
     title.is_empty() || title.eq_ignore_ascii_case("New chat")
+}
+
+fn run_shell_command(workspace_path: &str, shell_command: &str) -> Result<String> {
+    let output = Command::new("/bin/sh")
+        .args(["-c", shell_command])
+        .current_dir(workspace_path)
+        .output()
+        .with_context(|| format!("Failed to run shell command in {workspace_path}"))?;
+    Ok(format_command_output(&output))
+}
+
+fn format_command_output(output: &std::process::Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let mut text = String::new();
+    if !stdout.is_empty() {
+        text.push_str(&stdout);
+    }
+    if !stderr.is_empty() {
+        if !text.is_empty() && !text.ends_with('\n') {
+            text.push('\n');
+        }
+        text.push_str("[stderr]\n");
+        text.push_str(&stderr);
+    }
+    match output.status.code() {
+        Some(0) => {}
+        Some(code) => {
+            if !text.is_empty() && !text.ends_with('\n') {
+                text.push('\n');
+            }
+            text.push_str(&format!("[exit code {code}]"));
+        }
+        None => {
+            if !text.is_empty() && !text.ends_with('\n') {
+                text.push('\n');
+            }
+            text.push_str("[terminated abnormally]");
+        }
+    }
+    if text.is_empty() {
+        "(no output)".into()
+    } else {
+        text
+    }
 }
 
 fn git_status_files(workspace_path: &str) -> Result<Vec<WorkspaceFileStatusDto>> {

--- a/gui/src/hooks/useCommandRouter.ts
+++ b/gui/src/hooks/useCommandRouter.ts
@@ -18,6 +18,7 @@ const ARG_COMMANDS = new Set([
   "workspace-query",
   "workspace-search",
   "workflow",
+  "bash",
   "reasoning-effort",
 ]);
 
@@ -35,10 +36,11 @@ function parseSlashCommand(draft: string): ParsedCommand | null {
   if (match == null) {
     return null;
   }
+  const name = match[1];
   const rest = match[2]?.trim() ?? "";
   return {
-    name: match[1],
-    args: rest.length > 0 ? rest.split(/\s+/) : [],
+    name,
+    args: rest.length > 0 ? (name === "bash" ? [rest] : rest.split(/\s+/)) : [],
   };
 }
 

--- a/gui/src/services/desktop/client.ts
+++ b/gui/src/services/desktop/client.ts
@@ -70,7 +70,7 @@ const qaCommandRows: Array<[
 ]> = [
   ["help", "Show available slash commands.", null, "text"],
   ["agent", "Show active agent and available agents.", null, "agents"],
-  ["pwd", "Show current workspace path.", null, "text"],
+  ["bash", "Run a shell command in the workspace.", "<command>", "text"],
   ["sage", "Switch to Sage.", null, "agents"],
   ["reasoning-effort", "Update reasoning effort.", "<low|medium|high>", "text"],
   ["workspace-info", "Show indexed workspace metadata.", null, "workspaceInfo"],
@@ -100,7 +100,7 @@ const qaCommands: CommandDescriptor[] = qaCommandRows.map(
             : "builtin",
       name,
       requiresConversation: false,
-      requiresWorkspace: name === "pwd" || name.startsWith("workspace-"),
+      requiresWorkspace: name === "bash" || name.startsWith("workspace-"),
       resultKind,
       usage,
       value: name === "sage" ? "sage" : null,
@@ -228,11 +228,13 @@ function qaCommandResult(input: {
 
   switch (input.name) {
     case "help":
-      return { body: "| Command | What it does | UI expectation |\n|---|---|---|\n| `/help` | Lists commands | Inline table |\n| `/agent` | Shows current agent | Inline cards |\n| `/pwd` | Shows current workspace folder | Inline text |\n| `/workspace-info` | Shows metadata | Inline markdown/table |\n| `/workflow <goal>` | Builds a workflow draft | Review modal |", payload: null, resultKind: "text", savedPath: null, snapshot: null, title: "/help" };
+      return { body: "| Command | What it does | UI expectation |\n|---|---|---|\n| `/help` | Lists commands | Inline table |\n| `/agent` | Shows current agent | Inline cards |\n| `/bash <command>` | Runs a workspace shell command | Inline text |\n| `/workspace-info` | Shows metadata | Inline markdown/table |\n| `/workflow <goal>` | Builds a workflow draft | Review modal |", payload: null, resultKind: "text", savedPath: null, snapshot: null, title: "/help" };
     case "agent":
       return { body: "Current agent status.", payload: { kind: "agents", ...qaAgentsPayload() }, resultKind: "agents", savedPath: null, snapshot: null, title };
-    case "pwd":
-      return { body: input.workspacePath ?? QA_WORKSPACE_PATH, payload: null, resultKind: "text", savedPath: null, snapshot: null, title: "/pwd" };
+    case "bash": {
+      const command = input.args.join(" ").trim();
+      return { body: command.length > 0 ? `QA mock did not execute shell command:\n\n$ ${command}` : "usage: /bash <command>", payload: null, resultKind: "text", savedPath: null, snapshot: null, title: command.length > 0 ? `/bash ${command}` : "/bash" };
+    }
     case "sage":
       qaActiveAgentId = "sage";
       return { body: "Switched active agent to Sage.", payload: { kind: "agents", ...qaAgentsPayload() }, resultKind: "agents", savedPath: null, snapshot: null, title };

--- a/gui/src/services/desktop/client.ts
+++ b/gui/src/services/desktop/client.ts
@@ -70,6 +70,7 @@ const qaCommandRows: Array<[
 ]> = [
   ["help", "Show available slash commands.", null, "text"],
   ["agent", "Show active agent and available agents.", null, "agents"],
+  ["pwd", "Show current workspace path.", null, "text"],
   ["sage", "Switch to Sage.", null, "agents"],
   ["reasoning-effort", "Update reasoning effort.", "<low|medium|high>", "text"],
   ["workspace-info", "Show indexed workspace metadata.", null, "workspaceInfo"],
@@ -99,7 +100,7 @@ const qaCommands: CommandDescriptor[] = qaCommandRows.map(
             : "builtin",
       name,
       requiresConversation: false,
-      requiresWorkspace: name.startsWith("workspace-"),
+      requiresWorkspace: name === "pwd" || name.startsWith("workspace-"),
       resultKind,
       usage,
       value: name === "sage" ? "sage" : null,
@@ -227,9 +228,11 @@ function qaCommandResult(input: {
 
   switch (input.name) {
     case "help":
-      return { body: "| Command | What it does | UI expectation |\n|---|---|---|\n| `/help` | Lists commands | Inline table |\n| `/agent` | Shows current agent | Inline cards |\n| `/workspace-info` | Shows metadata | Inline markdown/table |\n| `/workflow <goal>` | Builds a workflow draft | Review modal |", payload: null, resultKind: "text", savedPath: null, snapshot: null, title: "/help" };
+      return { body: "| Command | What it does | UI expectation |\n|---|---|---|\n| `/help` | Lists commands | Inline table |\n| `/agent` | Shows current agent | Inline cards |\n| `/pwd` | Shows current workspace folder | Inline text |\n| `/workspace-info` | Shows metadata | Inline markdown/table |\n| `/workflow <goal>` | Builds a workflow draft | Review modal |", payload: null, resultKind: "text", savedPath: null, snapshot: null, title: "/help" };
     case "agent":
       return { body: "Current agent status.", payload: { kind: "agents", ...qaAgentsPayload() }, resultKind: "agents", savedPath: null, snapshot: null, title };
+    case "pwd":
+      return { body: input.workspacePath ?? QA_WORKSPACE_PATH, payload: null, resultKind: "text", savedPath: null, snapshot: null, title: "/pwd" };
     case "sage":
       qaActiveAgentId = "sage";
       return { body: "Switched active agent to Sage.", payload: { kind: "agents", ...qaAgentsPayload() }, resultKind: "agents", savedPath: null, snapshot: null, title };

--- a/src/main.zig
+++ b/src/main.zig
@@ -2014,7 +2014,7 @@ fn loadOrCreateId(io: Io, gpa: Allocator, home: []const u8, fname: []const u8) [
 /// Reasoning depth for codex/responses (OpenAI Responses `reasoning.effort`).
 const ReasoningEffort = enum { low, medium, high };
 
-const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/plan", "/key", "/keepcontext", "/effort", "/fast", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
+const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/bash", "/plan", "/key", "/keepcontext", "/effort", "/fast", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
 
 /// Lifecycle hooks (codex/Claude-style), loaded once at startup from
 /// .harness/settings.json's "hooks" object. Three events:
@@ -2269,7 +2269,7 @@ fn mcpServerConnected(tools: []const mcp.Tool, server: []const u8) bool {
 
 /// PATH captured at startup for skill detection (PATH won't change mid-run).
 var g_path_env: []const u8 = "";
-/// Human-facing current workspace folder shown in the REPL prompt and /pwd.
+/// Human-facing current workspace folder shown in the REPL prompt.
 var g_cwd_display: []const u8 = ".";
 
 fn binOnPath(io: Io, name: []const u8) bool {
@@ -5034,7 +5034,7 @@ const command_menu = [_]PickItem{
     .{ .name = "/model", .desc = "switch model/provider (picker)" },
     .{ .name = "/models", .desc = "list known models, context windows" },
     .{ .name = "/clear", .desc = "wipe the conversation, start fresh" },
-    .{ .name = "/pwd", .desc = "show the current workspace folder" },
+    .{ .name = "/bash", .desc = "run a shell command in the current workspace" },
     .{ .name = "/compact", .desc = "summarize history into a fresh context" },
     .{ .name = "/plan", .desc = "toggle plan mode (read-only, propose first)" },
     .{ .name = "/resume", .desc = "restore a saved session (picker)" },
@@ -5094,8 +5094,35 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         try out.flush();
         return;
     }
-    if (std.mem.eql(u8, line, "/pwd")) {
-        try out.print("{s}\n", .{g_cwd_display});
+    if (std.mem.eql(u8, line, "/bash") or std.mem.startsWith(u8, line, "/bash ")) {
+        const cmd = std.mem.trim(u8, line["/bash".len..], " \t\r\n");
+        if (cmd.len == 0) {
+            try out.writeAll("usage: /bash <command>\n");
+            try out.flush();
+            return;
+        }
+        var input_obj: std.json.ObjectMap = .empty;
+        try input_obj.put(arena, "command", .{ .string = cmd });
+        const call: ToolCall = .{ .id = "slash-bash", .name = "bash", .input = .{ .object = input_obj } };
+        if (try root.gateTool(call)) |denied| {
+            try out.print("{s}\n", .{denied.text});
+            try out.flush();
+            return;
+        }
+        const result = execTool(.{
+            .gpa = root.gpa,
+            .io = root.io,
+            .client = root.client,
+            .provider = root.provider,
+            .registry = root.registry,
+            .from_sub = false,
+            .approvals = root.approvals,
+            .tracer = root.tracer,
+            .snapshots = root.snapshots,
+            .tools_used = &root.tools_used,
+        }, call);
+        try out.writeAll(result.text);
+        if (result.text.len == 0 or result.text[result.text.len - 1] != '\n') try out.writeAll("\n");
         try out.flush();
         return;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -2269,6 +2269,8 @@ fn mcpServerConnected(tools: []const mcp.Tool, server: []const u8) bool {
 
 /// PATH captured at startup for skill detection (PATH won't change mid-run).
 var g_path_env: []const u8 = "";
+/// Human-facing current workspace folder shown in the REPL prompt and /pwd.
+var g_cwd_display: []const u8 = ".";
 
 fn binOnPath(io: Io, name: []const u8) bool {
     var it = std.mem.splitScalar(u8, g_path_env, ':');
@@ -3986,9 +3988,14 @@ pub fn main(init: std.process.Init) !void {
         style = Style.ansi;
         use_color = true;
     }
+    var cwd_buf: [4096]u8 = undefined;
+    g_cwd_display = if (Io.Dir.cwd().realPath(io, &cwd_buf)) |n|
+        try arena.dupe(u8, cwd_buf[0..n])
+    else |_|
+        try arena.dupe(u8, init.environ_map.get("PWD") orelse ".");
 
     if (!json_mode and oneshot_prompt == null) {
-        try out.print("{s}simple-harness{s} · / for commands · @ picks a file · esc interrupts · ↑/↓ history · tab completes · ctrl-d quits · trace → {s}\n", .{ style.bold, style.reset, trace_path });
+        try out.print("{s}codegraff{s} · folder: {s}{s}{s} · / for commands · @ picks a file · esc interrupts · ↑/↓ history · tab completes · ctrl-d quits · trace → {s}\n", .{ style.bold, style.reset, style.cyan, g_cwd_display, style.reset, trace_path });
         try out.flush();
         if (codex_account) |acct| {
             try out.print("logged into Codex (ChatGPT account {s}…) — /model gpt-5.5\n", .{acct[0..@min(acct.len, 8)]});
@@ -5027,6 +5034,7 @@ const command_menu = [_]PickItem{
     .{ .name = "/model", .desc = "switch model/provider (picker)" },
     .{ .name = "/models", .desc = "list known models, context windows" },
     .{ .name = "/clear", .desc = "wipe the conversation, start fresh" },
+    .{ .name = "/pwd", .desc = "show the current workspace folder" },
     .{ .name = "/compact", .desc = "summarize history into a fresh context" },
     .{ .name = "/plan", .desc = "toggle plan mode (read-only, propose first)" },
     .{ .name = "/resume", .desc = "restore a saved session (picker)" },
@@ -5083,6 +5091,11 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         root.last_cache_read = 0;
         root.todos.clearRetainingCapacity();
         try out.writeAll("context cleared — fresh conversation\n");
+        try out.flush();
+        return;
+    }
+    if (std.mem.eql(u8, line, "/pwd")) {
+        try out.print("{s}\n", .{g_cwd_display});
         try out.flush();
         return;
     }
@@ -7273,15 +7286,16 @@ const Agent = struct {
             const threshold = self.provider.compactAt();
             // % of the compaction budget already used — glanceable headroom.
             const pct = if (threshold > 0) self.last_context_tokens * 100 / threshold else 0;
-            try w.print("\n{s}[{s}{s}{s}{s}{s} · {d}/{d}k tok ({d}%){s}{s}]{s} {s}›{s} ", .{
-                style.dim,                style.reset,      style.cyan, self.provider.model, flag, style.dim,
-                self.last_context_tokens, threshold / 1000, pct,        cached,              cost, style.reset,
-                style.bold,               style.reset,
+            try w.print("\n{s}[{s}{s}{s}{s}{s} · {s}{s}{s} · {d}/{d}k tok ({d}%){s}{s}]{s} {s}›{s} ", .{
+                style.dim,   style.reset,   style.cyan,  self.provider.model,      flag,             style.dim,
+                style.reset, g_cwd_display, style.dim,   self.last_context_tokens, threshold / 1000, pct,
+                cached,      cost,          style.reset, style.bold,               style.reset,
             });
         } else {
-            try w.print("\n{s}[{s}{s}{s}{s}{s}{s}]{s} {s}›{s} ", .{
-                style.dim,   style.reset, style.cyan,  self.provider.model, flag, style.dim, cost,
-                style.reset, style.bold,  style.reset,
+            try w.print("\n{s}[{s}{s}{s}{s}{s} · {s}{s}{s}{s}]{s} {s}›{s} ", .{
+                style.dim,   style.reset,   style.cyan, self.provider.model, flag,        style.dim,
+                style.reset, g_cwd_display, style.dim,  cost,                style.reset, style.bold,
+                style.reset,
             });
         }
         try w.flush();


### PR DESCRIPTION
## Summary
- replace the proposed /pwd command with /bash <command>
- run CLI /bash through the existing bash tool path so approval/codedb guard/hooks still apply
- add GUI /bash command support with raw argument preservation and formatted stdout/stderr/exit output
- include the current folder in the startup banner and interactive model prompt

## Testing
- zig build test
- zig build
- cargo check --manifest-path gui/src-tauri/Cargo.toml *(using a temporary local graff sidecar at gui/src-tauri/binaries/graff-aarch64-apple-darwin)*
- cd gui && bun run build:deps && bun test