### PR TITLE
feat(#114): worktree auto-commit DX + git-safety rail + relicense (modified AGPL)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules/
 harness.trace.jsonl
 harness.trajectory.jsonl
 .harness/
+.graff/worktrees/
 .claude/scheduled_tasks.lock
 *.session.json
 .mcp.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,28 +1,707 @@
-BSD 3-Clause License
+                  codegraff — Modified GNU Affero General
+                     Public License, Version 3 (AGPLv3)
 
-Copyright (c) 2026, justrach
+Copyright (C) 2026 Rach Pradhan ("justrach") and Yu Xi Lim ("yxlyx").
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+This program is free software, licensed to the public under the terms of the
+GNU Affero General Public License, Version 3 (AGPL-3.0), the complete and
+unmodified text of which is reproduced below, AS MODIFIED by the Additional
+Terms and Reserved Rights set out in this preamble. These Additional Terms form
+part of this License and, to the extent of any conflict, prevail over the
+AGPL-3.0 text that follows.
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+--------------------------------------------------------------------------------
+RESERVED COMMERCIAL & CLOUD RIGHTS (Licensor carve-out)
+--------------------------------------------------------------------------------
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
+Notwithstanding anything in the AGPL-3.0 text below, the copyright holders
+Rach Pradhan ("justrach") and Yu Xi Lim ("yxlyx") (each a "Licensor") each
+retain and reserve, for themselves, all rights in and to this software,
+including the unrestricted, perpetual, irrevocable, and royalty-free right to
+use, reproduce, modify, prepare derivative works of, sublicense, distribute,
+host, operate, and commercially exploit this software and any modified or
+derivative version of it -- including, without limitation, the right to offer
+this software, or any product or service based on or incorporating it, as a
+private, proprietary, hosted, managed, or cloud offering -- free of, and
+without being bound by, any obligation of the AGPL-3.0 (including, without
+limitation, its copyleft, source-availability, and Section 13
+remote-network-interaction obligations). Each Licensor may additionally license
+this software to third parties under separate proprietary or commercial terms
+at that Licensor's sole discretion.
 
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
+This reservation runs solely and personally to the two Licensors named above.
+EVERY OTHER PERSON OR ENTITY receives, copies, runs, modifies, conveys, and
+interacts with this software strictly and only under the AGPL-3.0 as set out
+below -- including its Section 13 obligation to offer the Corresponding Source
+to all users who interact with a modified version remotely over a network.
+Nothing in this carve-out grants any right to anyone other than the two named
+Licensors.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+For commercial or proprietary licensing, contact the Licensors.
+
+--------------------------------------------------------------------------------
+The complete text of the GNU Affero General Public License, Version 3 follows.
+--------------------------------------------------------------------------------
+
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/LICENSE
+++ b/LICENSE
@@ -37,6 +37,15 @@ to all users who interact with a modified version remotely over a network.
 Nothing in this carve-out grants any right to anyone other than the two named
 Licensors.
 
+EXERCISE OF RESERVED RIGHTS. The rights reserved above are held by the two
+Licensors severally, not jointly: either Licensor may exercise, license, or
+otherwise act on any of these reserved rights independently, and may grant
+licenses to others, without the consent, signature, or joinder of the other
+Licensor. If at any time one Licensor is unavailable, unreachable, incapacitated,
+or otherwise unable or unwilling to act, Rach Pradhan ("justrach") may exercise
+these reserved rights and grant licenses alone, with full authority to act for
+both. Both Licensors have agreed to and signed these Additional Terms.
+
 For commercial or proprietary licensing, contact the Licensors.
 
 --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -663,24 +663,33 @@ current session. The system prompt tells the agent the file exists — so "profi
 yourself" or "why was that slow?" makes the agent read its own trace and answer
 from data. `/trace` toggles it.
 
-**Telemetry — anonymous, opt-out in releases.** Official release binaries ship
-with a default OTLP endpoint baked in (`-Dtelemetry-endpoint`), so they send
-anonymous usage + evolution telemetry to the project's collector by default —
-this is how install counts, model mix, and agent-evolution fitness are learned
-across the fleet. **Opt out any time** with `--no-telemetry` or
-`GRAFF_NO_TELEMETRY=1`. **Builds from source have no endpoint baked in and send
-nothing** unless you set `OTEL_EXPORTER_OTLP_ENDPOINT` (or `GRAFF_OTEL_ENDPOINT`)
-yourself; an env endpoint also overrides the release default. When live, the
-session ships one best-effort OTLP/HTTP JSON POST to `<endpoint>/v1/logs` at exit
-(plus mid-session batches): a `session` summary (duration, turns, API/tool
-call+error counts, models used, workflow and ultracode counts), one record per
-`workflow` run (phases, tasks, failures, wall-clock), and one per error (API
-failure, aborted turn). Resource attributes carry an anonymous per-install id
-(`~/.simple-harness-install-id`), version, OS, and arch — that id is how total
-installs are counted. The generated SDKs tag their child harness with
-`HARNESS_CLIENT=sdk-ts|sdk-py` plus their own id (`~/.simple-harness-sdk-id`), so
-SDK users are counted separately from direct CLI users. A flush failure never
-disturbs the session.
+**Telemetry — pseudonymous, opt-out, on by default.** *Every* build — release,
+source, and dev — bakes in a default OTLP endpoint (pass `-Dtelemetry-endpoint=""`
+to disable it at build time), so by default a session ships best-effort OTLP/HTTP
+JSON POSTs to `<endpoint>/v1/logs` (at exit, plus mid-session batches). **Opt out
+any time** with `--no-telemetry` or `GRAFF_NO_TELEMETRY=1`; setting
+`OTEL_EXPORTER_OTLP_ENDPOINT` (or `GRAFF_OTEL_ENDPOINT`) redirects it to your own
+collector instead.
+
+It's *pseudonymous, not anonymous*: records carry a **random** per-install id
+(`~/.simple-harness-install-id`, generated with `io.random` — not derived from your
+name, host, or user) plus your request IP, version, OS, and arch. The payload is
+**counts, hashes, and tool names**: a `session` summary (duration, turns, API/tool
+call+error counts, models used, workflow/ultracode counts), per-`workflow` and
+per-error records, and per-turn/score records keyed by a one-way **system-prompt
+fingerprint** + `prompt_sha` hashes with a tool-**name** sequence (e.g.
+`read_file, bash, edit_file`). It does **not** send your prompts, your code, file
+contents, file paths, or tool arguments — your input is never an argument to any
+telemetry call.
+
+**Fleet / evolution signals** (`fleet:propose|submit|elite_pull` — the
+agent-evolution fitness loop) ride the same channel and have a *separate* opt-out:
+`GRAFF_FLEET=off` or `/fleet off`. They're hashes and labels, with one exception —
+`fleet:propose` sends an agent's **system-prompt / persona text** (≤8192 chars: the
+evolved "genome"; graff's own text for built-in agents, *your* text for a custom
+agent or inline override). Error details are capped at 200 chars. The SDKs tag their
+child harness with `HARNESS_CLIENT=sdk-ts|sdk-py` and a separate id
+(`~/.simple-harness-sdk-id`). A flush failure never disturbs the session.
 
 </details>
 
