### PR TITLE
Queue follow-ups while a response is running

### DIFF
--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 #[cfg(target_os = "macos")]
 use std::os::unix::fs::PermissionsExt;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     path::{Path, PathBuf},
     process::Command,
     sync::Arc,
@@ -18,6 +18,13 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
+#[derive(Clone)]
+struct QueuedPrompt {
+    agent_id: Option<String>,
+    engine_prompt: String,
+    request_id: String,
+}
+
 #[derive(Clone, Default)]
 struct ConversationState {
     workspace_path: String,
@@ -25,6 +32,7 @@ struct ConversationState {
     title: String,
     messages: Vec<SessionMessageDto>,
     active_request_ids: Vec<String>,
+    queued_prompts: VecDeque<QueuedPrompt>,
     active_agent_id: Option<String>,
     plan_mode: bool,
     goal: Option<String>,
@@ -446,6 +454,7 @@ impl RuntimeManager {
         let title_model_arg = self.selected_model_name().await;
         let is_first_turn;
         let engine_prompt;
+        let should_queue;
         {
             let mut state = self.state.lock().await;
             set_active_workspace(&mut state, &input.workspace_path);
@@ -463,6 +472,7 @@ impl RuntimeManager {
                     title: title_from_prompt(&input.prompt),
                     messages: vec![],
                     active_request_ids: vec![],
+                    queued_prompts: VecDeque::new(),
                     active_agent_id,
                     plan_mode,
                     goal: None,
@@ -491,7 +501,16 @@ impl RuntimeManager {
                 request_id: request_id.clone(),
                 text: input.prompt.clone(),
             });
-            conversation.active_request_ids.push(request_id.clone());
+            should_queue = !conversation.active_request_ids.is_empty();
+            if should_queue {
+                conversation.queued_prompts.push_back(QueuedPrompt {
+                    agent_id: input.agent_id.clone(),
+                    engine_prompt: engine_prompt.clone(),
+                    request_id: request_id.clone(),
+                });
+            } else {
+                conversation.active_request_ids.push(request_id.clone());
+            }
         }
 
         // Managed chats are auto-created `chat_<id>` folders; once a chat has a
@@ -512,6 +531,10 @@ impl RuntimeManager {
         }
 
         self.emit().await?;
+
+        if should_queue {
+            return self.snapshot().await;
+        }
 
         if is_first_turn {
             let manager = self.clone();
@@ -557,11 +580,69 @@ impl RuntimeManager {
             .await;
         }
 
-        let rid = request_id.clone();
-        self.mutate_conversation(&conversation_id, move |conversation| {
-            conversation.active_request_ids.retain(|id| id != &rid);
-        })
-        .await;
+        let mut completed_request_id = request_id;
+        loop {
+            let next_prompt = {
+                let mut state = self.state.lock().await;
+                let Some(conversation) = state.conversations.get_mut(&conversation_id) else {
+                    break;
+                };
+                conversation
+                    .active_request_ids
+                    .retain(|id| id != &completed_request_id);
+                let next = conversation.queued_prompts.pop_front();
+                if let Some(next) = &next {
+                    conversation.plan_mode = next.agent_id.as_deref() == Some("muse");
+                    conversation.updated_at = now_millis();
+                    conversation
+                        .active_request_ids
+                        .push(next.request_id.clone());
+                }
+                next
+            };
+
+            let Some(next_prompt) = next_prompt else {
+                break;
+            };
+
+            self.emit().await?;
+
+            let next_plan_mode = next_prompt.agent_id.as_deref() == Some("muse");
+            if self.session_exists(&conversation_id).await {
+                self.send_control(
+                    &conversation_id,
+                    serde_json::json!({
+                        "type": "set_mode",
+                        "mode": if next_plan_mode { "plan" } else { "normal" },
+                    }),
+                )
+                .await?;
+            }
+
+            if let Err(error) = self
+                .stream_turn(
+                    &conversation_id,
+                    &next_prompt.request_id,
+                    &input.workspace_path,
+                    &next_prompt.engine_prompt,
+                )
+                .await
+            {
+                let message = format_error_chain(&error);
+                let id = format!("{}-error", next_prompt.request_id);
+                let rid = next_prompt.request_id.clone();
+                self.mutate_conversation(&conversation_id, move |conversation| {
+                    conversation.messages.push(SessionMessageDto::Error {
+                        id,
+                        request_id: rid,
+                        message,
+                    });
+                })
+                .await;
+            }
+
+            completed_request_id = next_prompt.request_id;
+        }
 
         let snapshot = self.snapshot().await?;
         let _ = self.emitter.emit_session_updated(snapshot.clone());
@@ -1481,6 +1562,7 @@ impl RuntimeManager {
         self.drop_session(&input.conversation_id).await;
         self.mutate_conversation(&input.conversation_id, |conversation| {
             conversation.active_request_ids.clear();
+            conversation.queued_prompts.clear();
         })
         .await;
         let _ = self.emit().await;
@@ -1540,6 +1622,7 @@ impl RuntimeManager {
                 title: "New chat".into(),
                 messages: vec![],
                 active_request_ids: vec![],
+                queued_prompts: VecDeque::new(),
                 active_agent_id: None,
                 plan_mode: false,
                 goal: None,
@@ -2171,6 +2254,7 @@ fn load_persisted_conversations() -> HashMap<String, ConversationState> {
                     title,
                     messages: conversation.messages,
                     active_request_ids: vec![],
+                    queued_prompts: VecDeque::new(),
                     active_agent_id: conversation.active_agent_id,
                     plan_mode: conversation.plan_mode,
                     goal: conversation.goal,
@@ -3582,6 +3666,7 @@ mod tests {
                 title: "Existing".into(),
                 messages: vec![],
                 active_request_ids: vec![],
+                queued_prompts: VecDeque::new(),
                 active_agent_id: None,
                 plan_mode: false,
                 goal: None,
@@ -3840,6 +3925,7 @@ mod tests {
                 title: "Old".into(),
                 messages: vec![],
                 active_request_ids: vec![],
+                queued_prompts: VecDeque::new(),
                 active_agent_id: None,
                 plan_mode: false,
                 goal: None,
@@ -3854,6 +3940,7 @@ mod tests {
                 title: "New".into(),
                 messages: vec![],
                 active_request_ids: vec![],
+                queued_prompts: VecDeque::new(),
                 active_agent_id: None,
                 plan_mode: false,
                 goal: None,

--- a/gui/src/components/PromptInputCard.test.tsx
+++ b/gui/src/components/PromptInputCard.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { ComponentProps } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type {
@@ -28,7 +29,9 @@ const promptSettings: PromptSettings = {
   fastEnabled: false,
 };
 
-function renderPromptInputCard() {
+function renderPromptInputCard(
+  overrides: Partial<ComponentProps<typeof PromptInputCard>> = {},
+) {
   return renderToStaticMarkup(
     <PromptInputCard
       canCompose
@@ -44,6 +47,7 @@ function renderPromptInputCard() {
       submitPrompt={async () => {}}
       updatePromptSettings={async () => {}}
       workspacePath="/workspace/codegraff"
+      {...overrides}
     />,
   );
 }
@@ -55,5 +59,22 @@ describe("PromptInputCard", () => {
     expect(html).toContain("max-w-44");
     expect(html).toContain("truncate");
     expect(html).toContain(`title="${longModelName}"`);
+  });
+
+  test("keeps the textarea editable and send-enabled for queued follow-ups", () => {
+    const html = renderPromptInputCard({ isRequestActive: true });
+
+    expect(html).toContain("Queue a follow-up…");
+    expect(html).toContain('aria-label="Send"');
+    expect(html).not.toContain("<textarea disabled");
+  });
+
+  test("keeps stop available while running with an empty draft", () => {
+    const html = renderPromptInputCard({
+      isRequestActive: true,
+      promptDraft: "",
+    });
+
+    expect(html).toContain('aria-label="Stop"');
   });
 });

--- a/gui/src/components/PromptInputCard.tsx
+++ b/gui/src/components/PromptInputCard.tsx
@@ -83,17 +83,15 @@ export function PromptInputCard({
   const isControlDisabled =
     isSendingPrompt || isRequestActive || !canCompose || isInputDisabled;
   // Keep the composer editable while a request streams so the user can draft
-  // their next message; only Send is repurposed to Stop. Enter is guarded by
-  // isSubmitDisabled (which includes isRequestActive) so a draft is never sent
-  // mid-stream — it just waits until the run finishes.
-  const isTextareaDisabled =
-    isSendingPrompt || !canCompose || isInputDisabled;
+  // and queue the next message. While streaming, a non-empty draft turns the
+  // primary button back into Send; an empty draft keeps it as Stop.
+  const isTextareaDisabled = isSendingPrompt || !canCompose || isInputDisabled;
   const isWorking = isRequestActive;
+  const isQueueSubmit = isWorking;
   const isSubmitDisabled =
     !canCompose ||
-    isSendingPrompt ||
-    isRequestActive ||
     isInputDisabled ||
+    (!isQueueSubmit && isSendingPrompt) ||
     promptDraft.trim().length === 0;
   const {
     handleModelChange,
@@ -127,7 +125,9 @@ export function PromptInputCard({
     void setFast(next);
   }
 
-  function handleAutocompleteSelect(command: Parameters<typeof onCommandSelect>[0]) {
+  function handleAutocompleteSelect(
+    command: Parameters<typeof onCommandSelect>[0],
+  ) {
     // The model picker lives in this component, so handle `/model` here rather
     // than routing it up.
     if (command.name === "model") {
@@ -149,11 +149,11 @@ export function PromptInputCard({
   useAutosizeTextarea(textareaRef, promptDraft);
 
   useEffect(() => {
-    if (focusSignal == null || isControlDisabled) {
+    if (focusSignal == null || isTextareaDisabled) {
       return;
     }
     textareaRef.current?.focus();
-  }, [focusSignal, isControlDisabled]);
+  }, [focusSignal, isTextareaDisabled]);
 
   // Highlight a leading slash-command token so the user sees they're issuing a
   // command. Only active in command mode, so normal prose typing is untouched.
@@ -171,12 +171,14 @@ export function PromptInputCard({
   }
 
   function handlePrimaryAction() {
-    if (isWorking) {
-      void stopPrompt();
+    if (!isSubmitDisabled) {
+      handleSubmit();
       return;
     }
 
-    handleSubmit();
+    if (isWorking) {
+      void stopPrompt();
+    }
   }
 
   function handlePlanningModeToggle() {
@@ -185,9 +187,7 @@ export function PromptInputCard({
 
   // Cmd/Ctrl+V of an image: persist the clipboard bytes to a temp file and add
   // it through the same attachment pipeline as a drag-dropped file.
-  async function handlePaste(
-    event: React.ClipboardEvent<HTMLTextAreaElement>,
-  ) {
+  async function handlePaste(event: React.ClipboardEvent<HTMLTextAreaElement>) {
     const items = event.clipboardData?.items;
     if (!items) {
       return;
@@ -264,9 +264,10 @@ export function PromptInputCard({
               id="prompt"
               className={cn(
                 "max-h-80 overflow-y-auto rounded-none border-0 bg-transparent px-0 py-0 text-sm shadow-none outline-none ring-0 placeholder:text-muted-foreground/80 focus-visible:border-transparent focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent",
-                commandMatch && "text-transparent caret-[color:var(--foreground)]",
+                commandMatch &&
+                  "text-transparent caret-[color:var(--foreground)]",
               )}
-              placeholder={placeholder}
+              placeholder={isWorking ? "Queue a follow-up…" : placeholder}
               value={promptDraft}
               onChange={(event) => setPromptDraft(event.target.value)}
               onPaste={handlePaste}
@@ -452,7 +453,10 @@ export function PromptInputCard({
                 className="inline-flex h-8 items-center gap-2 px-1.5 text-xs font-medium text-muted-foreground"
                 title="Planning uses the thinking agent"
               >
-                <Throbber variant="pulse" className="text-[color:var(--accent)]" />
+                <Throbber
+                  variant="pulse"
+                  className="text-[color:var(--accent)]"
+                />
                 {planningThinkingLabel}
               </span>
             ) : null}
@@ -461,11 +465,11 @@ export function PromptInputCard({
             type="button"
             size="icon-lg"
             className="rounded-full"
-            aria-label={isWorking ? "Stop" : "Send"}
+            aria-label={isWorking && isSubmitDisabled ? "Stop" : "Send"}
             onClick={handlePrimaryAction}
             disabled={isWorking ? false : isSubmitDisabled}
           >
-            {isWorking ? <SquareIcon /> : <ArrowUpIcon />}
+            {isWorking && isSubmitDisabled ? <SquareIcon /> : <ArrowUpIcon />}
           </Button>
         </CardFooter>
       </Card>


### PR DESCRIPTION
## Summary

Closes #45.

Adds queueing for follow-up prompts while a response is still streaming.

Changes:
- Keeps the prompt textarea enabled while a request is active.
- Shows `Queue a follow-up…` during active runs.
- Uses the primary button as Send when a running composer has a non-empty draft, and Stop when it is empty.
- Queues submitted prompts in the Tauri runtime and runs them FIFO after the active turn completes.
- Shows queued user messages immediately by adding them to conversation state at submit time.
- Clears queued prompts when the active run is stopped.
- Adds PromptInputCard coverage for editable/send-enabled running state and empty-draft stop state.

## Tests

- `zig build test`
- `cd gui && bun run build:deps && bun test`
- `cd gui/src-tauri && cargo test runtime::simple::tests`

## Local build / codesign

Built and ad-hoc signed locally for testing with:

```sh
cd /tmp/codegraff-queue-pr/gui
bunx tauri build --config '{"bundle":{"macOS":{"signingIdentity":"-"}}}'
```

Verified with:

```sh
codesign --verify --deep --strict --verbose=2 /private/tmp/codegraff-queue-pr/gui/src-tauri/target/release/bundle/macos/Codegraff.app
```

Local artifacts:
- `/private/tmp/codegraff-queue-pr/gui/src-tauri/target/release/bundle/macos/Codegraff.app`
- `/private/tmp/codegraff-queue-pr/gui/src-tauri/target/release/bundle/dmg/Codegraff_0.0.13_aarch64.dmg`
