### PR TITLE
Add TUI session headers

### DIFF
--- a/gui/src-tauri/src/runtime/simple.rs
+++ b/gui/src-tauri/src/runtime/simple.rs
@@ -60,6 +60,8 @@ struct RuntimeState {
     /// forwarded live to running sessions. None effort = the binary default.
     selected_effort: Option<String>,
     fast_enabled: bool,
+    /// Per-user model usage counters used to rank the model picker.
+    model_usage: ModelUsageByProvider,
     /// Last successful `graff --schema` model list. Refreshed when the prompt
     /// settings endpoint is read so the GUI picks up newly shipped models
     /// without an app restart.
@@ -121,6 +123,7 @@ impl RuntimeManager {
                 selected_model: persisted_prompt.selected_model,
                 selected_effort: persisted_prompt.selected_effort,
                 fast_enabled: persisted_prompt.fast_enabled,
+                model_usage: persisted_prompt.model_usage,
                 ..RuntimeState::default()
             })),
             sessions: Arc::new(Mutex::new(HashMap::new())),
@@ -164,13 +167,14 @@ impl RuntimeManager {
     pub async fn get_prompt_settings(&self, _: Option<String>) -> Result<PromptSettingsDto> {
         let catalog = self.refresh_model_catalog().await;
         let configured_provider_ids = configured_provider_ids().await;
-        let (selected_provider, selected_model, selected_effort, fast_enabled) = {
+        let (selected_provider, selected_model, selected_effort, fast_enabled, model_usage) = {
             let state = self.state.lock().await;
             (
                 state.selected_provider.clone(),
                 state.selected_model.clone(),
                 state.selected_effort.clone(),
                 state.fast_enabled,
+                state.model_usage.clone(),
             )
         };
 
@@ -181,10 +185,11 @@ impl RuntimeManager {
             selected_model.as_deref(),
             selected_effort,
             fast_enabled,
+            &model_usage,
         ))
     }
 
-    async fn selected_model_arg(&self) -> Option<String> {
+    async fn selected_model_pair(&self) -> Option<(String, String)> {
         let catalog = self.ensure_model_catalog().await;
         let configured_provider_ids = configured_provider_ids().await;
         let (selected_provider, selected_model) = {
@@ -200,7 +205,12 @@ impl RuntimeManager {
             selected_provider.as_deref(),
             selected_model.as_deref(),
         )
-        .map(|(provider, model)| prompt_model_arg(&provider, &model))
+    }
+
+    async fn selected_model_arg(&self) -> Option<String> {
+        self.selected_model_pair()
+            .await
+            .map(|(provider, model)| prompt_model_arg(&provider, &model))
     }
 
     /// Generates a short chat title with the active model (a one-shot graff run)
@@ -254,9 +264,18 @@ impl RuntimeManager {
                 selected_model: state.selected_model.clone(),
                 selected_effort: state.selected_effort.clone(),
                 fast_enabled: state.fast_enabled,
+                model_usage: state.model_usage.clone(),
             }
         };
         save_prompt_settings(&settings);
+    }
+
+    async fn record_model_usage(&self, provider_id: &str, model_id: &str) {
+        {
+            let mut state = self.state.lock().await;
+            increment_model_usage(&mut state.model_usage, provider_id, model_id, now_millis());
+        }
+        self.persist_prompt_settings().await;
     }
 
     /// Persists the model selection and applies it to the live session when possible.
@@ -440,6 +459,7 @@ impl RuntimeManager {
         Ok(vec![
             command("help", "Show available commands.", false),
             command("agent", "Show active agent.", false),
+            command("model", "Open the model picker.", false),
             command("goal", "Set/show the current objective.", true),
             command("loop", "Run an autonomous plan→act→verify pass.", true),
             bash_command(),
@@ -459,7 +479,10 @@ impl RuntimeManager {
         let request_id = format!("request-{}", Uuid::new_v4().simple());
         let plan_mode = input.agent_id.as_deref() == Some("muse");
         let loop_mode = input.agent_id.as_deref() == Some("loop");
-        let title_model_arg = self.selected_model_arg().await;
+        let usage_model_pair = self.selected_model_pair().await;
+        let title_model_arg = usage_model_pair
+            .as_ref()
+            .map(|(provider, model)| prompt_model_arg(provider, model));
         let is_first_turn;
         let engine_prompt;
         let should_queue;
@@ -516,7 +539,10 @@ impl RuntimeManager {
             // after a planning-mode turn completes (gate keys off "muse").
             conversation.request_agent_ids.insert(
                 request_id.clone(),
-                input.agent_id.clone().unwrap_or_else(|| "forge".to_string()),
+                input
+                    .agent_id
+                    .clone()
+                    .unwrap_or_else(|| "forge".to_string()),
             );
             should_queue = !conversation.active_request_ids.is_empty();
             if should_queue {
@@ -528,6 +554,10 @@ impl RuntimeManager {
             } else {
                 conversation.active_request_ids.push(request_id.clone());
             }
+        }
+
+        if let Some((provider_id, model_id)) = usage_model_pair.as_ref() {
+            self.record_model_usage(provider_id, model_id).await;
         }
 
         // Managed chats are auto-created `chat_<id>` folders; once a chat has a
@@ -2272,6 +2302,16 @@ struct PersistedConversation {
     updated_at: i64,
 }
 
+type ModelUsageByProvider = HashMap<String, HashMap<String, PersistedModelUsage>>;
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+struct PersistedModelUsage {
+    #[serde(default)]
+    prompt_count: u64,
+    #[serde(default)]
+    last_used_at: i64,
+}
+
 /// Path to the transcript store (`~/.codegraff-gui/conversations.json`).
 #[derive(serde::Serialize, serde::Deserialize, Default)]
 struct PersistedPromptSettings {
@@ -2283,6 +2323,8 @@ struct PersistedPromptSettings {
     selected_effort: Option<String>,
     #[serde(default)]
     fast_enabled: bool,
+    #[serde(default)]
+    model_usage: ModelUsageByProvider,
 }
 
 /// Path to the persisted prompt selection (`~/.codegraff-gui/prompt-settings.json`).
@@ -2489,7 +2531,9 @@ fn login_shell_env() -> &'static std::collections::HashMap<String, String> {
         std::thread::spawn(move || {
             // -il = interactive login shell: sources the login profile AND
             // .zshrc/.bashrc, where most users export their *_API_KEY.
-            let out = std::process::Command::new(&shell).args(["-ilc", "env"]).output();
+            let out = std::process::Command::new(&shell)
+                .args(["-ilc", "env"])
+                .output();
             let _ = tx.send(out);
         });
         let mut map = std::collections::HashMap::new();
@@ -2511,7 +2555,6 @@ fn bash_command() -> CommandDescriptorDto {
         argument_hint: Some("<command>".into()),
         ..command("bash", "Run a shell command in the workspace.", true)
     }
-
 }
 
 /// Spawns a persistent `graff --json` child for a conversation. `--yolo` skips
@@ -2798,6 +2841,65 @@ fn selected_pair_exists(
         .any(|candidate| candidate.provider == provider && candidate.name == model)
 }
 
+fn increment_model_usage(
+    usage: &mut ModelUsageByProvider,
+    provider_id: &str,
+    model_id: &str,
+    now: i64,
+) {
+    let entry = usage
+        .entry(provider_id.to_string())
+        .or_default()
+        .entry(model_id.to_string())
+        .or_default();
+    entry.prompt_count = entry.prompt_count.saturating_add(1);
+    entry.last_used_at = now;
+}
+
+fn model_usage_for<'a>(
+    usage: &'a ModelUsageByProvider,
+    provider_id: &str,
+    model_id: &str,
+) -> Option<&'a PersistedModelUsage> {
+    usage
+        .get(provider_id)
+        .and_then(|models| models.get(model_id))
+}
+
+fn model_sort_name(model: &ModelOption) -> String {
+    format!(
+        "{}\u{0}{}\u{0}{}",
+        model.name.to_lowercase(),
+        model
+            .provider_name
+            .as_deref()
+            .unwrap_or(&model.provider)
+            .to_lowercase(),
+        model.provider.to_lowercase()
+    )
+}
+
+fn usage_ranked_catalog_models<'a>(
+    catalog: &'a [ModelOption],
+    configured_provider_ids: &HashSet<String>,
+    model_usage: &ModelUsageByProvider,
+) -> Vec<&'a ModelOption> {
+    let mut models = filtered_catalog_models(catalog, configured_provider_ids);
+    models.sort_by(|left, right| {
+        let left_count = model_usage_for(model_usage, &left.provider, &left.name)
+            .map(|usage| usage.prompt_count)
+            .unwrap_or(0);
+        let right_count = model_usage_for(model_usage, &right.provider, &right.name)
+            .map(|usage| usage.prompt_count)
+            .unwrap_or(0);
+
+        right_count
+            .cmp(&left_count)
+            .then_with(|| model_sort_name(left).cmp(&model_sort_name(right)))
+    });
+    models
+}
+
 fn build_prompt_settings_from_catalog(
     catalog: &[ModelOption],
     configured_provider_ids: &HashSet<String>,
@@ -2805,6 +2907,7 @@ fn build_prompt_settings_from_catalog(
     selected_model: Option<&str>,
     selected_effort: Option<String>,
     fast_enabled: bool,
+    model_usage: &ModelUsageByProvider,
 ) -> PromptSettingsDto {
     if catalog.is_empty() {
         if configured_provider_ids.contains("codegraff") {
@@ -2834,7 +2937,8 @@ fn build_prompt_settings_from_catalog(
         };
     }
 
-    let available_catalog = filtered_catalog_models(catalog, configured_provider_ids);
+    let available_catalog =
+        usage_ranked_catalog_models(catalog, configured_provider_ids, model_usage);
     let available_models = available_catalog
         .iter()
         .map(|model| prompt_model_option(model))
@@ -3803,13 +3907,19 @@ mod tests {
     #[cfg(unix)]
     fn format_command_output_empty_is_no_output() {
         // stdout+stderr empty, exit 0 -> the "(no output)" placeholder.
-        assert_eq!(format_command_output(&mk_output(b"", b"", 0)), "(no output)");
+        assert_eq!(
+            format_command_output(&mk_output(b"", b"", 0)),
+            "(no output)"
+        );
     }
 
     #[test]
     #[cfg(unix)]
     fn format_command_output_stdout_only_unchanged() {
-        assert_eq!(format_command_output(&mk_output(b"hello\n", b"", 0)), "hello\n");
+        assert_eq!(
+            format_command_output(&mk_output(b"hello\n", b"", 0)),
+            "hello\n"
+        );
     }
 
     #[test]
@@ -3837,7 +3947,6 @@ mod tests {
         // raw status 2 -> WIFSIGNALED -> status.code() is None.
         assert!(format_command_output(&mk_output(b"", b"", 2)).contains("[terminated abnormally]"));
     }
-
 
     fn followup(
         id: &str,
@@ -4118,6 +4227,7 @@ mod tests {
             None,
             Some("high".into()),
             true,
+            &HashMap::new(),
         );
 
         assert!(settings.available_models.is_empty());
@@ -4140,6 +4250,7 @@ mod tests {
             None,
             None,
             false,
+            &HashMap::new(),
         );
 
         assert_eq!(settings.available_models.len(), 1);
@@ -4161,6 +4272,7 @@ mod tests {
             Some("gpt-5.5"),
             Some("medium".into()),
             false,
+            &HashMap::new(),
         );
 
         assert_eq!(settings.available_models.len(), 1);
@@ -4170,6 +4282,113 @@ mod tests {
             Some("deepseek-v4-pro")
         );
         assert_eq!(settings.selected_reasoning_effort, None);
+    }
+
+    fn usage_counts(entries: &[(&str, &str, u64)]) -> ModelUsageByProvider {
+        let mut usage = HashMap::new();
+        for (provider, model, count) in entries {
+            usage
+                .entry((*provider).to_string())
+                .or_insert_with(HashMap::new)
+                .insert(
+                    (*model).to_string(),
+                    PersistedModelUsage {
+                        prompt_count: *count,
+                        last_used_at: 0,
+                    },
+                );
+        }
+        usage
+    }
+
+    #[test]
+    fn prompt_settings_orders_models_alphabetically_without_usage() {
+        let settings = build_prompt_settings_from_catalog(
+            &[
+                model("codegraff", "zeta"),
+                model("codegraff", "alpha"),
+                model("codex", "beta"),
+            ],
+            &provider_ids(&["codegraff", "codex"]),
+            None,
+            None,
+            None,
+            false,
+            &HashMap::new(),
+        );
+
+        let ordered: Vec<_> = settings
+            .available_models
+            .iter()
+            .map(|model| model.model_id.as_str())
+            .collect();
+        assert_eq!(ordered, vec!["alpha", "beta", "zeta"]);
+    }
+
+    #[test]
+    fn prompt_settings_ranks_models_by_user_usage_then_alphabetically() {
+        let usage = usage_counts(&[
+            ("codegraff", "zeta", 2),
+            ("codex", "beta", 5),
+            ("openai", "removed", 99),
+        ]);
+        let settings = build_prompt_settings_from_catalog(
+            &[
+                model("codegraff", "zeta"),
+                model("codegraff", "alpha"),
+                model("codex", "beta"),
+                model("codex", "gamma"),
+            ],
+            &provider_ids(&["codegraff", "codex"]),
+            None,
+            None,
+            None,
+            false,
+            &usage,
+        );
+
+        let ordered: Vec<_> = settings
+            .available_models
+            .iter()
+            .map(|model| model.model_id.as_str())
+            .collect();
+        assert_eq!(ordered, vec!["beta", "zeta", "alpha", "gamma"]);
+    }
+
+    #[test]
+    fn prompt_settings_usage_ranking_does_not_change_default_selection() {
+        let usage = usage_counts(&[("codex", "popular", 100)]);
+        let settings = build_prompt_settings_from_catalog(
+            &[
+                model("codegraff", "deepseek-v4-pro"),
+                model("codex", "popular"),
+            ],
+            &provider_ids(&["codegraff", "codex"]),
+            None,
+            None,
+            None,
+            false,
+            &usage,
+        );
+
+        assert_eq!(settings.available_models[0].provider_id, "codex");
+        assert_eq!(settings.available_models[0].model_id, "popular");
+        assert_eq!(settings.selected_provider_id.as_deref(), Some("codegraff"));
+        assert_eq!(
+            settings.selected_model_id.as_deref(),
+            Some("deepseek-v4-pro")
+        );
+    }
+
+    #[test]
+    fn increment_model_usage_updates_count_and_timestamp() {
+        let mut usage = ModelUsageByProvider::new();
+        increment_model_usage(&mut usage, "codex", "gpt-5", 10);
+        increment_model_usage(&mut usage, "codex", "gpt-5", 20);
+
+        let entry = model_usage_for(&usage, "codex", "gpt-5").expect("usage entry");
+        assert_eq!(entry.prompt_count, 2);
+        assert_eq!(entry.last_used_at, 20);
     }
 
     #[test]
@@ -4189,8 +4408,15 @@ mod tests {
 
     #[test]
     fn prompt_settings_schema_fallback_requires_configured_codegraff() {
-        let unavailable =
-            build_prompt_settings_from_catalog(&[], &HashSet::new(), None, None, None, false);
+        let unavailable = build_prompt_settings_from_catalog(
+            &[],
+            &HashSet::new(),
+            None,
+            None,
+            None,
+            false,
+            &HashMap::new(),
+        );
         assert!(unavailable.available_models.is_empty());
 
         let available = build_prompt_settings_from_catalog(
@@ -4200,6 +4426,7 @@ mod tests {
             None,
             None,
             true,
+            &HashMap::new(),
         );
         assert_eq!(available.available_models.len(), 1);
         assert_eq!(available.selected_provider_id.as_deref(), Some("codegraff"));

--- a/src/main.zig
+++ b/src/main.zig
@@ -2224,7 +2224,7 @@ fn loadOrCreateId(io: Io, gpa: Allocator, home: []const u8, fname: []const u8) [
 /// Reasoning depth for codex/responses (OpenAI Responses `reasoning.effort`).
 const ReasoningEffort = enum { low, medium, high };
 
-const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/bash", "/plan", "/key", "/keepcontext", "/effort", "/fast", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
+const repl_commands = [_][]const u8{ "/model", "/models", "/clear", "/bash", "/plan", "/ultracode", "/key", "/keepcontext", "/effort", "/fast", "/reasoning", "/strict", "/yolo", "/trace", "/trajectory", "/agents", "/skills", "/hooks", "/compact", "/rewind", "/image", "/paste", "/save", "/resume", "/sessions", "/todo", "/jobs", "/cost", "/animation", "/mcp", "/help" };
 
 /// Lifecycle hooks (codex/Claude-style), loaded once at startup from
 /// .harness/settings.json's "hooks" object. Three events:
@@ -2525,6 +2525,68 @@ fn mcpServerConnected(tools: []const mcp.Tool, server: []const u8) bool {
 var g_path_env: []const u8 = "";
 /// Human-facing current workspace folder shown in the REPL prompt.
 var g_cwd_display: []const u8 = ".";
+
+/// Short task label for terminal/TUI headers. Mirrors the GUI's first-prompt
+/// fallback: use the user's first message as a compact tab/session title.
+fn titleFromPrompt(prompt: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, prompt, " \t\r\n");
+    if (trimmed.len == 0) return "Chat";
+    var end: usize = 0;
+    var codepoints: usize = 0;
+    while (end < trimmed.len and codepoints < 64) {
+        if (trimmed[end] == '\n' or trimmed[end] == '\r' or trimmed[end] == '\t') break;
+        const cp_len = std.unicode.utf8ByteSequenceLength(trimmed[end]) catch 1;
+        end += cp_len;
+        codepoints += 1;
+    }
+    var out = std.mem.trim(u8, trimmed[0..@min(end, trimmed.len)], " \t\r\n");
+    if (out.len == 0) return "Chat";
+    if (codepoints >= 64 and end < trimmed.len) {
+        if (std.mem.lastIndexOfScalar(u8, out, ' ')) |sp| {
+            if (sp >= 12) out = std.mem.trim(u8, out[0..sp], " ");
+        }
+    }
+    return out;
+}
+
+fn folderBasename(path: []const u8) []const u8 {
+    var end = path.len;
+    while (end > 1 and path[end - 1] == '/') end -= 1;
+    const trimmed = path[0..end];
+    if (std.mem.lastIndexOfScalar(u8, trimmed, '/')) |idx| return trimmed[idx + 1 ..];
+    return trimmed;
+}
+
+fn firstUserTitle(arena: Allocator, msgs: std.json.Array) []const u8 {
+    for (msgs.items) |m| {
+        if (m != .object) continue;
+        const role = if (m.object.get("role")) |r| (if (r == .string) r.string else "") else "";
+        if (!std.mem.eql(u8, role, "user")) continue;
+        return titleFromPrompt(extractText(arena, m));
+    }
+    return "Chat";
+}
+
+fn setTerminalTitle(w: *Io.Writer, title: []const u8, folder: []const u8) void {
+    if (!use_color or json_mode) return;
+    const folder_name = folderBasename(folder);
+    // OSC 0 is conventional xterm title; OSC 1/2 make iTerm/Ghostty-style tab
+    // and window titles update too instead of leaving the launch command there.
+    w.print("\x1b]0;Codegraff: {s} — {s}\x07\x1b]1;Codegraff: {s} — {s}\x07\x1b]2;Codegraff: {s} — {s}\x07", .{ title, folder_name, title, folder_name, title, folder_name }) catch return;
+    w.flush() catch return;
+}
+
+fn printSessionHeader(w: *Io.Writer, title: []const u8, folder: []const u8) !void {
+    if (json_mode) return;
+    try w.print("\n{s}╭─ Codegraff{s}\n{s}│ Working on:{s} {s}\n{s}│ Folder:{s} {s}\n{s}╰────────────────────────────{s}\n", .{
+        style.dim,   style.reset,
+        style.dim,   style.reset,
+        title,       style.dim,
+        style.reset, folder,
+        style.dim,   style.reset,
+    });
+    try w.flush();
+}
 
 fn binOnPath(io: Io, name: []const u8) bool {
     var it = std.mem.splitScalar(u8, g_path_env, ':');
@@ -2923,7 +2985,7 @@ fn saveSkillSetting(io: Io, gpa: Allocator, name: []const u8, enabled: bool) boo
 /// Persist the thinking controls (/effort, /fast) to .harness/settings.json,
 /// preserving every other key. Default values (medium effort, fast off) are
 /// removed rather than written so the file stays clean. Best-effort.
-fn saveThinkingSettings(io: Io, gpa: Allocator, effort: ReasoningEffort, fast: bool) bool {
+fn saveThinkingSettings(io: Io, gpa: Allocator, effort: ReasoningEffort, fast: bool, ultracode: bool) bool {
     Io.Dir.cwd().createDir(io, Approvals.settings_dir, .default_dir) catch {}; // already-exists is fine
     var arena_state = std.heap.ArenaAllocator.init(gpa);
     defer arena_state.deinit();
@@ -2943,6 +3005,11 @@ fn saveThinkingSettings(io: Io, gpa: Allocator, effort: ReasoningEffort, fast: b
         _ = root_obj.orderedRemove("fast");
     } else {
         root_obj.put(a, "fast", .{ .bool = true }) catch return false;
+    }
+    if (!ultracode) {
+        _ = root_obj.orderedRemove("ultracode");
+    } else {
+        root_obj.put(a, "ultracode", .{ .bool = true }) catch return false;
     }
     var aw: Io.Writer.Allocating = .init(gpa);
     defer aw.deinit();
@@ -2976,6 +3043,9 @@ fn loadThinkingSettings(io: Io, arena: Allocator, root: *Agent) void {
     };
     if (v.object.get("fast")) |fv| if (fv == .bool) {
         root.fast = fv.bool;
+    };
+    if (v.object.get("ultracode")) |uv| if (uv == .bool) {
+        root.ultracode = uv.bool;
     };
 }
 
@@ -4794,6 +4864,10 @@ pub fn main(init: std.process.Init) !void {
             if (root.messages.items.len > 0) {
                 // Estimate the restored context from the file size (~4 bytes/token).
                 const est: u64 = if (Io.Dir.cwd().statFile(io, "last" ++ session_ext, .{})) |st| @as(u64, @intCast(st.size)) / 4 else |_| 0;
+                const restored_title = firstUserTitle(arena, root.messages);
+                setTerminalTitle(out, restored_title, g_cwd_display);
+                try printSessionHeader(out, restored_title, g_cwd_display);
+                root.tui_header_shown = true;
                 try out.print("↩ resumed last session — {d} message(s) on {s} · /clear for a fresh start\n", .{ root.messages.items.len, root.provider.model });
                 try out.flush();
                 // Cold cache: if the restored context is as large as what would
@@ -4939,14 +5013,14 @@ pub fn main(init: std.process.Init) !void {
                     root.emit(.{ .type = "error", .message = "set_effort needs level 'low', 'medium', or 'high'" });
                     continue;
                 }
-                _ = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast);
+                _ = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast, root.ultracode);
                 root.emit(.{ .type = "effort", .ok = true, .level = level, .applies = root.effortApplies() });
                 continue;
             }
             if (std.mem.eql(u8, rtype, "set_fast")) {
                 const on = if (parsed.object.get("on")) |v| (if (v == .bool) v.bool else false) else false;
                 root.fast = on;
-                _ = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast);
+                _ = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast, root.ultracode);
                 root.emit(.{ .type = "fast", .ok = true, .on = on, .applies = root.provider.kind == .responses });
                 continue;
             }
@@ -5040,8 +5114,22 @@ pub fn main(init: std.process.Init) !void {
         // model can see (otherwise it only gets the path and resorts to OCR).
         stageGuiImageAttachment(&root, msg);
 
-        // "ultracode" codeword: opt this turn into multi-agent workflow mode.
-        if (std.ascii.indexOfIgnoreCase(msg, "ultracode") != null) {
+        // TUI/session header: once the first real prompt materializes the chat,
+        // show what this terminal tab is working on and the exact folder, like
+        // the GUI conversation header. Keep the terminal/window title in sync
+        // at the start of each user turn.
+        if (!json_mode) {
+            const turn_title = titleFromPrompt(base_msg);
+            setTerminalTitle(out, turn_title, g_cwd_display);
+            if (!root.tui_header_shown) {
+                try printSessionHeader(out, turn_title, g_cwd_display);
+                root.tui_header_shown = true;
+            }
+        }
+
+        // "ultracode" codeword or persistent /ultracode mode: opt turns into multi-agent workflow mode.
+        const ultracode_msg = try applyUltracodeSteering(arena, msg, root.ultracode);
+        if (ultracode_msg.explicit) {
             if (!json_mode) {
                 if (interactive) {
                     ultracodeShine(out, io);
@@ -5053,29 +5141,11 @@ pub fn main(init: std.process.Init) !void {
             }
             tracer.note("ultracode", msg[0..@min(msg.len, 120)]);
             if (g_telem) |t| t.ultracode();
-            const augmented = try std.fmt.allocPrint(arena,
-                \\{s}
-                \\
-                \\[harness note: the user invoked the "ultracode" codeword, opting
-                \\this turn into multi-agent orchestration. Fulfill the request with
-                \\the workflow tool: decompose it into sequential phases of parallel
-                \\subagents — fan out for coverage first, then a synthesis phase.
-                \\Tell code-exploration subagents to go through the repo with the
-                \\codedb tool (search / symbol / callers / outline / context) before
-                \\reaching for bash grep — it is indexed and structural.
-                \\Use the workflow even if you could do the work solo; skip it only
-                \\if the message needs a purely conversational reply.]
-            , .{msg});
-            if (root.pending_image) |img| {
-                try root.messages.append(try imageMessage(arena, root.provider.kind, augmented, img));
-                root.pending_image = null;
-            } else try root.messages.append(try textMessage(arena, "user", augmented));
-        } else {
-            if (root.pending_image) |img| {
-                try root.messages.append(try imageMessage(arena, root.provider.kind, msg, img));
-                root.pending_image = null;
-            } else try root.messages.append(try textMessage(arena, "user", msg));
         }
+        if (root.pending_image) |img| {
+            try root.messages.append(try imageMessage(arena, root.provider.kind, ultracode_msg.text, img));
+            root.pending_image = null;
+        } else try root.messages.append(try textMessage(arena, "user", ultracode_msg.text));
         snaps.turn += 1; // tag file edits in this turn (matches /rewind numbering)
         if (g_telem) |t| t.countTurn();
         // Trajectory: claim this turn's node id up front so subagents spawned
@@ -5621,6 +5691,63 @@ fn listPicker(root: *Agent, arena: Allocator, out: *Io.Writer, title: []const u8
     }
 }
 
+const UltracodeMessage = struct {
+    text: []const u8,
+    explicit: bool,
+};
+
+const ultracode_explicit_note =
+    \\[harness note: the user invoked the "ultracode" codeword, opting
+    \\this turn into multi-agent orchestration. Fulfill the request with
+    \\the workflow tool: decompose it into sequential phases of parallel
+    \\subagents — fan out for coverage first, then a synthesis phase.
+    \\Tell code-exploration subagents to go through the repo with the
+    \\codedb tool (search / symbol / callers / outline / context) before
+    \\reaching for bash grep — it is indexed and structural.
+    \\Use the workflow even if you could do the work solo; skip it only
+    \\if the message needs a purely conversational reply.]
+;
+
+const ultracode_persistent_note =
+    \\[harness note: ultracode mode is enabled for this session. Use the
+    \\workflow tool for coding tasks: decompose the work into sequential
+    \\phases with parallel subagents for exploration/review where helpful,
+    \\then synthesize and implement. Tell code-exploration subagents to go
+    \\through the repo with the codedb tool (search / symbol / callers /
+    \\outline / context) before reaching for bash grep — it is indexed and
+    \\structural.]
+;
+
+fn applyUltracodeSteering(arena: Allocator, msg: []const u8, persistent_enabled: bool) !UltracodeMessage {
+    const explicit = std.ascii.indexOfIgnoreCase(msg, "ultracode") != null;
+    if (explicit) {
+        return .{ .text = try std.fmt.allocPrint(arena, "{s}\n\n{s}", .{ msg, ultracode_explicit_note }), .explicit = true };
+    }
+    if (persistent_enabled) {
+        return .{ .text = try std.fmt.allocPrint(arena, "{s}\n\n{s}", .{ msg, ultracode_persistent_note }), .explicit = false };
+    }
+    return .{ .text = msg, .explicit = false };
+}
+
+const ultracode_on_first = [_]PickItem{
+    .{ .name = "on", .desc = "Enable ultracode orchestration" },
+    .{ .name = "off", .desc = "Disable ultracode orchestration" },
+};
+const ultracode_off_first = [_]PickItem{
+    .{ .name = "off", .desc = "Disable ultracode orchestration" },
+    .{ .name = "on", .desc = "Enable ultracode orchestration" },
+};
+
+fn ultracodeToggleItems(enabled: bool) []const PickItem {
+    return if (enabled) &ultracode_off_first else &ultracode_on_first;
+}
+
+fn pickUltracodeMode(root: *Agent, arena: Allocator, out: *Io.Writer) ?bool {
+    const items = ultracodeToggleItems(root.ultracode);
+    const idx = listPicker(root, arena, out, "Ultracode ›", items) orelse return null;
+    return std.mem.eql(u8, items[idx].name, "on");
+}
+
 /// The slash-command menu shown for a bare "/": every REPL command with a
 /// one-line description, picked via listPicker. Returns the command to run.
 const command_menu = [_]PickItem{
@@ -5630,6 +5757,7 @@ const command_menu = [_]PickItem{
     .{ .name = "/bash", .desc = "run a shell command in the current workspace" },
     .{ .name = "/compact", .desc = "summarize history into a fresh context" },
     .{ .name = "/plan", .desc = "toggle plan mode (read-only, propose first)" },
+    .{ .name = "/ultracode", .desc = "toggle persistent ultracode workflow mode" },
     .{ .name = "/resume", .desc = "restore a saved session (picker)" },
     .{ .name = "/save", .desc = "save the conversation" },
     .{ .name = "/sessions", .desc = "list saved sessions" },
@@ -5682,7 +5810,9 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         root.messages = std.json.Array.init(arena);
         root.last_context_tokens = 0;
         root.last_cache_read = 0;
+        root.tui_header_shown = false;
         root.todos.clearRetainingCapacity();
+        setTerminalTitle(out, "Chat", g_cwd_display);
         try out.writeAll("context cleared — fresh conversation\n");
         try out.flush();
         return;
@@ -5988,6 +6118,30 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         try out.flush();
         return;
     }
+    if (std.mem.eql(u8, line, "/ultracode") or std.mem.startsWith(u8, line, "/ultracode ")) {
+        const arg = std.mem.trim(u8, line["/ultracode".len..], " \t\r\n");
+        const next = if (arg.len == 0) blk: {
+            if (use_color and root.in != null) {
+                break :blk pickUltracodeMode(root, arena, out) orelse return;
+            }
+            try out.writeAll("usage: /ultracode on|off\n");
+            try out.flush();
+            return;
+        } else if (std.mem.eql(u8, arg, "on"))
+            true
+        else if (std.mem.eql(u8, arg, "off"))
+            false
+        else {
+            try out.writeAll("usage: /ultracode on|off\n");
+            try out.flush();
+            return;
+        };
+        root.ultracode = next;
+        const saved = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast, root.ultracode);
+        try out.print("ultracode mode: {s}{s}\n", .{ if (root.ultracode) "on" else "off", if (saved) "" else " (not persisted)" });
+        try out.flush();
+        return;
+    }
     if (std.mem.startsWith(u8, line, "/model") and !std.mem.startsWith(u8, line, "/models")) {
         const arg = std.mem.trim(u8, line["/model".len..], " \t");
         if (arg.len == 0) {
@@ -6131,7 +6285,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
     }
     if (std.mem.eql(u8, line, "/fast") or std.mem.eql(u8, line, "/fast on") or std.mem.eql(u8, line, "/fast off")) {
         root.fast = if (std.mem.eql(u8, line, "/fast on")) true else if (std.mem.eql(u8, line, "/fast off")) false else !root.fast;
-        _ = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast);
+        _ = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast, root.ultracode);
         try out.print("fast mode: {s}{s}\n", .{
             if (root.fast) "on" else "off",
             if (root.provider.kind != .responses) " (codex only — current model ignores it)" else "",
@@ -6153,7 +6307,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             try out.flush();
             return;
         }
-        _ = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast);
+        _ = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast, root.ultracode);
         try out.print("reasoning effort: {s}{s}\n", .{
             @tagName(root.reasoning),
             if (!root.effortApplies()) " (current model ignores it — applies to codex, deepseek, codegraff)" else "",
@@ -6597,6 +6751,7 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         \\  /models         list known models, context windows, compaction points
         \\  /clear          wipe the conversation and start fresh
         \\  /plan           toggle plan mode: read-only explore + propose; writes/edits denied
+        \\  /ultracode      toggle persistent workflow mode; bare opens on/off picker, or /ultracode on|off
         \\  /key [prov key] show API-key status; /key <provider> <key> adds one live (+ Keychain)
         \\  /login [tgt]    OAuth sign-in (no key to paste): codegraff | codex (alias oai) | kimi; bare → picker
         \\  /keepcontext    toggle keeping the conversation when /model switches wire format (default on)
@@ -6626,8 +6781,8 @@ fn handleCommand(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         \\
         \\esc during a response interrupts the turn (what streamed stays in history).
         \\"always allow" answers persist to .harness/settings.json in the cwd.
-        \\codeword: include "ultracode" in any message to force a multi-agent
-        \\workflow turn (phases of parallel subagents, then synthesis).
+        \\codeword: include "ultracode" in any message to force one multi-agent
+        \\workflow turn; /ultracode on persists that behavior for future prompts.
         \\
         \\launch flags: --model <name> · --yolo (skip prompts) · -p "prompt" (one-shot) · --system-prompt/--append-system-prompt · --timing · --cost · --json (SDK protocol) · --help · --version
         \\subcommands: `graff login [codex]` (OAuth) · `graff key set <provider> <key>` (Keychain) · `graff --schema`
@@ -7926,6 +8081,8 @@ const Agent = struct {
     cap_new: bool = false, // provider rejected max_tokens → use max_completion_tokens
     effort_rejected: bool = false, // model rejected reasoning_effort → drop it (e.g. gpt-5.5 on chat/completions wants /v1/responses)
     next_ask_id: u64 = 1,
+    ultracode: bool = false,
+    tui_header_shown: bool = false,
 
     fn prompt(self: *Agent) !void {
         if (json_mode) return; // SDK drives turns; no human prompt
@@ -13170,6 +13327,50 @@ test "priceFor: known model priced, unknown is null" {
     try std.testing.expect(priceFor("gpt-5.5") != null);
     try std.testing.expect(priceFor("claude-opus-4-8") != null);
     try std.testing.expect(priceFor("no-such-model") == null);
+}
+
+test "titleFromPrompt and folderBasename format TUI headers" {
+    try std.testing.expectEqualStrings("Chat", titleFromPrompt(" \n\t "));
+    try std.testing.expectEqualStrings("Refactor the auth middleware", titleFromPrompt("  Refactor the auth middleware\nwith tests"));
+    try std.testing.expectEqualStrings("codegraff", folderBasename("/Users/rach/src/codegraff"));
+    try std.testing.expectEqualStrings("codegraff", folderBasename("/Users/rach/src/codegraff/"));
+}
+
+test "ultracode toggle choices put the opposite state first" {
+    try std.testing.expectEqualStrings("on", ultracodeToggleItems(false)[0].name);
+    try std.testing.expectEqualStrings("off", ultracodeToggleItems(false)[1].name);
+    try std.testing.expectEqualStrings("off", ultracodeToggleItems(true)[0].name);
+    try std.testing.expectEqualStrings("on", ultracodeToggleItems(true)[1].name);
+}
+
+test "applyUltracodeSteering handles explicit and persistent modes" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    const plain = try applyUltracodeSteering(a, "fix this", false);
+    try std.testing.expect(!plain.explicit);
+    try std.testing.expectEqualStrings("fix this", plain.text);
+
+    const persistent = try applyUltracodeSteering(a, "fix this", true);
+    try std.testing.expect(!persistent.explicit);
+    try std.testing.expect(std.mem.indexOf(u8, persistent.text, "ultracode mode is enabled") != null);
+
+    const explicit = try applyUltracodeSteering(a, "ultracode fix this", true);
+    try std.testing.expect(explicit.explicit);
+    try std.testing.expect(std.mem.indexOf(u8, explicit.text, "user invoked the \"ultracode\" codeword") != null);
+    try std.testing.expect(std.mem.indexOf(u8, explicit.text, "ultracode mode is enabled") == null);
+}
+
+test "fillCompletions includes ultracode slash command" {
+    var out: std.ArrayList([]const u8) = .empty;
+    defer out.deinit(std.testing.allocator);
+    _ = fillCompletions(std.testing.allocator, "/ult", &out);
+    var found = false;
+    for (out.items) |item| {
+        if (std.mem.eql(u8, item, "/ultracode")) found = true;
+    }
+    try std.testing.expect(found);
 }
 
 test "visionModel: vision-capable model families only" {


### PR DESCRIPTION
## Summary

- Adds a visible TUI session header once a chat is materialized from the first prompt
- Includes the current workspace folder in that header
- Updates terminal/window/tab titles with the active task and folder
- Resets header/title state when clearing the conversation

## Verification

- [x] `zig build test`
- [x] `zig build`
- [x] `strings ./zig-out/bin/graff | grep -m1 "Working on:"`

## Notes

Unrelated local working-tree changes and `.graff/subagents` artifacts were intentionally not included in this PR.
