### PR TITLE
Fix sidebar project removal

### DIFF
--- a/gui/src-tauri/src/persistence/project_store.rs
+++ b/gui/src-tauri/src/persistence/project_store.rs
@@ -246,7 +246,7 @@ impl ProjectStore {
     }
 
     pub fn archive_workspace(&self, path: &Path) -> anyhow::Result<()> {
-        let canonical = canonicalize_project_path(path)?;
+        let canonical = canonicalize_workspace_removal_path(path);
         self.with_connection(|connection| {
             sql_query(
                 "
@@ -582,6 +582,10 @@ fn canonicalize_project_path(path: &Path) -> anyhow::Result<String> {
         .into_owned())
 }
 
+fn canonicalize_workspace_removal_path(path: &Path) -> String {
+    canonicalize_project_path(path).unwrap_or_else(|_| path.to_string_lossy().into_owned())
+}
+
 fn parse_workspace_kind(value: &str) -> RegisteredWorkspaceKind {
     match value {
         "managed_chat" => RegisteredWorkspaceKind::ManagedChat,
@@ -640,4 +644,43 @@ fn load_optional_saved_workspace_record(
     .load(connection)?;
 
     Ok(rows.into_iter().next())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_store() -> anyhow::Result<(ProjectStore, PathBuf)> {
+        let root = std::env::temp_dir().join(format!(
+            "codegraff-project-store-test-{}",
+            Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&root)?;
+        let store = ProjectStore::new(root.join("projects.sqlite"), root.join("managed-chats"))?;
+        Ok((store, root))
+    }
+
+    #[test]
+    fn archive_workspace_removes_registry_entry_for_missing_folder() -> anyhow::Result<()> {
+        let (store, root) = test_store()?;
+        let project_path = root.join("deleted-project");
+        fs::create_dir_all(&project_path)?;
+        let canonical_project_path = project_path.canonicalize()?;
+
+        store.add_project(&canonical_project_path)?;
+        fs::remove_dir_all(&canonical_project_path)?;
+
+        store.archive_workspace(&canonical_project_path)?;
+        fs::create_dir_all(&canonical_project_path)?;
+
+        let registered_paths: Vec<PathBuf> = store
+            .list_workspaces()?
+            .into_iter()
+            .map(|workspace| workspace.path)
+            .collect();
+        assert!(!registered_paths.contains(&canonical_project_path));
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
 }

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -1772,11 +1772,46 @@ impl RuntimeManager {
     pub async fn archive_workspace(&self, workspace_path: String) -> Result<SessionSnapshotDto> {
         self.projects
             .archive_workspace(Path::new(&workspace_path))?;
-        self.state
-            .lock()
-            .await
-            .workspaces
-            .retain(|path| path != &workspace_path);
+        let conversation_ids: Vec<String> = {
+            let state = self.state.lock().await;
+            state
+                .conversations
+                .values()
+                .filter(|conversation| conversation.workspace_path == workspace_path)
+                .map(|conversation| conversation.conversation_id.clone())
+                .collect()
+        };
+        for conversation_id in &conversation_ids {
+            self.drop_session(conversation_id).await;
+        }
+        let removed_conversation_ids: HashSet<String> = conversation_ids.into_iter().collect();
+        let mut state = self.state.lock().await;
+        state.workspaces.retain(|path| path != &workspace_path);
+        state
+            .conversations
+            .retain(|_, conversation| conversation.workspace_path != workspace_path);
+        state.selected_by_workspace.remove(&workspace_path);
+        state
+            .selected_by_workspace
+            .retain(|_, conversation_id| !removed_conversation_ids.contains(conversation_id));
+        if state.active_workspace_path.as_deref() == Some(&workspace_path) {
+            state.active_workspace_path = state.workspaces.first().cloned();
+            state.active_conversation_id = state
+                .active_workspace_path
+                .clone()
+                .and_then(|path| first_workspace_conversation_id(&state, &path));
+        } else if state
+            .active_conversation_id
+            .as_ref()
+            .is_some_and(|conversation_id| removed_conversation_ids.contains(conversation_id))
+        {
+            state.active_conversation_id = state
+                .active_workspace_path
+                .clone()
+                .and_then(|path| first_workspace_conversation_id(&state, &path));
+        }
+        drop(state);
+        self.persist_conversations().await;
         self.snapshot().await
     }
 

--- a/gui/src/components/SidebarItemActionsMenu.tsx
+++ b/gui/src/components/SidebarItemActionsMenu.tsx
@@ -39,10 +39,11 @@ export function SidebarItemActionsMenu({
   removeConfirmTitle,
   removeConfirmDescription,
 }: SidebarItemActionsMenuProps) {
+  const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false);
+  const [isRemovePending, setIsRemovePending] = useState(false);
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
   const [isRenamePending, setIsRenamePending] = useState(false);
   const [nameDraft, setNameDraft] = useState(currentName);
-  const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
 
   useFocusOnOpen(renameInputRef, {
@@ -74,9 +75,22 @@ export function SidebarItemActionsMenu({
     }
   }
 
-  function handleRemoveConfirm() {
-    onRemove();
-    setIsRemoveDialogOpen(false);
+  function handleRemoveDialogOpenChange(open: boolean) {
+    if (isRemovePending) {
+      return;
+    }
+
+    setIsRemoveDialogOpen(open);
+  }
+
+  async function handleRemoveSubmit() {
+    setIsRemovePending(true);
+    try {
+      await onRemove();
+      setIsRemoveDialogOpen(false);
+    } finally {
+      setIsRemovePending(false);
+    }
   }
 
   return (
@@ -111,9 +125,7 @@ export function SidebarItemActionsMenu({
             </DropdownMenuItem>
             <DropdownMenuItem
               variant="destructive"
-              onClick={() => {
-                setIsRemoveDialogOpen(true);
-              }}
+              onClick={() => handleRemoveDialogOpenChange(true)}
             >
               <RemoveIcon />
               {removeLabel}
@@ -169,37 +181,36 @@ export function SidebarItemActionsMenu({
         </DialogContent>
       </Dialog>
 
-      <Dialog
-        open={isRemoveDialogOpen}
-        onOpenChange={(open) => {
-          setIsRemoveDialogOpen(open);
-        }}
-      >
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>
-              {removeConfirmTitle ?? `Remove ${currentName}?`}
-            </DialogTitle>
-            <DialogDescription>
-              {removeConfirmDescription ?? "This can't be undone."}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setIsRemoveDialogOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={handleRemoveConfirm}
-            >
-              {removeLabel}
-            </Button>
-          </DialogFooter>
+      <Dialog open={isRemoveDialogOpen} onOpenChange={handleRemoveDialogOpenChange}>
+        <DialogContent className="max-w-md" showCloseButton={!isRemovePending}>
+          <div className="flex flex-col gap-4">
+            <DialogHeader>
+              <DialogTitle>{removeConfirmTitle ?? `Remove ${currentName}?`}</DialogTitle>
+              <DialogDescription>
+                {removeConfirmDescription ?? "This can't be undone."}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isRemovePending}
+                onClick={() => handleRemoveDialogOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                disabled={isRemovePending}
+                onClick={() => {
+                  void handleRemoveSubmit();
+                }}
+              >
+                {removeLabel}
+              </Button>
+            </DialogFooter>
+          </div>
         </DialogContent>
       </Dialog>
     </>

--- a/gui/src/components/types/sidebar.ts
+++ b/gui/src/components/types/sidebar.ts
@@ -54,7 +54,7 @@ export interface SidebarItemActionsMenuProps {
   dialogDescription: string;
   dialogTitle: string;
   menuAriaLabel: string;
-  onRemove: () => void;
+  onRemove: () => void | Promise<void>;
   onRename: (name: string | null) => Promise<void>;
   placeholder?: string;
   removeIcon: LucideIcon;


### PR DESCRIPTION
## Summary\n- add a confirmation dialog before destructive sidebar remove actions\n- make workspace removal tolerate missing backing folders\n- clear removed workspace conversations and active selection from runtime state\n\nFixes #43\n\n## Tests\n- cargo test --manifest-path gui/src-tauri/Cargo.toml archive_workspace_removes_registry_entry_for_missing_folder (with temporary local sidecar placeholder for Tauri build script)\n- bun run build:deps\n- bun x tsc -b --pretty false