### PR TITLE
Desktop auto-update + bundled graff CLI install (0.0.162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ context when the conversation gets long.
 
 ### Desktop app — macOS (Apple Silicon)
 
-Prefer a window over a terminal? Download the latest signed, notarized build, drag it to Applications, and open it. On first launch it installs a `codegraff` launcher on your PATH, so `codegraff <path>` opens that folder in the app (`code`-style). For the `graff` agent CLI itself, use the command-line install below — the desktop app runs whatever `graff` is on your PATH.
+Prefer a window over a terminal? Download the latest signed, notarized build, drag it to Applications, and open it. The desktop app is **fully self-contained** — it bundles the `graff` agent, so there's nothing else to install to start coding, and it keeps itself up to date automatically. On first launch it drops two commands on your PATH: `codegraff <path>` (opens that folder in the app, `code`-style) and `graff` itself (the agent CLI, in your terminal) — so the one install covers both the window and the command line. The terminal `graff` is symlinked into the app, so it auto-updates along with it. Not on Apple Silicon, or want a standalone CLI? Use the command-line install below.
 
 <p align="center">
-  <a href="https://github.com/justrach/codegraff/releases/latest"><img alt="Download Codegraff for macOS" src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white"></a>
+  <a href="https://github.com/justrach/codegraff/releases/latest/download/Codegraff.dmg"><img alt="Download Codegraff for macOS" src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white"></a>
+  <br/>
+  <sub><a href="https://github.com/justrach/codegraff/releases/latest">or browse all releases</a></sub>
 </p>
 
 ### Command line — macOS · Linux

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,8 @@
         "@legendapp/list": "^3.0.0-beta.44",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.7.0",
+        "@tauri-apps/plugin-process": "^2.3.0",
+        "@tauri-apps/plugin-updater": "^2.9.0",
         "@wterm/dom": "^0.1.9",
         "border-beam": "^1.0.1",
         "class-variance-authority": "^0.7.1",
@@ -322,6 +324,10 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.2", "", { "os": "win32", "cpu": "x64" }, "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA=="],
 
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.1", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
     },
     "gui": {
       "name": "codegraff-gui",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@base-ui/react": "^1.4.0",
         "@codegraff/diffs": "workspace:*",
@@ -21,6 +21,7 @@
         "clsx": "^2.1.1",
         "dockview-react": "^5.2.0",
         "lucide-react": "^1.8.0",
+        "mermaid": "^11.15.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-resizable-panels": "^4.10.0",
@@ -70,6 +71,8 @@
     },
   },
   "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -132,6 +135,10 @@
 
     "@base-ui/utils": ["@base-ui/utils@0.2.9", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw=="],
 
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
     "@codegraff/diffs": ["@codegraff/diffs@workspace:packages/diffs"],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.73.1", "", { "dependencies": { "commander": "^11.1.0", "conf": "^10.2.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "enquirer": "^2.4.1", "env-paths": "^2.2.1", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "open": "^8.4.2", "picomatch": "^4.0.4", "systeminformation": "^5.22.11", "undici": "^7.11.0", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-AWf8edAsSpINqJbtaZsaiV3PO+vw5pS4wJFl6ahYNdnp3gfFYeMxRCdsA9042bKP4UPCs8yr5FikSFlvkmFVag=="],
@@ -184,6 +191,10 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.3", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -195,6 +206,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@legendapp/list": ["@legendapp/list@3.0.6", "", { "dependencies": { "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "react": "*" } }, "sha512-umEkE+WQpw61Ep1lLQC6f/UzXl19Jxqysg+WUP5VnvfA9TxCCj0VsxU8n2ukEFTovSIrY3ab4aFNKgJt9P1Ngg=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -314,7 +327,71 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
@@ -327,6 +404,8 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/svgo": ["@types/svgo@1.3.6", "", {}, "sha512-AZU7vQcy/4WFEuwnwsNsJnFwupIpbllH1++LXScN6uxT1Z4zPzdrWG97w4/I7eFKFTvfy/bHFStWjdBAg2Vjug=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
@@ -349,6 +428,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.2", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.0" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg=="],
 
@@ -462,6 +543,8 @@
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -480,6 +563,78 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
@@ -487,6 +642,8 @@
     "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "debounce-fn": ["debounce-fn@4.0.0", "", { "dependencies": { "mimic-fn": "^3.0.0" } }, "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ=="],
 
@@ -508,6 +665,8 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
+
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -523,6 +682,8 @@
     "dom-serializer": ["dom-serializer@0.2.2", "", { "dependencies": { "domelementtype": "^2.0.1", "entities": "^2.0.0" } }, "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g=="],
 
     "domelementtype": ["domelementtype@1.3.1", "", {}, "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="],
+
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "domutils": ["domutils@1.7.0", "", { "dependencies": { "dom-serializer": "0", "domelementtype": "1" } }, "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg=="],
 
@@ -567,6 +728,8 @@
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.1", "", { "dependencies": { "es-abstract-get": "^1.0.0", "es-errors": "^1.3.0", "is-callable": "^1.2.7", "is-date-object": "^1.1.0", "is-symbol": "^1.1.1" } }, "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g=="],
+
+    "es-toolkit": ["es-toolkit@1.47.1", "", {}, "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -684,6 +847,8 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -710,17 +875,21 @@
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
@@ -828,9 +997,15 @@
 
     "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -862,6 +1037,8 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
@@ -871,6 +1048,8 @@
     "lucide-react": ["lucide-react@1.20.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -883,6 +1062,8 @@
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "mermaid": ["mermaid@11.15.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.1", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "es-toolkit": "^1.45.1", "katex": "^0.16.25", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
@@ -952,6 +1133,8 @@
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
@@ -961,6 +1144,8 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -975,6 +1160,10 @@
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1026,13 +1215,19 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
 
@@ -1112,6 +1307,8 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "svgo": ["svgo@1.3.2", "", { "dependencies": { "chalk": "^2.4.1", "coa": "^2.0.2", "css-select": "^2.0.0", "css-select-base-adapter": "^0.1.1", "css-tree": "1.0.0-alpha.37", "csso": "^4.0.2", "js-yaml": "^3.13.1", "mkdirp": "~0.5.1", "object.values": "^1.1.0", "sax": "~1.2.4", "stable": "^0.1.8", "unquote": "~1.1.1", "util.promisify": "~1.0.0" }, "bin": { "svgo": "./bin/svgo" } }, "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw=="],
@@ -1126,6 +1323,8 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
@@ -1133,6 +1332,8 @@
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
 
     "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
 
@@ -1183,6 +1384,8 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "util.promisify": ["util.promisify@1.0.1", "", { "dependencies": { "define-properties": "^1.1.3", "es-abstract": "^1.17.2", "has-symbols": "^1.0.1", "object.getownpropertydescriptors": "^2.1.0" } }, "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
@@ -1264,6 +1467,8 @@
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
+    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "coa/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "conf/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
@@ -1276,6 +1481,14 @@
 
     "csso/css-tree": ["css-tree@1.1.3", "", { "dependencies": { "mdn-data": "2.0.14", "source-map": "^0.6.1" } }, "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q=="],
 
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "dot-prop/is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
@@ -1285,6 +1498,8 @@
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -1301,6 +1516,8 @@
     "pkg-up/find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
@@ -1347,6 +1564,10 @@
     "conf/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.14", "", {}, "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/gui/package.json
+++ b/gui/package.json
@@ -28,6 +28,7 @@
     "clsx": "^2.1.1",
     "dockview-react": "^5.2.0",
     "lucide-react": "^1.8.0",
+    "mermaid": "^11.15.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-resizable-panels": "^4.10.0",

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codegraff-gui",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.0.162",
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.10",
   "type": "module",
@@ -22,6 +22,8 @@
     "@legendapp/list": "^3.0.0-beta.44",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.7.0",
+    "@tauri-apps/plugin-process": "^2.3.0",
+    "@tauri-apps/plugin-updater": "^2.9.0",
     "@wterm/dom": "^0.1.9",
     "border-beam": "^1.0.1",
     "class-variance-authority": "^0.7.1",

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -76,6 +76,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,7 +655,7 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "codegraff-gui"
-version = "0.0.13"
+version = "0.0.162"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -669,7 +678,9 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
+ "tauri-plugin-process",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "tiny_http",
  "tokio",
  "tonic",
@@ -951,6 +962,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1348,6 +1370,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2678,6 +2710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +2971,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,6 +3031,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3050,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3856,15 +3926,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4026,6 +4101,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,6 +4121,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4065,6 +4179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4129,6 +4252,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4720,6 +4866,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4921,6 +5078,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4933,6 +5100,39 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -5936,6 +6136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6649,6 +6858,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6816,6 +7035,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "codegraff-gui"
-version = "0.0.13"
+version = "0.0.162"
 description = "Desktop coding agent interface powered by Codegraff"
 authors = ["Codegraff contributors"]
 license = "Apache-2.0"
@@ -40,6 +40,8 @@ tauri = { version = "2.10.3", features = ["macos-private-api"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-log = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 tokio = { version = "1.51.0", features = ["io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tonic = { version = "0.14.5", features = ["tls-webpki-roots"] }
 ts-rs = "12.0.1"

--- a/gui/src-tauri/capabilities/default.json
+++ b/gui/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
-    "dialog:default"
+    "dialog:default",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/gui/src-tauri/src/cli_install.rs
+++ b/gui/src-tauri/src/cli_install.rs
@@ -50,12 +50,20 @@ pub fn ensure_cli_symlink(app: &tauri::App) {
         targets.push(home.join(".local").join("bin"));
     }
 
+    // The bundled agent CLI ships beside the app binary (externalBin →
+    // Contents/MacOS/graff). We link it onto PATH so installing the app also
+    // installs the `graff` terminal command.
+    let bundled_graff = exe.parent().map(|d| d.join("graff"));
+
     for dir in targets {
         let link = dir.join("codegraff");
         // Already current (handles app moves and the prior symlink form)?
         if let Ok(existing) = std::fs::read_to_string(&link) {
             if existing == script {
                 log::info!("codegraff launcher already current at {}", link.display());
+                if let Some(ref g) = bundled_graff {
+                    ensure_graff_on_path(&dir, g);
+                }
                 return;
             }
         }
@@ -73,12 +81,52 @@ pub fn ensure_cli_symlink(app: &tauri::App) {
         match written {
             Ok(()) => {
                 log::info!("codegraff launcher installed at {}", link.display());
+                if let Some(ref g) = bundled_graff {
+                    ensure_graff_on_path(&dir, g);
+                }
                 return;
             }
             Err(err) => {
                 log::warn!("could not write codegraff launcher into {}: {err}", dir.display());
             }
         }
+    }
+}
+
+/// Put the bundled `graff` agent CLI on PATH (next to the `codegraff` launcher),
+/// so installing the desktop app also gives you the terminal command. It's a
+/// symlink into the app bundle, so `graff` tracks the app's auto-updates.
+///
+/// Never clobbers a real `graff` — e.g. one installed by `install.sh` into ~/bin
+/// or a Homebrew copy. Only creates the link when nothing is there, or refreshes
+/// a symlink we previously made (one pointing into a .app bundle, e.g. after the
+/// app was moved or updated).
+#[cfg(target_os = "macos")]
+fn ensure_graff_on_path(dir: &std::path::Path, bundled_graff: &std::path::Path) {
+    use std::os::unix::fs::symlink;
+    if !bundled_graff.is_file() {
+        return;
+    }
+    let link = dir.join("graff");
+    match std::fs::symlink_metadata(&link) {
+        Ok(meta) => {
+            if !meta.file_type().is_symlink() {
+                // A regular file is a real install — never overwrite it.
+                return;
+            }
+            let current = std::fs::read_link(&link).unwrap_or_default();
+            if current == bundled_graff {
+                return; // already correct
+            }
+            if !current.to_string_lossy().contains(".app/Contents/MacOS/") {
+                return; // a symlink to something that isn't ours — leave it
+            }
+            let _ = std::fs::remove_file(&link);
+        }
+        Err(_) => {} // absent — fall through and create it
+    }
+    if symlink(bundled_graff, &link).is_ok() {
+        log::info!("graff CLI linked at {}", link.display());
     }
 }
 

--- a/gui/src-tauri/src/dto/runtime.rs
+++ b/gui/src-tauri/src/dto/runtime.rs
@@ -277,6 +277,12 @@ pub struct PromptSettingsDto {
     pub selected_model_id: Option<String>,
     pub selected_reasoning_effort: Option<String>,
     pub fast_enabled: bool,
+    /// Whether toggling fast actually changes harness behavior for the selected
+    /// provider. The harness only applies /fast on the codex provider (the
+    /// `responses` kind): it emits `service_tier:"priority"` there and reports
+    /// `applies:false` everywhere else. True only when the selected provider is
+    /// codex; the GUI greys out the toggle when this is false.
+    pub fast_applies: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS)]

--- a/gui/src-tauri/src/dto/session.rs
+++ b/gui/src-tauri/src/dto/session.rs
@@ -127,6 +127,11 @@ pub struct ConversationViewSnapshotDto {
     pub active_request_ids: Vec<String>,
     pub request_agent_ids: HashMap<String, String>,
     pub todos: Vec<SessionTodoDto>,
+    /// Steering objective for this chat, set via `/goal`. Surfaced in the UI as
+    /// the goal chip above the composer. Omitted from the payload when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub goal: Option<String>,
     pub followup: Option<super::followup::FollowupRequestDto>,
 }
 
@@ -180,6 +185,12 @@ pub struct SessionSnapshotDto {
     pub visible_active_request_ids: Vec<String>,
     pub visible_request_agent_ids: HashMap<String, String>,
     pub visible_todos: Vec<SessionTodoDto>,
+    /// Steering objective of the active chat, set via `/goal`. Mirrors
+    /// `ConversationViewSnapshotDto::goal` for the visible conversation. Omitted
+    /// from the payload when no goal is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub visible_goal: Option<String>,
     pub visible_followup: Option<super::followup::FollowupRequestDto>,
     pub conversation_views: Vec<ConversationViewSnapshotDto>,
     pub ui_error: Option<String>,

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -61,7 +61,9 @@ pub fn run() {
                 let _ = window.set_focus();
             }
         }))
-        .plugin(tauri_plugin_dialog::init());
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init());
     #[cfg(debug_assertions)]
     let builder = builder.plugin(
         tauri_plugin_log::Builder::default()

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -292,9 +292,16 @@ impl RuntimeManager {
                     &conversation_id,
                     serde_json::json!({
                         "type": "set_model",
-                        // Bare model only: let the harness prefer-direct (same as
-                        // the spawn-time --model), instead of pinning the gateway.
+                        // Send BOTH model and provider so the harness routes to the
+                        // exact provider the user picked in the menu (gpt-5.5 from
+                        // Codex vs the Codegraff gateway). A bare model can't be
+                        // pinned to a provider, so an explicit Codex pick was dropped
+                        // and models that exist under two providers (the two gpt-5.5
+                        // entries) failed to switch at all — the engine emits an
+                        // `error` event, send_control surfaces it, and the whole
+                        // update aborts (then the UI swallows it).
                         "model": selected_model.name.as_str(),
+                        "provider": selected_model.provider.as_str(),
                     }),
                 )
                 .await?;
@@ -3103,24 +3110,54 @@ fn followup_answer_line(request: &FollowupRequestDto, response: &FollowupRespons
 /// `current_dir` set to the workspace, and a relative program path would be
 /// resolved against that workspace (not the repo) — so a relative override like
 /// `CODEGRAFF_GUI_BINARY=../zig-out/bin/graff` must be canonicalized here.
+/// True only for a real, non-empty, executable file. A path that exists but is
+/// empty or not executable (e.g. an `externalBin` sidecar copy a `cargo build`
+/// left half-written, or a clobbered 0-byte binary) must NOT be returned as the
+/// engine path — a bare `is_file()` check would hand it back and shadow the
+/// working fallbacks below, and the spawn then dies with EACCES on exec.
+fn is_usable_binary(path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() || meta.len() == 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
 fn codegraff_binary() -> String {
-    // 1. Explicit override, canonicalized to absolute when it resolves to a file.
+    // 1. Explicit override, canonicalized to absolute when it resolves to a
+    //    usable file. A broken override falls through to the built-in rather
+    //    than failing the launch outright.
     if let Some(value) = std::env::var("CODEGRAFF_GUI_BINARY")
         .ok()
         .filter(|value| !value.trim().is_empty())
     {
         if let Ok(absolute) = std::fs::canonicalize(&value) {
-            return absolute.to_string_lossy().into_owned();
+            if is_usable_binary(&absolute) {
+                return absolute.to_string_lossy().into_owned();
+            }
         }
-        // Doesn't resolve from the current dir — fall through to the built-in.
+        // Doesn't resolve to a usable file — fall through to the built-in.
     }
     // 2. Bundled sidecar: Tauri's externalBin lands next to the app executable
     //    (Contents/MacOS/graff on macOS), so a packaged .app is self-contained —
     //    no separate CLI install needed. This is what fixes GUI-only users.
+    //    Guard on is_usable_binary: an interrupted `cargo build` can leave a
+    //    0-byte sidecar here, and a bare is_file() check would return it and
+    //    shadow the working binaries below (the EACCES-at-exec failure).
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
             let p = dir.join("graff");
-            if p.is_file() {
+            if is_usable_binary(&p) {
                 return p.to_string_lossy().into_owned();
             }
         }
@@ -3128,7 +3165,9 @@ fn codegraff_binary() -> String {
     // 3. Dev build: <crate>/../../zig-out/bin/graff (only exists on a dev machine).
     let candidate = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../zig-out/bin/graff");
     if let Ok(absolute) = std::fs::canonicalize(&candidate) {
-        return absolute.to_string_lossy().into_owned();
+        if is_usable_binary(&absolute) {
+            return absolute.to_string_lossy().into_owned();
+        }
     }
     // 4. Known install locations. A Finder/Dock-launched .app inherits launchd's
     //    minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin), which excludes ~/bin,
@@ -3139,7 +3178,7 @@ fn codegraff_binary() -> String {
     if let Ok(home) = std::env::var("HOME") {
         for rel in ["bin/graff", ".local/bin/graff"] {
             let p = Path::new(&home).join(rel);
-            if p.is_file() {
+            if is_usable_binary(&p) {
                 return p.to_string_lossy().into_owned();
             }
         }
@@ -3149,7 +3188,7 @@ fn codegraff_binary() -> String {
         "/usr/local/bin/graff",
         "/usr/bin/graff",
     ] {
-        if Path::new(abs).is_file() {
+        if is_usable_binary(Path::new(abs)) {
             return abs.to_string();
         }
     }

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -2780,8 +2780,15 @@ fn selected_prompt_model_pair(
         .or_else(|| default_model.map(|model| (model.provider.clone(), model.name.clone())))
 }
 
-fn prompt_model_arg(provider: &str, model: &str) -> String {
-    format!("{provider} {model}")
+fn prompt_model_arg(_provider: &str, model: &str) -> String {
+    // Pass the BARE model name and let the harness route it to a provider via the
+    // same prefer-direct resolution the TUI uses (`/model <name>`). Prefixing the
+    // provider ("kimi kimi-k2.7" or "kimi/kimi-k2.7") is NOT understood by
+    // `--model`: it falls back to the codegraff gateway, which then rejects the
+    // unknown model. The harness picks the right provider for a bare model name
+    // (kimi-k2.7 -> kimi when keyed; only falling back to codegraff if no direct
+    // provider is configured), so the GUI must call it exactly like the terminal.
+    model.to_string()
 }
 
 fn selected_pair_exists(
@@ -4098,12 +4105,12 @@ mod tests {
     }
 
     #[test]
-    fn prompt_model_arg_includes_provider_to_disambiguate_duplicate_names() {
-        assert_eq!(prompt_model_arg("codex", "gpt-5.5"), "codex gpt-5.5");
-        assert_eq!(
-            prompt_model_arg("codegraff", "gpt-5.5"),
-            "codegraff gpt-5.5"
-        );
+    fn prompt_model_arg_uses_bare_model_name() {
+        // The harness only recognizes bare model names (routed to a provider by
+        // prefer-direct, like the TUI's `/model`); a "provider model" prefix is
+        // not understood by --model and falls back to the codegraff gateway.
+        assert_eq!(prompt_model_arg("codex", "gpt-5.5"), "gpt-5.5");
+        assert_eq!(prompt_model_arg("kimi", "kimi-k2.7"), "kimi-k2.7");
     }
 
     #[test]

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -42,6 +42,8 @@ struct ConversationState {
     /// (harness semantics). Surfaced to the GUI's task-progress dock.
     todos: Vec<SessionTodoDto>,
     goal: Option<String>,
+    /// Persistent ultracode (multi-agent workflow) mode, scoped to this chat.
+    ultracode_enabled: bool,
     updated_at: i64,
 }
 
@@ -445,6 +447,7 @@ impl RuntimeManager {
             bash_command(),
             command("compact", "Compact current conversation.", true),
             command("workspace-status", "Show git status.", true),
+            command("ultracode", "Toggle persistent ultracode (multi-agent workflow) mode.", true),
         ])
     }
 
@@ -484,6 +487,7 @@ impl RuntimeManager {
                     queued_prompts: VecDeque::new(),
                     active_agent_id,
                     plan_mode,
+                    ultracode_enabled: false,
                     todos: Vec::new(),
                     goal: None,
                     updated_at: now_millis(),
@@ -1017,7 +1021,7 @@ impl RuntimeManager {
                 continue;
             };
             match event.get("type").and_then(serde_json::Value::as_str) {
-                Some("model" | "compact" | "mode" | "agent" | "effort" | "fast") => break event,
+                Some("model" | "compact" | "mode" | "agent" | "effort" | "fast" | "ultracode") => break event,
                 Some("error") => {
                     let message = event
                         .get("message")
@@ -1057,6 +1061,7 @@ impl RuntimeManager {
                     messages: conversation.messages.clone(),
                     active_agent_id: conversation.active_agent_id.clone(),
                     plan_mode: conversation.plan_mode,
+                    ultracode_enabled: conversation.ultracode_enabled,
                     goal: conversation.goal.clone(),
                     updated_at: conversation.updated_at,
                 })
@@ -1095,7 +1100,7 @@ impl RuntimeManager {
         let model_arg = self.selected_model_arg().await;
         let mut sessions = self.sessions.lock().await;
         if !sessions.contains_key(conversation_id) {
-            let (active_agent_id, plan_mode, effort, fast) = {
+            let (active_agent_id, plan_mode, effort, fast, ultracode) = {
                 let state = self.state.lock().await;
                 let conversation = state.conversations.get(conversation_id);
                 (
@@ -1107,6 +1112,7 @@ impl RuntimeManager {
                         .unwrap_or(false),
                     state.selected_effort.clone(),
                     state.fast_enabled,
+                    conversation.map(|c| c.ultracode_enabled).unwrap_or(false),
                 )
             };
             let session = spawn_graff_session(workspace_path, model_arg.as_deref())?;
@@ -1137,6 +1143,13 @@ impl RuntimeManager {
                 self.send_control(
                     conversation_id,
                     serde_json::json!({ "type": "set_fast", "on": true }),
+                )
+                .await?;
+            }
+            if ultracode {
+                self.send_control(
+                    conversation_id,
+                    serde_json::json!({ "type": "set_ultracode", "on": true }),
                 )
                 .await?;
             }
@@ -1202,6 +1215,39 @@ impl RuntimeManager {
                 result_kind: CommandResultKindDto::Agents,
                 payload: Some(CommandPayloadDto::Agents(self.agents_payload().await)),
             }),
+            "ultracode" => {
+                let conversation_id = conversation_id.context("Missing conversation")?;
+                let now_on = {
+                    let mut state = self.state.lock().await;
+                    let conversation = state
+                        .conversations
+                        .get_mut(&conversation_id)
+                        .context("Conversation not found")?;
+                    conversation.ultracode_enabled = !conversation.ultracode_enabled;
+                    conversation.ultracode_enabled
+                };
+                self.persist_conversations().await;
+                if self.session_exists(&conversation_id).await {
+                    self.send_control(
+                        &conversation_id,
+                        serde_json::json!({ "type": "set_ultracode", "on": now_on }),
+                    )
+                    .await?;
+                }
+                let body = if now_on {
+                    "Ultracode mode enabled for this chat."
+                } else {
+                    "Ultracode mode disabled for this chat."
+                };
+                Ok(CommandRunResultDto {
+                    title: "/ultracode".into(),
+                    body: Some(body.into()),
+                    snapshot: None,
+                    saved_path: None,
+                    result_kind: CommandResultKindDto::Text,
+                    payload: None,
+                })
+            }
             "goal" => {
                 let _workspace = workspace_path.context("Missing workspace")?;
                 let conversation_id = conversation_id.context("Missing conversation")?;
@@ -1679,6 +1725,7 @@ impl RuntimeManager {
                 queued_prompts: VecDeque::new(),
                 active_agent_id: None,
                 plan_mode: false,
+                ultracode_enabled: false,
                 todos: Vec::new(),
                 goal: None,
                 updated_at: now_millis(),
@@ -2267,6 +2314,8 @@ struct PersistedConversation {
     #[serde(default)]
     plan_mode: bool,
     #[serde(default)]
+    ultracode_enabled: bool,
+    #[serde(default)]
     goal: Option<String>,
     #[serde(default)]
     updated_at: i64,
@@ -2354,6 +2403,7 @@ fn load_persisted_conversations() -> HashMap<String, ConversationState> {
                     queued_prompts: VecDeque::new(),
                     active_agent_id: conversation.active_agent_id,
                     plan_mode: conversation.plan_mode,
+                    ultracode_enabled: conversation.ultracode_enabled,
                     todos: Vec::new(),
                     goal: conversation.goal,
                     updated_at: conversation.updated_at,
@@ -2469,7 +2519,7 @@ fn command(name: &str, usage: &str, requires_workspace: bool) -> CommandDescript
         is_agent_switch: false,
         execution_kind: CommandExecutionKindDto::Runnable,
         requires_workspace,
-        requires_conversation: matches!(name, "compact" | "goal" | "loop"),
+        requires_conversation: matches!(name, "compact" | "goal" | "loop" | "ultracode"),
         argument_hint: None,
         result_kind: CommandResultKindDto::Text,
     }
@@ -3956,6 +4006,7 @@ mod tests {
                 queued_prompts: VecDeque::new(),
                 active_agent_id: None,
                 plan_mode: false,
+                ultracode_enabled: false,
                 todos: Vec::new(),
                 goal: None,
                 updated_at: 10,
@@ -4226,6 +4277,7 @@ mod tests {
                 queued_prompts: VecDeque::new(),
                 active_agent_id: None,
                 plan_mode: false,
+                ultracode_enabled: false,
                 todos: Vec::new(),
                 goal: None,
                 updated_at: 10,
@@ -4243,6 +4295,7 @@ mod tests {
                 queued_prompts: VecDeque::new(),
                 active_agent_id: None,
                 plan_mode: false,
+                ultracode_enabled: false,
                 todos: Vec::new(),
                 goal: None,
                 updated_at: 20,

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -294,9 +294,16 @@ impl RuntimeManager {
                     &conversation_id,
                     serde_json::json!({
                         "type": "set_model",
-                        // Bare model only: let the harness prefer-direct (same as
-                        // the spawn-time --model), instead of pinning the gateway.
+                        // Send BOTH model and provider so the harness routes to the
+                        // exact provider the user picked in the menu (gpt-5.5 from
+                        // Codex vs the Codegraff gateway). A bare model can't be
+                        // pinned to a provider, so an explicit Codex pick was dropped
+                        // and models that exist under two providers (the two gpt-5.5
+                        // entries) failed to switch at all — the engine emits an
+                        // `error` event, send_control surfaces it, and the whole
+                        // update aborts (then the UI swallows it).
                         "model": selected_model.name.as_str(),
+                        "provider": selected_model.provider.as_str(),
                     }),
                 )
                 .await?;
@@ -3172,24 +3179,54 @@ fn followup_answer_line(request: &FollowupRequestDto, response: &FollowupRespons
 /// `current_dir` set to the workspace, and a relative program path would be
 /// resolved against that workspace (not the repo) — so a relative override like
 /// `CODEGRAFF_GUI_BINARY=../zig-out/bin/graff` must be canonicalized here.
+/// True only for a real, non-empty, executable file. A path that exists but is
+/// empty or not executable (e.g. an `externalBin` sidecar copy a `cargo build`
+/// left half-written, or a clobbered 0-byte binary) must NOT be returned as the
+/// engine path — a bare `is_file()` check would hand it back and shadow the
+/// working fallbacks below, and the spawn then dies with EACCES on exec.
+fn is_usable_binary(path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() || meta.len() == 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
 fn codegraff_binary() -> String {
-    // 1. Explicit override, canonicalized to absolute when it resolves to a file.
+    // 1. Explicit override, canonicalized to absolute when it resolves to a
+    //    usable file. A broken override falls through to the built-in rather
+    //    than failing the launch outright.
     if let Some(value) = std::env::var("CODEGRAFF_GUI_BINARY")
         .ok()
         .filter(|value| !value.trim().is_empty())
     {
         if let Ok(absolute) = std::fs::canonicalize(&value) {
-            return absolute.to_string_lossy().into_owned();
+            if is_usable_binary(&absolute) {
+                return absolute.to_string_lossy().into_owned();
+            }
         }
-        // Doesn't resolve from the current dir — fall through to the built-in.
+        // Doesn't resolve to a usable file — fall through to the built-in.
     }
     // 2. Bundled sidecar: Tauri's externalBin lands next to the app executable
     //    (Contents/MacOS/graff on macOS), so a packaged .app is self-contained —
     //    no separate CLI install needed. This is what fixes GUI-only users.
+    //    Guard on is_usable_binary: an interrupted `cargo build` can leave a
+    //    0-byte sidecar here, and a bare is_file() check would return it and
+    //    shadow the working binaries below (the EACCES-at-exec failure).
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
             let p = dir.join("graff");
-            if p.is_file() {
+            if is_usable_binary(&p) {
                 return p.to_string_lossy().into_owned();
             }
         }
@@ -3197,7 +3234,9 @@ fn codegraff_binary() -> String {
     // 3. Dev build: <crate>/../../zig-out/bin/graff (only exists on a dev machine).
     let candidate = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../zig-out/bin/graff");
     if let Ok(absolute) = std::fs::canonicalize(&candidate) {
-        return absolute.to_string_lossy().into_owned();
+        if is_usable_binary(&absolute) {
+            return absolute.to_string_lossy().into_owned();
+        }
     }
     // 4. Known install locations. A Finder/Dock-launched .app inherits launchd's
     //    minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin), which excludes ~/bin,
@@ -3208,7 +3247,7 @@ fn codegraff_binary() -> String {
     if let Ok(home) = std::env::var("HOME") {
         for rel in ["bin/graff", ".local/bin/graff"] {
             let p = Path::new(&home).join(rel);
-            if p.is_file() {
+            if is_usable_binary(&p) {
                 return p.to_string_lossy().into_owned();
             }
         }
@@ -3218,7 +3257,7 @@ fn codegraff_binary() -> String {
         "/usr/local/bin/graff",
         "/usr/bin/graff",
     ] {
-        if Path::new(abs).is_file() {
+        if is_usable_binary(Path::new(abs)) {
             return abs.to_string();
         }
     }

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -6,6 +6,7 @@ use crate::{
     terminal::TerminalManager,
 };
 use anyhow::{Context, Result};
+use base64::Engine;
 #[cfg(target_os = "macos")]
 use std::os::unix::fs::PermissionsExt;
 use std::{
@@ -961,11 +962,17 @@ impl RuntimeManager {
                 }
                 Some("turn") => break,
                 Some("error") => {
-                    let message = event
+                    let raw_message = event
                         .get("message")
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("graff error")
                         .to_string();
+                    let auth_error = is_provider_auth_error_message(&raw_message);
+                    let message = if auth_error {
+                        provider_auth_error_message(&raw_message)
+                    } else {
+                        raw_message
+                    };
                     let id = format!("{request_id}-error-{}", Uuid::new_v4().simple());
                     let rid = request_id.to_string();
                     self.mutate_conversation(conversation_id, move |conversation| {
@@ -976,6 +983,15 @@ impl RuntimeManager {
                         });
                     })
                     .await;
+                    if auth_error {
+                        // A rejected/expired credential can leave the long-lived
+                        // child in a bad state. Drop it so retrying after the
+                        // user reconnects spawns a fresh graff process instead
+                        // of reusing a session that already failed auth.
+                        self.drop_session(conversation_id).await;
+                        self.emit().await?;
+                        return Ok(());
+                    }
                     break;
                 }
                 // system_prompt / score acks and anything unrecognized: ignore.
@@ -2229,6 +2245,25 @@ pub(crate) fn format_error_chain(error: &anyhow::Error) -> String {
         .map(ToString::to_string)
         .collect::<Vec<_>>()
         .join(": ")
+}
+
+fn is_provider_auth_error_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("invalid_api_key")
+        || lower.contains("unauthorized")
+        || (lower.contains("api key")
+            && (lower.contains("invalid")
+                || lower.contains("expired")
+                || lower.contains("incorrect")))
+        || (lower.contains("token") && lower.contains("expired"))
+        || (lower.contains("authentication")
+            && (lower.contains("failed") || lower.contains("invalid")))
+}
+
+fn provider_auth_error_message(raw: &str) -> String {
+    format!(
+        "Provider authentication failed before the turn could run. The selected API key/login was rejected or expired. Re-open Settings → Providers and reconnect the provider, then retry.\n\nThe GUI dropped the live graff session so the next retry starts fresh.\n\n{raw}"
+    )
 }
 
 /// Runs a literal substring search over the workspace. Tries ripgrep first
@@ -3536,7 +3571,11 @@ fn env_has_provider_key(env_key: &str) -> bool {
 }
 
 fn provider_configured(provider: &CodegraffProvider, key_list: &str) -> bool {
-    if provider.env_key.as_deref().is_some_and(env_has_provider_key) {
+    if provider
+        .env_key
+        .as_deref()
+        .is_some_and(env_has_provider_key)
+    {
         return true;
     }
 
@@ -3585,8 +3624,8 @@ fn home_codex_auth_has_valid_token(home: Option<&Path>) -> bool {
 }
 
 /// Kimi OAuth login (`graff login kimi`) writes a JSON token file to
-/// `~/.kimi/credentials/graff-oauth.json`. The CLI auto-refreshes the
-/// access token when near expiry, so a non-empty access_token means logged in.
+/// `~/.kimi/credentials/graff-oauth.json`. Treat an expired token file as not
+/// configured so the GUI asks the user to reconnect before starting a run.
 fn kimi_auth_has_valid_token(home: Option<&Path>) -> bool {
     home.map(|home| {
         let path = home.join(".kimi/credentials/graff-oauth.json");
@@ -3596,10 +3635,17 @@ fn kimi_auth_has_valid_token(home: Option<&Path>) -> bool {
         let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
             return false;
         };
+        if value
+            .get("expires_at")
+            .and_then(serde_json::Value::as_i64)
+            .is_some_and(|expires_at| unix_seconds() >= expires_at.saturating_sub(60))
+        {
+            return false;
+        }
         value
             .get("access_token")
             .and_then(|token| token.as_str())
-            .map(|token| !token.trim().is_empty())
+            .map(|token| !token.trim().is_empty() && jwt_token_not_expired(token))
             .unwrap_or(false)
     })
     .unwrap_or(false)
@@ -3621,8 +3667,33 @@ fn codex_auth_text_has_valid_token(text: &str) -> bool {
         .and_then(|tokens| tokens.get("access_token"))
         .or_else(|| value.get("access_token"))
         .and_then(|token| token.as_str())
-        .map(|token| !token.trim().is_empty())
+        .map(|token| !token.trim().is_empty() && jwt_token_not_expired(token))
         .unwrap_or(false)
+}
+
+fn jwt_token_not_expired(token: &str) -> bool {
+    let Some(payload) = token.split('.').nth(1) else {
+        // API keys and opaque OAuth tokens do not expose an expiry locally; they
+        // still need the runtime auth-error handling above.
+        return true;
+    };
+    let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload) else {
+        return true;
+    };
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return true;
+    };
+    let Some(exp) = value.get("exp").and_then(serde_json::Value::as_i64) else {
+        return true;
+    };
+    unix_seconds() < exp.saturating_sub(60)
+}
+
+fn unix_seconds() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
 }
 
 fn provider_env_key(provider_id: &str) -> Option<String> {
@@ -4164,6 +4235,24 @@ mod tests {
         ));
         assert!(!codex_auth_text_has_valid_token("{}"));
         assert!(!codex_auth_text_has_valid_token("not json"));
+    }
+
+    #[test]
+    fn codex_auth_text_rejects_expired_jwt_token() {
+        let expired_payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(r#"{"exp":1}"#);
+        let token = format!("header.{expired_payload}.signature");
+        let auth = serde_json::json!({ "tokens": { "access_token": token } }).to_string();
+
+        assert!(!codex_auth_text_has_valid_token(&auth));
+    }
+
+    #[test]
+    fn provider_auth_error_detection_matches_invalid_api_key() {
+        assert!(is_provider_auth_error_message(
+            "api error: The API Key appears to be invalid or may have expired. Please verify your credentials and try again."
+        ));
+        assert!(provider_auth_error_message("invalid_api_key").contains("reconnect"));
     }
 
     #[test]

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -447,7 +447,11 @@ impl RuntimeManager {
             bash_command(),
             command("compact", "Compact current conversation.", true),
             command("workspace-status", "Show git status.", true),
-            command("ultracode", "Toggle persistent ultracode (multi-agent workflow) mode.", true),
+            command(
+                "ultracode",
+                "Toggle persistent ultracode (multi-agent workflow) mode.",
+                true,
+            ),
         ])
     }
 
@@ -520,7 +524,10 @@ impl RuntimeManager {
             // after a planning-mode turn completes (gate keys off "muse").
             conversation.request_agent_ids.insert(
                 request_id.clone(),
-                input.agent_id.clone().unwrap_or_else(|| "forge".to_string()),
+                input
+                    .agent_id
+                    .clone()
+                    .unwrap_or_else(|| "forge".to_string()),
             );
             should_queue = !conversation.active_request_ids.is_empty();
             if should_queue {
@@ -1021,7 +1028,9 @@ impl RuntimeManager {
                 continue;
             };
             match event.get("type").and_then(serde_json::Value::as_str) {
-                Some("model" | "compact" | "mode" | "agent" | "effort" | "fast" | "ultracode") => break event,
+                Some("model" | "compact" | "mode" | "agent" | "effort" | "fast" | "ultracode") => {
+                    break event;
+                }
                 Some("error") => {
                     let message = event
                         .get("message")
@@ -1115,7 +1124,8 @@ impl RuntimeManager {
                     conversation.map(|c| c.ultracode_enabled).unwrap_or(false),
                 )
             };
-            let session = spawn_graff_session(workspace_path, model_arg.as_deref())?;
+            let session =
+                spawn_graff_session(workspace_path, model_arg.as_deref(), conversation_id)?;
             sessions.insert(conversation_id.to_string(), session);
             drop(sessions);
             if let Some(agent_id) = active_agent_id.filter(|id| id != "forge") {
@@ -2374,9 +2384,9 @@ fn conversations_store_path() -> Option<PathBuf> {
     })
 }
 
-/// Loads persisted transcripts so past chats survive a restart. Live `graff`
-/// sessions are not restored — continuing a loaded chat starts a fresh session
-/// without the model's prior context (true resume needs a CLI protocol change).
+/// Loads persisted transcripts so past chats survive a restart. Continuing a
+/// chat now spawns `graff --json --resume <conversation_id>`, so new/updated
+/// chats also regain engine-side model context when their session file exists.
 fn load_persisted_conversations() -> HashMap<String, ConversationState> {
     let Some(path) = conversations_store_path() else {
         return HashMap::new();
@@ -2539,7 +2549,9 @@ fn login_shell_env() -> &'static std::collections::HashMap<String, String> {
         std::thread::spawn(move || {
             // -il = interactive login shell: sources the login profile AND
             // .zshrc/.bashrc, where most users export their *_API_KEY.
-            let out = std::process::Command::new(&shell).args(["-ilc", "env"]).output();
+            let out = std::process::Command::new(&shell)
+                .args(["-ilc", "env"])
+                .output();
             let _ = tx.send(out);
         });
         let mut map = std::collections::HashMap::new();
@@ -2561,16 +2573,23 @@ fn bash_command() -> CommandDescriptorDto {
         argument_hint: Some("<command>".into()),
         ..command("bash", "Run a shell command in the workspace.", true)
     }
-
 }
 
 /// Spawns a persistent `graff --json` child for a conversation. `--yolo` skips
 /// permission prompts (the GUI has no approval surface yet); stderr is discarded
 /// since the protocol carries errors as `error` events on stdout.
-fn spawn_graff_session(workspace_path: &str, model: Option<&str>) -> Result<GraffSession> {
+fn spawn_graff_session(
+    workspace_path: &str,
+    model: Option<&str>,
+    conversation_id: &str,
+) -> Result<GraffSession> {
     let bin = codegraff_binary();
     let mut command = tokio::process::Command::new(&bin);
-    command.arg("--json").arg("--yolo");
+    command
+        .arg("--json")
+        .arg("--yolo")
+        .arg("--resume")
+        .arg(conversation_id);
     if let Some(model) = model.filter(|model| !model.is_empty() && *model != "default") {
         command.arg("--model").arg(model);
     }
@@ -3853,13 +3872,19 @@ mod tests {
     #[cfg(unix)]
     fn format_command_output_empty_is_no_output() {
         // stdout+stderr empty, exit 0 -> the "(no output)" placeholder.
-        assert_eq!(format_command_output(&mk_output(b"", b"", 0)), "(no output)");
+        assert_eq!(
+            format_command_output(&mk_output(b"", b"", 0)),
+            "(no output)"
+        );
     }
 
     #[test]
     #[cfg(unix)]
     fn format_command_output_stdout_only_unchanged() {
-        assert_eq!(format_command_output(&mk_output(b"hello\n", b"", 0)), "hello\n");
+        assert_eq!(
+            format_command_output(&mk_output(b"hello\n", b"", 0)),
+            "hello\n"
+        );
     }
 
     #[test]
@@ -3887,7 +3912,6 @@ mod tests {
         // raw status 2 -> WIFSIGNALED -> status.code() is None.
         assert!(format_command_output(&mk_output(b"", b"", 2)).contains("[terminated abnormally]"));
     }
-
 
     fn followup(
         id: &str,

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -2125,6 +2125,7 @@ impl RuntimeManager {
                 .as_ref()
                 .map(|c| c.todos.clone())
                 .unwrap_or_default(),
+            visible_goal: visible.as_ref().and_then(|c| c.goal.clone()),
             visible_followup,
             conversation_views,
             ui_error: None,
@@ -2456,6 +2457,7 @@ fn conversation_view(
         active_request_ids: conversation.active_request_ids.clone(),
         request_agent_ids: conversation.request_agent_ids.clone(),
         todos: conversation.todos.clone(),
+        goal: conversation.goal.clone(),
         followup,
     }
 }

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -292,8 +292,9 @@ impl RuntimeManager {
                     &conversation_id,
                     serde_json::json!({
                         "type": "set_model",
+                        // Bare model only: let the harness prefer-direct (same as
+                        // the spawn-time --model), instead of pinning the gateway.
                         "model": selected_model.name.as_str(),
-                        "provider": selected_model.provider.as_str(),
                     }),
                 )
                 .await?;
@@ -2719,15 +2720,17 @@ fn filtered_catalog_models<'a>(
 }
 
 fn prompt_model_option(model: &ModelOption) -> PromptModelOptionDto {
-    // Effort-capable providers (mirrors the binary's effortApplies):
-    // codex takes reasoning.effort via the Responses API; codegraff and
-    // deepseek take a top-level reasoning_effort. But the gateway's gpt-*
-    // models go through /v1/chat/completions, which rejects reasoning_effort.
-    let effort_capable = match model.provider.as_str() {
-        "codex" => true,
-        "codegraff" | "deepseek" => !model.name.starts_with("gpt-"),
-        "kimi" => true,
-        _ => false,
+    // Effort applies exactly per the binary's providerTakesEffort: a grok-* model
+    // never takes effort (any provider); otherwise codex/codegraff/deepseek/kimi
+    // do. (No gpt- carve-out - the gateway honors reasoning_effort for gpt-* too;
+    // and grok must be excluded even on the codegraff provider.)
+    let effort_capable = if model.name.starts_with("grok") {
+        false
+    } else {
+        matches!(
+            model.provider.as_str(),
+            "codex" | "codegraff" | "deepseek" | "kimi"
+        )
     };
     let reasoning_efforts: Vec<String> = if effort_capable {
         vec!["low".into(), "medium".into(), "high".into()]
@@ -2757,16 +2760,14 @@ fn selected_prompt_model_pair(
 ) -> Option<(String, String)> {
     let available_catalog = filtered_catalog_models(catalog, configured_provider_ids);
 
+    // No codegraff-first bias: mirror the harness, which defaults to the first
+    // configured provider in spec/schema order and routes bare model names
+    // prefer-direct. Forcing codegraff here biased users onto the metered
+    // gateway even when a cheaper direct provider was keyed.
     let default_model = available_catalog
         .iter()
-        .find(|model| model.provider == "codegraff" && model.is_default)
+        .find(|model| model.is_default)
         .copied()
-        .or_else(|| {
-            available_catalog
-                .iter()
-                .find(|model| model.is_default)
-                .copied()
-        })
         .or_else(|| available_catalog.first().copied());
 
     selected_provider
@@ -3329,11 +3330,9 @@ fn validate_provider_auth_completion(
 /// locating where it's defined so the UI can offer to open that file.
 fn provider_env_override(provider: &CodegraffProvider) -> Option<ProviderEnvOverrideDto> {
     let env_key = provider.env_key.as_deref()?;
-    let is_set = std::env::var(env_key)
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .is_some();
-    if !is_set {
+    // Same env the spawned session sees (process env + login_shell_env), so the
+    // override hint matches what the harness actually uses.
+    if !env_has_provider_key(env_key) {
         return None;
     }
     let (file_path, line) = match find_env_definition(env_key) {
@@ -3395,14 +3394,26 @@ fn provider_auth_label(provider: &CodegraffProvider) -> String {
     }
 }
 
-fn provider_configured(provider: &CodegraffProvider, key_list: &str) -> bool {
-    if provider
-        .env_key
-        .as_deref()
-        .and_then(|env_key| std::env::var(env_key).ok())
-        .filter(|value| !value.trim().is_empty())
-        .is_some()
+/// True if `env_key` has a non-empty value in either the GUI process env OR the
+/// login-shell env the spawned harness session inherits (`login_shell_env`). On a
+/// Finder/Dock launch the GUI's own env is minimal, but the session is spawned
+/// with `command.envs(login_shell_env())`, so a provider keyed only via a shell
+/// export (e.g. KIMI_API_KEY in .zshrc) must still count as configured here -
+/// otherwise its models vanish from the picker yet the session can run them.
+fn env_has_provider_key(env_key: &str) -> bool {
+    if std::env::var(env_key)
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
     {
+        return true;
+    }
+    login_shell_env()
+        .iter()
+        .any(|(key, value)| key.as_str() == env_key && !value.trim().is_empty())
+}
+
+fn provider_configured(provider: &CodegraffProvider, key_list: &str) -> bool {
+    if provider.env_key.as_deref().is_some_and(env_has_provider_key) {
         return true;
     }
 

--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -2830,6 +2830,8 @@ fn build_prompt_settings_from_catalog(
                 selected_model_id: Some("default".into()),
                 selected_reasoning_effort: None,
                 fast_enabled,
+                // codegraff is the `chat` kind, not `responses`: /fast is a no-op.
+                fast_applies: false,
             };
         }
 
@@ -2839,6 +2841,7 @@ fn build_prompt_settings_from_catalog(
             selected_model_id: None,
             selected_reasoning_effort: None,
             fast_enabled,
+            fast_applies: false,
         };
     }
 
@@ -2865,12 +2868,22 @@ fn build_prompt_settings_from_catalog(
         None
     };
 
+    // /fast only changes behavior on the codex provider (the harness `responses`
+    // kind, which emits `service_tier:"priority"`); it reports `applies:false`
+    // for every other provider. Gate on the *resolved* provider so the GUI
+    // matches what the harness will actually do for the active selection.
+    let fast_applies = selected_pair
+        .as_ref()
+        .map(|(provider, _)| provider == "codex")
+        .unwrap_or(false);
+
     PromptSettingsDto {
         available_models,
         selected_provider_id: selected_pair.as_ref().map(|(provider, _)| provider.clone()),
         selected_model_id: selected_pair.as_ref().map(|(_, model)| model.clone()),
         selected_reasoning_effort: selected_pair.and(selected_effort),
         fast_enabled,
+        fast_applies,
     }
 }
 

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Codegraff",
-  "version": "0.0.13",
+  "version": "0.0.162",
   "identifier": "dev.codegraff.gui",
   "build": {
     "frontendDist": "../dist",
@@ -34,6 +34,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "externalBin": ["binaries/graff"],
     "targets": "all",
     "icon": [
@@ -46,6 +47,14 @@
     "macOS": {
       "signingIdentity": "Developer ID Application: Rachit Pradhan (WWP9DLJ27P)",
       "hardenedRuntime": true
+    }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/justrach/codegraff/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEM1RjYxOTJEOEJGQzgzNDUKUldSRmcveUxMUm4yeGJ3aDBQQTdkYU9aa2ppN2Z4dUlCcWxvbFhBbkNyeUFEaGRyNVB0K3c4dVQK"
     }
   }
 }

--- a/gui/src/app/App.tsx
+++ b/gui/src/app/App.tsx
@@ -265,7 +265,7 @@ function AppShell() {
   return (
     <TooltipProvider>
       <SidebarProvider className="min-h-screen bg-background">
-        <main className="app-shell relative flex h-screen w-full overflow-hidden bg-background">
+        <main className="app-shell relative flex h-screen w-full overflow-hidden bg-sidebar">
           <AppThemeToggle
             isDarkTheme={isDarkTheme}
             onToggleTheme={toggleTheme}
@@ -319,7 +319,7 @@ function AppShell() {
               collapsible
               collapsedSize={0}
               groupResizeBehavior="preserve-pixel-size"
-              className={`overflow-hidden${isSidebarAnimating ? " transition-[flex-grow] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]" : ""}`}
+              className={`cg-sidebar-region overflow-hidden${isSidebarAnimating ? " transition-[flex-grow] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]" : ""}`}
               onResize={(size) => {
                 const nextIsVisible = size.inPixels > 0;
                 if (!nextIsVisible) {
@@ -349,13 +349,13 @@ function AppShell() {
             />
             <ResizablePanel
               id="chat-panel"
-              className={
+              className={`cg-content-region${
                 isSidebarAnimating
-                  ? "transition-[flex-grow] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]"
-                  : undefined
-              }
+                  ? " transition-[flex-grow] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]"
+                  : ""
+              }`}
             >
-              <section className="flex h-full min-w-0 flex-1 overflow-hidden">
+              <section className="cg-content-card flex h-full min-w-0 flex-1 overflow-hidden">
                 {isSettingsViewOpen ? (
                   selectedSettingsSection === "providers" ? (
                     <ProvidersSettingsPane />

--- a/gui/src/app/SessionProvider.test.tsx
+++ b/gui/src/app/SessionProvider.test.tsx
@@ -128,6 +128,7 @@ const promptSettingsFixture: PromptSettings = {
   selectedProviderId: "openai",
   selectedReasoningEffort: "medium",
   fastEnabled: false,
+  fastApplies: false,
 };
 
 mock.module("../hooks/useSessionBootstrap", () => ({

--- a/gui/src/app/sessionStore.test.ts
+++ b/gui/src/app/sessionStore.test.ts
@@ -47,6 +47,7 @@ const promptSettingsFixture: PromptSettings = {
   selectedProviderId: "openai",
   selectedReasoningEffort: "medium",
   fastEnabled: false,
+  fastApplies: false,
 };
 
 function createSnapshot(

--- a/gui/src/app/sessionStore.test.ts
+++ b/gui/src/app/sessionStore.test.ts
@@ -260,11 +260,13 @@ describe("sessionStore", () => {
     expect(getPromptDraftState(sourceKey)).toEqual({
       isPending: false,
       isPlanningMode: false,
+      isUltraMode: false,
       value: "",
     });
     expect(getPromptDraftState(destinationKey)).toEqual({
       isPending: false,
       isPlanningMode: true,
+      isUltraMode: false,
       value: "ship it",
     });
 
@@ -273,6 +275,7 @@ describe("sessionStore", () => {
     expect(getPromptDraftState(destinationKey)).toEqual({
       isPending: false,
       isPlanningMode: true,
+      isUltraMode: false,
       value: "",
     });
 
@@ -281,6 +284,7 @@ describe("sessionStore", () => {
     expect(getPromptDraftState(destinationKey)).toEqual({
       isPending: false,
       isPlanningMode: false,
+      isUltraMode: false,
       value: "",
     });
     expect(sessionStore.getState().promptDraftsByKey[destinationKey]).toBeUndefined();

--- a/gui/src/app/sessionStore.test.ts
+++ b/gui/src/app/sessionStore.test.ts
@@ -290,6 +290,39 @@ describe("sessionStore", () => {
     expect(sessionStore.getState().promptDraftsByKey[destinationKey]).toBeUndefined();
   });
 
+  test("toggling Ultra mode persists even when the draft is otherwise unchanged", () => {
+    // Regression: writePromptDraftEntry's no-change guard previously omitted
+    // isUltraMode, so flipping Ultra while value/pending/planning stayed the same
+    // was discarded as a no-op — the composer's `cg-ultra-shine` never engaged.
+    const key = "/workspace/codegraff-gui::ultra-regression";
+
+    // A draft entry already exists (the user has typed) — the exact showcase
+    // scenario where the dropped update bit.
+    sessionStore.getState().setPromptDraftValue(key, "describe the job");
+
+    sessionStore.getState().setPromptDraftUltraMode(key, true);
+    expect(getPromptDraftState(key)).toEqual({
+      isPending: false,
+      isPlanningMode: false,
+      isUltraMode: true,
+      value: "describe the job",
+    });
+
+    // Toggling back off must also stick.
+    sessionStore.getState().setPromptDraftUltraMode(key, false);
+    expect(getPromptDraftState(key).isUltraMode).toBe(false);
+
+    // Ultra composes independently with planning mode.
+    sessionStore.getState().setPromptDraftPlanningMode(key, true);
+    sessionStore.getState().setPromptDraftUltraMode(key, true);
+    expect(getPromptDraftState(key)).toEqual({
+      isPending: false,
+      isPlanningMode: true,
+      isUltraMode: true,
+      value: "describe the job",
+    });
+  });
+
   test("attachments move from the workspace draft key to the conversation key without being lost", () => {
     const sourceKey = "workspace:/workspace/codegraff-gui";
     const destinationKey = "conversation:chat-1";

--- a/gui/src/app/sessionStore.ts
+++ b/gui/src/app/sessionStore.ts
@@ -68,7 +68,11 @@ function writePromptDraftEntry(
 ): Record<string, PromptDraftEntry> {
   const current = drafts[key] ?? null;
   const nextEntry =
-    entry == null || (entry.value === "" && !entry.isPending && !entry.isPlanningMode)
+    entry == null ||
+    (entry.value === "" &&
+      !entry.isPending &&
+      !entry.isPlanningMode &&
+      !entry.isUltraMode)
       ? null
       : entry;
 
@@ -81,7 +85,8 @@ function writePromptDraftEntry(
     delete nextDrafts[key];
     return nextDrafts;
   }
-
+    current?.isPlanningMode === nextEntry.isPlanningMode &&
+    current?.isUltraMode === nextEntry.isUltraMode
   if (
     current?.value === nextEntry.value &&
     current?.isPending === nextEntry.isPending &&
@@ -104,6 +109,7 @@ function setPromptDraftEntryValue(
   const current = getConversationDraftEntry(drafts, key) ?? {
     isPending: false,
     isPlanningMode: false,
+    isUltraMode: false,
     value: "",
   };
 
@@ -118,6 +124,7 @@ function setPromptDraftEntryPending(
   const current = getConversationDraftEntry(drafts, key) ?? {
     isPending: false,
     isPlanningMode: false,
+    isUltraMode: false,
     value: "",
   };
 
@@ -132,10 +139,26 @@ function setPromptDraftEntryPlanningMode(
   const current = getConversationDraftEntry(drafts, key) ?? {
     isPending: false,
     isPlanningMode: false,
+    isUltraMode: false,
     value: "",
   };
 
   return writePromptDraftEntry(drafts, key, { ...current, isPlanningMode });
+}
+
+function setPromptDraftEntryUltraMode(
+  drafts: Record<string, PromptDraftEntry>,
+  key: string,
+  isUltraMode: boolean,
+): Record<string, PromptDraftEntry> {
+  const current = getConversationDraftEntry(drafts, key) ?? {
+    isPending: false,
+    isPlanningMode: false,
+    isUltraMode: false,
+    value: "",
+  };
+
+  return writePromptDraftEntry(drafts, key, { ...current, isUltraMode });
 }
 
 function movePromptDraftEntry(
@@ -570,6 +593,19 @@ function createSessionStoreState(set: SessionStoreSetter): SessionStoreState {
         ),
       }));
     },
+    setPromptDraftUltraMode: (key, isUltraMode) => {
+      if (key == null) {
+        return;
+      }
+
+      set((current) => ({
+        promptDraftsByKey: setPromptDraftEntryUltraMode(
+          current.promptDraftsByKey,
+          key,
+          isUltraMode,
+        ),
+      }));
+    },
     setPromptDraftValue: (key, value) => {
       if (key == null) {
         return;
@@ -677,6 +713,7 @@ export function getPromptDraftState(promptDraftKey: string | null) {
     return {
       isPending: false,
       isPlanningMode: false,
+      isUltraMode: false,
       value: "",
     };
   }
@@ -685,6 +722,7 @@ export function getPromptDraftState(promptDraftKey: string | null) {
     sessionStore.getState().promptDraftsByKey[promptDraftKey] ?? {
       isPending: false,
       isPlanningMode: false,
+      isUltraMode: false,
       value: "",
     }
   );

--- a/gui/src/app/sessionStore.ts
+++ b/gui/src/app/sessionStore.ts
@@ -85,12 +85,12 @@ function writePromptDraftEntry(
     delete nextDrafts[key];
     return nextDrafts;
   }
-    current?.isPlanningMode === nextEntry.isPlanningMode &&
-    current?.isUltraMode === nextEntry.isUltraMode
+
   if (
     current?.value === nextEntry.value &&
     current?.isPending === nextEntry.isPending &&
-    current?.isPlanningMode === nextEntry.isPlanningMode
+    current?.isPlanningMode === nextEntry.isPlanningMode &&
+    current?.isUltraMode === nextEntry.isUltraMode
   ) {
     return drafts;
   }

--- a/gui/src/app/themeStore.ts
+++ b/gui/src/app/themeStore.ts
@@ -1,13 +1,21 @@
 import { create } from "zustand";
 
 export type ThemeMode = "light" | "dark";
-export type ThemePresetId = "warm-graphite" | "slate" | "nord" | "forest";
+export type ThemePresetId =
+  | "warm-graphite"
+  | "slate"
+  | "nord"
+  | "forest"
+  | "mono"
+  | "rose";
 
 export const THEME_PRESET_IDS: ThemePresetId[] = [
   "warm-graphite",
   "slate",
   "nord",
   "forest",
+  "mono",
+  "rose",
 ];
 
 const MODE_STORAGE_KEY = "codegraff:theme";

--- a/gui/src/app/themeStore.ts
+++ b/gui/src/app/themeStore.ts
@@ -73,7 +73,11 @@ const initialMode = readInitialMode();
 const initialPreset = readStoredPreset() ?? "warm-graphite";
 
 // Apply immediately at module import (before React renders) to avoid a flash.
-applyTheme(initialMode, initialPreset);
+// Guarded so the module is import-safe in non-DOM environments (SSR / unit tests
+// that render to static markup); applyTheme touches document.documentElement.
+if (typeof document !== "undefined") {
+  applyTheme(initialMode, initialPreset);
+}
 
 type ThemeStore = {
   mode: ThemeMode;

--- a/gui/src/app/types/sessionStore.ts
+++ b/gui/src/app/types/sessionStore.ts
@@ -20,6 +20,12 @@ import type {
 export interface PromptDraftEntry {
   isPending: boolean;
   isPlanningMode: boolean;
+  /**
+   * Per-turn opt-in to the harness `ultracode` codeword (multi-agent workflow
+   * mode). The codeword is injected into the outgoing message text at submit,
+   * then this flag is reset to false.
+   */
+  isUltraMode: boolean;
   value: string;
 }
 
@@ -64,6 +70,7 @@ export interface SessionStoreState {
     key: string | null,
     isPlanningMode: boolean,
   ) => void;
+  setPromptDraftUltraMode: (key: string | null, isUltraMode: boolean) => void;
   setPromptDraftValue: (key: string | null, value: string) => void;
   setWorkspacePromptSettings: (
     workspacePath: string | null,

--- a/gui/src/components/GoalChip.tsx
+++ b/gui/src/components/GoalChip.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { TargetIcon, XIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { cn } from "@/utils/cn";
+
+interface GoalChipProps {
+  /** The active steering objective, or null when no goal is set. */
+  goal: string | null;
+  /** Set/replace the goal (routes through `/goal <text>`). */
+  onEdit: (goal: string) => void;
+  /** Clear the goal (routes through `/goal clear`). */
+  onClear: () => void;
+  className?: string;
+}
+
+/**
+ * Surfaces the conversation's `/goal` steering objective as a small accent
+ * pill above the composer. The backend already augments every prompt with the
+ * goal; this just makes it visible and editable. Renders nothing when unset.
+ *
+ * - Click the text to edit inline (Enter saves, Escape cancels).
+ * - The ✕ clears the goal.
+ */
+export function GoalChip({ goal, onEdit, onClear, className }: GoalChipProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  if (goal == null || goal.trim().length === 0) {
+    return null;
+  }
+
+  function beginEdit() {
+    setDraft(goal ?? "");
+    setIsEditing(true);
+  }
+
+  function commitEdit() {
+    const next = draft.trim();
+    setIsEditing(false);
+    if (next.length === 0) {
+      // Emptying the field clears the goal rather than setting an empty one.
+      onClear();
+      return;
+    }
+    if (next !== goal) {
+      onEdit(next);
+    }
+  }
+
+  function cancelEdit() {
+    setIsEditing(false);
+    setDraft("");
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitEdit();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelEdit();
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        "mx-auto mb-2 flex w-full max-w-3xl items-center gap-1.5 rounded-full border border-[color:color-mix(in_oklab,var(--accent)_30%,transparent)] bg-[color:color-mix(in_oklab,var(--accent)_8%,transparent)] py-1 pr-1 pl-2.5 text-xs",
+        className,
+      )}
+    >
+      <TargetIcon
+        className="size-3.5 shrink-0 text-[color:var(--accent)]"
+        aria-hidden
+      />
+      <span className="shrink-0 font-medium text-[color:var(--accent)]">
+        Goal
+      </span>
+      {isEditing ? (
+        <Input
+          ref={inputRef}
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={commitEdit}
+          aria-label="Edit goal"
+          className="h-6 min-w-0 flex-1 rounded-sm border-[color:color-mix(in_oklab,var(--accent)_30%,transparent)] bg-transparent px-1.5 text-xs dark:bg-transparent"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={beginEdit}
+          title={`${goal}\n\nClick to edit · future turns in this chat are steered toward this goal`}
+          className="min-w-0 flex-1 truncate text-left text-foreground/90 hover:text-foreground"
+        >
+          {goal}
+        </button>
+      )}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label="Clear goal"
+        title="Clear goal"
+        className="shrink-0 rounded-full text-muted-foreground hover:text-foreground"
+        onClick={onClear}
+      >
+        <XIcon />
+      </Button>
+    </div>
+  );
+}

--- a/gui/src/components/PromptComposer.tsx
+++ b/gui/src/components/PromptComposer.tsx
@@ -5,6 +5,7 @@ import { usePrompt } from "../hooks/usePrompt";
 import { useCommandRouter } from "../hooks/useCommandRouter";
 import { CommandResultDialog } from "./CommandResultDialog";
 import { FollowupComposer } from "./FollowupComposer";
+import { GoalChip } from "./GoalChip";
 import { PromptActionAlert } from "./PromptActionAlert";
 import { PromptInputCard } from "./PromptInputCard";
 import { InterruptContinuePrompt } from "./conversation-panel/InterruptContinuePrompt";
@@ -26,15 +27,18 @@ export function PromptComposer({ binding, onCommandResult }: PromptComposerProps
     isPlanningMode,
     isRequestActive,
     isSendingPrompt,
+    isUltraMode,
     promptSettings,
     promptDraft,
     setPlanningMode,
     setPromptDraft,
+    setUltraMode,
     stopPrompt,
     submitPrompt,
     updatePromptSettings,
   } = usePrompt(binding);
-  const { messages, requestAgentIds, todos } = useConversationSession(binding);
+  const { goal, messages, requestAgentIds, todos } =
+    useConversationSession(binding);
   const { openProviderSettings } = useSettingsNavigation();
   const [dismissedInterruptId, setDismissedInterruptId] = useState<string | null>(
     null,
@@ -72,6 +76,39 @@ export function PromptComposer({ binding, onCommandResult }: PromptComposerProps
     }
     await submitPrompt();
   }, [promptDraft, submitPrompt, trySubmitAsCommand]);
+
+  // The goal chip mutates `/goal` directly (set/clear). The backend persists
+  // it on the conversation and returns a fresh snapshot, which we apply so the
+  // chip reflects the new state without a round-trip through the composer draft.
+  const runGoalCommand = useCallback(
+    (args: string[]) => {
+      if (workspacePath == null || binding == null) {
+        return;
+      }
+      void desktopClient
+        .runSlashCommand({
+          name: "goal",
+          args,
+          workspacePath,
+          conversationId: binding.conversationId,
+        })
+        .then((result) => {
+          if (result.snapshot != null) {
+            sessionStore.getState().applySessionSnapshot(result.snapshot);
+          }
+        })
+        .catch(() => null);
+    },
+    [binding, workspacePath],
+  );
+  const handleGoalEdit = useCallback(
+    (next: string) => runGoalCommand([next]),
+    [runGoalCommand],
+  );
+  const handleGoalClear = useCallback(
+    () => runGoalCommand(["clear"]),
+    [runGoalCommand],
+  );
 
   const handleApproveWorkflow = useCallback(
     async (prompt: string) => {
@@ -163,11 +200,17 @@ export function PromptComposer({ binding, onCommandResult }: PromptComposerProps
               onAction={openProviderSettings}
             />
           ) : null}
+          <GoalChip
+            goal={goal}
+            onEdit={handleGoalEdit}
+            onClear={handleGoalClear}
+          />
           <PromptInputCard
             canCompose={canCompose}
             isRequestActive={isRequestActive}
             isSendingPrompt={isSendingPrompt}
             isPlanningMode={isPlanningMode}
+            isUltraMode={isUltraMode}
             promptSettings={promptSettings}
             promptDraft={promptDraft}
             promptHistory={promptHistory}
@@ -176,6 +219,7 @@ export function PromptComposer({ binding, onCommandResult }: PromptComposerProps
             workspacePath={workspacePath}
             onCommandSelect={handleCommandSelect}
             setPlanningMode={setPlanningMode}
+            setUltraMode={setUltraMode}
             setPromptDraft={setPromptDraft}
             stopPrompt={stopPrompt}
             submitPrompt={handleSubmit}

--- a/gui/src/components/PromptInputCard.test.tsx
+++ b/gui/src/components/PromptInputCard.test.tsx
@@ -37,12 +37,14 @@ function renderPromptInputCard(
     <PromptInputCard
       canCompose
       isPlanningMode={false}
+      isUltraMode={false}
       isRequestActive={false}
       isSendingPrompt={false}
       onCommandSelect={(_: CommandDescriptor) => {}}
       promptDraft="Describe this repo"
       promptSettings={promptSettings}
       setPlanningMode={() => {}}
+      setUltraMode={() => {}}
       setPromptDraft={() => {}}
       stopPrompt={async () => {}}
       submitPrompt={async () => {}}

--- a/gui/src/components/PromptInputCard.test.tsx
+++ b/gui/src/components/PromptInputCard.test.tsx
@@ -27,6 +27,7 @@ const promptSettings: PromptSettings = {
   selectedProviderId: "anthropic",
   selectedReasoningEffort: "medium",
   fastEnabled: false,
+  fastApplies: false,
 };
 
 function renderPromptInputCard(

--- a/gui/src/components/PromptInputCard.tsx
+++ b/gui/src/components/PromptInputCard.tsx
@@ -143,9 +143,14 @@ export function PromptInputCard({
     setFastEnabled(promptSettings?.fastEnabled ?? false);
   }, [promptSettings?.fastEnabled]);
 
-  const isCodexModel = selectedModel?.providerId === "codex";
+  // Whether /fast actually changes harness behavior. The harness only applies
+  // the priority service tier on the codex provider (the `responses` kind); it
+  // is a no-op everywhere else. The runtime reports this authoritatively via
+  // `fastApplies`, so the toggle stays active only when it's true.
+  const fastApplies = promptSettings?.fastApplies ?? false;
 
   function handleFastToggle() {
+    if (!fastApplies) return;
     const next = !fastEnabled;
     setFastEnabled(next);
     void setFast(next);
@@ -533,26 +538,29 @@ export function PromptInputCard({
               <MapIcon data-icon="inline-start" />
               <span className="text-xs">Plan</span>
             </Button>
-            {isCodexModel ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                aria-label="Toggle fast mode"
-                aria-pressed={fastEnabled}
-                className={cn(
-                  "text-muted-foreground hover:bg-transparent hover:text-foreground",
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              aria-label="Toggle fast mode"
+              aria-pressed={fastApplies && fastEnabled}
+              className={cn(
+                "text-muted-foreground hover:bg-transparent hover:text-foreground",
+                fastApplies &&
                   fastEnabled &&
-                    "border-[color:var(--accent)] bg-[color:color-mix(in_oklab,var(--accent)_10%,transparent)] text-foreground hover:bg-[color:color-mix(in_oklab,var(--accent)_14%,transparent)]",
-                )}
-                disabled={isControlDisabled}
-                onClick={handleFastToggle}
-                title="Codex priority service tier — lower latency"
-              >
-                <ZapIcon data-icon="inline-start" />
-                <span className="text-xs">Fast</span>
-              </Button>
-            ) : null}
+                  "border-[color:var(--accent)] bg-[color:color-mix(in_oklab,var(--accent)_10%,transparent)] text-foreground hover:bg-[color:color-mix(in_oklab,var(--accent)_14%,transparent)]",
+              )}
+              disabled={isControlDisabled || !fastApplies}
+              onClick={handleFastToggle}
+              title={
+                fastApplies
+                  ? "Codex priority service tier — lower latency"
+                  : "Fast (priority) — codex only"
+              }
+            >
+              <ZapIcon data-icon="inline-start" />
+              <span className="text-xs">Fast</span>
+            </Button>
             {isPlanningMode ? (
               <span
                 className="inline-flex h-8 items-center gap-2 px-1.5 text-xs font-medium text-muted-foreground"

--- a/gui/src/components/PromptInputCard.tsx
+++ b/gui/src/components/PromptInputCard.tsx
@@ -3,6 +3,7 @@ import {
   ArrowUpIcon,
   ChevronDownIcon,
   MapIcon,
+  SparklesIcon,
   SquareIcon,
   ZapIcon,
 } from "lucide-react";
@@ -64,6 +65,7 @@ export function PromptInputCard({
   isRequestActive,
   isSendingPrompt,
   isPlanningMode,
+  isUltraMode,
   placeholder = "Ask about this workspace…",
   promptSettings,
   promptDraft,
@@ -74,6 +76,7 @@ export function PromptInputCard({
   workspacePath,
   onCommandSelect,
   setPlanningMode,
+  setUltraMode,
   setPromptDraft,
   stopPrompt,
   submitPrompt,
@@ -339,6 +342,7 @@ export function PromptInputCard({
           "relative gap-0 rounded-2xl border border-foreground/5 bg-background/50 p-2 transition-colors transition-shadow ring-0",
           isPlanningMode &&
             "border-[color:var(--accent)] ring-5 ring-[color:color-mix(in_oklab,var(--accent)_14%,transparent)] border-dashed",
+          isUltraMode && "cg-ultra-shine border-transparent",
         )}
       >
         <CardHeader className="sr-only">
@@ -374,7 +378,13 @@ export function PromptInputCard({
                 commandMatch &&
                   "text-transparent caret-[color:var(--foreground)]",
               )}
-              placeholder={isWorking ? "Queue a follow-up…" : placeholder}
+              placeholder={
+                isWorking
+                  ? "Queue a follow-up…"
+                  : isUltraMode
+                    ? "Describe the job — Ultra fans out parallel agents"
+                    : placeholder
+              }
               value={promptDraft}
               onChange={(event) => handleDraftChange(event.target.value)}
               onPaste={handlePaste}
@@ -561,6 +571,27 @@ export function PromptInputCard({
               <ZapIcon data-icon="inline-start" />
               <span className="text-xs">Fast</span>
             </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              aria-label="Toggle Ultra mode"
+              aria-pressed={isUltraMode}
+              className={cn(
+                "text-muted-foreground hover:bg-transparent hover:text-foreground",
+                isUltraMode &&
+                  "border-[color:var(--accent)] bg-[color:color-mix(in_oklab,var(--accent)_12%,transparent)] text-foreground shadow-[0_0_12px_-3px_color-mix(in_oklab,var(--accent)_75%,transparent)] hover:bg-[color:color-mix(in_oklab,var(--accent)_16%,transparent)]",
+              )}
+              disabled={isControlDisabled}
+              onClick={() => setUltraMode(!isUltraMode)}
+              title="Ultra — engage the ultracode codeword: fan out parallel agents for this turn"
+            >
+              <SparklesIcon
+                data-icon="inline-start"
+                className={cn(isUltraMode && "text-[color:var(--accent)]")}
+              />
+              <span className="text-xs">Ultra</span>
+            </Button>
             {isPlanningMode ? (
               <span
                 className="inline-flex h-8 items-center gap-2 px-1.5 text-xs font-medium text-muted-foreground"
@@ -577,7 +608,11 @@ export function PromptInputCard({
           <Button
             type="button"
             size="icon-lg"
-            className="rounded-full"
+            className={cn(
+              "rounded-full transition-shadow",
+              isUltraMode &&
+                "shadow-[0_0_18px_-2px_color-mix(in_oklab,var(--accent)_70%,transparent)] ring-2 ring-[color:color-mix(in_oklab,var(--accent)_45%,transparent)]",
+            )}
             aria-label={isWorking && isSubmitDisabled ? "Stop" : "Send"}
             onClick={handlePrimaryAction}
             disabled={isWorking ? false : isSubmitDisabled}

--- a/gui/src/components/chat/ChatActivityRow.tsx
+++ b/gui/src/components/chat/ChatActivityRow.tsx
@@ -126,9 +126,21 @@ function ActivityOperationRow({
   const isExpandable = result != null;
   const label = formatOperationLabel(operation, workspacePath);
   const isCommand = operation.detail.kind === "shell";
+  // Per-node live status, from what the stream gives us today: a node is
+  // running until its tool_result lands, then done or errored.
+  const status = !operation.completed
+    ? "running"
+    : operation.isError
+      ? "error"
+      : "done";
   const icon = renderOperationIcon(
     operation,
-    "size-3.5 shrink-0 text-muted-foreground/60",
+    cn(
+      "size-3.5 shrink-0",
+      status === "running" && "animate-pulse text-[color:var(--accent)]",
+      status === "error" && "text-destructive",
+      status === "done" && "text-muted-foreground/60",
+    ),
   );
 
   const content = (

--- a/gui/src/components/chat/ChatActivityRow.tsx
+++ b/gui/src/components/chat/ChatActivityRow.tsx
@@ -43,12 +43,12 @@ import { ActivityResultRenderer } from "./activity-results/ActivityResultRendere
 import { getActivityResultModel } from "./utils/getActivityResultModel";
 
 const activityTriggerClassName = cn(
-  "group inline-flex min-w-0 items-center gap-1.5 text-left transition hover:text-foreground",
+  "group flex min-w-0 items-center gap-1.5 text-left transition hover:text-foreground",
   CHAT_MUTED_TEXT_CLASS,
 );
 
 const activityTextClassName = cn(
-  "inline-flex min-w-0 items-center",
+  "flex min-w-0 items-center",
   CHAT_MUTED_TEXT_CLASS,
 );
 
@@ -134,9 +134,9 @@ function ActivityOperationRow({
   const content = (
     <>
       {icon}
-      <span className="min-w-0">
+      <span className="min-w-0 flex-1">
         {isCommand ? (
-          <code className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+          <code className="inline-block max-w-full truncate align-middle rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
             {label}
           </code>
         ) : (

--- a/gui/src/components/chat/ChatThread.tsx
+++ b/gui/src/components/chat/ChatThread.tsx
@@ -132,10 +132,24 @@ export function ChatThread({
   }, [items.length]);
 
   // The thread re-renders on every streaming update, so keep locked chats pinned
-  // after both React commit and LegendList's follow-up layout measurements.
+  // after both React commit and LegendList's follow-up layout measurements. When
+  // we're NOT following, re-measure the real scroll node instead: if a content or
+  // layout change has settled us at the physical bottom (e.g. a long turn just
+  // finished with nothing below it), recover the follow state so the
+  // jump-to-latest pill doesn't linger. The DOM read only runs while the pill is
+  // actually showing, so it never taxes the streaming-follow path.
   useEffect(() => {
     if (isFollowingRef.current) {
       scheduleFollowToBottom();
+      return;
+    }
+    const node = listRef.current?.getScrollableNode();
+    if (
+      node != null &&
+      node.scrollHeight - node.clientHeight - node.scrollTop <=
+        BOTTOM_LOCK_THRESHOLD
+    ) {
+      setFollowing(true);
     }
   });
 
@@ -169,8 +183,15 @@ export function ChatThread({
         event.nativeEvent;
       const offset = contentOffset.y;
       const previousOffset = lastScrollOffsetRef.current;
+      // LegendList virtualizes with estimated item sizes, so the event's
+      // contentSize can disagree with the real scroll height — measure the
+      // actual scrollable node so "at the bottom" is exact and the pill doesn't
+      // linger while you're parked at the end.
+      const node = listRef.current?.getScrollableNode() ?? null;
       const distanceFromBottom =
-        contentSize.height - layoutMeasurement.height - offset;
+        node != null
+          ? node.scrollHeight - node.clientHeight - node.scrollTop
+          : contentSize.height - layoutMeasurement.height - offset;
       const isAtBottom = distanceFromBottom <= BOTTOM_LOCK_THRESHOLD;
 
       if (
@@ -186,7 +207,10 @@ export function ChatThread({
         userWantsFollowRef.current = true;
       }
 
-      if (isAtBottom && userWantsFollowRef.current && !isFollowingRef.current) {
+      // Physically at the bottom ⇒ following again, regardless of recent scroll
+      // intent — this is what clears a pill left lingering after you return.
+      if (isAtBottom && !isFollowingRef.current) {
+        userWantsFollowRef.current = true;
         setFollowing(true);
         scheduleFollowToBottom();
       }
@@ -205,6 +229,16 @@ export function ChatThread({
     }
     if (event.deltaY > 0) {
       userWantsFollowRef.current = true;
+      // A downward flick while already pinned emits no scroll event, so
+      // recover the follow state here too.
+      const node = listRef.current?.getScrollableNode() ?? null;
+      if (
+        node != null &&
+        node.scrollHeight - node.clientHeight - node.scrollTop <=
+          BOTTOM_LOCK_THRESHOLD
+      ) {
+        setFollowing(true);
+      }
     }
   }, [setFollowing]);
 

--- a/gui/src/components/chat/ChatWorkRow.tsx
+++ b/gui/src/components/chat/ChatWorkRow.tsx
@@ -1,106 +1,23 @@
-import { useEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
-
 import { CHAT_MUTED_TEXT_CLASS } from "./constants/chatStyles";
-import { useRunningNow } from "./hooks/useRunningNow";
 import { ChatActivityRow } from "./ChatActivityRow";
-import { ChatStatusLabel } from "./ChatStatusLabel";
-import { getWorkHeaderLabelText } from "./utils/workHeaderLabel";
-import type {
-  ChatWorkRowProps,
-  WorkHeaderLabelProps,
-} from "./types/chatComponents";
+import type { ChatWorkRowProps } from "./types/chatComponents";
 
-function WorkHeaderLabel({
-  failedStepCount,
-  isRunning,
-  requestTiming,
-}: WorkHeaderLabelProps) {
-  const now = useRunningNow(isRunning);
-  const label = getWorkHeaderLabelText({
-    failedStepCount,
-    isRunning,
-    requestTiming,
-    nowMs: now,
-  });
-
-  return (
-    <span className="inline-flex min-w-0 items-center gap-1.5">
-      {isRunning ? (
-        <span className="shimmer shimmer-invert shimmer-repeat-delay-0">
-          {label}
-        </span>
-      ) : (
-        <ChatStatusLabel text={label} />
-      )}
-    </span>
-  );
-}
-
-export function ChatWorkRow({
-  item,
-  requestTiming,
-  workspacePath,
-}: ChatWorkRowProps) {
-  const [open, setOpen] = useState(item.isRunning || item.hasError);
-  const previousRunningRef = useRef(item.isRunning);
-
-  // Drive open state from running→idle transitions WITHOUT remounting. Stable
-  // keys (here and in chatThreadList) preserve the user's manual expands across
-  // completion. On a clean finish we leave the group open so the results the
-  // user was watching don't collapse out from under them; errors force-open.
-  // Past (already-idle) turns mount collapsed via the initial state above.
-  useEffect(() => {
-    const wasRunning = previousRunningRef.current;
-    previousRunningRef.current = item.isRunning;
-    if (wasRunning && !item.isRunning && item.hasError) {
-      setOpen(true);
-    }
-  }, [item.isRunning, item.hasError]);
-
-  const canExpand = item.activities.length > 0;
-
-  const header = (
-    <>
-      <WorkHeaderLabel
-        failedStepCount={item.failedStepCount}
-        isRunning={item.isRunning}
-        requestTiming={requestTiming}
-      />
-      {!item.isRunning && canExpand ? (
-        open ? (
-          <ChevronDown className="size-4 text-current" />
-        ) : (
-          <ChevronRight className="size-4 text-current" />
-        )
-      ) : null}
-    </>
-  );
+// The per-turn work timeline. No "Working/Worked for Ns" header at all — while
+// the turn is starting with nothing to show yet, a calm "Thinking" shimmer;
+// otherwise just the activity rows themselves.
+export function ChatWorkRow({ item, workspacePath }: ChatWorkRowProps) {
+  const hasActivities = item.activities.length > 0;
 
   return (
     <div className="grid min-w-0 gap-1">
-      {item.isRunning ? (
-        canExpand ? null : (
-          <span
-            className={`shimmer shimmer-invert shimmer-repeat-delay-0 ${CHAT_MUTED_TEXT_CLASS}`}
-          >
-            Thinking
-          </span>
-        )
-      ) : canExpand ? (
-        <button
-          type="button"
-          onClick={() => setOpen((current) => !current)}
-          className={`inline-flex min-w-0 items-center justify-between gap-2 border-b border-border pb-1 text-left ${CHAT_MUTED_TEXT_CLASS}`}
+      {item.isRunning && !hasActivities ? (
+        <span
+          className={`shimmer shimmer-invert shimmer-repeat-delay-0 ${CHAT_MUTED_TEXT_CLASS}`}
         >
-          {header}
-        </button>
-      ) : (
-        <div className={`inline-flex min-w-0 items-center justify-between gap-2 ${CHAT_MUTED_TEXT_CLASS}`}>
-          {header}
-        </div>
-      )}
-      {canExpand && (item.isRunning || open) ? (
+          Thinking
+        </span>
+      ) : null}
+      {hasActivities ? (
         <div className="grid min-w-0 gap-1">
           {item.activities.map((activityItem) => (
             <ChatActivityRow

--- a/gui/src/components/chat/ChatWorkRow.tsx
+++ b/gui/src/components/chat/ChatWorkRow.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 
 import { CHAT_MUTED_TEXT_CLASS } from "./constants/chatStyles";
 import { useRunningNow } from "./hooks/useRunningNow";
@@ -27,9 +27,12 @@ function WorkHeaderLabel({
   return (
     <span className="inline-flex min-w-0 items-center gap-1.5">
       {isRunning ? (
-        <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
-      ) : null}
-      <ChatStatusLabel text={label} />
+        <span className="shimmer shimmer-invert shimmer-repeat-delay-0">
+          {label}
+        </span>
+      ) : (
+        <ChatStatusLabel text={label} />
+      )}
     </span>
   );
 }

--- a/gui/src/components/chat/ChatWorkRow.tsx
+++ b/gui/src/components/chat/ChatWorkRow.tsx
@@ -79,7 +79,15 @@ export function ChatWorkRow({
 
   return (
     <div className="grid min-w-0 gap-1">
-      {!item.isRunning && canExpand ? (
+      {item.isRunning ? (
+        canExpand ? null : (
+          <span
+            className={`shimmer shimmer-invert shimmer-repeat-delay-0 ${CHAT_MUTED_TEXT_CLASS}`}
+          >
+            Thinking
+          </span>
+        )
+      ) : canExpand ? (
         <button
           type="button"
           onClick={() => setOpen((current) => !current)}
@@ -88,7 +96,7 @@ export function ChatWorkRow({
           {header}
         </button>
       ) : (
-        <div className={`inline-flex min-w-0 items-center justify-between gap-2 border-b border-border pb-1 ${CHAT_MUTED_TEXT_CLASS}`}>
+        <div className={`inline-flex min-w-0 items-center justify-between gap-2 ${CHAT_MUTED_TEXT_CLASS}`}>
           {header}
         </div>
       )}

--- a/gui/src/components/chat/markdown/MarkdownRenderer.tsx
+++ b/gui/src/components/chat/markdown/MarkdownRenderer.tsx
@@ -11,6 +11,7 @@ import {
 } from "../utils/chatLinks";
 import { openFilePathFromChat, openUrlFromChat } from "../utils/chatOpen";
 import { CodeBlock } from "./CodeBlock";
+import { MermaidDiagram } from "./MermaidDiagram";
 import { dropRedundantCodeHeadings, parseMarkdown } from "./parser";
 import type { MdBlock, MdInline, MdListItem, TableAlign } from "./types";
 
@@ -54,6 +55,9 @@ function renderBlock(block: MdBlock, workspacePath?: string | null): ReactNode {
         </p>
       );
     case "code":
+      if (block.lang === "mermaid") {
+        return <MermaidDiagram code={block.value} />;
+      }
       return <CodeBlock value={block.value} lang={block.lang} />;
     case "thematicBreak":
       return <hr className="border-border/70" />;

--- a/gui/src/components/chat/markdown/MermaidDiagram.tsx
+++ b/gui/src/components/chat/markdown/MermaidDiagram.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { Maximize2, X } from "lucide-react";
 
 import { useThemeStore } from "@/app/themeStore";
 import { CodeBlock } from "./CodeBlock";
 
-// Lazy-load mermaid once (it is a large dependency) and reuse the module so it
-// stays out of the initial bundle and only loads when a diagram is shown.
+// Lazy-load mermaid (large dep) once and reuse the module so it stays out of
+// the initial bundle and only loads when a diagram is actually rendered.
 let mermaidModule: Promise<typeof import("mermaid").default> | null = null;
 function loadMermaid() {
   if (mermaidModule == null) {
@@ -15,10 +16,93 @@ function loadMermaid() {
 
 let renderSeq = 0;
 
+// Fullscreen overlay that lets a dense diagram be scroll-zoomed and drag-panned.
+function MermaidZoom({ svg, onClose }: { svg: string; onClose: () => void }) {
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const dragOrigin = useRef<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  function handleWheel(event: React.WheelEvent) {
+    event.preventDefault();
+    const factor = Math.exp(-event.deltaY * 0.0015);
+    setScale((current) => Math.min(12, Math.max(0.4, current * factor)));
+  }
+
+  function handlePointerDown(event: React.PointerEvent) {
+    dragOrigin.current = {
+      x: event.clientX - offset.x,
+      y: event.clientY - offset.y,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }
+
+  function handlePointerMove(event: React.PointerEvent) {
+    if (dragOrigin.current == null) {
+      return;
+    }
+    setOffset({
+      x: event.clientX - dragOrigin.current.x,
+      y: event.clientY - dragOrigin.current.y,
+    });
+  }
+
+  function handlePointerUp() {
+    dragOrigin.current = null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div className="pointer-events-none absolute left-1/2 top-4 -translate-x-1/2 rounded-full border border-border/60 bg-card/80 px-3 py-1 text-xs text-muted-foreground">
+        scroll to zoom · drag to pan · esc to close
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close diagram"
+        className="absolute right-4 top-4 inline-flex size-9 items-center justify-center rounded-full border border-border bg-card/80 text-foreground transition hover:bg-card"
+      >
+        <X className="size-4" />
+      </button>
+      <div
+        className="h-full w-full cursor-grab touch-none select-none active:cursor-grabbing"
+        onClick={(event) => event.stopPropagation()}
+        onWheel={handleWheel}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerUp}
+      >
+        <div
+          className="flex h-full w-full items-center justify-center [&_svg]:h-auto [&_svg]:max-w-none"
+          style={{
+            transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
+            transformOrigin: "center",
+          }}
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+      </div>
+    </div>
+  );
+}
+
 export function MermaidDiagram({ code }: { code: string }) {
   const mode = useThemeStore((state) => state.mode);
   const [svg, setSvg] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
+  const [zoomed, setZoomed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -50,7 +134,6 @@ export function MermaidDiagram({ code }: { code: string }) {
     };
   }, [code, mode]);
 
-  // Won't parse -> fall back to the raw fenced source so nothing is lost.
   if (failed) {
     return <CodeBlock value={code} lang="mermaid" />;
   }
@@ -64,10 +147,29 @@ export function MermaidDiagram({ code }: { code: string }) {
   }
 
   return (
-    <div
-      className="cg-mermaid max-w-full overflow-x-auto rounded-md border border-border/70 bg-card/40 p-3 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-w-full"
-      // mermaid renders with securityLevel "strict", which sanitizes the SVG.
-      dangerouslySetInnerHTML={{ __html: svg }}
-    />
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        title="Click to zoom"
+        onClick={() => setZoomed(true)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setZoomed(true);
+          }
+        }}
+        className="cg-mermaid group relative cursor-zoom-in rounded-md border border-border/70 bg-card/40"
+      >
+        <div
+          className="max-w-full overflow-x-auto p-3 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-w-full"
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+        <div className="pointer-events-none absolute right-2 top-2 rounded-md bg-card/70 p-1 text-muted-foreground opacity-0 transition group-hover:opacity-100">
+          <Maximize2 className="size-3.5" />
+        </div>
+      </div>
+      {zoomed ? <MermaidZoom svg={svg} onClose={() => setZoomed(false)} /> : null}
+    </>
   );
 }

--- a/gui/src/components/chat/markdown/MermaidDiagram.tsx
+++ b/gui/src/components/chat/markdown/MermaidDiagram.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+
+import { useThemeStore } from "@/app/themeStore";
+import { CodeBlock } from "./CodeBlock";
+
+// Lazy-load mermaid once (it is a large dependency) and reuse the module so it
+// stays out of the initial bundle and only loads when a diagram is shown.
+let mermaidModule: Promise<typeof import("mermaid").default> | null = null;
+function loadMermaid() {
+  if (mermaidModule == null) {
+    mermaidModule = import("mermaid").then((module) => module.default);
+  }
+  return mermaidModule;
+}
+
+let renderSeq = 0;
+
+export function MermaidDiagram({ code }: { code: string }) {
+  const mode = useThemeStore((state) => state.mode);
+  const [svg, setSvg] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setFailed(false);
+
+    void (async () => {
+      try {
+        const mermaid = await loadMermaid();
+        mermaid.initialize({
+          startOnLoad: false,
+          securityLevel: "strict",
+          theme: mode === "dark" ? "dark" : "default",
+          fontFamily: "inherit",
+        });
+        const id = `cg-mermaid-${(renderSeq += 1)}`;
+        const { svg: rendered } = await mermaid.render(id, code);
+        if (!cancelled) {
+          setSvg(rendered);
+        }
+      } catch {
+        if (!cancelled) {
+          setFailed(true);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, mode]);
+
+  // Won't parse -> fall back to the raw fenced source so nothing is lost.
+  if (failed) {
+    return <CodeBlock value={code} lang="mermaid" />;
+  }
+
+  if (svg == null) {
+    return (
+      <div className="rounded-md border border-border/70 bg-card/40 px-3 py-2 text-xs text-muted-foreground">
+        Rendering diagram…
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="cg-mermaid max-w-full overflow-x-auto rounded-md border border-border/70 bg-card/40 p-3 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-w-full"
+      // mermaid renders with securityLevel "strict", which sanitizes the SVG.
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/gui/src/components/chat/utils/chatActivity.ts
+++ b/gui/src/components/chat/utils/chatActivity.ts
@@ -1,6 +1,20 @@
 import type { ActivityOperation } from "../types/chatThread";
 import { classifyUnknownToolName } from "./classifyActivityResult";
 
+// MCP tools arrive as `mcp__<server>__<tool>`; show a readable "server · tool"
+// instead of the raw double-underscore name.
+function prettifyToolName(name: string): string {
+  if (name.startsWith("mcp__")) {
+    const parts = name.slice(5).split("__").filter(Boolean);
+    if (parts.length >= 2) {
+      const [server, ...rest] = parts;
+      return `${server} · ${rest.join(" ").replace(/_/g, " ")}`;
+    }
+    return parts.join(" ").replace(/_/g, " ");
+  }
+  return name;
+}
+
 // Turn a raw tool name like "webfetch" / "web_fetch" into a readable verb
 // phrase, e.g. "Fetched web content".
 function formatUnknownToolLabel(name: string): string {
@@ -8,9 +22,9 @@ function formatUnknownToolLabel(name: string): string {
     case "web":
       return "Fetched web content";
     case "github":
-      return `Ran ${name} on GitHub`;
+      return `Ran ${prettifyToolName(name)} on GitHub`;
     default:
-      return `Ran ${name}`;
+      return `Ran ${prettifyToolName(name)}`;
   }
 }
 

--- a/gui/src/components/general-settings/constants/themePresets.ts
+++ b/gui/src/components/general-settings/constants/themePresets.ts
@@ -33,4 +33,16 @@ export const THEME_PRESETS: ThemePresetMeta[] = [
     description: "Warm-neutral base with a sage-green accent.",
     swatch: { bg: "#14160f", surface: "#1d2018", accent: "#82b06a", text: "#e8ebe0" },
   },
+  {
+    id: "mono",
+    name: "Mono",
+    description: "Pure black & white — monochrome, no hue.",
+    swatch: { bg: "#0a0a0a", surface: "#161618", accent: "#fafafa", text: "#fafafa" },
+  },
+  {
+    id: "rose",
+    name: "Rose",
+    description: "Soft pinks with a bright rose accent.",
+    swatch: { bg: "#1a0e14", surface: "#251521", accent: "#ff6b9d", text: "#f7dde7" },
+  },
 ];

--- a/gui/src/components/new-chat-screen/NewChatPromptSection.tsx
+++ b/gui/src/components/new-chat-screen/NewChatPromptSection.tsx
@@ -39,10 +39,12 @@ export function NewChatPromptSection({
     isPlanningMode,
     isRequestActive,
     isSendingPrompt,
+    isUltraMode,
     promptSettings,
     promptDraft,
     setPlanningMode,
     setPromptDraft,
+    setUltraMode,
     stopPrompt,
     submitPrompt,
     updatePromptSettings,
@@ -133,6 +135,7 @@ export function NewChatPromptSection({
               : "Ask anything…"
         }
         isPlanningMode={isPlanningMode}
+        isUltraMode={isUltraMode}
         promptDraft={promptDraft}
         promptHistory={promptHistory}
         promptSettings={promptSettings}
@@ -141,6 +144,7 @@ export function NewChatPromptSection({
         workspacePath={workspacePath}
         onCommandSelect={handleCommandSelect}
         setPlanningMode={setPlanningMode}
+        setUltraMode={setUltraMode}
         setPromptDraft={setPromptDraft}
         stopPrompt={stopPrompt}
         submitPrompt={handleSubmit}

--- a/gui/src/components/providers-settings/ProviderSetupDialog.tsx
+++ b/gui/src/components/providers-settings/ProviderSetupDialog.tsx
@@ -27,6 +27,7 @@ import {
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
 import {
   completeProviderAuth,
+  listProviders,
   listenProviderOAuthCallback,
   openExternalUrl,
   startProviderAuth,
@@ -75,6 +76,12 @@ export function ProviderSetupDialog({
   const [isStartingAuth, setIsStartingAuth] = useState(false);
   const [isSubmittingAuth, setIsSubmittingAuth] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  // True while polling for a CLI login (codegraff/codex/kimi) to land on disk.
+  // The external Terminal runs `graff login …` (a device-code flow that polls
+  // every few seconds); this polls `list_providers` so the dialog auto-completes
+  // the moment the credential file appears — no manual "Finish setup" click and
+  // no clicking-too-early error.
+  const [isDetectingLogin, setIsDetectingLogin] = useState(false);
   const providerId = provider?.id ?? null;
 
   const defaultAuthMethod = useMemo(() => {
@@ -94,6 +101,7 @@ export function ProviderSetupDialog({
     setUrlParameterValues({});
     setIsStartingAuth(false);
     setIsSubmittingAuth(false);
+    setIsDetectingLogin(false);
     setActionError(null);
   }
 
@@ -102,9 +110,15 @@ export function ProviderSetupDialog({
       return;
     }
 
-    const nextAuthMethod = initialAuthMethod ?? defaultAuthMethod;
-    resetSetupState(nextAuthMethod);
-    setPendingAutoStartMethod(nextAuthMethod);
+    const timer = window.setTimeout(() => {
+      const nextAuthMethod = initialAuthMethod ?? defaultAuthMethod;
+      resetSetupState(nextAuthMethod);
+      setPendingAutoStartMethod(nextAuthMethod);
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
   }, [defaultAuthMethod, initialAuthMethod, isOpen, provider]);
 
   async function refreshPromptSettings() {
@@ -191,6 +205,75 @@ export function ProviderSetupDialog({
       }
     };
   }, [authFlow, providerId]);
+
+  // Auto-detect CLI login completion: poll list_providers while a cli_login flow
+  // is active. The moment the provider flips to configured, auto-complete — no
+  // need for the user to manually click "Finish setup" (which would error if
+  // clicked before the OAuth file lands).
+  useEffect(() => {
+    if (authFlow?.kind !== "cli_login" || providerId == null) {
+      const resetTimer = window.setTimeout(() => {
+        setIsDetectingLogin(false);
+      }, 0);
+      return () => {
+        window.clearTimeout(resetTimer);
+      };
+    }
+
+    let isCancelled = false;
+    const startTimer = window.setTimeout(() => {
+      if (isCancelled) return;
+      setIsDetectingLogin(true);
+      setActionError(null);
+    }, 0);
+
+    async function poll() {
+      // Give the external Terminal a moment to get going before the first check.
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      while (!isCancelled) {
+        try {
+          const providers = await listProviders(workspacePath);
+          if (isCancelled) return;
+          const current = providers.find((p) => p.id === providerId);
+          if (current?.configured) {
+            // Credential landed — complete the auth session.
+            try {
+              const updatedProvider = await completeProviderAuth({
+                authSessionId: authFlow!.authSessionId,
+                apiKey: null,
+                authorizationCode: null,
+                urlParameters: [],
+              });
+              if (isCancelled) return;
+              onProviderUpdated(updatedProvider);
+              await ensureWorkspacePromptSettingsLoaded(workspacePath, {
+                force: true,
+              });
+              closeSetupDialog();
+            } catch (error) {
+              if (isCancelled) return;
+              // The file appeared but completion failed — surface it and stop
+              // polling so the user can retry with "Finish setup".
+              setActionError(normalizeProviderError(error));
+              setIsDetectingLogin(false);
+            }
+            return;
+          }
+        } catch {
+          // Transient listProviders failure — keep polling.
+        }
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+    }
+
+    void poll();
+
+    return () => {
+      isCancelled = true;
+      window.clearTimeout(startTimer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authFlow?.kind, authFlow?.authSessionId, providerId, workspacePath]);
 
   function closeSetupDialog() {
     setPendingAutoStartMethod(null);
@@ -441,11 +524,26 @@ export function ProviderSetupDialog({
             ) : null}
 
             {authFlow?.kind === "cli_login" ? (
-              <div className="flex flex-col gap-4">
-                <p className="rounded-lg border border-border/60 px-3 py-3 text-sm text-muted-foreground">
-                  {authFlow.apiKeyHint ??
-                    "Login launched in Terminal. Complete the CLI flow there, then finish setup here."}
-                  </p>
+              <div className="flex flex-col gap-3">
+                <div className="flex items-center gap-2.5 rounded-lg border border-border/60 px-3 py-3 text-sm text-muted-foreground">
+                  {isDetectingLogin ? (
+                    <>
+                      <LoaderCircle
+                        className="size-4 shrink-0 animate-spin text-[color:var(--accent)]"
+                        strokeWidth={2}
+                      />
+                      <span>
+                        Waiting for login to complete in Terminal… The dialog
+                        closes automatically once detected.
+                      </span>
+                    </>
+                  ) : (
+                    <span>
+                      {authFlow.apiKeyHint ??
+                        "Login launched in Terminal. Complete the CLI flow there, then finish setup here."}
+                    </span>
+                  )}
+                </div>
               </div>
             ) : null}
 
@@ -558,7 +656,7 @@ export function ProviderSetupDialog({
             {authFlow?.kind === "device_code" || authFlow?.kind === "cli_login" ? (
               <Button
                 type="button"
-                disabled={isSubmittingAuth}
+                disabled={isSubmittingAuth || isDetectingLogin}
                 onClick={() => {
                   void handleSubmitSetup();
                 }}

--- a/gui/src/components/types/prompt.ts
+++ b/gui/src/components/types/prompt.ts
@@ -30,6 +30,7 @@ export interface PromptInputCardProps {
   isRequestActive: boolean;
   isSendingPrompt: boolean;
   isPlanningMode: boolean;
+  isUltraMode: boolean;
   placeholder?: string;
   promptSettings: PromptSettings | null;
   promptDraft: string;
@@ -40,6 +41,7 @@ export interface PromptInputCardProps {
   workspacePath?: string | null;
   onCommandSelect: (command: CommandDescriptor) => void;
   setPlanningMode: (value: boolean) => void;
+  setUltraMode: (value: boolean) => void;
   setPromptDraft: (value: string) => void;
   stopPrompt: () => Promise<void>;
   submitPrompt: () => Promise<void>;

--- a/gui/src/hooks/useConversationActions.ts
+++ b/gui/src/hooks/useConversationActions.ts
@@ -101,12 +101,23 @@ export function useConversationActions(binding?: ChatBinding | null) {
         }
 
         const attachments = getAttachments(promptDraftKey);
-        const prompt = appendAttachmentsToPrompt(trimmedPrompt, attachments);
+        let prompt = appendAttachmentsToPrompt(trimmedPrompt, attachments);
+
+        // Ultra mode: inject the `ultracode` codeword the harness watches for
+        // (case-insensitive substring → multi-agent workflow turn). Skip it if
+        // the user already typed it. The toggle is a per-turn opt-in, so it is
+        // reset below once the prompt has been captured.
+        if (draftState.isUltraMode && !/ultracode/i.test(prompt)) {
+          prompt = `${prompt}\n\nultracode`;
+        }
 
         // Clear the composer immediately on send so the draft + any attachment
         // don't linger in the bar while the turn runs (the prompt is already
-        // captured above).
+        // captured above). Reset Ultra explicitly: clearing only blanks the
+        // value, which on its own would leave the Ultra flag (and the lit
+        // toggle) stuck on for the next turn.
         sessionStore.getState().clearPromptDraft(promptDraftKey);
+        sessionStore.getState().setPromptDraftUltraMode(promptDraftKey, false);
         sessionStore.getState().clearAttachments(promptDraftKey);
         sessionStore.getState().setPromptDraftPending(promptDraftKey, true);
         try {

--- a/gui/src/hooks/useSession.ts
+++ b/gui/src/hooks/useSession.ts
@@ -224,6 +224,7 @@ export function useConversationSession(binding?: ChatBinding | null) {
           meta.runtimeStatus,
         ),
         followupRequest: currentView?.followup ?? null,
+        goal: currentView?.goal ?? null,
         hasCurrentWorkspace: currentWorkspacePath != null,
         // An existing conversation is selected but its view (messages) has not
         // streamed in yet. Used to show a loading placeholder instead of
@@ -303,6 +304,12 @@ export function usePromptDraft(binding?: ChatBinding | null) {
     },
     [promptDraftKey],
   );
+  const setUltraMode = useCallback(
+    (value: boolean) => {
+      sessionStore.getState().setPromptDraftUltraMode(promptDraftKey, value);
+    },
+    [promptDraftKey],
+  );
 
   const draftState = useSessionStore(
     useShallow((state) => {
@@ -335,6 +342,7 @@ export function usePromptDraft(binding?: ChatBinding | null) {
           !isConversationRunning,
         followupRequest,
         isPlanningMode: draftEntry?.isPlanningMode ?? false,
+        isUltraMode: draftEntry?.isUltraMode ?? false,
         isSendingPrompt: draftEntry?.isPending ?? false,
         promptDraft: draftEntry?.value ?? "",
         promptSettings: meta.promptSettings,
@@ -347,7 +355,8 @@ export function usePromptDraft(binding?: ChatBinding | null) {
       ...draftState,
       setPlanningMode,
       setPromptDraft,
+      setUltraMode,
     }),
-    [draftState, setPlanningMode, setPromptDraft],
+    [draftState, setPlanningMode, setPromptDraft, setUltraMode],
   );
 }

--- a/gui/src/main.tsx
+++ b/gui/src/main.tsx
@@ -5,9 +5,14 @@ import '@codegraff/diffs/style.css'
 import './styles/index.css'
 import './styles/diffs.css'
 import App from './app/App'
+import { checkForUpdates } from './services/updater'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
 )
+
+// Auto-check for a newer desktop build on launch (non-blocking; prompts only
+// when an update is available). Manual checks call checkForUpdates({silent:false}).
+void checkForUpdates()

--- a/gui/src/services/desktop/client.ts
+++ b/gui/src/services/desktop/client.ts
@@ -189,6 +189,7 @@ function qaPromptSettings(): PromptSettings {
     selectedProviderId: "anthropic",
     selectedReasoningEffort: qaReasoningEffort,
     fastEnabled: false,
+    fastApplies: false,
   };
 }
 

--- a/gui/src/services/desktop/types/contracts.generated.ts
+++ b/gui/src/services/desktop/types/contracts.generated.ts
@@ -43,7 +43,15 @@ export type SessionSnapshot = { activeWorkspacePath: string | null, activeConver
 
 export type PromptModelOption = { providerId: string, providerName: string, modelId: string, modelName: string | null, contextLength: bigint | null, supportsReasoning: boolean, reasoningEfforts: Array<string>, };
 
-export type PromptSettings = { availableModels: Array<PromptModelOption>, selectedProviderId: string | null, selectedModelId: string | null, selectedReasoningEffort: string | null, fastEnabled: boolean, };
+export type PromptSettings = { availableModels: Array<PromptModelOption>, selectedProviderId: string | null, selectedModelId: string | null, selectedReasoningEffort: string | null, fastEnabled: boolean,
+/**
+ * Whether toggling fast actually changes harness behavior for the selected
+ * provider. The harness only applies /fast on the codex provider (the
+ * `responses` kind): it emits `service_tier:"priority"` there and reports
+ * `applies:false` everywhere else. True only when the selected provider is
+ * codex; the GUI greys out the toggle when this is false.
+ */
+fastApplies: boolean, };
 
 export type UpdatePromptSettingsInput = { workspacePath: string | null, providerId: string, modelId: string, reasoningEffort: string | null, };
 

--- a/gui/src/services/desktop/types/contracts.generated.ts
+++ b/gui/src/services/desktop/types/contracts.generated.ts
@@ -29,7 +29,12 @@ export type ConversationSessionSummary = { conversationId: string, title: string
 
 export type ChatBinding = { workspacePath: string, conversationId: string, };
 
-export type ConversationViewSnapshot = { workspacePath: string, conversationId: string, messages: Array<SessionMessage>, activeRequestIds: Array<string>, requestAgentIds: { [key in string]: string }, todos: Array<SessionTodo>, followup: FollowupRequest | null, };
+export type ConversationViewSnapshot = { workspacePath: string, conversationId: string, messages: Array<SessionMessage>, activeRequestIds: Array<string>, requestAgentIds: { [key in string]: string }, todos: Array<SessionTodo>,
+/**
+ * Steering objective for this chat, set via `/goal`. Surfaced in the UI as
+ * the goal chip above the composer. Omitted from the payload when unset.
+ */
+goal?: string, followup: FollowupRequest | null, };
 
 export type WorkspaceKind = "project" | "managed_chat";
 
@@ -39,7 +44,13 @@ export type SavedWorkspaceSummary = { id: string, name: string, updatedAt: bigin
 
 export type SavedWorkspaceDetail = { id: string, name: string, layoutJson: string, updatedAt: bigint, };
 
-export type SessionSnapshot = { activeWorkspacePath: string | null, activeConversationId: string | null, visibleMessages: Array<SessionMessage>, visibleActiveRequestIds: Array<string>, visibleRequestAgentIds: { [key in string]: string }, visibleTodos: Array<SessionTodo>, visibleFollowup: FollowupRequest | null, conversationViews: Array<ConversationViewSnapshot>, uiError: string | null, workspaces: Array<WorkspaceSession>, savedWorkspaces: Array<SavedWorkspaceSummary>, };
+export type SessionSnapshot = { activeWorkspacePath: string | null, activeConversationId: string | null, visibleMessages: Array<SessionMessage>, visibleActiveRequestIds: Array<string>, visibleRequestAgentIds: { [key in string]: string }, visibleTodos: Array<SessionTodo>,
+/**
+ * Steering objective of the active chat, set via `/goal`. Mirrors
+ * `ConversationViewSnapshotDto::goal` for the visible conversation. Omitted
+ * from the payload when no goal is set.
+ */
+visibleGoal?: string, visibleFollowup: FollowupRequest | null, conversationViews: Array<ConversationViewSnapshot>, uiError: string | null, workspaces: Array<WorkspaceSession>, savedWorkspaces: Array<SavedWorkspaceSummary>, };
 
 export type PromptModelOption = { providerId: string, providerName: string, modelId: string, modelName: string | null, contextLength: bigint | null, supportsReasoning: boolean, reasoningEfforts: Array<string>, };
 

--- a/gui/src/services/updater.ts
+++ b/gui/src/services/updater.ts
@@ -1,0 +1,60 @@
+import { ask, message } from "@tauri-apps/plugin-dialog";
+import { relaunch } from "@tauri-apps/plugin-process";
+import { check } from "@tauri-apps/plugin-updater";
+
+let inFlight = false;
+
+/**
+ * Check GitHub for a newer desktop build and, if one exists, offer to install
+ * it. Downloads the signed updater artifact (verified against the bundled
+ * minisign public key), applies it, and relaunches.
+ *
+ * The updater endpoint and pubkey live in `src-tauri/tauri.conf.json`. This
+ * complements the CLI's `graff update`: that updates only the bundled `graff`
+ * binary, while this swaps the whole desktop app.
+ *
+ * @param silent When true (the on-launch path) stay quiet if already current or
+ *   if the check fails. The manual "Check for Updates" path passes false so the
+ *   user always gets feedback.
+ */
+export async function checkForUpdates({ silent = true }: { silent?: boolean } = {}): Promise<void> {
+  if (inFlight) return;
+  inFlight = true;
+  try {
+    const update = await check();
+    if (!update) {
+      if (!silent) {
+        await message("You're on the latest version of Codegraff.", {
+          title: "Codegraff",
+          kind: "info",
+        });
+      }
+      return;
+    }
+
+    const accepted = await ask(
+      `Codegraff ${update.version} is available (you have ${update.currentVersion}).\n\nInstall it now and relaunch?`,
+      {
+        title: "Update available",
+        kind: "info",
+        okLabel: "Install & Relaunch",
+        cancelLabel: "Later",
+      },
+    );
+    if (!accepted) return;
+
+    await update.downloadAndInstall();
+    await relaunch();
+  } catch (err) {
+    if (silent) {
+      console.error("[updater] check failed", err);
+    } else {
+      await message(`Update check failed: ${String(err)}`, {
+        title: "Codegraff",
+        kind: "error",
+      });
+    }
+  } finally {
+    inFlight = false;
+  }
+}

--- a/gui/src/styles/index.css
+++ b/gui/src/styles/index.css
@@ -1186,7 +1186,7 @@
     content: "";
     border-radius: inherit;
     background: linear-gradient(
-        90deg,
+        90deg in oklab,
         #ff5f6d,
         #ffb347,
         #ffe66d,
@@ -1220,7 +1220,7 @@
     content: "";
     border-radius: inherit;
     background: linear-gradient(
-        90deg,
+        90deg in oklab,
         #ff5f6d,
         #ffb347,
         #ffe66d,

--- a/gui/src/styles/index.css
+++ b/gui/src/styles/index.css
@@ -1,3 +1,160 @@
+
+:root[data-theme="mono"] {
+    --background: #ffffff;
+    --foreground: #0a0a0a;
+    --card: #f4f4f5;
+    --card-foreground: #0a0a0a;
+    --popover: #f4f4f5;
+    --popover-foreground: #0a0a0a;
+    --primary: #0a0a0a;
+    --primary-foreground: #ffffff;
+    --secondary: #e8e8ea;
+    --secondary-foreground: #0a0a0a;
+    --muted: #ececee;
+    --muted-foreground: #5f5f66;
+    --accent: #18181b;
+    --accent-foreground: #ffffff;
+    --destructive: #b42318;
+    --border: #e1e1e4;
+    --input: #e1e1e4;
+    --ring: #18181b;
+    --chart-1: #18181b;
+    --chart-2: #3f3f46;
+    --chart-3: #71717a;
+    --chart-4: #a1a1aa;
+    --chart-5: #d4d4d8;
+    --sidebar: #f4f4f5;
+    --sidebar-foreground: #0a0a0a;
+    --sidebar-primary: #18181b;
+    --sidebar-primary-foreground: #ffffff;
+    --sidebar-accent: #e8e8ea;
+    --sidebar-accent-foreground: #0a0a0a;
+    --sidebar-border: #e1e1e4;
+    --sidebar-ring: #18181b;
+    --accent-dim: #3f3f46;
+    --success: #3f7d4f;
+    --warn: #9a6e1b;
+    --faint: #b6b6bb;
+    --diff-add-bg: #eaf2ea;
+    --diff-del-bg: #f7e9e9;
+}
+[data-theme="mono"].dark {
+    --background: #0a0a0a;
+    --foreground: #fafafa;
+    --card: #161618;
+    --card-foreground: #fafafa;
+    --popover: #161618;
+    --popover-foreground: #fafafa;
+    --primary: #fafafa;
+    --primary-foreground: #0a0a0a;
+    --secondary: #242427;
+    --secondary-foreground: #fafafa;
+    --muted: #242427;
+    --muted-foreground: #a1a1aa;
+    --accent: #fafafa;
+    --accent-foreground: #0a0a0a;
+    --destructive: #f0654a;
+    --border: #2a2a2e;
+    --input: #2a2a2e;
+    --ring: #fafafa;
+    --chart-1: #fafafa;
+    --chart-2: #d4d4d8;
+    --chart-3: #a1a1aa;
+    --chart-4: #71717a;
+    --chart-5: #52525b;
+    --sidebar: #161618;
+    --sidebar-foreground: #fafafa;
+    --sidebar-primary: #fafafa;
+    --sidebar-primary-foreground: #0a0a0a;
+    --sidebar-accent: #242427;
+    --sidebar-accent-foreground: #fafafa;
+    --sidebar-border: #2a2a2e;
+    --sidebar-ring: #fafafa;
+    --accent-dim: #d4d4d8;
+    --success: #6abf7f;
+    --warn: #d9a441;
+    --faint: #52525b;
+    --diff-add-bg: #16241a;
+    --diff-del-bg: #2a1818;
+}
+:root[data-theme="rose"] {
+    --background: #fff5f8;
+    --foreground: #43162a;
+    --card: #ffe9f0;
+    --card-foreground: #43162a;
+    --popover: #ffe9f0;
+    --popover-foreground: #43162a;
+    --primary: #43162a;
+    --primary-foreground: #fff5f8;
+    --secondary: #ffd6e4;
+    --secondary-foreground: #43162a;
+    --muted: #ffdae7;
+    --muted-foreground: #985570;
+    --accent: #e23e72;
+    --accent-foreground: #fff5f8;
+    --destructive: #c4304a;
+    --border: #f7c6d8;
+    --input: #f7c6d8;
+    --ring: #e23e72;
+    --chart-1: #e23e72;
+    --chart-2: #d96a98;
+    --chart-3: #b5487a;
+    --chart-4: #e88aa8;
+    --chart-5: #985570;
+    --sidebar: #ffe9f0;
+    --sidebar-foreground: #43162a;
+    --sidebar-primary: #e23e72;
+    --sidebar-primary-foreground: #fff5f8;
+    --sidebar-accent: #ffd6e4;
+    --sidebar-accent-foreground: #43162a;
+    --sidebar-border: #f7c6d8;
+    --sidebar-ring: #e23e72;
+    --accent-dim: #c22f60;
+    --success: #4f9d7a;
+    --warn: #c98a2b;
+    --faint: #dbabbd;
+    --diff-add-bg: #e9f1e6;
+    --diff-del-bg: #ffdde7;
+}
+[data-theme="rose"].dark {
+    --background: #1a0e14;
+    --foreground: #f7dde7;
+    --card: #251521;
+    --card-foreground: #f7dde7;
+    --popover: #251521;
+    --popover-foreground: #f7dde7;
+    --primary: #f7dde7;
+    --primary-foreground: #1a0e14;
+    --secondary: #341f2c;
+    --secondary-foreground: #f7dde7;
+    --muted: #341f2c;
+    --muted-foreground: #c79aac;
+    --accent: #ff6b9d;
+    --accent-foreground: #1a0e14;
+    --destructive: #e8617a;
+    --border: #3e2533;
+    --input: #3e2533;
+    --ring: #ff6b9d;
+    --chart-1: #ff6b9d;
+    --chart-2: #ff9bbd;
+    --chart-3: #d96a98;
+    --chart-4: #b5487a;
+    --chart-5: #c79aac;
+    --sidebar: #251521;
+    --sidebar-foreground: #f7dde7;
+    --sidebar-primary: #ff6b9d;
+    --sidebar-primary-foreground: #1a0e14;
+    --sidebar-accent: #341f2c;
+    --sidebar-accent-foreground: #f7dde7;
+    --sidebar-border: #3e2533;
+    --sidebar-ring: #ff6b9d;
+    --accent-dim: #e85b8d;
+    --success: #6abf9f;
+    --warn: #d9a441;
+    --faint: #5c3d4c;
+    --diff-add-bg: #182619;
+    --diff-del-bg: #2e1820;
+}
 @import "tailwindcss";
 @import "tw-shimmer";
 @import "tw-animate-css";
@@ -1064,7 +1221,7 @@
 /* Soft outer bloom so the card reads as "lit" against the dark surface. */
 .cg-ultra-shine::after {
     position: absolute;
-    inset: -1px;
+    inset: 0;
     z-index: -2;
     content: "";
     border-radius: inherit;
@@ -1080,8 +1237,8 @@
         #ff5fa2,
         #ff5f6d
     );
-    filter: blur(11px);
-    opacity: 0.35;
+    filter: blur(6px);
+    opacity: 0.22;
     animation: cg-ultra-spin 4s linear infinite;
 }
 
@@ -1089,5 +1246,42 @@
     .cg-ultra-shine::before,
     .cg-ultra-shine::after {
         animation: none;
+    }
+}
+
+/* --- Inset content pane + sidebar spotlight ---
+   macOS detail-pane layout: the content sits flush against the sidebar and the
+   window edges, rounded only on the corners that face the sidebar so the sidebar
+   surface shows through the rounded notch. The whole window wears the sidebar
+   colour (bg-sidebar on .app-shell); the content pane is the brighter --background
+   surface laid over it. The sidebar still recedes while you work in the content —
+   dimming so the active side reads as "lit" — then lights back up on hover. */
+.cg-content-region {
+    padding: 0;
+}
+
+.cg-content-card {
+    border-radius: 0.75rem 0 0 0.75rem;
+    background: var(--pane-surface);
+}
+
+.cg-sidebar-region {
+    transition: opacity 0.45s cubic-bezier(0.16, 1, 0.3, 1);
+    will-change: opacity;
+}
+
+/* Working in the content (composer focused, a control active) dims the sidebar. */
+.app-shell:has(.cg-content-card:focus-within) .cg-sidebar-region {
+    opacity: 0.48;
+}
+
+/* …but hovering the sidebar lights it back up, even while the composer holds focus. */
+.app-shell:has(.cg-content-card:focus-within) .cg-sidebar-region:hover {
+    opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .cg-sidebar-region {
+        transition: none;
     }
 }

--- a/gui/src/styles/index.css
+++ b/gui/src/styles/index.css
@@ -1153,20 +1153,13 @@
 }
 
 /* --- Ultra mode shine (the `ultracode` codeword opt-in) ---
-   When Ultra is engaged on the composer, the card wears a slowly rotating
-   rainbow border, mirroring the harness TUI's `ultracodeShine`. The border is
-   painted into a masked ::before so the conic gradient only shows as a ring,
-   and the hue sweep is driven by animating a registered --cg-ultra-angle
-   custom property (smooth, GPU-cheap — no layout, no repaint of children). */
-@property --cg-ultra-angle {
-    syntax: "<angle>";
-    inherits: false;
-    initial-value: 0deg;
-}
-
-@keyframes cg-ultra-spin {
+   When Ultra is engaged on the composer, the card wears a rainbow that travels
+   left→right as a WAVE (a flowing linear gradient), rather than a conic gradient
+   pinwheeling around the centre. The border is painted into a masked ::before so
+   the gradient only shows as a ring; a soft blurred ::after gives the lit bloom. */
+@keyframes cg-ultra-wave {
     to {
-        --cg-ultra-angle: 360deg;
+        background-position: -200% 0;
     }
 }
 
@@ -1192,8 +1185,8 @@
     padding: 1.5px;
     content: "";
     border-radius: inherit;
-    background: conic-gradient(
-        from var(--cg-ultra-angle),
+    background: linear-gradient(
+        90deg,
         #ff5f6d,
         #ffb347,
         #ffe66d,
@@ -1204,6 +1197,7 @@
         #ff5fa2,
         #ff5f6d
     );
+    background-size: 200% 100%;
     /* Show the gradient only as a ring: fill minus content box. */
     -webkit-mask:
         linear-gradient(#000 0 0) content-box,
@@ -1214,19 +1208,19 @@
         linear-gradient(#000 0 0);
     mask-composite: exclude;
     animation:
-        cg-ultra-spin 4s linear infinite,
+        cg-ultra-wave 6s linear infinite,
         cg-ultra-glow 2.4s ease-in-out infinite;
 }
 
-/* Soft outer bloom so the card reads as "lit" against the dark surface. */
+/* Soft outer bloom so the card reads as "lit". */
 .cg-ultra-shine::after {
     position: absolute;
     inset: 0;
     z-index: -2;
     content: "";
     border-radius: inherit;
-    background: conic-gradient(
-        from var(--cg-ultra-angle),
+    background: linear-gradient(
+        90deg,
         #ff5f6d,
         #ffb347,
         #ffe66d,
@@ -1237,9 +1231,10 @@
         #ff5fa2,
         #ff5f6d
     );
+    background-size: 200% 100%;
     filter: blur(6px);
     opacity: 0.22;
-    animation: cg-ultra-spin 4s linear infinite;
+    animation: cg-ultra-wave 6s linear infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/gui/src/styles/index.css
+++ b/gui/src/styles/index.css
@@ -994,3 +994,100 @@
         animation: none;
     }
 }
+
+/* --- Ultra mode shine (the `ultracode` codeword opt-in) ---
+   When Ultra is engaged on the composer, the card wears a slowly rotating
+   rainbow border, mirroring the harness TUI's `ultracodeShine`. The border is
+   painted into a masked ::before so the conic gradient only shows as a ring,
+   and the hue sweep is driven by animating a registered --cg-ultra-angle
+   custom property (smooth, GPU-cheap — no layout, no repaint of children). */
+@property --cg-ultra-angle {
+    syntax: "<angle>";
+    inherits: false;
+    initial-value: 0deg;
+}
+
+@keyframes cg-ultra-spin {
+    to {
+        --cg-ultra-angle: 360deg;
+    }
+}
+
+@keyframes cg-ultra-glow {
+    0%,
+    100% {
+        opacity: 0.85;
+    }
+    50% {
+        opacity: 1;
+    }
+}
+
+.cg-ultra-shine {
+    position: relative;
+    isolation: isolate;
+}
+
+.cg-ultra-shine::before {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    padding: 1.5px;
+    content: "";
+    border-radius: inherit;
+    background: conic-gradient(
+        from var(--cg-ultra-angle),
+        #ff5f6d,
+        #ffb347,
+        #ffe66d,
+        #5cd68a,
+        #36c5d6,
+        #5b7cff,
+        #b06aff,
+        #ff5fa2,
+        #ff5f6d
+    );
+    /* Show the gradient only as a ring: fill minus content box. */
+    -webkit-mask:
+        linear-gradient(#000 0 0) content-box,
+        linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask:
+        linear-gradient(#000 0 0) content-box,
+        linear-gradient(#000 0 0);
+    mask-composite: exclude;
+    animation:
+        cg-ultra-spin 4s linear infinite,
+        cg-ultra-glow 2.4s ease-in-out infinite;
+}
+
+/* Soft outer bloom so the card reads as "lit" against the dark surface. */
+.cg-ultra-shine::after {
+    position: absolute;
+    inset: -1px;
+    z-index: -2;
+    content: "";
+    border-radius: inherit;
+    background: conic-gradient(
+        from var(--cg-ultra-angle),
+        #ff5f6d,
+        #ffb347,
+        #ffe66d,
+        #5cd68a,
+        #36c5d6,
+        #5b7cff,
+        #b06aff,
+        #ff5fa2,
+        #ff5f6d
+    );
+    filter: blur(11px);
+    opacity: 0.35;
+    animation: cg-ultra-spin 4s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .cg-ultra-shine::before,
+    .cg-ultra-shine::after {
+        animation: none;
+    }
+}

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# simple-harness installer. Prefers a prebuilt binary from the latest GitHub
+# graff-harness installer. Prefers a prebuilt binary from the latest GitHub
 # release; falls back to building from source with Zig. Styled after the
 # codedb/codegraff installers.
 #
@@ -164,7 +164,7 @@ main() {
   local platform
   platform="$(detect_platform)"
 
-  printf "\n  ${W}simple-harness${N} ${D}installer${N}\n\n"
+  printf "\n  ${W}graff-harness${N} ${D}installer${N}\n\n"
   printf "  ${D}platform${N}  $platform\n"
   printf "  ${D}install${N}   $INSTALL_DIR\n\n"
 

--- a/scripts/release-gui-update.sh
+++ b/scripts/release-gui-update.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Build, sign, and notarize the Codegraff desktop app together with the
+# auto-updater payload, then assemble latest.json for the GitHub release.
+#
+# The desktop app (the .dmg) auto-updates via Tauri's updater plugin: on launch
+# it fetches
+#   https://github.com/justrach/codegraff/releases/latest/download/latest.json
+# and, if a newer version is listed, downloads + verifies + installs the
+# Codegraff.app.tar.gz payload referenced there. (This is separate from the CLI's
+# `graff update`, which only swaps the bundled graff binary.)
+#
+# Two signatures are involved and BOTH are required:
+#   1. Apple Developer ID + notarization  -> Gatekeeper lets the app run.
+#   2. Tauri minisign keypair             -> the updater trusts the payload.
+# The minisign public key is baked into src-tauri/tauri.conf.json; the private
+# key lives at ~/.tauri/codegraff_updater.key (override with
+# TAURI_SIGNING_PRIVATE_KEY_PATH). Lose it and you can never ship an update that
+# existing installs will accept.
+#
+# Prerequisites: a notarytool keychain profile (default: notary-local).
+#
+# Usage:  scripts/release-gui-update.sh            # build + notarize + assemble
+#         DRY_NOTARY=1 scripts/release-gui-update.sh   # skip the notarize/staple steps
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GUI="$ROOT/gui"
+KEY="${TAURI_SIGNING_PRIVATE_KEY_PATH:-$HOME/.tauri/codegraff_updater.key}"
+NOTARY_PROFILE="${NOTARY_PROFILE:-notary-local}"
+
+[ -f "$KEY" ] || { echo "missing updater private key: $KEY" >&2; exit 1; }
+
+export TAURI_SIGNING_PRIVATE_KEY="$(cat "$KEY")"
+export TAURI_SIGNING_PRIVATE_KEY_PASSWORD="${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}"
+
+cd "$GUI"
+VER="$(grep -m1 '"version"' src-tauri/tauri.conf.json | sed -E 's/.*"version" *: *"([^"]+)".*/\1/')"
+echo ">> building Codegraff $VER (this signs the app with Developer ID + the updater payload with minisign)"
+bun tauri build
+
+# Cargo here uses a shared target dir (~/.cargo/shared-target), not src-tauri/target,
+# so resolve it from cargo metadata instead of assuming the default location.
+TARGET_DIR="$(cargo metadata --no-deps --format-version 1 --manifest-path src-tauri/Cargo.toml 2>/dev/null | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')"
+TARGET_DIR="${TARGET_DIR:-src-tauri/target}"
+BUNDLE="$TARGET_DIR/release/bundle"
+APP="$BUNDLE/macos/Codegraff.app"
+TARBALL="$BUNDLE/macos/Codegraff.app.tar.gz"
+DMG="$(ls "$BUNDLE"/dmg/Codegraff_*.dmg | head -1)"
+
+[ -d "$APP" ]    || { echo "no .app at $APP" >&2; exit 1; }
+[ -f "$DMG" ]    || { echo "no .dmg under $BUNDLE/dmg" >&2; exit 1; }
+[ -f "$TARBALL" ] || { echo "no updater tarball — is bundle.createUpdaterArtifacts set?" >&2; exit 1; }
+
+if [ -z "${DRY_NOTARY:-}" ]; then
+  echo ">> notarizing dmg"
+  xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
+  xcrun stapler staple "$DMG"
+
+  # The updater tarball Tauri just produced wraps the NOT-yet-notarized .app, so
+  # notarize + staple the .app, then rebuild + re-sign the tarball from it.
+  echo ">> notarizing app (for the updater payload)"
+  ZIP="$(mktemp -d)/Codegraff.app.zip"
+  ditto -c -k --keepParent "$APP" "$ZIP"
+  xcrun notarytool submit "$ZIP" --keychain-profile "$NOTARY_PROFILE" --wait
+  xcrun stapler staple "$APP"
+
+  echo ">> rebuilding + re-signing updater tarball from the stapled app"
+  tar -C "$BUNDLE/macos" -czf "$TARBALL" "Codegraff.app"
+  rm -f "$TARBALL.sig"
+  # Use the exported env vars (an empty `-p ""` gets swallowed by the shell).
+  bun tauri signer sign "$TARBALL"
+fi
+
+SIG="$(cat "$TARBALL.sig")"
+PUB_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+LATEST="$BUNDLE/latest.json"
+cat > "$LATEST" <<EOF
+{
+  "version": "$VER",
+  "pub_date": "$PUB_DATE",
+  "platforms": {
+    "darwin-aarch64": {
+      "signature": "$SIG",
+      "url": "https://github.com/justrach/codegraff/releases/download/v$VER/Codegraff.app.tar.gz"
+    }
+  }
+}
+EOF
+
+# Stable-named copy so the README's direct link
+# (releases/latest/download/Codegraff.dmg) always resolves regardless of version.
+STABLE_DMG="$BUNDLE/dmg/Codegraff.dmg"
+cp "$DMG" "$STABLE_DMG"
+
+echo
+echo ">> done. Artifacts:"
+echo "   dmg:         $DMG"
+echo "   dmg (latest): $STABLE_DMG"
+echo "   updater:     $TARBALL (+ .sig)"
+echo "   manifest:    $LATEST"
+echo
+echo ">> upload to the v$VER release (the tarball name must match latest.json's url):"
+echo "   gh release upload v$VER -R justrach/codegraff \\"
+echo "     \"$DMG\" \"$STABLE_DMG\" \"$TARBALL\" \"$LATEST\" --clobber"

--- a/sdk/generate.py
+++ b/sdk/generate.py
@@ -71,10 +71,18 @@ export type ProviderId = {provider_union};
  *  to ignore in consumer code too. */
 export type Event =
   | {{ type: "text"; text: string }}
+  | {{ type: "reasoning"; text: string }}
+  | {{ type: "started"; provider: string; model: string }}
+  | {{ type: "model_call_started"; provider: string; model: string }}
+  | {{ type: "model_call_finished"; provider: string; model: string; ok: boolean; ms: number }}
   | {{ type: "tool_call"; name: string; input: Record<string, unknown> }}
+  | {{ type: "tool_call_started"; name: string; input: Record<string, unknown> }}
+  | {{ type: "tool_rejected"; name: string; reason: "budget" | "duplicate" | string; input: Record<string, unknown>; message: string }}
   | {{ type: "ask_user"; call_id: string; question: string; input: Record<string, unknown> }}
   | {{ type: "tool_result"; name: string; is_error: boolean; text: string }}
-  | {{ type: "turn"; text: string; context_tokens: number; cost_usd: number }}
+  | {{ type: "tool_call_finished"; name: string; is_error: boolean; ms: number }}
+  | {{ type: "finalizing" }}
+  | {{ type: "turn"; text: string; context_tokens: number; cost_usd: number; complete?: boolean; metadata_complete?: boolean }}
   | {{ type: "system_prompt"; ok: boolean; append: boolean; chars: number }}
   | {{ type: "score"; ok: boolean; prompt_sha: string }}
   | {{ type: "error"; message: string }};
@@ -103,6 +111,10 @@ export interface HarnessOptions {{
   systemPrompt?: string;
   /** Append extra text to the end of the system prompt. */
   appendSystemPrompt?: string;
+  /** Hard per-turn root tool-call budget. */
+  maxToolCalls?: number;
+  /** Reject duplicate root tool name+normalized-input calls per turn. */
+  dedupeToolCalls?: boolean;
   /** Extra raw flags. `--json` is always added. */
   args?: string[];
 }}
@@ -127,6 +139,8 @@ function spawnArgs(o: HarnessOptions): string[] {{
   const a = ["--json"];
   if (o.yolo) a.push("--yolo");
   if (o.model) a.push("--model", o.model);
+  if (o.maxToolCalls !== undefined) a.push("--max-tool-calls", String(o.maxToolCalls));
+  if (o.dedupeToolCalls) a.push("--dedupe-tool-calls");
   if (o.systemPrompt) a.push("--system-prompt", o.systemPrompt);
   if (o.appendSystemPrompt) a.push("--append-system-prompt", o.appendSystemPrompt);
   if (o.args) a.push(...o.args);
@@ -475,10 +489,18 @@ export type ProviderId = {provider_union};
  *  event, so unknown events pass through and are safe to ignore. */
 export type Event =
   | {{ type: "text"; text: string }}
+  | {{ type: "reasoning"; text: string }}
+  | {{ type: "started"; provider: string; model: string }}
+  | {{ type: "model_call_started"; provider: string; model: string }}
+  | {{ type: "model_call_finished"; provider: string; model: string; ok: boolean; ms: number }}
   | {{ type: "tool_call"; name: string; input: Record<string, unknown> }}
+  | {{ type: "tool_call_started"; name: string; input: Record<string, unknown> }}
+  | {{ type: "tool_rejected"; name: string; reason: "budget" | "duplicate" | string; input: Record<string, unknown>; message: string }}
   | {{ type: "ask_user"; call_id: string; question: string; input: Record<string, unknown> }}
   | {{ type: "tool_result"; name: string; is_error: boolean; text: string }}
-  | {{ type: "turn"; text: string; context_tokens: number; cost_usd: number }}
+  | {{ type: "tool_call_finished"; name: string; is_error: boolean; ms: number }}
+  | {{ type: "finalizing" }}
+  | {{ type: "turn"; text: string; context_tokens: number; cost_usd: number; complete?: boolean; metadata_complete?: boolean }}
   | {{ type: "system_prompt"; ok: boolean; append: boolean; chars: number }}
   | {{ type: "score"; ok: boolean; prompt_sha: string }}
   | {{ type: "error"; message: string }};
@@ -504,6 +526,10 @@ export interface RemoteOptions {{
   systemPrompt?: string;
   /** Append extra text to the system prompt. */
   appendSystemPrompt?: string;
+  /** Hard per-turn root tool-call budget for the child session. */
+  maxToolCalls?: number;
+  /** Reject duplicate root tool name+normalized-input calls per turn. */
+  dedupeToolCalls?: boolean;
   /** Attach to an existing session instead of creating one. */
   sessionId?: string;
 }}
@@ -590,6 +616,8 @@ export class RemoteHarness {{
     if (opts.yolo !== undefined) body.yolo = opts.yolo;
     if (opts.systemPrompt) body.system_prompt = opts.systemPrompt;
     if (opts.appendSystemPrompt) body.append_system_prompt = opts.appendSystemPrompt;
+    if (opts.maxToolCalls !== undefined) body.maxToolCalls = opts.maxToolCalls;
+    if (opts.dedupeToolCalls !== undefined) body.dedupeToolCalls = opts.dedupeToolCalls;
     const res = await this.req("POST", "/v1/sessions", body);
     const data = (await res.json()) as {{ session_id: string }};
     return data.session_id;
@@ -877,13 +905,19 @@ class Harness:
                  cwd: Optional[str] = None, env: Optional[dict] = None,
                  model: Optional[str] = None, yolo: bool = False,
                  system_prompt: Optional[str] = None,
-                 append_system_prompt: Optional[str] = None):
+                 append_system_prompt: Optional[str] = None,
+                 max_tool_calls: Optional[int] = None,
+                 dedupe_tool_calls: bool = False):
         binary = binary or _default_binary()
         argv = [binary, "--json"]
         if yolo:
             argv.append("--yolo")
         if model:
             argv += ["--model", model]
+        if max_tool_calls is not None:
+            argv += ["--max-tool-calls", str(max_tool_calls)]
+        if dedupe_tool_calls:
+            argv.append("--dedupe-tool-calls")
         if system_prompt:
             argv += ["--system-prompt", system_prompt]
         if append_system_prompt:
@@ -1093,6 +1127,8 @@ class RemoteHarness:
                  model: Optional[str] = None, yolo: bool = False,
                  system_prompt: Optional[str] = None,
                  append_system_prompt: Optional[str] = None,
+                 max_tool_calls: Optional[int] = None,
+                 dedupe_tool_calls: bool = False,
                  session_id: Optional[str] = None):
         self.base = url.rstrip("/")
         self.token = token
@@ -1108,6 +1144,10 @@ class RemoteHarness:
             opts["system_prompt"] = system_prompt
         if append_system_prompt:
             opts["append_system_prompt"] = append_system_prompt
+        if max_tool_calls is not None:
+            opts["maxToolCalls"] = max_tool_calls
+        if dedupe_tool_calls:
+            opts["dedupeToolCalls"] = True
         resp = self._request("POST", "/v1/sessions", opts)
         self.session_id = json.loads(resp.read())["session_id"]
 

--- a/sdk/py/harness_sdk.py
+++ b/sdk/py/harness_sdk.py
@@ -184,13 +184,19 @@ class Harness:
                  cwd: Optional[str] = None, env: Optional[dict] = None,
                  model: Optional[str] = None, yolo: bool = False,
                  system_prompt: Optional[str] = None,
-                 append_system_prompt: Optional[str] = None):
+                 append_system_prompt: Optional[str] = None,
+                 max_tool_calls: Optional[int] = None,
+                 dedupe_tool_calls: bool = False):
         binary = binary or _default_binary()
         argv = [binary, "--json"]
         if yolo:
             argv.append("--yolo")
         if model:
             argv += ["--model", model]
+        if max_tool_calls is not None:
+            argv += ["--max-tool-calls", str(max_tool_calls)]
+        if dedupe_tool_calls:
+            argv.append("--dedupe-tool-calls")
         if system_prompt:
             argv += ["--system-prompt", system_prompt]
         if append_system_prompt:
@@ -400,6 +406,8 @@ class RemoteHarness:
                  model: Optional[str] = None, yolo: bool = False,
                  system_prompt: Optional[str] = None,
                  append_system_prompt: Optional[str] = None,
+                 max_tool_calls: Optional[int] = None,
+                 dedupe_tool_calls: bool = False,
                  session_id: Optional[str] = None):
         self.base = url.rstrip("/")
         self.token = token
@@ -415,6 +423,10 @@ class RemoteHarness:
             opts["system_prompt"] = system_prompt
         if append_system_prompt:
             opts["append_system_prompt"] = append_system_prompt
+        if max_tool_calls is not None:
+            opts["maxToolCalls"] = max_tool_calls
+        if dedupe_tool_calls:
+            opts["dedupeToolCalls"] = True
         resp = self._request("POST", "/v1/sessions", opts)
         self.session_id = json.loads(resp.read())["session_id"]
 

--- a/sdk/ts/harness.ts
+++ b/sdk/ts/harness.ts
@@ -22,10 +22,18 @@ export type ProviderId = "anthropic" | "codegraff" | "deepseek" | "openai" | "mi
  *  to ignore in consumer code too. */
 export type Event =
   | { type: "text"; text: string }
+  | { type: "reasoning"; text: string }
+  | { type: "started"; provider: string; model: string }
+  | { type: "model_call_started"; provider: string; model: string }
+  | { type: "model_call_finished"; provider: string; model: string; ok: boolean; ms: number }
   | { type: "tool_call"; name: string; input: Record<string, unknown> }
+  | { type: "tool_call_started"; name: string; input: Record<string, unknown> }
+  | { type: "tool_rejected"; name: string; reason: "budget" | "duplicate" | string; input: Record<string, unknown>; message: string }
   | { type: "ask_user"; call_id: string; question: string; input: Record<string, unknown> }
   | { type: "tool_result"; name: string; is_error: boolean; text: string }
-  | { type: "turn"; text: string; context_tokens: number; cost_usd: number }
+  | { type: "tool_call_finished"; name: string; is_error: boolean; ms: number }
+  | { type: "finalizing" }
+  | { type: "turn"; text: string; context_tokens: number; cost_usd: number; complete?: boolean; metadata_complete?: boolean }
   | { type: "system_prompt"; ok: boolean; append: boolean; chars: number }
   | { type: "score"; ok: boolean; prompt_sha: string }
   | { type: "error"; message: string };
@@ -54,6 +62,10 @@ export interface HarnessOptions {
   systemPrompt?: string;
   /** Append extra text to the end of the system prompt. */
   appendSystemPrompt?: string;
+  /** Hard per-turn root tool-call budget. */
+  maxToolCalls?: number;
+  /** Reject duplicate root tool name+normalized-input calls per turn. */
+  dedupeToolCalls?: boolean;
   /** Extra raw flags. `--json` is always added. */
   args?: string[];
 }
@@ -78,6 +90,8 @@ function spawnArgs(o: HarnessOptions): string[] {
   const a = ["--json"];
   if (o.yolo) a.push("--yolo");
   if (o.model) a.push("--model", o.model);
+  if (o.maxToolCalls !== undefined) a.push("--max-tool-calls", String(o.maxToolCalls));
+  if (o.dedupeToolCalls) a.push("--dedupe-tool-calls");
   if (o.systemPrompt) a.push("--system-prompt", o.systemPrompt);
   if (o.appendSystemPrompt) a.push("--append-system-prompt", o.appendSystemPrompt);
   if (o.args) a.push(...o.args);

--- a/sdk/ts/remote.ts
+++ b/sdk/ts/remote.ts
@@ -19,10 +19,18 @@ export type ProviderId = "anthropic" | "codegraff" | "deepseek" | "openai" | "mi
  *  event, so unknown events pass through and are safe to ignore. */
 export type Event =
   | { type: "text"; text: string }
+  | { type: "reasoning"; text: string }
+  | { type: "started"; provider: string; model: string }
+  | { type: "model_call_started"; provider: string; model: string }
+  | { type: "model_call_finished"; provider: string; model: string; ok: boolean; ms: number }
   | { type: "tool_call"; name: string; input: Record<string, unknown> }
+  | { type: "tool_call_started"; name: string; input: Record<string, unknown> }
+  | { type: "tool_rejected"; name: string; reason: "budget" | "duplicate" | string; input: Record<string, unknown>; message: string }
   | { type: "ask_user"; call_id: string; question: string; input: Record<string, unknown> }
   | { type: "tool_result"; name: string; is_error: boolean; text: string }
-  | { type: "turn"; text: string; context_tokens: number; cost_usd: number }
+  | { type: "tool_call_finished"; name: string; is_error: boolean; ms: number }
+  | { type: "finalizing" }
+  | { type: "turn"; text: string; context_tokens: number; cost_usd: number; complete?: boolean; metadata_complete?: boolean }
   | { type: "system_prompt"; ok: boolean; append: boolean; chars: number }
   | { type: "score"; ok: boolean; prompt_sha: string }
   | { type: "error"; message: string };
@@ -48,6 +56,10 @@ export interface RemoteOptions {
   systemPrompt?: string;
   /** Append extra text to the system prompt. */
   appendSystemPrompt?: string;
+  /** Hard per-turn root tool-call budget for the child session. */
+  maxToolCalls?: number;
+  /** Reject duplicate root tool name+normalized-input calls per turn. */
+  dedupeToolCalls?: boolean;
   /** Attach to an existing session instead of creating one. */
   sessionId?: string;
 }
@@ -134,6 +146,8 @@ export class RemoteHarness {
     if (opts.yolo !== undefined) body.yolo = opts.yolo;
     if (opts.systemPrompt) body.system_prompt = opts.systemPrompt;
     if (opts.appendSystemPrompt) body.append_system_prompt = opts.appendSystemPrompt;
+    if (opts.maxToolCalls !== undefined) body.maxToolCalls = opts.maxToolCalls;
+    if (opts.dedupeToolCalls !== undefined) body.dedupeToolCalls = opts.dedupeToolCalls;
     const res = await this.req("POST", "/v1/sessions", body);
     const data = (await res.json()) as { session_id: string };
     return data.session_id;

--- a/src/main.zig
+++ b/src/main.zig
@@ -4917,10 +4917,10 @@ pub fn main(init: std.process.Init) !void {
             }
             try out.flush();
             break :blk e.text;
-        } else if (interactive)
-            (try readLine(&root, in, out, gpa, &history, &linebuf)) orelse break
-        else
-            (try in.takeDelimiter('\n')) orelse break;
+        } else if (interactive) blk: {
+            try root.prompt();
+            break :blk (try readLine(&root, in, out, gpa, &history, &linebuf)) orelse break;
+        } else (try in.takeDelimiter('\n')) orelse break;
         const line = std.mem.trim(u8, raw_line, " \t\r");
         if (line.len == 0) continue;
         const loop_prompt: ?[]const u8 = if (!json_mode and std.mem.startsWith(u8, line, "/loop "))

--- a/src/main.zig
+++ b/src/main.zig
@@ -7815,6 +7815,27 @@ fn loadSession(root: *Agent, keys: Keys, arena: Allocator, name: []const u8) !vo
 
     root.provider = try keys.providerById(pid, model);
     root.messages = msgs;
+    // Repair histories written by older builds where a Responses
+    // `function_call_output.output` was persisted as a byte array instead of a
+    // string. The Responses API rejects that ("input[N].output[0]: expected an
+    // object, got an integer instead"), and we restore messages verbatim — so a
+    // poisoned last.session.json would otherwise re-break every resume.
+    for (root.messages.items) |*m| {
+        if (m.* != .object) continue;
+        const mtype = if (m.object.get("type")) |t| (if (t == .string) t.string else "") else "";
+        if (!std.mem.eql(u8, mtype, "function_call_output")) continue;
+        const out = m.object.get("output") orelse continue;
+        if (out == .string) continue; // already correct
+        var repaired: std.ArrayList(u8) = .empty;
+        if (out == .array) {
+            for (out.array.items) |el| {
+                if (el == .integer and el.integer >= 0 and el.integer <= 255) {
+                    try repaired.append(arena, @intCast(el.integer));
+                }
+            }
+        }
+        try m.object.put(arena, "output", .{ .string = repaired.items });
+    }
     root.strict = strict;
     root.last_context_tokens = 0;
     root.cap_new = false; // per-provider; relearn on rejection

--- a/src/main.zig
+++ b/src/main.zig
@@ -71,6 +71,8 @@ var use_color = false; // stdout is a TTY and NO_COLOR unset → enables color +
 var show_timing = false;
 var show_cost = false;
 var json_mode = false; // --json: structured JSONL events on stdout instead of human text
+var max_tool_calls: ?u64 = null; // --max-tool-calls: hard per-turn root tool budget
+var dedupe_tool_calls = false; // --dedupe-tool-calls: reject duplicate root calls in a turn
 var plan_mode = false; // /plan: read-only — mutating tools are denied, the model proposes
 var unattended = false; // -p one-shot: no human to prompt; unapproved tool calls are denied
 
@@ -84,10 +86,17 @@ const schema_protocol_json =
     \\  "events": [
     \\    {"type": "text", "text": "assistant text delta"},
     \\    {"type": "reasoning", "text": "reasoning/thinking delta (GUI shows a collapsible Thinking block)"},
+    \\    {"type": "started", "provider": "provider", "model": "model"},
+    \\    {"type": "model_call_started", "provider": "provider", "model": "model"},
+    \\    {"type": "model_call_finished", "provider": "provider", "model": "model", "ok": true, "ms": 0},
     \\    {"type": "tool_call", "name": "tool", "input": {}},
+    \\    {"type": "tool_call_started", "name": "tool", "input": {}},
+    \\    {"type": "tool_rejected", "name": "tool", "reason": "budget|duplicate", "input": {}, "message": "..."},
     \\    {"type": "ask_user", "call_id": "...", "question": "...", "input": {"question": "...", "options": ["..."]}},
     \\    {"type": "tool_result", "name": "tool", "is_error": false, "text": "..."},
-    \\    {"type": "turn", "text": "final assistant text", "context_tokens": 0, "cost_usd": 0.0},
+    \\    {"type": "tool_call_finished", "name": "tool", "is_error": false, "ms": 0},
+    \\    {"type": "finalizing"},
+    \\    {"type": "turn", "text": "final assistant text", "context_tokens": 0, "cost_usd": 0.0, "complete": true, "metadata_complete": true},
     \\    {"type": "system_prompt", "ok": true, "append": false, "chars": 0},
     \\    {"type": "model", "ok": true, "provider": "provider", "model": "model", "context": 0, "note": "context kept"},
     \\    {"type": "compact", "ok": true, "chars": 0},
@@ -111,7 +120,7 @@ const schema_serve_json =
     \\  "endpoints": [
     \\    {"method": "GET", "path": "/healthz", "description": "liveness + version, no auth"},
     \\    {"method": "GET", "path": "/v1/schema", "description": "this schema document"},
-    \\    {"method": "POST", "path": "/v1/sessions", "description": "create a session (a graff --json child); optional JSON body {\"model\",\"yolo\",\"system_prompt\",\"append_system_prompt\"} overrides serve-level defaults; responds {\"session_id\":\"<16 hex>\"}"},
+    \\    {"method": "POST", "path": "/v1/sessions", "description": "create a session (a graff --json child); optional JSON body {\"model\",\"yolo\",\"system_prompt\",\"append_system_prompt\",\"maxToolCalls\",\"dedupeToolCalls\"} overrides serve-level defaults; responds {\"session_id\":\"<16 hex>\"}"},
     \\    {"method": "POST", "path": "/v1/sessions/{id}", "description": "body is ONE stdio-protocol request object (user / set_system_prompt / set_model / compact / set_mode / set_agent / score / answer); non-answer requests stream application/x-ndjson events until the request's terminal event (turn/error, or the request-specific ack); answer requests return JSON ack while the original user stream continues; one non-answer request in flight per session at a time"},
     \\    {"method": "DELETE", "path": "/v1/sessions/{id}", "description": "graceful close: waits for any in-flight request, then EOFs the child's stdin"}
     \\  ]
@@ -127,6 +136,8 @@ const schema_flags_json =
     \\  {"flag": "--system-prompt", "arg": "text", "description": "replace the built-in system prompt (cwd project-instructions file is still appended)"},
     \\  {"flag": "--append-system-prompt", "arg": "text", "description": "append extra text to the end of the system prompt"},
     \\  {"flag": "--json", "arg": null, "description": "structured stdio protocol (JSON in, JSONL events out)"},
+    \\  {"flag": "--max-tool-calls", "arg": "N", "description": "hard per-turn root tool-call budget; rejected calls emit tool_rejected/tool_result"},
+    \\  {"flag": "--dedupe-tool-calls", "arg": null, "description": "reject duplicate root tool name+normalized-input calls per turn"},
     \\  {"flag": "--no-telemetry", "arg": null, "description": "disable anonymous OTEL usage telemetry for this run"}
     \\]
 ;
@@ -365,11 +376,33 @@ fn contextFor(provider_id: []const u8, model: []const u8) u64 {
 /// a key/login available so `/model sonnet` lands on a usable provider. Returns
 /// null when nothing matches (caller falls back to the query verbatim so the
 /// providerFor claude*/gateway fallback still applies).
+fn normalizeModelAlias(dst: *[128]u8, s: []const u8) []const u8 {
+    var n: usize = 0;
+    for (s) |c| {
+        if (c == '-' or c == '_' or c == ' ') continue;
+        if (n >= dst.len) break;
+        dst[n] = std.ascii.toLower(c);
+        n += 1;
+    }
+    return dst[0..n];
+}
+
+fn modelAliasEquals(name: []const u8, query: []const u8) bool {
+    var nb: [128]u8 = undefined;
+    var qb: [128]u8 = undefined;
+    return std.mem.eql(u8, normalizeModelAlias(&nb, name), normalizeModelAlias(&qb, query));
+}
+
 fn resolveModelName(keys: Keys, query: []const u8) ?[]const u8 {
     for (model_table) |m| if (std.mem.eql(u8, m.name, query)) return m.name;
+    for (model_table) |m| if (modelAliasEquals(m.name, query)) return m.name;
+    var qbuf: [128]u8 = undefined;
+    const qnorm = normalizeModelAlias(&qbuf, query);
     var fallback: ?[]const u8 = null;
     for (model_table) |m| {
-        if (std.ascii.indexOfIgnoreCase(m.name, query) == null) continue;
+        var nbuf: [128]u8 = undefined;
+        const nnorm = normalizeModelAlias(&nbuf, m.name);
+        if (std.ascii.indexOfIgnoreCase(m.name, query) == null and std.mem.indexOf(u8, nnorm, qnorm) == null) continue;
         if (keys.get(m.provider) != null) return m.name;
         if (fallback == null) fallback = m.name;
     }
@@ -4059,6 +4092,8 @@ const usage_text =
     \\  --timing         show per-tool wall-clock on result lines
     \\  --cost           show running session spend in the prompt
     \\  --json           structured stdio protocol (JSON in, JSONL events out)
+    \\  --max-tool-calls N  reject root tool calls after N per turn (JSON-safe budget)
+    \\  --dedupe-tool-calls reject duplicate root tool name+input calls per turn
     \\  --no-telemetry   disable anonymous usage telemetry for this run
     \\  -h, --help       this help
     \\  -V, --version    print version
@@ -4313,6 +4348,11 @@ pub fn main(init: std.process.Init) !void {
                     show_cost = true;
                 } else if (std.mem.eql(u8, arg, "--json")) {
                     json_mode = true;
+                } else if (std.mem.eql(u8, arg, "--max-tool-calls")) {
+                    const mv = it.next() orelse std.process.fatal("--max-tool-calls needs a non-negative integer — harness --help", .{});
+                    max_tool_calls = std.fmt.parseInt(u64, mv, 10) catch std.process.fatal("--max-tool-calls needs a non-negative integer, got '{s}'", .{mv});
+                } else if (std.mem.eql(u8, arg, "--dedupe-tool-calls")) {
+                    dedupe_tool_calls = true;
                 } else if (std.mem.eql(u8, arg, "--schema")) {
                     schema_flag = true;
                 } else if (std.mem.eql(u8, arg, "--refresh")) {
@@ -5081,6 +5121,14 @@ pub fn main(init: std.process.Init) !void {
                 root.emit(.{ .type = "system_prompt", .ok = true, .append = append, .chars = root.sys_normal.len });
                 continue;
             }
+            if (parsed.object.get("maxToolCalls") orelse parsed.object.get("max_tool_calls")) |v| switch (v) {
+                .integer => |n| max_tool_calls = if (n >= 0) @intCast(n) else null,
+                .null => max_tool_calls = null,
+                else => {},
+            };
+            if (parsed.object.get("dedupeToolCalls") orelse parsed.object.get("dedupe_tool_calls")) |v| {
+                if (v == .bool) dedupe_tool_calls = v.bool;
+            }
             break :blk text;
         } else line;
 
@@ -5160,6 +5208,9 @@ pub fn main(init: std.process.Init) !void {
             break :blk id;
         } else 0;
         root.tools_used.clear(io); // per-turn tool log for the turn's node
+        root.tool_calls_this_turn = 0;
+        root.seen_tool_keys.clearRetainingCapacity();
+        if (json_mode) root.emit(.{ .type = "started", .provider = root.provider.id, .model = root.provider.model });
         const turn_started = Io.Timestamp.now(io, .awake);
         // A failed turn must never kill the session: ApiError is already
         // reported inside request(); anything else is surfaced here. Either
@@ -5209,7 +5260,14 @@ pub fn main(init: std.process.Init) !void {
             },
             error.ApiError => {
                 if (g_telem) |t| t.errorEvent("api", root.last_api_error orelse "api error");
-                if (json_mode) root.emit(.{ .type = "error", .message = root.last_api_error orelse "api error" });
+                if (json_mode) {
+                    root.emit(.{ .type = "error", .message = root.last_api_error orelse "api error" });
+                    const partial = std.mem.trim(u8, root.partial_text.items, " \t\r\n");
+                    if (partial.len > 0) {
+                        root.emit(.{ .type = "finalizing" });
+                        root.emit(.{ .type = "turn", .text = partial, .context_tokens = root.last_context_tokens, .cost_usd = g_cost.snap(io).usd, .complete = false, .metadata_complete = root.last_context_tokens > 0 });
+                    }
+                }
                 saveSession(&root, arena, root.session_name) catch {};
                 continue;
             },
@@ -5224,7 +5282,14 @@ pub fn main(init: std.process.Init) !void {
                 continue;
             },
         };
-        if (json_mode) root.emit(.{ .type = "turn", .text = final_text, .context_tokens = root.last_context_tokens, .cost_usd = g_cost.snap(io).usd });
+        if (json_mode) {
+            const emitted_text = if (final_text.len == 0 and root.partial_text.items.len > 0)
+                std.mem.trim(u8, root.partial_text.items, " \t\r\n")
+            else
+                final_text;
+            root.emit(.{ .type = "finalizing" });
+            root.emit(.{ .type = "turn", .text = emitted_text, .context_tokens = root.last_context_tokens, .cost_usd = g_cost.snap(io).usd, .complete = true, .metadata_complete = root.last_context_tokens > 0 });
+        }
 
         // turn_end lifecycle hooks (best-effort; interrupted/errored turns
         // `continue` above and never reach here, so ok is always true).
@@ -7408,6 +7473,8 @@ fn serveCreate(st: *ServeState, req: *std.http.Server.Request) !void {
     var yolo = st.cfg.yolo;
     var sys = st.cfg.system_prompt;
     var append_sys = st.cfg.append_system_prompt;
+    var max_tools: ?u64 = null;
+    var dedupe_tools = false;
     if (std.mem.trim(u8, body, " \t\r\n").len > 0) {
         const v = std.json.parseFromSliceLeaky(Value, arena, body, .{ .allocate = .alloc_always }) catch
             return respondJson(st, req, .bad_request, "{\"error\":\"body must be a JSON object\"}");
@@ -7424,12 +7491,20 @@ fn serveCreate(st: *ServeState, req: *std.http.Server.Request) !void {
         if (v.object.get("append_system_prompt")) |s| if (s == .string) {
             append_sys = s.string;
         };
+        if (v.object.get("maxToolCalls") orelse v.object.get("max_tool_calls")) |m| if (m == .integer and m.integer >= 0) {
+            max_tools = @intCast(m.integer);
+        };
+        if (v.object.get("dedupeToolCalls") orelse v.object.get("dedupe_tool_calls")) |d| if (d == .bool) {
+            dedupe_tools = d.bool;
+        };
     }
 
     var argv: std.ArrayList([]const u8) = .empty;
     try argv.appendSlice(arena, &.{ st.exe, "--json" });
     if (yolo) try argv.append(arena, "--yolo");
     if (model) |m| try argv.appendSlice(arena, &.{ "--model", m });
+    if (max_tools) |n| try argv.appendSlice(arena, &.{ "--max-tool-calls", try std.fmt.allocPrint(arena, "{d}", .{n}) });
+    if (dedupe_tools) try argv.append(arena, "--dedupe-tool-calls");
     if (sys) |s| try argv.appendSlice(arena, &.{ "--system-prompt", s });
     if (append_sys) |s| try argv.appendSlice(arena, &.{ "--append-system-prompt", s });
 
@@ -8081,6 +8156,8 @@ const Agent = struct {
     sys_normal: []const u8 = main_system_prompt, // root system prompt (+ project instructions)
     sys_override: ?[]const u8 = null, // subagent-only: per-child system prompt (swarm prompt variants)
     tools_used: ToolSink = .{}, // external tool calls this agent made (per turn for the root)
+    tool_calls_this_turn: u64 = 0, // root-only hard budget counter (--max-tool-calls)
+    seen_tool_keys: std.ArrayList([]const u8) = .empty, // root-only per-turn dedupe keys
     md_buf: std.ArrayList(u8) = .empty, // current incomplete streamed line (markdown rendering)
     md_fence: bool = false, // inside a ``` code fence while streaming
     md_kind: MdKind = .classify, // incremental renderer: current line's classification
@@ -8247,6 +8324,7 @@ const Agent = struct {
             const body = try self.buildBody(tools, force, live, stream_usage);
             defer self.gpa.free(body);
             const t0: Io.Timestamp = .now(self.io, .awake);
+            if (json_mode and !self.sub) self.emit(.{ .type = "model_call_started", .provider = self.provider.id, .model = self.provider.model });
             // HTTP calls are flaky: a kept-alive connection the server closed
             // (HttpConnectionClosing), a reset, a truncated TLS read. Retry a
             // few times with a fresh connection; on persistent failure surface
@@ -8317,6 +8395,7 @@ const Agent = struct {
                     .ok => |obj| {
                         self.recordUsageResponses(obj);
                         if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, self.last_context_tokens, self.last_cache_read, false);
+                        if (json_mode and !self.sub) self.emit(.{ .type = "model_call_finished", .provider = self.provider.id, .model = self.provider.model, .ok = true, .ms = ms });
                         return obj;
                     },
                     .err => |msg| {
@@ -8343,6 +8422,7 @@ const Agent = struct {
                     };
                     self.recordUsage(root);
                     if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, self.last_context_tokens, self.last_cache_read, false);
+                    if (json_mode and !self.sub) self.emit(.{ .type = "model_call_finished", .provider = self.provider.id, .model = self.provider.model, .ok = true, .ms = ms });
                     return root;
                 }
             }
@@ -8387,6 +8467,7 @@ const Agent = struct {
 
             self.recordUsage(root);
             if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, self.last_context_tokens, self.last_cache_read, false);
+            if (json_mode and !self.sub) self.emit(.{ .type = "model_call_finished", .provider = self.provider.id, .model = self.provider.model, .ok = true, .ms = ms });
             return root;
         }
     }
@@ -8703,6 +8784,10 @@ const Agent = struct {
         var ext_idx: std.ArrayList(usize) = .empty;
         defer ext_idx.deinit(self.gpa);
         for (calls, 0..) |call, i| {
+            if (try self.rejectToolCall(call)) |denied| {
+                results[i] = denied;
+                continue;
+            }
             try self.sayToolUse(call);
             if (isMetaName(call.name)) {
                 results[i] = try self.handleMeta(call);
@@ -8763,6 +8848,50 @@ const Agent = struct {
         // Show a compact ✓/✗ + preview for each non-meta call (no-op for subs).
         for (calls, results) |call, r| self.sayToolResult(call.name, r);
         return results;
+    }
+
+    fn rejectToolCall(self: *Agent, call: ToolCall) !?ExecResult {
+        if (self.sub) return null;
+        if (std.mem.eql(u8, call.name, "attempt_completion")) return null;
+        if (max_tool_calls) |max| {
+            if (self.tool_calls_this_turn >= max) {
+                const message = try std.fmt.allocPrint(self.arena, "tool call budget exhausted ({d}/{d}) — answer with what you have or ask for a higher --max-tool-calls", .{ self.tool_calls_this_turn, max });
+                self.emitToolRejected(call, "budget", message);
+                return .{ .text = message, .is_error = true };
+            }
+        }
+        if (dedupe_tool_calls) {
+            const key = try self.toolDedupeKey(call);
+            for (self.seen_tool_keys.items) |seen| {
+                if (std.mem.eql(u8, seen, key)) {
+                    const message = try std.fmt.allocPrint(self.arena, "duplicate tool call rejected: {s} with the same normalized input already ran this turn", .{call.name});
+                    self.emitToolRejected(call, "duplicate", message);
+                    return .{ .text = message, .is_error = true };
+                }
+            }
+            try self.seen_tool_keys.append(self.arena, key);
+        }
+        self.tool_calls_this_turn += 1;
+        return null;
+    }
+
+    fn toolDedupeKey(self: *Agent, call: ToolCall) ![]const u8 {
+        var aw: Io.Writer.Allocating = .init(self.arena);
+        const w = &aw.writer;
+        try w.writeAll(call.name);
+        try w.writeByte('\n');
+        var s: std.json.Stringify = .{ .writer = w };
+        try s.write(call.input);
+        const key = aw.writer.buffered();
+        for (key) |*c| {
+            c.* = if (std.ascii.isWhitespace(c.*)) ' ' else std.ascii.toLower(c.*);
+        }
+        return key;
+    }
+
+    fn emitToolRejected(self: *Agent, call: ToolCall, reason: []const u8, message: []const u8) void {
+        if (!json_mode) return;
+        self.emit(.{ .type = "tool_rejected", .name = call.name, .reason = reason, .input = call.input, .message = message });
     }
 
     /// The permission gate, root side: an unapproved bash command prompts
@@ -8980,6 +9109,7 @@ const Agent = struct {
         if (json_mode) {
             if (std.mem.eql(u8, call.name, "ask_user")) return;
             self.emit(.{ .type = "tool_call", .name = call.name, .input = call.input });
+            self.emit(.{ .type = "tool_call_started", .name = call.name, .input = call.input });
             return;
         }
         // The ⚙ line would just repeat prose that already streamed live.
@@ -9006,6 +9136,7 @@ const Agent = struct {
         if (json_mode) {
             if (isMetaName(name) and !std.mem.eql(u8, name, "ask_user")) return;
             self.emit(.{ .type = "tool_result", .name = name, .is_error = r.is_error, .text = r.text });
+            self.emit(.{ .type = "tool_call_finished", .name = name, .is_error = r.is_error, .ms = r.ms });
             return;
         }
         if (isMetaName(name)) return;
@@ -12914,9 +13045,10 @@ test "codex catalog excludes unsupported codex-suffixed models" {
     try std.testing.expect(providerModelInTable("openai", "gpt-5.2"));
 }
 
-test "resolveModelName exact match and miss" {
+test "resolveModelName exact aliases and miss" {
     const keys = Keys{ .values = [_]?[]const u8{null} ** provider_specs.len };
     try std.testing.expect(resolveModelName(keys, "gpt-5.5") != null); // exact name
+    try std.testing.expectEqualStrings("glm-5.2", resolveModelName(keys, "glm5.2").?); // natural alias
     try std.testing.expect(resolveModelName(keys, "totally-unknown-zzz") == null);
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -2224,7 +2224,7 @@ fn loadOrCreateId(io: Io, gpa: Allocator, home: []const u8, fname: []const u8) [
 /// Reasoning depth for codex/responses (OpenAI Responses `reasoning.effort`).
 const ReasoningEffort = enum { low, medium, high };
 
-const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/bash", "/plan", "/key", "/keepcontext", "/effort", "/fast", "/ultracode", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
+const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/new", "/rename", "/goal", "/loop", "/bash", "/plan", "/key", "/keepcontext", "/effort", "/fast", "/ultracode", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
 
 /// Lifecycle hooks (codex/Claude-style), loaded once at startup from
 /// .harness/settings.json's "hooks" object. Three events:
@@ -3998,6 +3998,32 @@ fn writeAnthropicMessages(s: *std.json.Stringify, messages: std.json.Array, cach
     try s.endArray();
 }
 
+fn writeOpenAIMessageNormalized(s: *std.json.Stringify, m: Value) !void {
+    if (m != .object) return s.write(m);
+    const role = if (m.object.get("role")) |v| (if (v == .string) v.string else "") else "";
+    const is_assistant_tool_call = std.mem.eql(u8, role, "assistant") and m.object.get("tool_calls") != null;
+    const null_content = if (m.object.get("content")) |v| v == .null else false;
+    if (!is_assistant_tool_call or !null_content) return s.write(m);
+
+    try s.beginObject();
+    var it = m.object.iterator();
+    var wrote_content = false;
+    while (it.next()) |kv| {
+        try s.objectField(kv.key_ptr.*);
+        if (std.mem.eql(u8, kv.key_ptr.*, "content")) {
+            try s.write("");
+            wrote_content = true;
+        } else {
+            try s.write(kv.value_ptr.*);
+        }
+    }
+    if (!wrote_content) {
+        try s.objectField("content");
+        try s.write("");
+    }
+    try s.endObject();
+}
+
 const harness_version: []const u8 = @import("build_options").version;
 
 /// OTLP endpoint baked into release builds (-Dtelemetry-endpoint); "" in dev
@@ -4023,6 +4049,9 @@ const usage_text =
     \\
     \\flags:
     \\  --model <name>   start on this model (same fuzzy resolution as /model)
+    \\  --resume <name>  resume/autosave <name>.session.json
+    \\  --new            start a fresh autosaved session
+    \\  --no-resume      do not auto-load last.session.json
     \\  --system-prompt <text>          replace the built-in system prompt
     \\  --append-system-prompt <text>   append extra text to the system prompt
     \\  --yolo           skip all permission prompts for the session
@@ -4264,6 +4293,9 @@ pub fn main(init: std.process.Init) !void {
     var host_flag: []const u8 = "127.0.0.1"; // harness serve
     var port_flag: u16 = 8787; // harness serve
     var token_flag: ?[]const u8 = null; // harness serve
+    var resume_flag: ?[]const u8 = null; // restore/save this named session
+    var no_resume_flag = false; // start without auto-loading last.session.json
+    var new_session_flag = false; // start a fresh autosaved session
     var positionals: std.ArrayList([]const u8) = .empty;
     {
         var it = try std.process.Args.Iterator.initAllocator(init.minimal.args, gpa);
@@ -4295,6 +4327,13 @@ pub fn main(init: std.process.Init) !void {
                     update_force = true;
                 } else if (std.mem.eql(u8, arg, "--check")) {
                     update_check = true;
+                } else if (std.mem.eql(u8, arg, "--resume")) {
+                    const rv = it.next() orelse std.process.fatal("--resume needs a session name — harness --help", .{});
+                    resume_flag = try arena.dupe(u8, rv);
+                } else if (std.mem.eql(u8, arg, "--no-resume")) {
+                    no_resume_flag = true;
+                } else if (std.mem.eql(u8, arg, "--new")) {
+                    new_session_flag = true;
                 } else if (std.mem.eql(u8, arg, "--model")) {
                     const mv = it.next() orelse std.process.fatal("--model needs a value — harness --help", .{});
                     model_flag = try arena.dupe(u8, mv);
@@ -4736,8 +4775,13 @@ pub fn main(init: std.process.Init) !void {
         .tools_openai = try renderRootTools(arena, .openai, &root_specs, mcp_tools),
         .tools_responses = try renderRootTools(arena, .responses, &root_specs, mcp_tools),
     };
+    root.session_name = if (resume_flag) |name| name else if (new_session_flag) try std.fmt.allocPrint(arena, "session-{d}", .{unixMs(io)}) else "last";
     loadThinkingSettings(io, arena, &root); // {"effort":...,"fast":...} persisted by /effort and /fast
     tracer.note("session", root.provider.model);
+
+    if (oneshot_prompt != null and resume_flag != null and !new_session_flag and !no_resume_flag) {
+        loadSession(&root, keys, arena, root.session_name) catch {};
+    }
 
     // One-shot print mode: run the single prompt to completion, print the
     // final text to stdout, exit. Tool progress goes to stderr (say() with no
@@ -4762,7 +4806,7 @@ pub fn main(init: std.process.Init) !void {
         if (CostTally.render(g_cost.snap(io), &uw)) {
             std.debug.print("[usage] {s}\n", .{uw.buffered()});
         } else |_| {}
-        saveSession(&root, arena, "last") catch |err| {
+        saveSession(&root, arena, root.session_name) catch |err| {
             std.debug.print("⚠ session save failed: {s}\n", .{@errorName(err)});
         };
         return;
@@ -4790,17 +4834,17 @@ pub fn main(init: std.process.Init) !void {
     var prev_turn_id: u64 = 0;
     var prev_prompt_fp: [16]u8 = promptFingerprint(root.systemPrompt());
 
-    // opencode-style auto-resume: a fresh process has a cold provider prompt
-    // cache, but last.session.json on disk survives — restore it so the
-    // conversation just continues. Best-effort: a missing/keyless/corrupt file
-    // silently starts fresh.
-    if (interactive and oneshot_prompt == null) {
-        if (loadSession(&root, keys, arena, "last")) |_| {
+    // opencode-style auto-resume: restore the selected autosave target so
+    // the conversation just continues. JSON/GUI sessions opt in via --resume.
+    // Best-effort: a missing/keyless/corrupt file silently starts fresh.
+    if (oneshot_prompt == null and !new_session_flag and !no_resume_flag and (interactive or resume_flag != null)) {
+        if (loadSession(&root, keys, arena, root.session_name)) |_| {
             if (root.messages.items.len > 0) {
                 // Estimate the restored context from the file size (~4 bytes/token).
-                const est: u64 = if (Io.Dir.cwd().statFile(io, "last" ++ session_ext, .{})) |st| @as(u64, @intCast(st.size)) / 4 else |_| 0;
-                try out.print("↩ resumed last session — {d} message(s) on {s} · /clear for a fresh start\n", .{ root.messages.items.len, root.provider.model });
-                try out.flush();
+                const est_path = try std.fmt.allocPrint(arena, "{s}{s}", .{ root.session_name, session_ext });
+                const est: u64 = if (Io.Dir.cwd().statFile(io, est_path, .{})) |st| @as(u64, @intCast(st.size)) / 4 else |_| 0;
+                if (!json_mode) try out.print("↩ resumed {s}{s} — {d} message(s) on {s} · /new or /clear for a fresh start\n", .{ root.session_name, session_ext, root.messages.items.len, root.provider.model });
+                if (!json_mode) try out.flush();
                 // Cold cache: if the restored context is as large as what would
                 // trigger live compaction, the first turn would re-bill the whole
                 // thing — summarize up front instead.
@@ -4837,12 +4881,16 @@ pub fn main(init: std.process.Init) !void {
             (try in.takeDelimiter('\n')) orelse break;
         const line = std.mem.trim(u8, raw_line, " \t\r");
         if (line.len == 0) continue;
+        const loop_prompt: ?[]const u8 = if (!json_mode and std.mem.startsWith(u8, line, "/loop "))
+            std.mem.trim(u8, line["/loop".len..], " \t")
+        else
+            null;
         if (!json_mode) {
             const l = if (line.len > 0 and line[0] == '/') line[1..] else line;
             if (std.mem.eql(u8, l, "exit") or std.mem.eql(u8, l, "quit") or std.mem.eql(u8, l, "q")) break;
         }
 
-        if (!json_mode and line[0] == '/') {
+        if (!json_mode and line[0] == '/' and loop_prompt == null) {
             // Bare "/" on a TTY: open the filterable command menu.
             if (interactive and line.len == 1) {
                 if (listPicker(&root, arena, out, "Command ›", &command_menu)) |idx| {
@@ -4862,7 +4910,7 @@ pub fn main(init: std.process.Init) !void {
         // {"type":"score","prompt_sha":"...","score":0.7,"notes":"..."}
         // appends an evaluation record for an agent variant to the
         // trajectory archive (the DGM evaluation phase writing back).
-        const base_msg: []const u8 = if (json_mode) blk: {
+        const base_msg: []const u8 = if (loop_prompt) |lp| lp else if (json_mode) blk: {
             const parsed = std.json.parseFromSliceLeaky(Value, arena, line, .{ .allocate = .alloc_always }) catch {
                 root.emit(.{ .type = "error", .message = "invalid JSON (expect {\"type\":\"user\",\"text\":\"...\"})" });
                 continue;
@@ -5035,9 +5083,23 @@ pub fn main(init: std.process.Init) !void {
             break :blk text;
         } else line;
 
+        // Persistent goal steering is prepended to every normal/loop turn.
+        const goal_msg: []const u8 = if (root.goal) |goal| try std.fmt.allocPrint(arena,
+            \\{s}
+            \\
+            \\[harness goal: {s}]
+        , .{ base_msg, goal }) else base_msg;
+
+        // /loop asks the model to work autonomously through plan→act→verify.
+        const loop_msg: []const u8 = if (loop_prompt != null) try std.fmt.allocPrint(arena,
+            \\{s}
+            \\
+            \\[harness note: /loop was used. Work autonomously until the prompt is satisfied: make a brief plan, execute it with tools, verify the result, and only stop when you can report completion or you need a required human decision. Keep iterations tight and avoid asking for confirmation between routine steps.]
+        , .{goal_msg}) else goal_msg;
+
         // Plan mode: steer the model to explore read-only and present a plan
         // (the gate enforces the read-only part regardless).
-        const msg: []const u8 = if (!plan_mode) base_msg else try std.fmt.allocPrint(arena,
+        const msg: []const u8 = if (!plan_mode) loop_msg else try std.fmt.allocPrint(arena,
             \\{s}
             \\
             \\[harness note: plan mode is ON — read-only. Explore with read-only
@@ -5045,7 +5107,7 @@ pub fn main(init: std.process.Init) !void {
             \\the changes themselves, sequence, risks) and ask the user to
             \\approve it. Do not write files or run mutating commands — the
             \\gate will deny them. The user toggles execution back on with /plan.]
-        , .{base_msg});
+        , .{loop_msg});
 
         // Promote a GUI `@[image]` attachment to a native vision block when the
         // model can see (otherwise it only gets the path and resorts to OCR).
@@ -5141,13 +5203,13 @@ pub fn main(init: std.process.Init) !void {
                 g_force_interrupt = false;
                 try out.print("{s}{s}{s}\n", .{ style.yellow, int_msg, style.reset });
                 try out.flush();
-                saveSession(&root, arena, "last") catch {};
+                saveSession(&root, arena, root.session_name) catch {};
                 continue;
             },
             error.ApiError => {
                 if (g_telem) |t| t.errorEvent("api", root.last_api_error orelse "api error");
                 if (json_mode) root.emit(.{ .type = "error", .message = root.last_api_error orelse "api error" });
-                saveSession(&root, arena, "last") catch {};
+                saveSession(&root, arena, root.session_name) catch {};
                 continue;
             },
             else => |e| {
@@ -5157,7 +5219,7 @@ pub fn main(init: std.process.Init) !void {
                 } else {
                     root.say("[turn aborted: {t}]\n", .{e}) catch {};
                 }
-                saveSession(&root, arena, "last") catch {};
+                saveSession(&root, arena, root.session_name) catch {};
                 continue;
             },
         };
@@ -5181,19 +5243,19 @@ pub fn main(init: std.process.Init) !void {
         // opencode-style continuous autosave: persist after every turn so a
         // crash or quit never loses the thread — last.session.json, the same
         // file /resume reads. Best-effort; a write failure never breaks the loop.
-        saveSession(&root, arena, "last") catch {};
+        saveSession(&root, arena, root.session_name) catch {};
     }
     // Final save on exit also captures command-driven edits since the last turn
     // (/clear, /rewind) so the next start resumes the true end state.
     if (!json_mode and root.messages.items.len > 0) {
-        saveSession(&root, arena, "last") catch |err| {
+        saveSession(&root, arena, root.session_name) catch |err| {
             out.print("{s}⚠ session save failed: {t}{s}\n", .{ style.yellow, err, style.reset }) catch {};
             out.flush() catch {};
         };
-        out.print("{s}↩ session saved → last{s}{s}\n", .{ style.dim, style.reset, session_ext }) catch {};
+        out.print("{s}↩ session saved → {s}{s}{s}\n", .{ style.dim, root.session_name, style.reset, session_ext }) catch {};
         out.flush() catch {};
     } else {
-        saveSession(&root, arena, "last") catch {};
+        saveSession(&root, arena, root.session_name) catch {};
     }
     try out.writeAll("\n");
     try out.flush();
@@ -5650,6 +5712,10 @@ const command_menu = [_]PickItem{
     .{ .name = "/model", .desc = "switch model/provider (picker)" },
     .{ .name = "/models", .desc = "list known models, context windows" },
     .{ .name = "/clear", .desc = "wipe the conversation, start fresh" },
+    .{ .name = "/new", .desc = "start a new autosaved session" },
+    .{ .name = "/rename", .desc = "rename the current session title" },
+    .{ .name = "/goal", .desc = "set/show persistent objective steering" },
+    .{ .name = "/loop", .desc = "run an autonomous plan→act→verify prompt" },
     .{ .name = "/bash", .desc = "run a shell command in the current workspace" },
     .{ .name = "/compact", .desc = "summarize history into a fresh context" },
     .{ .name = "/plan", .desc = "toggle plan mode (read-only, propose first)" },
@@ -5707,7 +5773,55 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         root.last_context_tokens = 0;
         root.last_cache_read = 0;
         root.todos.clearRetainingCapacity();
+        saveSession(root, arena, root.session_name) catch {};
         try out.writeAll("context cleared — fresh conversation\n");
+        try out.flush();
+        return;
+    }
+    if (std.mem.eql(u8, line, "/new")) {
+        root.messages = std.json.Array.init(arena);
+        root.last_context_tokens = 0;
+        root.last_cache_read = 0;
+        root.todos.clearRetainingCapacity();
+        root.goal = null;
+        root.ultracode_mode = false;
+        root.session_title = null;
+        root.session_name = try std.fmt.allocPrint(arena, "session-{d}", .{unixMs(root.io)});
+        saveSession(root, arena, root.session_name) catch {};
+        try out.print("new session → {s}{s}\n", .{ root.session_name, session_ext });
+        try out.flush();
+        return;
+    }
+    if (std.mem.startsWith(u8, line, "/rename")) {
+        const title = std.mem.trim(u8, line["/rename".len..], " \t");
+        if (title.len == 0) {
+            try out.writeAll("usage: /rename <title>\n");
+        } else {
+            root.session_title = try arena.dupe(u8, title);
+            saveSession(root, arena, root.session_name) catch {};
+            try out.print("session title → {s}\n", .{title});
+        }
+        try out.flush();
+        return;
+    }
+    if (std.mem.startsWith(u8, line, "/goal")) {
+        const text = std.mem.trim(u8, line["/goal".len..], " \t");
+        if (text.len == 0) {
+            if (root.goal) |goal| try out.print("Current goal: {s}\nClear it with /goal clear.\n", .{goal}) else try out.writeAll("No active goal. Set one with /goal <objective>.\n");
+        } else if (std.ascii.eqlIgnoreCase(text, "clear") or std.ascii.eqlIgnoreCase(text, "off")) {
+            root.goal = null;
+            saveSession(root, arena, root.session_name) catch {};
+            try out.writeAll("Goal cleared. Future turns will not get goal steering.\n");
+        } else {
+            root.goal = try arena.dupe(u8, text);
+            saveSession(root, arena, root.session_name) catch {};
+            try out.print("Goal set: {s}\nFuture turns in this session will include this objective as steering.\n", .{text});
+        }
+        try out.flush();
+        return;
+    }
+    if (std.mem.eql(u8, line, "/loop")) {
+        try out.writeAll("usage: /loop <prompt> — run an autonomous plan→act→verify pass.\n");
         try out.flush();
         return;
     }
@@ -6165,7 +6279,12 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
     }
     if (std.mem.eql(u8, line, "/ultracode") or std.mem.eql(u8, line, "/ultracode on") or std.mem.eql(u8, line, "/ultracode off")) {
         root.ultracode_mode = if (std.mem.eql(u8, line, "/ultracode on")) true else if (std.mem.eql(u8, line, "/ultracode off")) false else !root.ultracode_mode;
-        try out.print("ultracode mode: {s}\n", .{if (root.ultracode_mode) "on" else "off"});
+        if (root.ultracode_mode) {
+            ultracodeShine(out, root.io);
+            try out.writeAll("\xe2\x9a\xa1 multi-agent workflow mode engaged\n");
+        } else {
+            try out.writeAll("ultracode mode: off\n");
+        }
         try out.flush();
         return;
     }
@@ -6544,12 +6663,13 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
     }
     if (std.mem.startsWith(u8, line, "/save")) {
         const arg = std.mem.trim(u8, line["/save".len..], " \t");
-        const name = if (arg.len == 0) "last" else arg;
+        const name = if (arg.len == 0) root.session_name else arg;
         saveSession(root, arena, name) catch |err| {
             try out.print("save failed: {t}\n", .{err});
             try out.flush();
             return;
         };
+        root.session_name = name;
         try out.print("saved session → {s}{s}\n", .{ name, session_ext });
         try out.flush();
         return;
@@ -6588,6 +6708,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             try out.flush();
             return;
         };
+        root.session_name = name;
         try out.print("resumed {s}{s} — {d} message(s), {s} via {s}{s}\n", .{
             name,                                 session_ext, root.messages.items.len, root.provider.model, root.provider.id,
             if (root.strict) " (strict)" else "",
@@ -6608,7 +6729,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             if (entry.kind != .file) continue;
             if (!std.mem.endsWith(u8, entry.name, session_ext)) continue;
             const base = entry.name[0 .. entry.name.len - session_ext.len];
-            try out.print("  {s}\n", .{base});
+            try out.print("  {s}{s}\n", .{ base, if (std.mem.eql(u8, base, root.session_name)) "  ← current" else "" });
             n += 1;
         }
         if (n == 0) try out.writeAll("(no saved sessions in cwd)\n");
@@ -6626,6 +6747,10 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         \\  /model <name>   switch model/provider, fuzzy match (e.g. "sonnet", "opus")
         \\  /models         list known models, context windows, compaction points
         \\  /clear          wipe the conversation and start fresh
+        \\  /new            start a fresh autosaved session
+        \\  /rename <title> set the current session title
+        \\  /goal [text]    set/show persistent objective steering; /goal clear clears
+        \\  /loop <prompt>  run an autonomous plan→act→verify pass
         \\  /plan           toggle plan mode: read-only explore + propose; writes/edits denied
         \\  /key [prov key] show API-key status; /key <provider> <key> adds one live (+ Keychain)
         \\  /login [tgt]    OAuth sign-in (no key to paste): codegraff | codex (alias oai) | kimi; bare → picker
@@ -6645,7 +6770,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         \\  /rewind [n]     list past prompts; /rewind <n> drops prompt n+after & reverts its file edits
         \\  /image <path>   attach an image to your next message (vision models only)
         \\  /paste          attach the clipboard image — macOS; also Ctrl-V (⌘V can't be captured)
-        \\  /save [name]    write the conversation to <name>.session.json (default: last)
+        \\  /save [name]    write the conversation to <name>.session.json (default: current)
         \\  /resume [name]  restore a saved conversation (no arg → interactive picker)
         \\  /sessions       list saved sessions in the cwd
         \\  /todo           show the current task list
@@ -7807,6 +7932,29 @@ fn keyCommand(io: Io, gpa: Allocator, arena: Allocator, home: []const u8, args: 
     try out.writeAll("usage: graff key set <provider> <key>  |  graff key list\n");
     try out.flush();
 }
+
+fn sessionTitle(root: *Agent) []const u8 {
+    if (root.session_title) |title| return title;
+    for (root.messages.items) |m| {
+        if (m != .object) continue;
+        const role = if (m.object.get("role")) |v| (if (v == .string) v.string else "") else "";
+        if (!std.mem.eql(u8, role, "user")) continue;
+        if (m.object.get("content")) |c| switch (c) {
+            .string => |text| return utf8Prefix(std.mem.trim(u8, text, " \t\r\n"), 80),
+            .array => |arr| for (arr.items) |part| {
+                if (part == .object) {
+                    const typ = if (part.object.get("type")) |v| (if (v == .string) v.string else "") else "";
+                    if (std.mem.eql(u8, typ, "text")) {
+                        if (part.object.get("text")) |tv| if (tv == .string) return utf8Prefix(std.mem.trim(u8, tv.string, " \t\r\n"), 80);
+                    }
+                }
+            },
+            else => {},
+        };
+    }
+    return "Untitled session";
+}
+
 /// Save the conversation (messages + provider id/model + strict flag) to
 /// <name>.session.json in the cwd. The JSON message array is already the
 /// provider-native wire shape, so resume is a verbatim restore.
@@ -7821,6 +7969,14 @@ fn saveSession(root: *Agent, arena: Allocator, name: []const u8) !void {
     try s.write(root.provider.model);
     try s.objectField("strict");
     try s.write(root.strict);
+    try s.objectField("ultracode_mode");
+    try s.write(root.ultracode_mode);
+    try s.objectField("goal");
+    if (root.goal) |goal| try s.write(goal) else try s.write(null);
+    try s.objectField("title");
+    if (root.session_title) |title| try s.write(title) else try s.write(sessionTitle(root));
+    try s.objectField("updated_ms");
+    try s.write(unixMs(root.io));
     try s.objectField("messages");
     try s.write(Value{ .array = root.messages });
     try s.endObject();
@@ -7842,10 +7998,16 @@ fn loadSession(root: *Agent, keys: Keys, arena: Allocator, name: []const u8) !vo
     const model = if (obj.get("model")) |v| v.string else return error.BadSession;
     const msgs = if (obj.get("messages")) |v| (if (v == .array) v.array else return error.BadSession) else return error.BadSession;
     const strict = if (obj.get("strict")) |v| (v == .bool and v.bool) else false;
+    const ultracode_mode = if (obj.get("ultracode_mode")) |v| (v == .bool and v.bool) else false;
+    const goal = if (obj.get("goal")) |v| (if (v == .string and v.string.len > 0) v.string else null) else null;
+    const title = if (obj.get("title")) |v| (if (v == .string and v.string.len > 0) v.string else null) else null;
 
     root.provider = try keys.providerById(pid, model);
     root.messages = msgs;
     root.strict = strict;
+    root.ultracode_mode = ultracode_mode;
+    root.goal = goal;
+    root.session_title = title;
     root.last_context_tokens = 0;
     root.cap_new = false; // per-provider; relearn on rejection
     root.effort_rejected = false;
@@ -7935,6 +8097,9 @@ const Agent = struct {
     reasoning: ReasoningEffort = .medium, // reasoning/thinking depth — codex, deepseek, codegraff (/effort, /reasoning)
     fast: bool = false, // codex "fast" mode → priority service_tier (/fast)
     ultracode_mode: bool = false, // persistent ultracode (multi-agent workflow) mode (/ultracode)
+    goal: ?[]const u8 = null, // persistent objective steering (/goal)
+    session_name: []const u8 = "last", // autosave/resume target (<name>.session.json)
+    session_title: ?[]const u8 = null, // human-readable title/rename metadata
     sys_strict: []const u8 = main_system_prompt_strict,
     tools_anthropic: []const u8 = tools_anthropic_sub,
     tools_openai: []const u8 = tools_openai_sub,
@@ -9029,7 +9194,7 @@ const Agent = struct {
                 try s.objectField("content");
                 try s.write(self.systemPrompt());
                 try s.endObject();
-                for (self.messages.items) |m| try s.write(m);
+                for (self.messages.items) |m| try writeOpenAIMessageNormalized(&s, m);
                 try s.endArray();
                 // Reasoning-effort hint for OpenAI-compatible providers that
                 // honor it (codegraff gateway, deepseek). Mirrors the

--- a/src/main.zig
+++ b/src/main.zig
@@ -4032,7 +4032,7 @@ const harness_version: []const u8 = @import("build_options").version;
 const default_telemetry_endpoint: []const u8 = @import("build_options").telemetry_endpoint;
 
 const usage_text =
-    \\simple-harness — a minimal agentic coding harness in Zig (zero deps)
+    \\graff — a minimal agentic coding harness in Zig (zero deps)
     \\
     \\usage:
     \\  graff [flags]                    start the REPL
@@ -4380,7 +4380,7 @@ pub fn main(init: std.process.Init) !void {
     if (help_flag or version_flag) {
         var hbuf: [4096]u8 = undefined;
         var hw = Io.File.stdout().writer(io, &hbuf);
-        if (help_flag) try hw.interface.writeAll(usage_text) else try hw.interface.print("simple-harness {s}\n", .{harness_version});
+        if (help_flag) try hw.interface.writeAll(usage_text) else try hw.interface.print("graff {s}\n", .{harness_version});
         try hw.interface.flush();
         return;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -79,7 +79,7 @@ var unattended = false; // -p one-shot: no human to prompt; unapproved tool call
 const schema_protocol_json =
     \\{
     \\  "transport": "newline-delimited JSON over stdin/stdout (--json)",
-    \\  "request": "one JSON object per line: {\"type\":\"user\",\"text\":\"...\"} sends a user turn; {\"type\":\"answer\",\"text\":\"...\",\"cancelled\":false,\"call_id\":\"optional\"} answers an active ask_user event; {\"type\":\"set_system_prompt\",\"text\":\"...\",\"append\":false} replaces (or with append=true extends) the system prompt between turns and acks with a system_prompt event; {\"type\":\"set_model\",\"model\":\"gpt-5.5\",\"provider\":\"codex\"}, {\"type\":\"compact\"}, {\"type\":\"set_mode\",\"mode\":\"plan|normal\"}, and {\"type\":\"set_agent\",\"id\":\"reviewer\"}, {\"type\":\"set_effort\",\"level\":\"low|medium|high\"}, and {\"type\":\"set_fast\",\"on\":true} are live control requests acked by model/compact/mode/agent/effort/fast events. For compatibility, set_model also accepts legacy {\"name\":\"provider model|model\"}. NOTE: the system prompt heads the KV-cached prefix, so any mutation invalidates the cache for the whole conversation (per Manus context-engineering lessons) — set it at spawn when possible and mutate only at task boundaries",
+    \\  "request": "one JSON object per line: {\"type\":\"user\",\"text\":\"...\"} sends a user turn; {\"type\":\"answer\",\"text\":\"...\",\"cancelled\":false,\"call_id\":\"optional\"} answers an active ask_user event; {\"type\":\"set_system_prompt\",\"text\":\"...\",\"append\":false} replaces (or with append=true extends) the system prompt between turns and acks with a system_prompt event; {\"type\":\"set_model\",\"model\":\"gpt-5.5\",\"provider\":\"codex\"}, {\"type\":\"compact\"}, {\"type\":\"set_mode\",\"mode\":\"plan|normal\"}, and {\"type\":\"set_agent\",\"id\":\"reviewer\"}, {\"type\":\"set_effort\",\"level\":\"low|medium|high\"}, and {\"type\":\"set_fast\",\"on\":true} are live control requests acked by model/compact/mode/agent/effort/fast/ultracode events. For compatibility, set_model also accepts legacy {\"name\":\"provider model|model\"}. NOTE: the system prompt heads the KV-cached prefix, so any mutation invalidates the cache for the whole conversation (per Manus context-engineering lessons) — set it at spawn when possible and mutate only at task boundaries",
     \\  "score_request": "{\"type\":\"score\",\"prompt_sha\":\"<16 hex>\",\"score\":0.7,\"notes\":\"...\",\"parent_sha\":\"<16 hex, optional>\"} appends an evaluation record for an agent/prompt variant to harness.trajectory.jsonl (the append-only DGM-style archive; prompt_sha = first 8 bytes of SHA-256 of the system prompt, hex; parent_sha records which prompt this variant was mutated from — the lineage edge DGM parent selection counts children with) and acks with a score event",
     \\  "events": [
     \\    {"type": "text", "text": "assistant text delta"},
@@ -2224,7 +2224,7 @@ fn loadOrCreateId(io: Io, gpa: Allocator, home: []const u8, fname: []const u8) [
 /// Reasoning depth for codex/responses (OpenAI Responses `reasoning.effort`).
 const ReasoningEffort = enum { low, medium, high };
 
-const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/bash", "/plan", "/key", "/keepcontext", "/effort", "/fast", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
+const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/bash", "/plan", "/key", "/keepcontext", "/effort", "/fast", "/ultracode", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
 
 /// Lifecycle hooks (codex/Claude-style), loaded once at startup from
 /// .harness/settings.json's "hooks" object. Three events:
@@ -4955,6 +4955,12 @@ pub fn main(init: std.process.Init) !void {
                 root.emit(.{ .type = "fast", .ok = true, .on = on, .applies = root.provider.kind == .responses });
                 continue;
             }
+            if (std.mem.eql(u8, rtype, "set_ultracode")) {
+                const on = if (parsed.object.get("on")) |v| (if (v == .bool) v.bool else false) else false;
+                root.ultracode_mode = on;
+                root.emit(.{ .type = "ultracode", .ok = true, .on = on });
+                continue;
+            }
             if (std.mem.eql(u8, rtype, "score")) {
                 const sha = if (parsed.object.get("prompt_sha")) |v| (if (v == .string) v.string else "") else "";
                 const sc: f64 = if (parsed.object.get("score")) |v| switch (v) {
@@ -5046,7 +5052,7 @@ pub fn main(init: std.process.Init) !void {
         stageGuiImageAttachment(&root, msg);
 
         // "ultracode" codeword: opt this turn into multi-agent workflow mode.
-        if (std.ascii.indexOfIgnoreCase(msg, "ultracode") != null) {
+        if (std.ascii.indexOfIgnoreCase(msg, "ultracode") != null or root.ultracode_mode) {
             if (!json_mode) {
                 if (interactive) {
                     ultracodeShine(out, io);
@@ -5659,6 +5665,7 @@ const command_menu = [_]PickItem{
     .{ .name = "/effort", .desc = "thinking depth: low|medium|high (codex, deepseek, codegraff)" },
     .{ .name = "/reasoning", .desc = "alias for /effort" },
     .{ .name = "/fast", .desc = "codex priority service tier — lower latency (gpt-5.5)" },
+    .{ .name = "/ultracode", .desc = "toggle persistent ultracode (multi-agent workflow) mode" },
     .{ .name = "/image", .desc = "attach an image to the next message" },
     .{ .name = "/paste", .desc = "attach the clipboard image" },
     .{ .name = "/trace", .desc = "toggle the JSONL event trace" },
@@ -6153,6 +6160,12 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             if (root.fast) "on" else "off",
             if (root.provider.kind != .responses) " (codex only — current model ignores it)" else "",
         });
+        try out.flush();
+        return;
+    }
+    if (std.mem.eql(u8, line, "/ultracode") or std.mem.eql(u8, line, "/ultracode on") or std.mem.eql(u8, line, "/ultracode off")) {
+        root.ultracode_mode = if (std.mem.eql(u8, line, "/ultracode on")) true else if (std.mem.eql(u8, line, "/ultracode off")) false else !root.ultracode_mode;
+        try out.print("ultracode mode: {s}\n", .{if (root.ultracode_mode) "on" else "off"});
         try out.flush();
         return;
     }
@@ -7921,6 +7934,7 @@ const Agent = struct {
     keep_context: bool = true, // carry the conversation across wire-format model switches (/keepcontext)
     reasoning: ReasoningEffort = .medium, // reasoning/thinking depth — codex, deepseek, codegraff (/effort, /reasoning)
     fast: bool = false, // codex "fast" mode → priority service_tier (/fast)
+    ultracode_mode: bool = false, // persistent ultracode (multi-agent workflow) mode (/ultracode)
     sys_strict: []const u8 = main_system_prompt_strict,
     tools_anthropic: []const u8 = tools_anthropic_sub,
     tools_openai: []const u8 = tools_openai_sub,

--- a/src/main.zig
+++ b/src/main.zig
@@ -2672,6 +2672,8 @@ var g_steer_queue: std.ArrayList(SteerEntry) = .empty; // completed lines
 var g_steer_echoed = false; // "↳ steer ›" prefix shown for the current line
 var g_out: ?*Io.Writer = null; // stdout writer for steer echo (set in main)
 var g_force_interrupt = false; // Ctrl-F force caused the last interrupt
+var g_5xx_body_buf: [600]u8 = undefined; // snippet of the last 5xx/429 error body
+var g_5xx_body_len: usize = 0; // 0 = no body captured
 
 /// Pops the next queued steering prompt (FIFO), or null if none.
 fn popSteer() ?SteerEntry {
@@ -4760,6 +4762,9 @@ pub fn main(init: std.process.Init) !void {
         if (CostTally.render(g_cost.snap(io), &uw)) {
             std.debug.print("[usage] {s}\n", .{uw.buffered()});
         } else |_| {}
+        saveSession(&root, arena, "last") catch |err| {
+            std.debug.print("⚠ session save failed: {s}\n", .{@errorName(err)});
+        };
         return;
     }
 
@@ -5130,11 +5135,13 @@ pub fn main(init: std.process.Init) !void {
                 g_force_interrupt = false;
                 try out.print("{s}{s}{s}\n", .{ style.yellow, int_msg, style.reset });
                 try out.flush();
+                saveSession(&root, arena, "last") catch {};
                 continue;
             },
             error.ApiError => {
                 if (g_telem) |t| t.errorEvent("api", root.last_api_error orelse "api error");
                 if (json_mode) root.emit(.{ .type = "error", .message = root.last_api_error orelse "api error" });
+                saveSession(&root, arena, "last") catch {};
                 continue;
             },
             else => |e| {
@@ -5144,6 +5151,7 @@ pub fn main(init: std.process.Init) !void {
                 } else {
                     root.say("[turn aborted: {t}]\n", .{e}) catch {};
                 }
+                saveSession(&root, arena, "last") catch {};
                 continue;
             },
         };
@@ -5171,7 +5179,16 @@ pub fn main(init: std.process.Init) !void {
     }
     // Final save on exit also captures command-driven edits since the last turn
     // (/clear, /rewind) so the next start resumes the true end state.
-    saveSession(&root, arena, "last") catch {};
+    if (!json_mode and root.messages.items.len > 0) {
+        saveSession(&root, arena, "last") catch |err| {
+            out.print("{s}⚠ session save failed: {t}{s}\n", .{ style.yellow, err, style.reset }) catch {};
+            out.flush() catch {};
+        };
+        out.print("{s}↩ session saved → last{s}{s}\n", .{ style.dim, style.reset, session_ext }) catch {};
+        out.flush() catch {};
+    } else {
+        saveSession(&root, arena, "last") catch {};
+    }
     try out.writeAll("\n");
     try out.flush();
 }
@@ -8079,15 +8096,23 @@ const Agent = struct {
                             if (throttled) {
                                 const delay_ms = @min(@as(u64, 1000) << @intCast(@min(attempt, 3)), 8000);
                                 const what: []const u8 = if (err == error.RateLimited) "rate limited (429)" else "server error (5xx)";
-                                try self.say("[{s} — retrying in {d}s ({d}/{d})]\n", .{ what, delay_ms / 1000, attempt + 1, max_attempts });
-                                if (self.tracer) |tr| tr.note("retry", what);
+                                if (g_5xx_body_len > 0) {
+                                    try self.say("[{s} — retrying in {d}s ({d}/{d})] {s}\n", .{ what, delay_ms / 1000, attempt + 1, max_attempts, g_5xx_body_buf[0..g_5xx_body_len] });
+                                } else {
+                                    try self.say("[{s} — retrying in {d}s ({d}/{d})]\n", .{ what, delay_ms / 1000, attempt + 1, max_attempts });
+                                }
+                                if (self.tracer) |tr| tr.note("retry", if (g_5xx_body_len > 0) g_5xx_body_buf[0..g_5xx_body_len] else what);
                                 self.sleepInterruptible(delay_ms) catch return error.Interrupted;
                             } else {
                                 try self.say("[network error: {t} — retrying ({d}/{d})]\n", .{ err, attempt + 1, max_attempts });
                             }
                             continue;
                         }
-                        try self.say("[request failed: {t} — giving up this turn]\n", .{err});
+                        if (g_5xx_body_len > 0) {
+                            try self.say("[request failed: {t} — giving up this turn] {s}\n", .{ err, g_5xx_body_buf[0..g_5xx_body_len] });
+                        } else {
+                            try self.say("[request failed: {t} — giving up this turn]\n", .{err});
+                        }
                         // Network give-up is its own error kind: the ApiError
                         // handler's last_api_error is an API envelope, stale
                         // or null on a pure transport failure.
@@ -9224,6 +9249,10 @@ const Agent = struct {
         // off and retries (surfaced in the trace as a "retry" note).
         const status_code = @intFromEnum(response.head.status);
         if (status_code == 429 or status_code >= 500) {
+            // Drain a snippet of the error body so the retry message can
+            // surface the gateway's diagnostic (e.g. "upstream timeout")
+            // instead of a bare "server error (5xx)".
+            capture5xxBodyStream(self.gpa, &response);
             if (req.connection) |conn| conn.closing = true;
             return if (status_code == 429) error.RateLimited else error.ServerError;
         }
@@ -10955,6 +10984,44 @@ fn providerHeaders(provider: Provider, bearer: []const u8, buf: *[6]std.http.Hea
     return buf[0..n];
 }
 
+/// Copy up to g_5xx_body_buf.len bytes of an error response body into the
+/// global buffer so request()'s retry message can surface the gateway's
+/// diagnostic (e.g. "upstream timeout connecting to anthropic") instead of a
+/// bare "server error (5xx)".
+fn capture5xxBody(src: []const u8) void {
+    const n = @min(src.len, g_5xx_body_buf.len);
+    if (n > 0) @memcpy(g_5xx_body_buf[0..n], src[0..n]);
+    g_5xx_body_len = n;
+}
+
+/// Same, but drains from a streaming Response whose head has been received but
+/// whose body hasn't been read yet. Best-effort: a read failure just leaves
+/// g_5xx_body_len at 0.
+fn capture5xxBodyStream(gpa: Allocator, response: *std.http.Client.Response) void {
+    g_5xx_body_len = 0;
+    const dbuf: []u8 = switch (response.head.content_encoding) {
+        .identity => &.{},
+        .zstd => gpa.alloc(u8, std.compress.zstd.default_window_len) catch return,
+        .deflate, .gzip => gpa.alloc(u8, std.compress.flate.max_window_len) catch return,
+        .compress => return,
+    };
+    defer if (dbuf.len > 0) gpa.free(dbuf);
+    var tbuf: [64]u8 = undefined;
+    var dec: std.http.Decompress = undefined;
+    const reader = response.readerDecompressing(&tbuf, &dec, dbuf);
+    var aw: Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    while (g_5xx_body_len < g_5xx_body_buf.len) {
+        _ = reader.streamDelimiterEnding(&aw.writer, '\n') catch break;
+        const chunk = aw.writer.buffered();
+        if (chunk.len == 0) break;
+        const n = @min(chunk.len, g_5xx_body_buf.len - g_5xx_body_len);
+        @memcpy(g_5xx_body_buf[g_5xx_body_len..][0..n], chunk[0..n]);
+        g_5xx_body_len += n;
+        aw.clearRetainingCapacity();
+    }
+}
+
 /// POST the request body; returns the raw response body (caller frees).
 /// std.http.Client.fetch is thread-safe, so subagents on pool threads share
 /// this client (and its connection pool).
@@ -10983,7 +11050,10 @@ fn post(gpa: Allocator, client: *std.http.Client, provider: Provider, body: []co
         .extra_headers = extra,
     });
     const code = @intFromEnum(res.status);
-    if (code == 429 or code >= 500) return if (code == 429) error.RateLimited else error.ServerError;
+    if (code == 429 or code >= 500) {
+        capture5xxBody(aw.writer.buffered());
+        return if (code == 429) error.RateLimited else error.ServerError;
+    }
     return aw.toOwnedSlice();
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -4050,8 +4050,8 @@ const usage_text =
     \\flags:
     \\  --model <name>   start on this model (same fuzzy resolution as /model)
     \\  --resume <name>  resume/autosave <name>.session.json
-    \\  --new            start a fresh autosaved session
-    \\  --no-resume      do not auto-load last.session.json
+    \\  --new            start a fresh autosaved session (default)
+    \\  --no-resume      ignore --resume and start fresh
     \\  --system-prompt <text>          replace the built-in system prompt
     \\  --append-system-prompt <text>   append extra text to the system prompt
     \\  --yolo           skip all permission prompts for the session
@@ -4775,7 +4775,8 @@ pub fn main(init: std.process.Init) !void {
         .tools_openai = try renderRootTools(arena, .openai, &root_specs, mcp_tools),
         .tools_responses = try renderRootTools(arena, .responses, &root_specs, mcp_tools),
     };
-    root.session_name = if (resume_flag) |name| name else if (new_session_flag) try std.fmt.allocPrint(arena, "session-{d}", .{unixMs(io)}) else "last";
+    const fresh_session_name = try std.fmt.allocPrint(arena, "session-{d}", .{unixMs(io)});
+    root.session_name = if (resume_flag) |name| (if (!new_session_flag and !no_resume_flag) name else fresh_session_name) else fresh_session_name;
     loadThinkingSettings(io, arena, &root); // {"effort":...,"fast":...} persisted by /effort and /fast
     tracer.note("session", root.provider.model);
 
@@ -4834,10 +4835,10 @@ pub fn main(init: std.process.Init) !void {
     var prev_turn_id: u64 = 0;
     var prev_prompt_fp: [16]u8 = promptFingerprint(root.systemPrompt());
 
-    // opencode-style auto-resume: restore the selected autosave target so
-    // the conversation just continues. JSON/GUI sessions opt in via --resume.
-    // Best-effort: a missing/keyless/corrupt file silently starts fresh.
-    if (oneshot_prompt == null and !new_session_flag and !no_resume_flag and (interactive or resume_flag != null)) {
+    // Explicit resume only: bare `graff` starts fresh, while `--resume <name>`
+    // restores that autosave target. Best-effort: a missing/keyless/corrupt
+    // file silently starts fresh.
+    if (oneshot_prompt == null and resume_flag != null and !new_session_flag and !no_resume_flag) {
         if (loadSession(&root, keys, arena, root.session_name)) |_| {
             if (root.messages.items.len > 0) {
                 // Estimate the restored context from the file size (~4 bytes/token).

--- a/src/main.zig
+++ b/src/main.zig
@@ -8144,13 +8144,13 @@ const Agent = struct {
             const threshold = self.provider.compactAt();
             // % of the compaction budget already used — glanceable headroom.
             const pct = if (threshold > 0) self.last_context_tokens * 100 / threshold else 0;
-            try w.print("\n{s}[{s}{s}{s}{s}{s} · {s}{s}{s} · {d}/{d}k tok ({d}%){s}{s}]{s} {s}›{s} ", .{
+            try w.print("\n{s}[{s}{s}{s}{s}{s} · cwd {s}{s}{s} · {d}/{d}k tok ({d}%){s}{s}]{s} {s}›{s} ", .{
                 style.dim,   style.reset,   style.cyan,  self.provider.model,      flag,             style.dim,
                 style.reset, g_cwd_display, style.dim,   self.last_context_tokens, threshold / 1000, pct,
                 cached,      cost,          style.reset, style.bold,               style.reset,
             });
         } else {
-            try w.print("\n{s}[{s}{s}{s}{s}{s} · {s}{s}{s}{s}]{s} {s}›{s} ", .{
+            try w.print("\n{s}[{s}{s}{s}{s}{s} · cwd {s}{s}{s}{s}]{s} {s}›{s} ", .{
                 style.dim,   style.reset,   style.cyan, self.provider.model, flag,        style.dim,
                 style.reset, g_cwd_display, style.dim,  cost,                style.reset, style.bold,
                 style.reset,

--- a/src/main.zig
+++ b/src/main.zig
@@ -8509,15 +8509,24 @@ const Agent = struct {
         const usage = response.get("usage") orelse return;
         if (usage != .object) return;
         const u = usage.object;
-        if (u.get("total_tokens")) |v| {
-            if (v == .integer and v.integer > 0) self.last_context_tokens = @intCast(v.integer);
+        const in_tokens = usageInt(u, "input_tokens");
+        const out_tokens = usageInt(u, "output_tokens");
+        const total_tokens = usageInt(u, "total_tokens");
+        if (total_tokens > 0) {
+            self.last_context_tokens = @intCast(total_tokens);
+        } else {
+            // Some Codex/Responses builds report only input/output counts.
+            // Still surface the prompt token counter instead of leaving the
+            // prompt stuck at "model · sub" with no context usage.
+            const computed_total = in_tokens + out_tokens;
+            if (computed_total > 0) self.last_context_tokens = @intCast(computed_total);
         }
         var cached: i64 = 0;
         if (u.get("input_tokens_details")) |d| if (d == .object) {
             cached = usageInt(d.object, "cached_tokens");
             if (cached > 0) self.last_cache_read = @intCast(cached);
         };
-        self.recordCost(usageInt(u, "input_tokens") - cached, cached, usageInt(u, "output_tokens"));
+        self.recordCost(in_tokens - cached, cached, out_tokens);
     }
 
     /// Consume a Codex `response` object: append its output items to history

--- a/src/main.zig
+++ b/src/main.zig
@@ -2704,6 +2704,7 @@ const SteerEntry = struct { text: []const u8, force: bool };
 var g_steer_queue: std.ArrayList(SteerEntry) = .empty; // completed lines
 var g_steer_echoed = false; // "↳ steer ›" prefix shown for the current line
 var g_out: ?*Io.Writer = null; // stdout writer for steer echo (set in main)
+var g_gui_mu: Io.Mutex = .init; // serializes --json stdout across pool-thread subagent emits (guiEmit + Agent.emit)
 var g_force_interrupt = false; // Ctrl-F force caused the last interrupt
 var g_5xx_body_buf: [600]u8 = undefined; // snippet of the last 5xx/429 error body
 var g_5xx_body_len: usize = 0; // 0 = no body captured
@@ -8279,6 +8280,11 @@ const Agent = struct {
     /// field, e.g. tool input, serializes correctly). Best-effort.
     fn emit(self: *Agent, ev: anytype) void {
         const w = self.out orelse return;
+        // --json: the GUI stream is shared with pool-thread subagent emits
+        // (guiEmit), so serialize + flush under the lock — a raw line must never
+        // land mid-buffer and two writers must never interleave on stdout.
+        if (json_mode) g_gui_mu.lockUncancelable(self.io);
+        defer if (json_mode) g_gui_mu.unlock(self.io);
         var s: std.json.Stringify = .{ .writer = w };
         s.write(ev) catch return;
         w.writeByte('\n') catch return;
@@ -12487,6 +12493,22 @@ fn execSubagent(ctx: ToolCtx, input: Value) !ToolOutput {
     return runSub(ctx, "subagent", label, prompt, sys_override);
 }
 
+/// Surface a workflow subagent as a synthetic `tool_call` / `tool_result` on the
+/// --json GUI stream so each parallel worker shows as its own live row — the
+/// orchestrator's children otherwise run detached (out=null), so the GUI only
+/// ever saw the single `workflow` op. Pool-thread safe: serializes on g_gui_mu
+/// with Agent.emit (same json stdout writer, g_out). No-op outside --json mode.
+fn guiEmit(io: Io, ev: anytype) void {
+    if (!json_mode) return;
+    const w = g_out orelse return;
+    g_gui_mu.lockUncancelable(io);
+    defer g_gui_mu.unlock(io);
+    var s: std.json.Stringify = .{ .writer = w };
+    s.write(ev) catch return;
+    w.writeByte('\n') catch return;
+    w.flush() catch return;
+}
+
 /// Run one isolated subagent to completion: fresh arena, fresh history,
 /// same shared http client and provider. Runs entirely on this pool thread;
 /// its own tool calls fan out further via io.async. `sys_override` swaps the
@@ -12521,11 +12543,15 @@ fn runSub(ctx: ToolCtx, kind: []const u8, label: []const u8, prompt: []const u8,
     const sub_id = subagentId(&id_buf, ordinal, label, prompt);
     const sprite = subagentSprite(ordinal);
     subagentLaunchCard(arena, sub_id, sprite, label, kind, prompt);
+    // Live agent tree: surface workflow_task children as their own GUI rows.
+    const wf_task = std.mem.eql(u8, kind, "workflow_task");
+    if (wf_task) guiEmit(ctx.io, .{ .type = "tool_call", .name = "subagent", .input = .{ .description = label } });
     try agent.messages.append(try textMessage(arena, "user", prompt));
     defer agent.tools_used.deinit(gpa);
     const report = agent.runTurn();
     const run_ms: i64 = @intCast(@max(0, sub_start.untilNow(ctx.io, .awake).toMilliseconds()));
     const run_ok = if (report) |r| r.len > 0 else |_| false;
+    if (wf_task) guiEmit(ctx.io, .{ .type = "tool_result", .name = "subagent", .is_error = !run_ok });
     const tools = agent.tools_used.render(arena);
     const fp = promptFingerprint(agent.systemPrompt());
     if (g_traj) |tj| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -8080,6 +8080,27 @@ fn loadSession(root: *Agent, keys: Keys, arena: Allocator, name: []const u8) !vo
 
     root.provider = try keys.providerById(pid, model);
     root.messages = msgs;
+    // Repair histories written by older builds where a Responses
+    // `function_call_output.output` was persisted as a byte array instead of a
+    // string. The Responses API rejects that ("input[N].output[0]: expected an
+    // object, got an integer instead"), and we restore messages verbatim — so a
+    // poisoned last.session.json would otherwise re-break every resume.
+    for (root.messages.items) |*m| {
+        if (m.* != .object) continue;
+        const mtype = if (m.object.get("type")) |t| (if (t == .string) t.string else "") else "";
+        if (!std.mem.eql(u8, mtype, "function_call_output")) continue;
+        const out = m.object.get("output") orelse continue;
+        if (out == .string) continue; // already correct
+        var repaired: std.ArrayList(u8) = .empty;
+        if (out == .array) {
+            for (out.array.items) |el| {
+                if (el == .integer and el.integer >= 0 and el.integer <= 255) {
+                    try repaired.append(arena, @intCast(el.integer));
+                }
+            }
+        }
+        try m.object.put(arena, "output", .{ .string = repaired.items });
+    }
     root.strict = strict;
     root.ultracode_mode = ultracode_mode;
     root.goal = goal;


### PR DESCRIPTION
Ships the 0.0.162 desktop release:

- **Auto-update**: Tauri updater plugin; the app checks `latest.json` on launch and self-installs signed updates.
- **CLI on install**: first launch symlinks the bundled `graff` agent onto PATH (without clobbering an existing install), so the .dmg gives you the terminal command too.
- **Version**: GUI bumped to 0.0.162 to match the release tag.
- **README**: direct macOS download link (`Codegraff.dmg`).
- **install.sh**: installer banner renamed to `graff-harness`.
- **Release tooling**: `scripts/release-gui-update.sh` (build + Developer-ID sign + notarize via notary-local + minisign updater payload + assemble latest.json).

Release assets for v0.0.162 are already built, notarized, stapled, and uploaded.