### PR TITLE
fix(gui): auto-detect CLI provider login

### DIFF
--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -6,6 +6,7 @@ use crate::{
     terminal::TerminalManager,
 };
 use anyhow::{Context, Result};
+use base64::Engine;
 #[cfg(target_os = "macos")]
 use std::os::unix::fs::PermissionsExt;
 use std::{
@@ -961,11 +962,17 @@ impl RuntimeManager {
                 }
                 Some("turn") => break,
                 Some("error") => {
-                    let message = event
+                    let raw_message = event
                         .get("message")
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("graff error")
                         .to_string();
+                    let auth_error = is_provider_auth_error_message(&raw_message);
+                    let message = if auth_error {
+                        provider_auth_error_message(&raw_message)
+                    } else {
+                        raw_message
+                    };
                     let id = format!("{request_id}-error-{}", Uuid::new_v4().simple());
                     let rid = request_id.to_string();
                     self.mutate_conversation(conversation_id, move |conversation| {
@@ -976,6 +983,15 @@ impl RuntimeManager {
                         });
                     })
                     .await;
+                    if auth_error {
+                        // A rejected/expired credential can leave the long-lived
+                        // child in a bad state. Drop it so retrying after the
+                        // user reconnects spawns a fresh graff process instead
+                        // of reusing a session that already failed auth.
+                        self.drop_session(conversation_id).await;
+                        self.emit().await?;
+                        return Ok(());
+                    }
                     break;
                 }
                 // system_prompt / score acks and anything unrecognized: ignore.
@@ -2229,6 +2245,25 @@ pub(crate) fn format_error_chain(error: &anyhow::Error) -> String {
         .map(ToString::to_string)
         .collect::<Vec<_>>()
         .join(": ")
+}
+
+fn is_provider_auth_error_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("invalid_api_key")
+        || lower.contains("unauthorized")
+        || (lower.contains("api key")
+            && (lower.contains("invalid")
+                || lower.contains("expired")
+                || lower.contains("incorrect")))
+        || (lower.contains("token") && lower.contains("expired"))
+        || (lower.contains("authentication")
+            && (lower.contains("failed") || lower.contains("invalid")))
+}
+
+fn provider_auth_error_message(raw: &str) -> String {
+    format!(
+        "Provider authentication failed before the turn could run. The selected API key/login was rejected or expired. Re-open Settings → Providers and reconnect the provider, then retry.\n\nThe GUI dropped the live graff session so the next retry starts fresh.\n\n{raw}"
+    )
 }
 
 /// Runs a literal substring search over the workspace. Tries ripgrep first
@@ -3536,7 +3571,11 @@ fn env_has_provider_key(env_key: &str) -> bool {
 }
 
 fn provider_configured(provider: &CodegraffProvider, key_list: &str) -> bool {
-    if provider.env_key.as_deref().is_some_and(env_has_provider_key) {
+    if provider
+        .env_key
+        .as_deref()
+        .is_some_and(env_has_provider_key)
+    {
         return true;
     }
 
@@ -3585,8 +3624,8 @@ fn home_codex_auth_has_valid_token(home: Option<&Path>) -> bool {
 }
 
 /// Kimi OAuth login (`graff login kimi`) writes a JSON token file to
-/// `~/.kimi/credentials/graff-oauth.json`. The CLI auto-refreshes the
-/// access token when near expiry, so a non-empty access_token means logged in.
+/// `~/.kimi/credentials/graff-oauth.json`. Treat an expired token file as not
+/// configured so the GUI asks the user to reconnect before starting a run.
 fn kimi_auth_has_valid_token(home: Option<&Path>) -> bool {
     home.map(|home| {
         let path = home.join(".kimi/credentials/graff-oauth.json");
@@ -3596,10 +3635,17 @@ fn kimi_auth_has_valid_token(home: Option<&Path>) -> bool {
         let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
             return false;
         };
+        if value
+            .get("expires_at")
+            .and_then(serde_json::Value::as_i64)
+            .is_some_and(|expires_at| unix_seconds() >= expires_at.saturating_sub(60))
+        {
+            return false;
+        }
         value
             .get("access_token")
             .and_then(|token| token.as_str())
-            .map(|token| !token.trim().is_empty())
+            .map(|token| !token.trim().is_empty() && jwt_token_not_expired(token))
             .unwrap_or(false)
     })
     .unwrap_or(false)
@@ -3621,8 +3667,33 @@ fn codex_auth_text_has_valid_token(text: &str) -> bool {
         .and_then(|tokens| tokens.get("access_token"))
         .or_else(|| value.get("access_token"))
         .and_then(|token| token.as_str())
-        .map(|token| !token.trim().is_empty())
+        .map(|token| !token.trim().is_empty() && jwt_token_not_expired(token))
         .unwrap_or(false)
+}
+
+fn jwt_token_not_expired(token: &str) -> bool {
+    let Some(payload) = token.split('.').nth(1) else {
+        // API keys and opaque OAuth tokens do not expose an expiry locally; they
+        // still need the runtime auth-error handling above.
+        return true;
+    };
+    let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload) else {
+        return true;
+    };
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return true;
+    };
+    let Some(exp) = value.get("exp").and_then(serde_json::Value::as_i64) else {
+        return true;
+    };
+    unix_seconds() < exp.saturating_sub(60)
+}
+
+fn unix_seconds() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
 }
 
 fn provider_env_key(provider_id: &str) -> Option<String> {
@@ -4164,6 +4235,24 @@ mod tests {
         ));
         assert!(!codex_auth_text_has_valid_token("{}"));
         assert!(!codex_auth_text_has_valid_token("not json"));
