### PR TITLE
Constrain chat message text selection

### DIFF
--- a/gui/src/components/chat/ChatMessageRow.tsx
+++ b/gui/src/components/chat/ChatMessageRow.tsx
@@ -33,7 +33,7 @@ function UserChatMessage({ text, workspacePath }: UserChatMessageProps) {
     .filter((item): item is NonNullable<typeof item> => item != null);
 
   return (
-    <article className="cg-message-in flex w-full flex-col items-end gap-2 select-text">
+    <article className="cg-message-in flex w-full flex-col items-end gap-2 select-none">
       {attachments.length > 0 ? (
         <AttachmentTray
           attachments={attachments}
@@ -43,7 +43,7 @@ function UserChatMessage({ text, workspacePath }: UserChatMessageProps) {
       ) : null}
       {body.length > 0 ? (
         <div
-          className="w-fit rounded-xl bg-muted px-3.5 py-1.5 text-sm text-foreground"
+          className="w-fit select-text rounded-xl bg-muted px-3.5 py-1.5 text-sm text-foreground"
           style={{ maxWidth: "min(42rem, 85%)" }}
         >
           <ChatInlineText as="p" text={body} workspacePath={workspacePath} />

--- a/gui/src/components/chat/utils/chatThreadList.tsx
+++ b/gui/src/components/chat/utils/chatThreadList.tsx
@@ -115,7 +115,7 @@ export function renderChatThreadItem(
 
   return (
     <div
-      className="mx-auto min-w-0 w-full max-w-3xl select-text"
+      className="mx-auto min-w-0 w-full max-w-3xl select-none"
       style={{ paddingBottom: index === itemCount - 1 ? 0 : THREAD_ITEM_GAP }}
     >
       {row}


### PR DESCRIPTION
## Summary
- Disable selection on chat thread row wrappers
- Re-enable text selection only on the user message bubble
- Prevent copying surrounding status/row text when selecting a user prompt

## Testing
- git diff --check
- TypeScript build not run: node/bun unavailable in this environment