@@ -855,4 +864,16 @@ list, and the GitHub issues for what's in flight:
 
 ---
 
-<p align="center"><sub>Built in Zig 0.16 · <a href="LICENSE">BSD 3-Clause</a> · <a href="architecture.md">architecture.md</a> · <a href="uxlog.md">uxlog.md</a></sub></p>
+## License
+
+codegraff is licensed under a **modified GNU AGPL-3.0** (see [`LICENSE`](LICENSE)):
+the public receives it under the AGPL-3.0 — so network use triggers the Section 13
+obligation to make Corresponding Source available to remote users — while the
+authors **Rach Pradhan (justrach)** and **Yu Xi Lim (yxlyx)** reserve full rights
+to use, distribute, and offer it (and modified versions) as a private, proprietary,
+or hosted/cloud product, free of those obligations. For commercial or proprietary
+licensing, contact the authors.
+
+---
+
+<p align="center"><sub>Built in Zig 0.16 · <a href="LICENSE">AGPL-3.0 (modified)</a> · <a href="architecture.md">architecture.md</a> · <a href="uxlog.md">uxlog.md</a></sub></p>

--- a/sdk/py/LICENSE
+++ b/sdk/py/LICENSE
@@ -1,0 +1,204 @@
+Copyright 2026 Rach Pradhan (justrach) and Yu Xi Lim (yxlyx)
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.1"
 readme = "README.md"
 description = "Python client for the codegraff agent — drives `graff --json` over stdio. Constants auto-generated from `graff --schema`."
 requires-python = ">=3.8"
-license = { text = "BSD-3-Clause" }
+license = { text = "Apache-2.0" }
 keywords = ["codegraff", "graff", "agent", "llm", "harness", "sdk"]
 
 [project.urls]

--- a/sdk/ts/LICENSE
+++ b/sdk/ts/LICENSE
@@ -1,0 +1,204 @@
+Copyright 2026 Rach Pradhan (justrach) and Yu Xi Lim (yxlyx)
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -27,5 +27,5 @@
   "keywords": ["codegraff", "graff", "agent", "llm", "harness", "sdk"],
   "files": ["harness.ts", "remote.ts", "README.md"],
   "engines": { "node": ">=18" },
-  "license": "BSD-3-Clause"
+  "license": "Apache-2.0"
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -492,6 +492,11 @@ const main_system_prompt =
     \\GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME, and GIT_COMMITTER_EMAIL env vars
     \\on every git command so the bot identity is preserved in the commit log.
     \\
