### PR TITLE
Add prompt history key navigation

### DIFF
--- a/gui/src/components/PromptComposer.tsx
+++ b/gui/src/components/PromptComposer.tsx
@@ -62,6 +62,9 @@ export function PromptComposer({ binding, onCommandResult }: PromptComposerProps
   } = useCommandRouter(binding, { onCommandResult });
   const requiresProviderSetup =
     promptSettings != null && promptSettings.availableModels.length === 0;
+  const promptHistory = messages
+    .filter((message) => message.kind === "user")
+    .map((message) => message.text);
 
   const handleSubmit = useCallback(async () => {
     if (trySubmitAsCommand(promptDraft)) {
@@ -167,6 +170,7 @@ export function PromptComposer({ binding, onCommandResult }: PromptComposerProps
             isPlanningMode={isPlanningMode}
             promptSettings={promptSettings}
             promptDraft={promptDraft}
+            promptHistory={promptHistory}
             isInputDisabled={requiresProviderSetup}
             binding={binding}
             workspacePath={workspacePath}

--- a/gui/src/components/PromptInputCard.tsx
+++ b/gui/src/components/PromptInputCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import {
   ArrowUpIcon,
   ChevronDownIcon,
@@ -40,10 +40,24 @@ import { usePromptModelPicker } from "@/hooks/usePromptModelPicker";
 import { savePastedImage, setFast } from "@/services/desktop/client";
 import { cn } from "@/utils/cn";
 import {
+  getPromptHistoryNavigationResult,
+  type PromptHistoryCursor,
+} from "./promptHistoryNavigation";
+import {
   formatPlanningThinkingLabel,
   formatReasoningEffortLabel,
 } from "@/utils/reasoning";
 import type { PromptInputCardProps } from "./types/prompt";
+
+const EMPTY_PROMPT_HISTORY: string[] = [];
+
+function isCaretOnFirstLine(textarea: HTMLTextAreaElement) {
+  return !textarea.value.slice(0, textarea.selectionStart).includes("\n");
+}
+
+function isCaretOnLastLine(textarea: HTMLTextAreaElement) {
+  return !textarea.value.slice(textarea.selectionEnd).includes("\n");
+}
 
 export function PromptInputCard({
   canCompose,
@@ -53,6 +67,7 @@ export function PromptInputCard({
   placeholder = "Ask about this workspace…",
   promptSettings,
   promptDraft,
+  promptHistory = EMPTY_PROMPT_HISTORY,
   focusSignal,
   isInputDisabled = false,
   binding,
@@ -114,9 +129,20 @@ export function PromptInputCard({
   const [fastEnabled, setFastEnabled] = useState(
     promptSettings?.fastEnabled ?? false,
   );
+  const [historyCursor, setHistoryCursor] =
+    useState<PromptHistoryCursor>(null);
+  const [draftBeforeHistory, setDraftBeforeHistory] = useState("");
+  const promptHistoryLengthRef = useRef(promptHistory.length);
+
+  function resetHistoryNavigation() {
+    setHistoryCursor(null);
+    setDraftBeforeHistory("");
+  }
+
   useEffect(() => {
     setFastEnabled(promptSettings?.fastEnabled ?? false);
   }, [promptSettings?.fastEnabled]);
+
   const isCodexModel = selectedModel?.providerId === "codex";
 
   function handleFastToggle() {
@@ -167,7 +193,83 @@ export function PromptInputCard({
       return;
     }
 
+    resetHistoryNavigation();
     void submitPrompt();
+  }
+
+  function handleDraftChange(value: string) {
+    resetHistoryNavigation();
+    setPromptDraft(value);
+  }
+
+  function moveCaretToEndOnNextFrame() {
+    requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      if (textarea == null) {
+        return;
+      }
+
+      const end = textarea.value.length;
+      textarea.setSelectionRange(end, end);
+    });
+  }
+
+  function handleHistoryNavigation(
+    event: KeyboardEvent<HTMLTextAreaElement>,
+  ) {
+    if (
+      event.nativeEvent.isComposing ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return false;
+    }
+
+    const direction =
+      event.key === "ArrowUp"
+        ? "previous"
+        : event.key === "ArrowDown"
+          ? "next"
+          : null;
+    if (direction == null) {
+      return false;
+    }
+
+    const textarea = event.currentTarget;
+    if (direction === "previous" && !isCaretOnFirstLine(textarea)) {
+      return false;
+    }
+    if (direction === "next" && !isCaretOnLastLine(textarea)) {
+      return false;
+    }
+
+    const didHistoryLengthChange =
+      promptHistoryLengthRef.current !== promptHistory.length;
+    const effectiveCursor = didHistoryLengthChange ? null : historyCursor;
+    const effectiveDraftBeforeHistory = didHistoryLengthChange
+      ? ""
+      : draftBeforeHistory;
+    promptHistoryLengthRef.current = promptHistory.length;
+
+    const result = getPromptHistoryNavigationResult({
+      direction,
+      promptHistory,
+      cursor: effectiveCursor,
+      currentDraft: promptDraft,
+      draftBeforeHistory: effectiveDraftBeforeHistory,
+    });
+    if (result == null) {
+      return false;
+    }
+
+    event.preventDefault();
+    setHistoryCursor(result.cursor);
+    setDraftBeforeHistory(result.draftBeforeHistory);
+    setPromptDraft(result.draft);
+    moveCaretToEndOnNextFrame();
+    return true;
   }
 
   function handlePrimaryAction() {
@@ -269,7 +371,7 @@ export function PromptInputCard({
               )}
               placeholder={isWorking ? "Queue a follow-up…" : placeholder}
               value={promptDraft}
-              onChange={(event) => setPromptDraft(event.target.value)}
+              onChange={(event) => handleDraftChange(event.target.value)}
               onPaste={handlePaste}
               onScroll={(event) => {
                 if (commandOverlayRef.current != null) {
@@ -281,6 +383,9 @@ export function PromptInputCard({
                 // The command menu consumes Enter/Tab/arrows while open, so a
                 // command is completed rather than sent.
                 if (commandAutocomplete.handleKeyDown(event)) {
+                  return;
+                }
+                if (handleHistoryNavigation(event)) {
                   return;
                 }
                 if (event.key !== "Enter") {

--- a/gui/src/components/new-chat-screen/NewChatPromptSection.tsx
+++ b/gui/src/components/new-chat-screen/NewChatPromptSection.tsx
@@ -68,6 +68,9 @@ export function NewChatPromptSection({
     followupRequest == null &&
     interrupt == null &&
     lastAssistant != null;
+  const promptHistory = messages
+    .filter((message) => message.kind === "user")
+    .map((message) => message.text);
   const handleSubmit = useCallback(async () => {
     if (trySubmitAsCommand(promptDraft)) {
       return;
@@ -131,6 +134,7 @@ export function NewChatPromptSection({
         }
         isPlanningMode={isPlanningMode}
         promptDraft={promptDraft}
+        promptHistory={promptHistory}
         promptSettings={promptSettings}
         isInputDisabled={!hasCurrentWorkspace}
         binding={binding}

--- a/gui/src/components/promptHistoryNavigation.test.ts
+++ b/gui/src/components/promptHistoryNavigation.test.ts
@@ -1,0 +1,165 @@
+import { expect, test } from "bun:test";
+
+import {
+  getPromptHistoryNavigationResult,
+  type PromptHistoryCursor,
+} from "./promptHistoryNavigation";
+
+test("returns null when navigating previous with empty history", () => {
+  expect(
+    getPromptHistoryNavigationResult({
+      direction: "previous",
+      promptHistory: [],
+      cursor: null,
+      currentDraft: "draft",
+      draftBeforeHistory: "",
+    }),
+  ).toBeNull();
+});
+
+test("returns newest prompt when navigating previous from a draft", () => {
+  expect(
+    getPromptHistoryNavigationResult({
+      direction: "previous",
+      promptHistory: ["first", "second", "third"],
+      cursor: null,
+      currentDraft: "draft in progress",
+      draftBeforeHistory: "",
+    }),
+  ).toEqual({
+    cursor: 2,
+    draft: "third",
+    draftBeforeHistory: "draft in progress",
+  });
+});
+
+test("walks backward and forward through history before restoring draft", () => {
+  const promptHistory = ["first", "second", "third"];
+
+  let cursor: PromptHistoryCursor = null;
+  let draft = "draft in progress";
+  let draftBeforeHistory = "";
+
+  let result = getPromptHistoryNavigationResult({
+    direction: "previous",
+    promptHistory,
+    cursor,
+    currentDraft: draft,
+    draftBeforeHistory,
+  });
+  expect(result).toEqual({
+    cursor: 2,
+    draft: "third",
+    draftBeforeHistory: "draft in progress",
+  });
+
+  cursor = result!.cursor;
+  draft = result!.draft;
+  draftBeforeHistory = result!.draftBeforeHistory;
+
+  result = getPromptHistoryNavigationResult({
+    direction: "previous",
+    promptHistory,
+    cursor,
+    currentDraft: draft,
+    draftBeforeHistory,
+  });
+  expect(result).toEqual({
+    cursor: 1,
+    draft: "second",
+    draftBeforeHistory: "draft in progress",
+  });
+
+  cursor = result!.cursor;
+  draft = result!.draft;
+  draftBeforeHistory = result!.draftBeforeHistory;
+
+  result = getPromptHistoryNavigationResult({
+    direction: "next",
+    promptHistory,
+    cursor,
+    currentDraft: draft,
+    draftBeforeHistory,
+  });
+  expect(result).toEqual({
+    cursor: 2,
+    draft: "third",
+    draftBeforeHistory: "draft in progress",
+  });
+
+  cursor = result!.cursor;
+  draft = result!.draft;
+  draftBeforeHistory = result!.draftBeforeHistory;
+
+  result = getPromptHistoryNavigationResult({
+    direction: "next",
+    promptHistory,
+    cursor,
+    currentDraft: draft,
+    draftBeforeHistory,
+  });
+  expect(result).toEqual({
+    cursor: null,
+    draft: "draft in progress",
+    draftBeforeHistory: "",
+  });
+});
+
+test("keeps previous navigation pinned at oldest prompt", () => {
+  expect(
+    getPromptHistoryNavigationResult({
+      direction: "previous",
+      promptHistory: ["first", "second", "third"],
+      cursor: 0,
+      currentDraft: "first",
+      draftBeforeHistory: "draft in progress",
+    }),
+  ).toEqual({
+    cursor: 0,
+    draft: "first",
+    draftBeforeHistory: "draft in progress",
+  });
+});
+
+test("preserves duplicate prompts as separate history entries", () => {
+  const promptHistory = ["same", "different", "same"];
+
+  let result = getPromptHistoryNavigationResult({
+    direction: "previous",
+    promptHistory,
+    cursor: null,
+    currentDraft: "draft",
+    draftBeforeHistory: "",
+  });
+  expect(result).toEqual({
+    cursor: 2,
+    draft: "same",
+    draftBeforeHistory: "draft",
+  });
+
+  result = getPromptHistoryNavigationResult({
+    direction: "previous",
+    promptHistory,
+    cursor: result!.cursor,
+    currentDraft: result!.draft,
+    draftBeforeHistory: result!.draftBeforeHistory,
+  });
+  expect(result).toEqual({
+    cursor: 1,
+    draft: "different",
+    draftBeforeHistory: "draft",
+  });
+
+  result = getPromptHistoryNavigationResult({
+    direction: "previous",
+    promptHistory,
+    cursor: result!.cursor,
+    currentDraft: result!.draft,
+    draftBeforeHistory: result!.draftBeforeHistory,
+  });
+  expect(result).toEqual({
+    cursor: 0,
+    draft: "same",
+    draftBeforeHistory: "draft",
+  });
+});

--- a/gui/src/components/promptHistoryNavigation.ts
+++ b/gui/src/components/promptHistoryNavigation.ts
@@ -1,0 +1,59 @@
+export type PromptHistoryCursor = number | null;
+
+export type PromptHistoryNavigationDirection = "previous" | "next";
+
+export interface PromptHistoryNavigationInput {
+  direction: PromptHistoryNavigationDirection;
+  promptHistory: string[];
+  cursor: PromptHistoryCursor;
+  currentDraft: string;
+  draftBeforeHistory: string;
+}
+
+export interface PromptHistoryNavigationResult {
+  cursor: PromptHistoryCursor;
+  draft: string;
+  draftBeforeHistory: string;
+}
+
+export function getPromptHistoryNavigationResult({
+  direction,
+  promptHistory,
+  cursor,
+  currentDraft,
+  draftBeforeHistory,
+}: PromptHistoryNavigationInput): PromptHistoryNavigationResult | null {
+  if (promptHistory.length === 0) {
+    return null;
+  }
+
+  if (direction === "previous") {
+    const nextCursor =
+      cursor == null ? promptHistory.length - 1 : Math.max(0, cursor - 1);
+
+    return {
+      cursor: nextCursor,
+      draft: promptHistory[nextCursor] ?? currentDraft,
+      draftBeforeHistory: cursor == null ? currentDraft : draftBeforeHistory,
+    };
+  }
+
+  if (cursor == null) {
+    return null;
+  }
+
+  const nextCursor = cursor + 1;
+  if (nextCursor >= promptHistory.length) {
+    return {
+      cursor: null,
+      draft: draftBeforeHistory,
+      draftBeforeHistory: "",
+    };
+  }
+
+  return {
+    cursor: nextCursor,
+    draft: promptHistory[nextCursor] ?? currentDraft,
+    draftBeforeHistory,
+  };
+}

--- a/gui/src/components/types/prompt.ts
+++ b/gui/src/components/types/prompt.ts
@@ -33,6 +33,7 @@ export interface PromptInputCardProps {
   placeholder?: string;
   promptSettings: PromptSettings | null;
   promptDraft: string;
+  promptHistory?: string[];
   focusSignal?: number;
   isInputDisabled?: boolean;
   binding?: ChatBinding | null;


### PR DESCRIPTION
## Summary\n- add Up/Down prompt history navigation for chat prompt textareas\n- preserve and restore the in-progress draft while browsing history\n- avoid hijacking multiline cursor movement, modifier shortcuts, IME composition, and command autocomplete keys\n- add focused prompt history navigation tests\n\nFixes #47\n\n## Tests\n- bun --cwd gui test src/components/promptHistoryNavigation.test.ts src/components/PromptInputCard.test.tsx\n- bun --cwd gui test\n- bun --cwd gui run build:deps\n- cd gui && bun x tsc -b --pretty false