+    }
+
+    #[test]
+    fn codex_auth_text_rejects_expired_jwt_token() {
+        let expired_payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(r#"{"exp":1}"#);
+        let token = format!("header.{expired_payload}.signature");
+        let auth = serde_json::json!({ "tokens": { "access_token": token } }).to_string();
+
+        assert!(!codex_auth_text_has_valid_token(&auth));
+    }
+
+    #[test]
+    fn provider_auth_error_detection_matches_invalid_api_key() {
+        assert!(is_provider_auth_error_message(
+            "api error: The API Key appears to be invalid or may have expired. Please verify your credentials and try again."
+        ));
+        assert!(provider_auth_error_message("invalid_api_key").contains("reconnect"));
     }
 
     #[test]

--- a/gui/src/components/providers-settings/ProviderSetupDialog.tsx
+++ b/gui/src/components/providers-settings/ProviderSetupDialog.tsx
@@ -27,6 +27,7 @@ import {
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
 import {
   completeProviderAuth,
+  listProviders,
   listenProviderOAuthCallback,
   openExternalUrl,
   startProviderAuth,
@@ -75,6 +76,12 @@ export function ProviderSetupDialog({
   const [isStartingAuth, setIsStartingAuth] = useState(false);
   const [isSubmittingAuth, setIsSubmittingAuth] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  // True while polling for a CLI login (codegraff/codex/kimi) to land on disk.
+  // The external Terminal runs `graff login …` (a device-code flow that polls
+  // every few seconds); this polls `list_providers` so the dialog auto-completes
+  // the moment the credential file appears — no manual "Finish setup" click and
+  // no clicking-too-early error.
+  const [isDetectingLogin, setIsDetectingLogin] = useState(false);
   const providerId = provider?.id ?? null;
 
   const defaultAuthMethod = useMemo(() => {
@@ -94,6 +101,7 @@ export function ProviderSetupDialog({
     setUrlParameterValues({});
     setIsStartingAuth(false);
     setIsSubmittingAuth(false);
+    setIsDetectingLogin(false);
     setActionError(null);
   }
 
@@ -102,9 +110,15 @@ export function ProviderSetupDialog({
       return;
     }
 
-    const nextAuthMethod = initialAuthMethod ?? defaultAuthMethod;
-    resetSetupState(nextAuthMethod);
-    setPendingAutoStartMethod(nextAuthMethod);
+    const timer = window.setTimeout(() => {
+      const nextAuthMethod = initialAuthMethod ?? defaultAuthMethod;
+      resetSetupState(nextAuthMethod);
+      setPendingAutoStartMethod(nextAuthMethod);
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
   }, [defaultAuthMethod, initialAuthMethod, isOpen, provider]);
 
   async function refreshPromptSettings() {
@@ -191,6 +205,75 @@ export function ProviderSetupDialog({
       }
     };
   }, [authFlow, providerId]);
+
+  // Auto-detect CLI login completion: poll list_providers while a cli_login flow
+  // is active. The moment the provider flips to configured, auto-complete — no
+  // need for the user to manually click "Finish setup" (which would error if
+  // clicked before the OAuth file lands).
+  useEffect(() => {
+    if (authFlow?.kind !== "cli_login" || providerId == null) {
+      const resetTimer = window.setTimeout(() => {
+        setIsDetectingLogin(false);
+      }, 0);
+      return () => {
+        window.clearTimeout(resetTimer);
+      };
+    }
+
+    let isCancelled = false;
+    const startTimer = window.setTimeout(() => {
+      if (isCancelled) return;
+      setIsDetectingLogin(true);
+      setActionError(null);
+    }, 0);
+
+    async function poll() {
+      // Give the external Terminal a moment to get going before the first check.
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      while (!isCancelled) {
+        try {
+          const providers = await listProviders(workspacePath);
+          if (isCancelled) return;
+          const current = providers.find((p) => p.id === providerId);
+          if (current?.configured) {
+            // Credential landed — complete the auth session.
+            try {
+              const updatedProvider = await completeProviderAuth({
+                authSessionId: authFlow!.authSessionId,
+                apiKey: null,
+                authorizationCode: null,
+                urlParameters: [],
+              });
+              if (isCancelled) return;
+              onProviderUpdated(updatedProvider);
+              await ensureWorkspacePromptSettingsLoaded(workspacePath, {
+                force: true,
+              });
+              closeSetupDialog();
+            } catch (error) {
+              if (isCancelled) return;
+              // The file appeared but completion failed — surface it and stop
+              // polling so the user can retry with "Finish setup".
+              setActionError(normalizeProviderError(error));
+              setIsDetectingLogin(false);
+            }
+            return;
+          }
+        } catch {
+          // Transient listProviders failure — keep polling.
+        }
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+    }
+
+    void poll();
+
+    return () => {
+      isCancelled = true;
+      window.clearTimeout(startTimer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authFlow?.kind, authFlow?.authSessionId, providerId, workspacePath]);
 
   function closeSetupDialog() {
     setPendingAutoStartMethod(null);
@@ -441,11 +524,26 @@ export function ProviderSetupDialog({
             ) : null}
 
             {authFlow?.kind === "cli_login" ? (
-              <div className="flex flex-col gap-4">
-                <p className="rounded-lg border border-border/60 px-3 py-3 text-sm text-muted-foreground">
-                  {authFlow.apiKeyHint ??
-                    "Login launched in Terminal. Complete the CLI flow there, then finish setup here."}
-                  </p>
+              <div className="flex flex-col gap-3">
+                <div className="flex items-center gap-2.5 rounded-lg border border-border/60 px-3 py-3 text-sm text-muted-foreground">
+                  {isDetectingLogin ? (
+                    <>
+                      <LoaderCircle
+                        className="size-4 shrink-0 animate-spin text-[color:var(--accent)]"
+                        strokeWidth={2}
+                      />
+                      <span>
+                        Waiting for login to complete in Terminal… The dialog
+                        closes automatically once detected.
+                      </span>
+                    </>
+                  ) : (
+                    <span>
+                      {authFlow.apiKeyHint ??
+                        "Login launched in Terminal. Complete the CLI flow there, then finish setup here."}
+                    </span>
+                  )}
+                </div>
               </div>
             ) : null}
 
@@ -558,7 +656,7 @@ export function ProviderSetupDialog({
             {authFlow?.kind === "device_code" || authFlow?.kind === "cli_login" ? (
               <Button
                 type="button"
-                disabled={isSubmittingAuth}
+                disabled={isSubmittingAuth || isDetectingLogin}
                 onClick={() => {
                   void handleSubmitSetup();
                 }}

--- a/src/main.zig
+++ b/src/main.zig
@@ -4917,10 +4917,10 @@ pub fn main(init: std.process.Init) !void {
             }
             try out.flush();
             break :blk e.text;
-        } else if (interactive)
-            (try readLine(&root, in, out, gpa, &history, &linebuf)) orelse break
-        else
-            (try in.takeDelimiter('\n')) orelse break;
+        } else if (interactive) blk: {
+            try root.prompt();
+            break :blk (try readLine(&root, in, out, gpa, &history, &linebuf)) orelse break;
+        } else (try in.takeDelimiter('\n')) orelse break;
         const line = std.mem.trim(u8, raw_line, " \t\r");
         if (line.len == 0) continue;
         const loop_prompt: ?[]const u8 = if (!json_mode and std.mem.startsWith(u8, line, "/loop "))


### PR DESCRIPTION
## Summary\n- Poll provider status while a CLI login flow is active\n- Auto-complete provider setup once the credential lands on disk\n- Disable the manual finish button while detection is in progress\n\n## Checks\n- cd gui && bun run build:deps && bunx tsc -b\n- cd gui/src-tauri && cargo check\n\nNote: release workflow / SDK packaging changes from the stash were already present on release/0.0.161, so this PR contains only the remaining provider setup dialog fix.