+    \\Never run git commands that discard work — `reset --hard`, `clean -f`,
+    \\`checkout --`/`restore`, force-push, or `branch -D` — unless the user
+    \\explicitly asks. Their existing commits and any -w worktree
+    \\auto-checkpoints are the user's safety net; do not blow them away.
+    \\
     \\Be direct and concise.
 ;
 
@@ -1154,6 +1159,23 @@ const Approvals = struct {
             "php",    "sh",      "bash", "osascript", "awk",
         };
         for (interps) |i| if (std.mem.eql(u8, word, i)) return true;
+        return false;
+    }
+
+    /// Git subcommands that can destroy committed or working-tree work — the
+    /// user's, or a -w worktree's auto-checkpoints. Codex keeps `.git` read-only
+    /// to the agent and opencode forbids `git reset --hard`; we do the same to a
+    /// degree: these never auto-run (not under --yolo, not via a blanket `git`
+    /// allow), so they always reach a human y/n. Scans the whole command so a
+    /// chained `cd x && git reset --hard` is caught too.
+    fn isDestructiveGit(cmd: []const u8) bool {
+        if (std.mem.indexOf(u8, cmd, "git ") == null) return false;
+        const pats = [_][]const u8{
+            "reset --hard", "clean -f",  "checkout --", "checkout .",
+            "push --force", "push -f",   "branch -D",   "stash clear",
+            "stash drop",   "restore .",
+        };
+        for (pats) |p| if (std.mem.indexOf(u8, cmd, p) != null) return true;
         return false;
     }
 };
@@ -2934,6 +2956,8 @@ fn mcpServerConnected(tools: []const mcp.Tool, server: []const u8) bool {
 var g_path_env: []const u8 = "";
 /// Human-facing current workspace folder shown in the REPL prompt.
 var g_cwd_display: []const u8 = ".";
+var g_worktree_branch: ?[]const u8 = null; // -w: the worktree's scratch branch; non-null = auto-commit each turn's edits to it
+var g_worktree_autocommit: bool = true; // --no-autocommit turns off the per-turn checkpoint commits
 
 /// Short task label for terminal/TUI headers. Mirrors the GUI's first-prompt
 /// fallback: use the user's first message as a compact tab/session title.
@@ -3647,7 +3671,6 @@ fn animIndex(name: []const u8) ?usize {
 fn animThinking(w: *Io.Writer) Io.Writer.Error!void {
     try w.print(" {s}thinking…{s}", .{ style.dim, style.reset });
 }
-
 
 fn animGlitter(w: *Io.Writer, i: usize) Io.Writer.Error!void {
     // 🎂 EGG (limyuxi_birthday_white): a glittery pink sparkle spinner. Saturated
@@ -5361,6 +5384,8 @@ const usage_text =
     \\  graff key list                   show which providers have keys
     \\  graff mcp add <name> -- <cmd>     add an MCP server to .mcp.json
     \\  graff mcp                         list configured MCP servers
+    \\  graff worktree list              list the per-tab worktrees created by -w
+    \\  graff worktree merge <name>      squash-land worktree-<name> onto the current branch + clean up
     \\  graff --schema                   print the machine-readable interface (SDK codegen)
     \\  graff serve                      HTTP/NDJSON bridge over the --json protocol
     \\                                   (--host/--port/--token; sessions are --json children)
@@ -5378,6 +5403,7 @@ const usage_text =
     \\  --eval <cmd>                    scoring command for an eval-driven loop (the `eval` tool runs it)
     \\  --until <0-100>                 eval-loop target score; stop when reached (default 90)
     \\  -w, --worktree <name>           isolate this session in a git worktree (.graff/worktrees/<name>) so parallel agents don't collide on files
+    \\  --no-autocommit                 with -w, don't auto-commit each turn (default on; land work with `graff worktree merge`)
     \\  --yolo           skip all permission prompts for the session
     \\  -p, --print      one-shot print mode (answer on stdout, progress on stderr)
     \\  --timing         show per-tool wall-clock on result lines
@@ -5663,6 +5689,8 @@ pub fn main(init: std.process.Init) !void {
                     max_tool_calls = std.fmt.parseInt(u64, mv, 10) catch std.process.fatal("--max-tool-calls needs a non-negative integer, got '{s}'", .{mv});
                 } else if (std.mem.eql(u8, arg, "--dedupe-tool-calls")) {
                     dedupe_tool_calls = true;
+                } else if (std.mem.eql(u8, arg, "--no-autocommit")) {
+                    g_worktree_autocommit = false;
                 } else if (std.mem.eql(u8, arg, "--schema")) {
                     schema_flag = true;
                 } else if (std.mem.eql(u8, arg, "--refresh")) {
@@ -5718,7 +5746,7 @@ pub fn main(init: std.process.Init) !void {
     // (`harness "say hi"`). Subcommands (login/key) are not prompts.
     const is_subcommand = positionals.items.len > 0 and
         (std.mem.eql(u8, positionals.items[0], "login") or std.mem.eql(u8, positionals.items[0], "key") or std.mem.eql(u8, positionals.items[0], "mcp") or
-            std.mem.eql(u8, positionals.items[0], "serve") or std.mem.eql(u8, positionals.items[0], "update") or std.mem.eql(u8, positionals.items[0], "title") or std.mem.eql(u8, positionals.items[0], "repl"));
+            std.mem.eql(u8, positionals.items[0], "serve") or std.mem.eql(u8, positionals.items[0], "update") or std.mem.eql(u8, positionals.items[0], "title") or std.mem.eql(u8, positionals.items[0], "repl") or std.mem.eql(u8, positionals.items[0], "worktree"));
     var oneshot_prompt: ?[]const u8 = null;
     if (!is_subcommand and positionals.items.len > 0) {
         oneshot_prompt = try std.mem.join(arena, " ", positionals.items);
@@ -5786,6 +5814,14 @@ pub fn main(init: std.process.Init) !void {
         if (update_force and update_check)
             std.process.fatal("--force and --check are mutually exclusive — use `graff update` (without --check) to install", .{});
         try updateCommand(io, gpa, arena, init.environ_map, update_force, update_check);
+        return;
+    }
+
+    // `graff worktree list` / `graff worktree merge <name>`: manage the per-tab
+    // scratch worktrees that -w creates. merge squash-lands a tab's work as one
+    // clean commit on the current branch, then removes the worktree + branch.
+    if (positionals.items.len > 0 and std.mem.eql(u8, positionals.items[0], "worktree")) {
+        try worktreeCommand(gpa, io, arena, positionals.items[1..]);
         return;
     }
 
@@ -5911,8 +5947,10 @@ pub fn main(init: std.process.Init) !void {
         const wt_z = arena.dupeZ(u8, wt_path) catch std.process.fatal("--worktree: out of memory", .{});
         if (std.posix.system.chdir(wt_z.ptr) != 0)
             std.process.fatal("--worktree '{s}': could not enter {s} (is this a git repository?)", .{ wt, wt_path });
+        g_worktree_branch = wt_branch; // non-null = auto-commit each turn to this scratch branch
         if (!json_mode) {
-            out.print("{s}worktree:{s} {s}{s}{s} (branch {s}) — edits isolated from the main checkout\n", .{ style.dim, style.reset, style.cyan, wt_path, style.reset, wt_branch }) catch {};
+            const ac: []const u8 = if (g_worktree_autocommit) " · auto-committing each turn (`graff worktree merge` to land it)" else "";
+            out.print("{s}worktree:{s} {s}{s}{s} (branch {s}) — edits isolated from the main checkout{s}\n", .{ style.dim, style.reset, style.cyan, wt_path, style.reset, wt_branch, ac }) catch {};
             out.flush() catch {};
         }
     }
@@ -6292,6 +6330,11 @@ pub fn main(init: std.process.Init) !void {
         saveSession(&root, arena, root.session_name) catch |err| {
             std.debug.print("⚠ session save failed: {s}\n", .{@errorName(err)});
         };
+
+        // --worktree: checkpoint the one-shot's edits to the scratch branch too.
+        // Headless swarm agents (graff -w name -p "task") are the main -w use
+        // case — they must not exit with their work left uncommitted.
+        worktreeAutoCommit(gpa, io, std.fmt.allocPrint(arena, "wip: {s}", .{titleFromPrompt(prompt_text)}) catch "wip: graff oneshot");
         // One-shot returns here, before the REPL cleanup defer below is even
         // registered, so free the root's gpa-backed buffers explicitly (else a
         // tool-using one-shot leaks its tool log / render buffers on exit).
@@ -6838,6 +6881,11 @@ pub fn main(init: std.process.Init) !void {
         // crash or quit never loses the thread — last.session.json, the same
         // file /resume reads. Best-effort; a write failure never breaks the loop.
         saveSession(&root, arena, root.session_name) catch {};
+
+        // --worktree checkpoint: commit this turn's edits to the scratch branch
+        // so the work is durable + rewindable across restarts. No-op when not in
+        // a worktree or when --no-autocommit is set.
+        worktreeAutoCommit(gpa, io, std.fmt.allocPrint(arena, "wip: {s}", .{titleFromPrompt(base_msg)}) catch "wip: graff checkpoint");
     }
     // Final save on exit also captures command-driven edits since the last turn
     // (/clear, /rewind) so the next start resumes the true end state.
@@ -6851,6 +6899,11 @@ pub fn main(init: std.process.Init) !void {
     } else {
         saveSession(&root, arena, root.session_name) catch {};
     }
+
+    // Capture edits from an interrupted/aborted final turn (those `continue`
+    // before the per-turn checkpoint) so a worktree never quits with work left
+    // uncommitted on its scratch branch.
+    worktreeAutoCommit(gpa, io, "wip: session end");
     try out.writeAll("\n");
     try out.flush();
 }
@@ -10991,7 +11044,18 @@ const Agent = struct {
     /// when cleared to execute. Subagents never prompt; their gate is the
     /// allowlist check in execToolInner.
     fn gateTool(self: *Agent, call: ToolCall) !?ExecResult {
-        if (self.sub) return null; // subagents: gated structurally, not by prompt
+        if (self.sub) {
+            // Destructive git is blocked for subagents outright — they have no
+            // human to confirm with. The root agent falls through to a y/n
+            // prompt below. Completes the Codex-style `.git` guard across both.
+            if (std.mem.eql(u8, call.name, "bash") and call.input == .object) {
+                if (call.input.object.get("command")) |cv| if (cv == .string and Approvals.isDestructiveGit(cv.string)) return .{
+                    .text = try self.arena.dupe(u8, "destructive git is blocked for subagents (no one to confirm) — leave reset --hard / clean -f / force-push / branch -D to the root session"),
+                    .is_error = true,
+                };
+            }
+            return null; // subagents: otherwise gated structurally, not by prompt
+        }
         const approvals = self.approvals orelse return null;
 
         // Plan mode: read-only, regardless of approvals — deny mutating tools
@@ -11025,9 +11089,17 @@ const Agent = struct {
             const cmd_val = call.input.object.get("command") orelse return null;
             if (cmd_val != .string) return null;
             const cmd = std.mem.trim(u8, cmd_val.string, " \t");
-            if (approvals.allowed(self.io, cmd)) return null;
+            // Destructive git (reset --hard, clean -f, branch -D, force-push…)
+            // never auto-runs — not under --yolo, not via a blanket `git` allow —
+            // so the agent can't wipe the user's work or a worktree's checkpoints.
+            // It falls through to a human y/n (or a deny in non-interactive runs).
+            const destructive_git = Approvals.isDestructiveGit(cmd);
+            if (!destructive_git and approvals.allowed(self.io, cmd)) return null;
             key = firstWord(cmd);
-            prompt_line = std.fmt.bufPrint(&line_buf, "run: {s}", .{cmd}) catch cmd;
+            prompt_line = if (destructive_git)
+                std.fmt.bufPrint(&line_buf, "DESTRUCTIVE git — run: {s}", .{cmd}) catch cmd
+            else
+                std.fmt.bufPrint(&line_buf, "run: {s}", .{cmd}) catch cmd;
         } else if (std.mem.eql(u8, call.name, "write_file") or std.mem.eql(u8, call.name, "edit_file")) {
             if (approvals.allowedExact(self.io, call.name)) return null;
             key = call.name;
@@ -14676,6 +14748,153 @@ fn runCapped(gpa: Allocator, io: Io, argv: []const []const u8, stdout_cap: usize
     };
 }
 
+/// True if a CappedRun child exited cleanly (status 0).
+fn ranOk(r: CappedRun) bool {
+    return r.term == .exited and r.term.exited == 0;
+}
+
+/// True if the current git working tree has uncommitted *tracked* changes
+/// (staged or unstaged). Untracked files (`?? …`) don't count — `git reset
+/// --hard` leaves them alone, so they're safe around a worktree land.
+fn gitTreeDirty(gpa: Allocator, io: Io) bool {
+    const r = runCapped(gpa, io, &.{ "git", "status", "--porcelain" }, 1 << 16, 8192, 30_000) catch return false;
+    defer {
+        gpa.free(r.stdout);
+        gpa.free(r.stderr);
+    }
+    if (!ranOk(r)) return false;
+    var it = std.mem.tokenizeScalar(u8, r.stdout, '\n');
+    while (it.next()) |line| {
+        if (line.len >= 2 and !std.mem.startsWith(u8, line, "??")) return true;
+    }
+    return false;
+}
+
+/// Per-turn checkpoint commit for `-w` sessions. The worktree branch is a
+/// throwaway scratch branch, so committing every turn is free and gives durable
+/// rewind points across restarts; `graff worktree merge` later --squashes the
+/// whole trail into one clean commit. No-op outside a worktree or under
+/// --no-autocommit. Best-effort: a clean tree (nothing to commit) or a missing
+/// git identity just means no commit this turn, never a failed turn. --no-verify
+/// so a slow or strict pre-commit hook can't block a checkpoint.
+fn worktreeAutoCommit(gpa: Allocator, io: Io, msg: []const u8) void {
+    if (g_worktree_branch == null or !g_worktree_autocommit) return;
+    // Stage everything except graff's own runtime artifacts — trace/trajectory/
+    // sessions/keys/MCP config must never ride into the squash-merge onto the
+    // user's branch. .gitignore hides these in the graff repo, but a *target*
+    // repo (the swarm's real use case) won't, so exclude them explicitly here.
+    const add = runCapped(gpa, io, &.{
+        "git",                       "add",
+        "-A",                        "--",
+        ":(exclude).graff",          ":(exclude).harness",
+        ":(exclude)harness.*.jsonl", ":(exclude)*.session.json",
+        ":(exclude).mcp.json",       ":(exclude).simple-harness-*",
+    }, 4096, 4096, 30_000) catch return;
+    gpa.free(add.stdout);
+    gpa.free(add.stderr);
+    const c = runCapped(gpa, io, &.{ "git", "commit", "--no-verify", "-m", msg }, 8192, 8192, 30_000) catch return;
+    gpa.free(c.stdout);
+    gpa.free(c.stderr);
+}
+
+/// `graff worktree <list|merge <name>>` — manage the per-tab scratch worktrees
+/// that `-w` creates. `list` shows them; `merge <name>` squash-merges
+/// worktree-<name> into the current branch as one clean commit, then removes the
+/// worktree and deletes its branch. Run from the main checkout.
+fn worktreeCommand(gpa: Allocator, io: Io, arena: Allocator, args: []const []const u8) !void {
+    var buf: [4096]u8 = undefined;
+    var w = Io.File.stdout().writer(io, &buf);
+    const out = &w.interface;
+    defer out.flush() catch {};
+
+    const action = if (args.len > 0) args[0] else "list";
+
+    if (std.mem.eql(u8, action, "list") or std.mem.eql(u8, action, "ls")) {
+        const r = runCapped(gpa, io, &.{ "git", "worktree", "list" }, 1 << 16, 8192, 30_000) catch {
+            try out.writeAll("not a git repository (no worktrees)\n");
+            return;
+        };
+        defer {
+            gpa.free(r.stdout);
+            gpa.free(r.stderr);
+        }
+        if (!ranOk(r)) {
+            try out.writeAll(r.stderr);
+            return;
+        }
+        try out.writeAll(r.stdout);
+        return;
+    }
+
+    if (std.mem.eql(u8, action, "merge")) {
+        if (args.len < 2) {
+            try out.writeAll("usage: graff worktree merge <name>\n");
+            return;
+        }
+        const name = args[1];
+        const wt_path = try std.fmt.allocPrint(arena, ".graff/worktrees/{s}", .{name});
+        const wt_branch = try std.fmt.allocPrint(arena, "worktree-{s}", .{name});
+
+        // Refuse to land into a dirty tree: the conflict-recovery below resets
+        // tracked files, which would eat uncommitted work. Untracked files (the
+        // worktrees, traces) are fine — reset --hard leaves them be.
+        if (gitTreeDirty(gpa, io)) {
+            try out.print("✗ your working tree has uncommitted changes — commit or stash them first, then `graff worktree merge {s}`\n", .{name});
+            return;
+        }
+
+        // 1) squash-merge the scratch branch into the current branch (staged, not committed).
+        const m = runCapped(gpa, io, &.{ "git", "merge", "--squash", wt_branch }, 1 << 16, 1 << 16, 60_000) catch {
+            try out.writeAll("✗ could not run git merge (is this a git repository?)\n");
+            return;
+        };
+        const merged = ranOk(m);
+        gpa.free(m.stdout);
+        gpa.free(m.stderr);
+        if (!merged) {
+            // Overlapping changes. A --squash merge leaves the index/worktree
+            // half-merged with no MERGE_HEAD to --abort, so restore the branch to
+            // clean ourselves (safe — we verified it was clean above) and leave
+            // the worktree intact for the user to land another way.
+            if (runCapped(gpa, io, &.{ "git", "reset", "--hard", "HEAD" }, 8192, 8192, 30_000)) |r| {
+                gpa.free(r.stdout);
+                gpa.free(r.stderr);
+            } else |_| {}
+            try out.print("✗ couldn't auto-land {s} — it overlaps changes already on this branch.\n  current branch left clean, worktree intact. Land it first, or merge by hand: git merge {s}\n", .{ wt_branch, wt_branch });
+            return;
+        }
+
+        // 2) commit the squashed result as one clean commit on the current branch.
+        const cmsg = std.fmt.allocPrint(arena, "{s}: land worktree", .{name}) catch "land worktree";
+        const c = runCapped(gpa, io, &.{ "git", "commit", "--no-verify", "-m", cmsg }, 8192, 8192, 30_000) catch {
+            try out.writeAll("✗ git commit failed — worktree left intact\n");
+            return;
+        };
+        const committed = ranOk(c);
+        gpa.free(c.stdout);
+        gpa.free(c.stderr);
+        if (!committed) {
+            try out.print("⚠ nothing to land from {s} (empty or already merged) — worktree left intact\n", .{wt_branch});
+            return;
+        }
+
+        // 3) clean up: remove the worktree dir, then delete its now-free branch.
+        if (runCapped(gpa, io, &.{ "git", "worktree", "remove", "--force", wt_path }, 8192, 8192, 30_000)) |r| {
+            gpa.free(r.stdout);
+            gpa.free(r.stderr);
+        } else |_| {}
+        if (runCapped(gpa, io, &.{ "git", "branch", "-D", wt_branch }, 8192, 8192, 30_000)) |r| {
+            gpa.free(r.stdout);
+            gpa.free(r.stderr);
+        } else |_| {}
+
+        try out.print("✓ landed {s} → current branch as one commit, removed the worktree\n", .{wt_branch});
+        return;
+    }
+
+    try out.print("unknown worktree command '{s}' — use: graff worktree list | graff worktree merge <name>\n", .{action});
+}
+
 /// One background bash job (`bash` with run_in_background:true). A pump task
 /// continuously drains stdout+stderr into `buf` so the child never blocks on
 /// a full pipe; bash_output returns the bytes past `cursor`; bash_kill stops
@@ -16300,6 +16519,28 @@ test "Approvals.isInterpreter: flags first words that grant arbitrary code execu
     try std.testing.expect(!Approvals.isInterpreter("ls"));
     try std.testing.expect(!Approvals.isInterpreter("git"));
     try std.testing.expect(!Approvals.isInterpreter("python3x"));
+}
+
+test "Approvals.isDestructiveGit: flags work-destroying git, lets safe git through" {
+    // destructive — must always reach a human, even under --yolo or a `git` allow
+    try std.testing.expect(Approvals.isDestructiveGit("git reset --hard HEAD~3"));
+    try std.testing.expect(Approvals.isDestructiveGit("git clean -fd"));
+    try std.testing.expect(Approvals.isDestructiveGit("git push --force origin main"));
+    try std.testing.expect(Approvals.isDestructiveGit("git push -f"));
+    try std.testing.expect(Approvals.isDestructiveGit("git branch -D worktree-docs"));
+    try std.testing.expect(Approvals.isDestructiveGit("git checkout -- src/main.zig"));
+    try std.testing.expect(Approvals.isDestructiveGit("git checkout ."));
+    try std.testing.expect(Approvals.isDestructiveGit("git stash clear"));
+    try std.testing.expect(Approvals.isDestructiveGit("cd sub && git reset --hard")); // chained
+    try std.testing.expect(Approvals.isDestructiveGit("git -C /repo reset --hard")); // -C form
+    // safe — the normal auto-allow path is fine
+    try std.testing.expect(!Approvals.isDestructiveGit("git status"));
+    try std.testing.expect(!Approvals.isDestructiveGit("git commit -m wip"));
+    try std.testing.expect(!Approvals.isDestructiveGit("git reset --soft HEAD~1"));
+    try std.testing.expect(!Approvals.isDestructiveGit("git checkout main"));
+    try std.testing.expect(!Approvals.isDestructiveGit("git branch -d merged-feature"));
+    try std.testing.expect(!Approvals.isDestructiveGit("git restore --staged f.txt"));
+    try std.testing.expect(!Approvals.isDestructiveGit("ls -la"));
 }
 
 test "Agent.firstWord: splits the command on the first whitespace" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -5377,6 +5377,7 @@ const usage_text =
     \\  --goal <text>                   seed a standing objective (tracked as a todo checklist) for every turn
     \\  --eval <cmd>                    scoring command for an eval-driven loop (the `eval` tool runs it)
     \\  --until <0-100>                 eval-loop target score; stop when reached (default 90)
+    \\  -w, --worktree <name>           isolate this session in a git worktree (.graff/worktrees/<name>) so parallel agents don't collide on files
     \\  --yolo           skip all permission prompts for the session
     \\  -p, --print      one-shot print mode (answer on stdout, progress on stderr)
     \\  --timing         show per-tool wall-clock on result lines
@@ -5625,6 +5626,7 @@ pub fn main(init: std.process.Init) !void {
     var resume_flag: ?[]const u8 = null; // restore/save this named session
     var goal_flag: ?[]const u8 = null; // --goal: standing objective (todos) every turn gets, incl. --json/-p
     var eval_cmd_flag: ?[]const u8 = null; // --eval: scoring command for the eval-driven loop
+    var worktree_flag: ?[]const u8 = null; // --worktree/-w: isolate this session in a git worktree (parallel agents, no file collisions)
     var eval_target_flag: ?u8 = null; // --until: target score 0-100 for the eval loop
     var no_resume_flag = false; // start without auto-loading last.session.json
     var new_session_flag = false; // start a fresh autosaved session
@@ -5639,6 +5641,8 @@ pub fn main(init: std.process.Init) !void {
             } else if (std.mem.startsWith(u8, arg, "-")) {
                 if (std.mem.eql(u8, arg, "--yolo")) {
                     yolo_flag = true;
+                } else if (std.mem.eql(u8, arg, "--worktree") or std.mem.eql(u8, arg, "-w")) {
+                    worktree_flag = it.next() orelse std.process.fatal("--worktree needs a name (e.g. --worktree agent1)", .{});
                 } else if (std.mem.eql(u8, arg, "--goal")) {
                     goal_flag = it.next() orelse std.process.fatal("--goal needs an objective", .{});
                 } else if (std.mem.eql(u8, arg, "--eval")) {
@@ -5894,8 +5898,29 @@ pub fn main(init: std.process.Init) !void {
         style = Style.ansi;
         use_color = true;
     }
+    // --worktree/-w: run this session in an isolated git worktree so parallel
+    // agents don't collide on files. Creates .graff/worktrees/<name> on branch
+    // worktree-<name> (from HEAD) and enters it; reuses it if it already exists.
+    if (worktree_flag) |wt| {
+        const wt_path = try std.fmt.allocPrint(arena, ".graff/worktrees/{s}", .{wt});
+        const wt_branch = try std.fmt.allocPrint(arena, "worktree-{s}", .{wt});
+        if (runCapped(gpa, io, &.{ "git", "worktree", "add", wt_path, "-b", wt_branch }, 8192, 8192, 60_000)) |r| {
+            gpa.free(r.stdout);
+            gpa.free(r.stderr);
+        } else |_| {}
+        const wt_z = arena.dupeZ(u8, wt_path) catch std.process.fatal("--worktree: out of memory", .{});
+        if (std.posix.system.chdir(wt_z.ptr) != 0)
+            std.process.fatal("--worktree '{s}': could not enter {s} (is this a git repository?)", .{ wt, wt_path });
+        if (!json_mode) {
+            out.print("{s}worktree:{s} {s}{s}{s} (branch {s}) — edits isolated from the main checkout\n", .{ style.dim, style.reset, style.cyan, wt_path, style.reset, wt_branch }) catch {};
+            out.flush() catch {};
+        }
+    }
     var cwd_buf: [4096]u8 = undefined;
-    g_cwd_display = if (Io.Dir.cwd().realPath(io, &cwd_buf)) |n|
+    g_cwd_display = if (worktree_flag) |wt|
+        // After chdir into the worktree, realPath(AT_FDCWD) is unreliable; derive from the launch dir.
+        std.fmt.allocPrint(arena, "{s}/.graff/worktrees/{s}", .{ init.environ_map.get("PWD") orelse ".", wt }) catch try arena.dupe(u8, init.environ_map.get("PWD") orelse ".")
+    else if (Io.Dir.cwd().realPath(io, &cwd_buf)) |n|
         try arena.dupe(u8, cwd_buf[0..n])
     else |_|
         try arena.dupe(u8, init.environ_map.get("PWD") orelse ".");


### PR DESCRIPTION
Builds the per-tab worktree workflow on top of `-w` (#114), plus the agent
git-safety rail and a relicense to modified AGPL-3.0.

## Worktree DX (#114)
- Each `-w <name>` session **auto-commits** its edits to the scratch branch every
  turn, on one-shot `-p` exit (the headless-swarm path), and on session exit —
  excluding graff's own runtime artifacts (`.graff`, `harness.*.jsonl`, sessions,
  keys, mcp). `--no-autocommit` opts out.
- `graff worktree list` / `graff worktree merge <name>` squash-land a tab as one
  commit then remove the worktree + branch. **Non-destructive convergence**: merge
  refuses a dirty tree and, on an overlap conflict, restores the branch to clean
  (no half-merged `UU` state) with the worktree intact.

## Agent git-safety rail
Mirrors Codex's read-only `.git` and opencode's "never `reset --hard`": destructive
git (`reset --hard`, `clean -f`, `checkout --`/`restore`, force-push, `branch -D`,
`stash clear/drop`) never auto-runs — forced to a human y/n even under `--yolo` or a
blanket `git` allow, and blocked outright for subagents. Protects the user's work
and the worktree auto-checkpoints. `isDestructiveGit` is unit-tested.

## Relicense
- Root harness: **BSD-3-Clause → modified GNU AGPL-3.0**. Public receives AGPL-3.0
  (incl. Section 13); Rach Pradhan (justrach) and Yu Xi Lim (yxlyx) reserve full
  private/proprietary/cloud rights (held severally — either may act alone; justrach
  as fallback if one is unavailable).
- SDKs (`sdk/py`, `sdk/ts`): BSD-3-Clause → **Apache-2.0** (full LICENSE files added).
- README: corrected the telemetry section to match the code (pseudonymous install
  id; counts/hashes/tool-names sent, never prompts/code/paths/args; `fleet:propose`
  persona-text vector; `--no-telemetry` / `GRAFF_FLEET=off` opt-outs).

## Verification
Built clean, tests green. Verified end-to-end against a 6-agent Codex swarm
(`--model codex`) on a real repo: parallel worktree isolation incl. concurrent
same-file edits, code-only commits, clean squash-merges, graceful overlap conflicts.

---
Closes #114
Closes #107
Related: #54 — adds the `graff worktree` tooling it requests; the codedb-pro
per-cwd indexing across worktrees is still open.
