### PR TITLE
feat(fleet): tag eval-loop + SDK scores with their niche and ride the genome

### DIFF
--- a/docs/hyperagents.md
+++ b/docs/hyperagents.md
@@ -344,6 +344,36 @@ artifact are ever transmitted.
 | **D — Promote** | central worker (automatic) | challenger beats the incumbent built-in by margin M over W days with ≥K distinct installs → flip `live` |
 | **E — Distribute** | startup pull / release | graff fetches the elites for *its* tier; `loadAgentTypes` prefers a live fleet elite over the baked built-in |
 
+### Driving Propose (B) yourself
+
+Two entry points feed a niche's cell. Both tag the score with the niche so the
+worker can group it into `(niche × provider_class × eval_set_hash)`, and both
+ride the genome (the persona's `prompt_text`) over on `fleet:propose` so a
+promoted cell actually has a persona to serve:
+
+- **Harness eval loop.** Name the role the eval optimizes:
+
+  ```
+  graff --eval ./score.sh --until 95 --niche reviewer
+  ```
+
+  On each new best, `runEval` emits `fleet:propose` (the genome) plus a
+  niche-tagged `score` and `fleet:submit`. Without `--niche` the score lands in
+  the anonymous `""` cell, which `pullElites` can never match to a built-in, so
+  an eval session that wants to grow a champion must name its role.
+
+- **SDK.** Pass `niche` to `score()` with the full persona text:
+
+  ```python
+  h.score(persona_text, 95.0, niche="reviewer", eval_set_hash=suite_hash)
+  ```
+  ```ts
+  await h.score(personaText, 95, "", undefined, "reviewer");
+  ```
+
+  Given the full text plus a niche, `score()` first emits `fleet:propose`
+  carrying the genome (deduped by `prompt_sha`), then the niche-tagged score.
+
 ### Why the backend can decide unattended: signing ≠ attestation
 
 Step 0's HMAC proves a score *came from a real graff build* and wasn't
@@ -406,9 +436,9 @@ both clients, since the SDKs are generated):
 
 | body | kind | emitted by | attrs | meaning |
 |---|---|---|---|---|
-| `score` | — | harness (on `h.score()`) | `prompt_sha`, `value`, `parent_sha`, `provider_class`, `artifact_sha`, `eval_set_hash`, `sig` | a signed fitness write-back (the gradient) |
-| `fleet` | `propose` | SDK driver | `niche`, `prompt_sha`, `parent_sha`, `provider_class` | a variant was generated/mutated |
-| `fleet` | `submit` | SDK driver | `niche`, `prompt_sha`, `provider_class`, `eval_set_hash` | a scored variant was submitted to the fleet |
+| `score` | — | harness (on `h.score()`) | `prompt_sha`, `value`, `parent_sha`, `provider_class`, `artifact_sha`, `eval_set_hash`, `niche`, `sig` | a signed fitness write-back (the gradient) |
+| `fleet` | `propose` | harness · SDK driver | `niche`, `prompt_sha`, `parent_sha`, `provider_class`, `prompt_text` | a variant was generated/mutated (carries the genome) |
+| `fleet` | `submit` | harness · SDK driver | `niche`, `prompt_sha`, `provider_class`, `eval_set_hash` | a scored variant was submitted to the fleet |
 | `fleet` | `elite_pull` | SDK driver | `provider_class`, `eval_set_hash`, `n_elites` | current elites fetched from `/v1/elites` |
 | `fleet` | `promote` | worker | `niche`, `provider_class`, `prompt_sha`, `lcb`, `n_installs` | the backend flipped a new champion live |
 
@@ -417,11 +447,12 @@ so a dashboard confirms the federated loop is running (variants proposed →
 scores submitted → cells promoted) per client, exactly as `prompt_variants` /
 `scores_recorded` did for the local loop.
 
-SDK surface (both clients): `score()` already carries the signed fields and now
-emits `fleet:submit`; new `pullElites(providerClass)` / `pull_elites(...)`
-returns the live champions and emits `fleet:elite_pull`; `proposeVariant(...)`
-(thin helper around `subagent` with a `system_prompt` override) emits
-`fleet:propose`. All gated by the same telemetry opt-out as the rest of the SDK.
+SDK surface (both clients): `score(promptOrSha, value, …, niche)` carries the
+signed fields and emits `fleet:submit`; when handed the full persona text plus a
+`niche` it also emits `fleet:propose` carrying the genome, so the cell it submits
+into is promotable. `pullElites(providerClass)` / `pull_elites(...)` returns the
+live champions and emits `fleet:elite_pull`. All gated by the same telemetry
+opt-out as the rest of the SDK.
 
 ### Scaffolded vs TODO
 
@@ -430,7 +461,9 @@ returns the live champions and emits `fleet:elite_pull`; `proposeVariant(...)`
   fields, the SDK `fleet` signal emitters, and — as of this change — the
   **harness-side `fleet` emitters too**: `Telemetry.fleetEvent` (body `fleet`,
   matching the SDK `_fleet_signal`), `fleet:propose` at the variant spawn
-  (`runSub`), `fleet:submit` at the `score` write-back, a `providerClass()`
+  (`runSub`) and on each eval-loop best (`runEval`, gated on `--niche`), both
+  carrying the genome `prompt_text`; the niche-tagged `fleet:submit` at the
+  `score` write-back, a `providerClass()`
   tier tag, and the graff-side startup pull (`pullElites` → `fleet:elite_pull`,
   with `loadAgentTypes`/builtins deferring to a live champion's prompt). Verified
   live: a harness session moved `/v1/stats` `submits` and `elite_pulls`.

--- a/sdk/generate.py
+++ b/sdk/generate.py
@@ -370,19 +370,28 @@ export class Harness {{
    *  text (fingerprinted for you) or an existing 16-hex fingerprint.
    *  Pass `parent` (text or sha) when the variant was mutated from another
    *  prompt: that genome-lineage edge is what DGM parent selection counts
-   *  children with. Call between turns; resolves on the harness's ack. */
-  async score(promptOrSha: string, value: number, notes = "", parent?: string): Promise<void> {{
+   *  children with. Pass `niche` (reviewer/researcher/implementer/skeptic, or
+   *  a custom agent) to file the score into that MAP-Elites cell so the fleet
+   *  can promote a champion for the role; with the full persona text the genome
+   *  also rides over on a `fleet:propose`. Call between turns; resolves on the
+   *  harness's ack. */
+  async score(promptOrSha: string, value: number, notes = "", parent?: string, niche?: string): Promise<void> {{
     const sha = /^[0-9a-f]{{16}}$/.test(promptOrSha) ? promptOrSha : promptFingerprint(promptOrSha);
     const parent_sha = parent === undefined ? undefined
       : /^[0-9a-f]{{16}}$/.test(parent) ? parent : promptFingerprint(parent);
-    this.proc.stdin.write(JSON.stringify({{ type: "score", prompt_sha: sha, score: value, notes, parent_sha }}) + "\\n");
+    // Genome-send (docs §9.B): a cell only promotes when a score's prompt_sha
+    // joins a stored genome, so when we hold the full persona text + a niche,
+    // register it first on a `fleet:propose` (deduped by prompt_sha on the
+    // collector). This is the SDK analog of the harness eval loop's propose.
+    if (niche && !/^[0-9a-f]{{16}}$/.test(promptOrSha)) fleetSignal("propose", {{ niche, prompt_sha: sha, parent_sha: parent_sha ?? "", prompt_text: promptOrSha }});
+    this.proc.stdin.write(JSON.stringify({{ type: "score", prompt_sha: sha, score: value, notes, parent_sha, niche }}) + "\\n");
     // Same edge-version tolerance as setSystemPrompt: skip unknown events
     // while waiting for the ack.
     while (true) {{
       const ev = await this.next();
       if (ev === null) {{ reportError("died", "harness closed before acking score"); throw new Error("harness closed"); }}
       if (ev.type === "error") throw new Error(ev.message);
-      if (ev.type === "score") {{ fleetSignal("submit", {{ prompt_sha: sha, parent_sha: parent_sha ?? "" }}); return; }}
+      if (ev.type === "score") {{ fleetSignal("submit", {{ prompt_sha: sha, parent_sha: parent_sha ?? "", niche: niche ?? "" }}); return; }}
     }}
   }}
 
@@ -678,11 +687,15 @@ export class RemoteHarness {{
 
   /** Record an evaluation score in the server-side trajectory archive —
    *  same semantics as the stdio SDK's `score()`. */
-  async score(promptOrSha: string, value: number, notes = "", parent?: string): Promise<void> {{
+  async score(promptOrSha: string, value: number, notes = "", parent?: string, niche?: string): Promise<void> {{
     const sha = HEX16.test(promptOrSha) ? promptOrSha : await promptFingerprint(promptOrSha);
     const parent_sha = parent === undefined ? undefined
       : HEX16.test(parent) ? parent : await promptFingerprint(parent);
-    for await (const ev of this.send({{ type: "score", prompt_sha: sha, score: value, notes, parent_sha }})) {{
+    // `niche` files the score into a MAP-Elites cell so the fleet can promote a
+    // champion for the role; the remote harness reads it from the request and
+    // tags its own score/submit. (Genome capture rides the harness process,
+    // which holds the persona text the remote bridge only references by sha.)
+    for await (const ev of this.send({{ type: "score", prompt_sha: sha, score: value, notes, parent_sha, niche }})) {{
       if (ev.type === "error") throw new Error(ev.message);
       if (ev.type === "score") return;
     }}
@@ -1023,7 +1036,8 @@ class Harness:
 
     def score(self, prompt_or_sha: str, value: float, notes: str = "",
               parent: Optional[str] = None, judge_id: str = "",
-              artifact_sha: str = "", eval_set_hash: str = "") -> None:
+              artifact_sha: str = "", eval_set_hash: str = "",
+              niche: str = "") -> None:
         """Record an evaluation score for an agent/prompt variant in the
         trajectory archive (harness.trajectory.jsonl) — the DGM evaluation
         phase writing back. `prompt_or_sha` is either the full system-prompt
@@ -1036,7 +1050,11 @@ class Harness:
         names the evaluator, `artifact_sha` the thing it judged, and
         `eval_set_hash` the held-out eval used — all folded into the record's
         HMAC so a forged fitness row is detectable (see `verify_score`).
-        Call between turns; blocks until the harness acks."""
+        `niche` (reviewer/researcher/implementer/skeptic, or a custom agent)
+        files the score into that MAP-Elites cell so the fleet can promote a
+        champion for the role; with the full persona text the genome also rides
+        over on a `fleet:propose`. Call between turns; blocks until the harness
+        acks."""
         assert self.proc.stdin and self.proc.stdout
         sha = prompt_or_sha if re.fullmatch(r"[0-9a-f]{{16}}", prompt_or_sha) \\
             else prompt_fingerprint(prompt_or_sha)
@@ -1050,6 +1068,15 @@ class Harness:
             req["artifact_sha"] = artifact_sha
         if eval_set_hash:
             req["eval_set_hash"] = eval_set_hash
+        if niche:
+            req["niche"] = niche
+        # Genome-send (docs §9.B): a cell only promotes when a score's prompt_sha
+        # joins a stored genome, so when we hold the full persona text + a niche,
+        # register it first (deduped by prompt_sha on the collector).
+        if niche and not re.fullmatch(r"[0-9a-f]{{16}}", prompt_or_sha):
+            _fleet_signal("propose", {{"niche": niche, "prompt_sha": sha,
+                                      "parent_sha": req.get("parent_sha", ""),
+                                      "prompt_text": prompt_or_sha}})
         self.proc.stdin.write(json.dumps(req) + "\\n")
         self.proc.stdin.flush()
         for line in self.proc.stdout:
@@ -1063,7 +1090,7 @@ class Harness:
             if ev.get("type") == "error":
                 raise RuntimeError(ev["message"])
             if ev.get("type") == "score":
-                _fleet_signal("submit", {{"prompt_sha": sha, "eval_set_hash": eval_set_hash}})
+                _fleet_signal("submit", {{"prompt_sha": sha, "eval_set_hash": eval_set_hash, "niche": niche}})
                 return
         _report_error("died", f"harness closed before acking score (rc={{self.proc.poll()}})")
         raise RuntimeError("harness closed before acking score")
@@ -1226,9 +1253,11 @@ class RemoteHarness:
 
     def score(self, prompt_or_sha: str, value: float, notes: str = "",
               parent: Optional[str] = None, judge_id: str = "",
-              artifact_sha: str = "", eval_set_hash: str = "") -> None:
+              artifact_sha: str = "", eval_set_hash: str = "",
+              niche: str = "") -> None:
         """Record an evaluation score in the server-side trajectory archive —
-        same semantics (and provenance fields) as `Harness.score`."""
+        same semantics (and provenance fields) as `Harness.score`, including
+        the `niche` MAP-Elites tag and genome-send."""
         sha = prompt_or_sha if re.fullmatch(r"[0-9a-f]{{16}}", prompt_or_sha) \\
             else prompt_fingerprint(prompt_or_sha)
         req = {{"type": "score", "prompt_sha": sha, "score": value, "notes": notes}}
@@ -1241,6 +1270,14 @@ class RemoteHarness:
             req["artifact_sha"] = artifact_sha
         if eval_set_hash:
             req["eval_set_hash"] = eval_set_hash
+        if niche:
+            req["niche"] = niche
+        # Genome-send (docs §9.B): register the persona when we hold the full
+        # text + a niche so a promoted cell has a genome to serve.
+        if niche and not re.fullmatch(r"[0-9a-f]{{16}}", prompt_or_sha):
+            _fleet_signal("propose", {{"niche": niche, "prompt_sha": sha,
+                                      "parent_sha": req.get("parent_sha", ""),
+                                      "prompt_text": prompt_or_sha}})
         for ev in self._send(req):
             if ev.get("type") == "error":
                 raise RuntimeError(ev["message"])

--- a/sdk/py/harness_sdk.py
+++ b/sdk/py/harness_sdk.py
@@ -302,7 +302,8 @@ class Harness:
 
     def score(self, prompt_or_sha: str, value: float, notes: str = "",
               parent: Optional[str] = None, judge_id: str = "",
-              artifact_sha: str = "", eval_set_hash: str = "") -> None:
+              artifact_sha: str = "", eval_set_hash: str = "",
+              niche: str = "") -> None:
         """Record an evaluation score for an agent/prompt variant in the
         trajectory archive (harness.trajectory.jsonl) — the DGM evaluation
         phase writing back. `prompt_or_sha` is either the full system-prompt
@@ -315,7 +316,11 @@ class Harness:
         names the evaluator, `artifact_sha` the thing it judged, and
         `eval_set_hash` the held-out eval used — all folded into the record's
         HMAC so a forged fitness row is detectable (see `verify_score`).
-        Call between turns; blocks until the harness acks."""
+        `niche` (reviewer/researcher/implementer/skeptic, or a custom agent)
+        files the score into that MAP-Elites cell so the fleet can promote a
+        champion for the role; with the full persona text the genome also rides
+        over on a `fleet:propose`. Call between turns; blocks until the harness
+        acks."""
         assert self.proc.stdin and self.proc.stdout
         sha = prompt_or_sha if re.fullmatch(r"[0-9a-f]{16}", prompt_or_sha) \
             else prompt_fingerprint(prompt_or_sha)
@@ -329,6 +334,15 @@ class Harness:
             req["artifact_sha"] = artifact_sha
         if eval_set_hash:
             req["eval_set_hash"] = eval_set_hash
+        if niche:
+            req["niche"] = niche
+        # Genome-send (docs §9.B): a cell only promotes when a score's prompt_sha
+        # joins a stored genome, so when we hold the full persona text + a niche,
+        # register it first (deduped by prompt_sha on the collector).
+        if niche and not re.fullmatch(r"[0-9a-f]{16}", prompt_or_sha):
+            _fleet_signal("propose", {"niche": niche, "prompt_sha": sha,
+                                      "parent_sha": req.get("parent_sha", ""),
+                                      "prompt_text": prompt_or_sha})
         self.proc.stdin.write(json.dumps(req) + "\n")
         self.proc.stdin.flush()
         for line in self.proc.stdout:
@@ -342,7 +356,7 @@ class Harness:
             if ev.get("type") == "error":
                 raise RuntimeError(ev["message"])
             if ev.get("type") == "score":
-                _fleet_signal("submit", {"prompt_sha": sha, "eval_set_hash": eval_set_hash})
+                _fleet_signal("submit", {"prompt_sha": sha, "eval_set_hash": eval_set_hash, "niche": niche})
                 return
         _report_error("died", f"harness closed before acking score (rc={self.proc.poll()})")
         raise RuntimeError("harness closed before acking score")
@@ -505,9 +519,11 @@ class RemoteHarness:
 
     def score(self, prompt_or_sha: str, value: float, notes: str = "",
               parent: Optional[str] = None, judge_id: str = "",
-              artifact_sha: str = "", eval_set_hash: str = "") -> None:
+              artifact_sha: str = "", eval_set_hash: str = "",
+              niche: str = "") -> None:
         """Record an evaluation score in the server-side trajectory archive —
-        same semantics (and provenance fields) as `Harness.score`."""
+        same semantics (and provenance fields) as `Harness.score`, including
+        the `niche` MAP-Elites tag and genome-send."""
         sha = prompt_or_sha if re.fullmatch(r"[0-9a-f]{16}", prompt_or_sha) \
             else prompt_fingerprint(prompt_or_sha)
         req = {"type": "score", "prompt_sha": sha, "score": value, "notes": notes}
@@ -520,6 +536,14 @@ class RemoteHarness:
             req["artifact_sha"] = artifact_sha
         if eval_set_hash:
             req["eval_set_hash"] = eval_set_hash
+        if niche:
+            req["niche"] = niche
+        # Genome-send (docs §9.B): register the persona when we hold the full
+        # text + a niche so a promoted cell has a genome to serve.
+        if niche and not re.fullmatch(r"[0-9a-f]{16}", prompt_or_sha):
+            _fleet_signal("propose", {"niche": niche, "prompt_sha": sha,
+                                      "parent_sha": req.get("parent_sha", ""),
+                                      "prompt_text": prompt_or_sha})
         for ev in self._send(req):
             if ev.get("type") == "error":
                 raise RuntimeError(ev["message"])

--- a/sdk/ts/harness.ts
+++ b/sdk/ts/harness.ts
@@ -321,19 +321,28 @@ export class Harness {
    *  text (fingerprinted for you) or an existing 16-hex fingerprint.
    *  Pass `parent` (text or sha) when the variant was mutated from another
    *  prompt: that genome-lineage edge is what DGM parent selection counts
-   *  children with. Call between turns; resolves on the harness's ack. */
-  async score(promptOrSha: string, value: number, notes = "", parent?: string): Promise<void> {
+   *  children with. Pass `niche` (reviewer/researcher/implementer/skeptic, or
+   *  a custom agent) to file the score into that MAP-Elites cell so the fleet
+   *  can promote a champion for the role; with the full persona text the genome
+   *  also rides over on a `fleet:propose`. Call between turns; resolves on the
+   *  harness's ack. */
+  async score(promptOrSha: string, value: number, notes = "", parent?: string, niche?: string): Promise<void> {
     const sha = /^[0-9a-f]{16}$/.test(promptOrSha) ? promptOrSha : promptFingerprint(promptOrSha);
     const parent_sha = parent === undefined ? undefined
       : /^[0-9a-f]{16}$/.test(parent) ? parent : promptFingerprint(parent);
-    this.proc.stdin.write(JSON.stringify({ type: "score", prompt_sha: sha, score: value, notes, parent_sha }) + "\n");
+    // Genome-send (docs §9.B): a cell only promotes when a score's prompt_sha
+    // joins a stored genome, so when we hold the full persona text + a niche,
+    // register it first on a `fleet:propose` (deduped by prompt_sha on the
+    // collector). This is the SDK analog of the harness eval loop's propose.
+    if (niche && !/^[0-9a-f]{16}$/.test(promptOrSha)) fleetSignal("propose", { niche, prompt_sha: sha, parent_sha: parent_sha ?? "", prompt_text: promptOrSha });
+    this.proc.stdin.write(JSON.stringify({ type: "score", prompt_sha: sha, score: value, notes, parent_sha, niche }) + "\n");
     // Same edge-version tolerance as setSystemPrompt: skip unknown events
     // while waiting for the ack.
     while (true) {
       const ev = await this.next();
       if (ev === null) { reportError("died", "harness closed before acking score"); throw new Error("harness closed"); }
       if (ev.type === "error") throw new Error(ev.message);
-      if (ev.type === "score") { fleetSignal("submit", { prompt_sha: sha, parent_sha: parent_sha ?? "" }); return; }
+      if (ev.type === "score") { fleetSignal("submit", { prompt_sha: sha, parent_sha: parent_sha ?? "", niche: niche ?? "" }); return; }
     }
   }
 

--- a/sdk/ts/remote.ts
+++ b/sdk/ts/remote.ts
@@ -208,11 +208,15 @@ export class RemoteHarness {
 
   /** Record an evaluation score in the server-side trajectory archive —
    *  same semantics as the stdio SDK's `score()`. */
-  async score(promptOrSha: string, value: number, notes = "", parent?: string): Promise<void> {
+  async score(promptOrSha: string, value: number, notes = "", parent?: string, niche?: string): Promise<void> {
     const sha = HEX16.test(promptOrSha) ? promptOrSha : await promptFingerprint(promptOrSha);
     const parent_sha = parent === undefined ? undefined
       : HEX16.test(parent) ? parent : await promptFingerprint(parent);
-    for await (const ev of this.send({ type: "score", prompt_sha: sha, score: value, notes, parent_sha })) {
+    // `niche` files the score into a MAP-Elites cell so the fleet can promote a
+    // champion for the role; the remote harness reads it from the request and
+    // tags its own score/submit. (Genome capture rides the harness process,
+    // which holds the persona text the remote bridge only references by sha.)
+    for await (const ev of this.send({ type: "score", prompt_sha: sha, score: value, notes, parent_sha, niche })) {
       if (ev.type === "error") throw new Error(ev.message);
       if (ev.type === "score") return;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -316,7 +316,7 @@ const model_table = [_]ModelInfo{
     .{ .provider = "mlx", .name = "mlx-community/Qwen3.6-27B-OptiQ-4bit", .context = 262_144 },
     // LM Studio serves whatever model is loaded; "lmstudio" is a routing alias —
     // swap for your loaded model id if LM Studio requires an exact match (GET :1234/v1/models).
-    .{ .provider = "lmstudio", .name = "lmstudio", .context = 32_768 },
+    .{ .provider = "lmstudio", .name = "lmstudio", .context = 200_000 },
     .{ .provider = "anthropic", .name = "claude-fable-5", .context = 1_000_000 },
     .{ .provider = "anthropic", .name = "claude-opus-4-8", .context = 1_000_000 },
     .{ .provider = "anthropic", .name = "claude-opus-4-7", .context = 1_000_000 },

--- a/src/main.zig
+++ b/src/main.zig
@@ -5490,6 +5490,7 @@ const usage_text =
     \\  --goal <text>                   seed a standing objective (tracked as a todo checklist) for every turn
     \\  --eval <cmd>                    scoring command for an eval-driven loop (the `eval` tool runs it)
     \\  --until <0-100>                 eval-loop target score; stop when reached (default 90)
+    \\  --niche <name>                  fleet niche this eval optimizes (reviewer/researcher/implementer/skeptic or a custom agent); tags submitted scores so the DGM can promote a champion for that role
     \\  -w, --worktree <name>           isolate this session in a git worktree (.graff/worktrees/<name>) so parallel agents don't collide on files
     \\  --no-autocommit                 with -w, don't auto-commit each turn (default on; land work with `graff worktree merge`)
     \\  --yolo           skip all permission prompts for the session
@@ -5743,6 +5744,7 @@ pub fn main(init: std.process.Init) !void {
     var eval_cmd_flag: ?[]const u8 = null; // --eval: scoring command for the eval-driven loop
     var worktree_flag: ?[]const u8 = null; // --worktree/-w: isolate this session in a git worktree (parallel agents, no file collisions)
     var eval_target_flag: ?u8 = null; // --until: target score 0-100 for the eval loop
+    var eval_niche_flag: ?[]const u8 = null; // --niche: fleet niche this eval-driven session optimizes (tags submitted scores)
     var no_resume_flag = false; // start without auto-loading last.session.json
     var new_session_flag = false; // start a fresh autosaved session
     var positionals: std.ArrayList([]const u8) = .empty;
@@ -5765,6 +5767,8 @@ pub fn main(init: std.process.Init) !void {
                 } else if (std.mem.eql(u8, arg, "--until")) {
                     const uv = it.next() orelse std.process.fatal("--until needs a score 0-100", .{});
                     eval_target_flag = std.fmt.parseInt(u8, uv, 10) catch std.process.fatal("--until must be a number 0-100", .{});
+                } else if (std.mem.eql(u8, arg, "--niche")) {
+                    eval_niche_flag = it.next() orelse std.process.fatal("--niche needs a name (e.g. --niche reviewer)", .{});
                 } else if (std.mem.eql(u8, arg, "--no-telemetry")) {
                     no_telemetry_flag = true;
                 } else if (std.mem.eql(u8, arg, "--timing")) {
@@ -6361,6 +6365,7 @@ pub fn main(init: std.process.Init) !void {
     if (goal_flag) |g| root.goal = try arena.dupe(u8, g); // --goal applies to every turn (incl. --json/-p/SDK)
     if (eval_cmd_flag) |c| root.eval_cmd = try arena.dupe(u8, c);
     if (eval_target_flag) |t| root.eval_target = t;
+    if (eval_niche_flag) |n| root.eval_niche = try arena.dupe(u8, n);
     tracer.note("session", root.provider.model);
     // Distribute (docs §9.E): pull this tier's live fleet champions and prefer
     // them over the baked builtins. Best-effort + bounded; emits fleet:elite_pull.
@@ -10472,6 +10477,7 @@ const Agent = struct {
     todos: std.ArrayList(TodoItem) = .empty,
     eval_cmd: ?[]const u8 = null, // --eval: shell command that scores the current output (eval-driven loop)
     eval_target: u8 = 90, // --until: stop when the score reaches this (0-100)
+    eval_niche: []const u8 = "", // --niche: fleet niche this eval session optimizes; tags submitted scores into a promotable (niche × tier × suite) cell
     eval_judge: ?[]const u8 = null, // --judge: LLM-as-judge rubric, min()-blended with the --eval score (runJudge). Dormant until a CLI flag sets it.
     eval_iter: u32 = 0, // eval-loop iteration counter (scores log)
     eval_best: f64 = -1, // best score seen this session (-1 = none yet)
@@ -11497,18 +11503,30 @@ const Agent = struct {
         if (combined) |s| {
             if (improved and s > 0) { // s>0: skip the initial-state / total-failure 0 (don't pollute the cell mean)
                 if (g_telem) |t| {
-                    const genome_fp = promptFingerprint(self.systemPrompt());
+                    const sys = self.systemPrompt();
+                    const genome_fp = promptFingerprint(sys);
                     const esh_fp = promptFingerprint(cmd);
                     const genome: []const u8 = &genome_fp;
                     const esh: []const u8 = &esh_fp;
                     const run_id: []const u8 = &g_run_id;
                     const pclass = providerClass(self.provider.model);
+                    // --niche tags this score's cell. Without it the score lands in the
+                    // anonymous "" niche, which pullElites can never match to a builtin —
+                    // so an eval session that wants to grow a champion must name its role.
+                    const niche = self.eval_niche;
+                    // Genome-send (graff-dgm.md §B): the eval genome is this agent's own
+                    // persona, never spawned via runSub, so its prompt_text never reached
+                    // the worker. A cell only promotes when harness_scores joins to a
+                    // harness_genomes row, so ride the genome text over on a `propose`
+                    // (deduped by prompt_sha) before the score — else a winning eval cell
+                    // has nothing to serve. Gated on a niche: a "" cell is unpromotable.
+                    if (niche.len > 0) t.fleetEvent("propose", niche, genome, "", pclass, "", 0, sys);
                     const sig = signScore(genome, "", s, run_id, "", "", esh);
                     const sig_s: []const u8 = if (g_score_key != null) &sig else "";
                     var provbuf: [512]u8 = undefined;
-                    const prov = std.fmt.bufPrint(&provbuf, "{s}\t{s}\t{s}\t{s}\t{s}", .{ "", "", esh, pclass, "" }) catch "";
+                    const prov = std.fmt.bufPrint(&provbuf, "{s}\t{s}\t{s}\t{s}\t{s}", .{ "", "", esh, pclass, niche }) catch "";
                     t.scoreEvent(genome, "", s, run_id, sig_s, prov);
-                    t.fleetEvent("submit", "", genome, "", pclass, esh, 0, "");
+                    t.fleetEvent("submit", niche, genome, "", pclass, esh, 0, "");
                 }
             }
         }


### PR DESCRIPTION
## Why

The eval-driven submit path (`runEval`) and the SDK `score()` both filed scores into the anonymous `""` niche and never sent the persona text. A cell only promotes when `harness_scores` joins `harness_genomes (prompt_sha -> text)`, and `pullElites` can only override a built-in it matches by niche name. Net effect: **only the manually-seeded `reviewer` cell could ever grow a champion** — every other role permanently ran the baked built-in.

## What

**Harness**
- New `--niche <name>` flag (`Agent.eval_niche`).
- `runEval` now tags the niche on the `score` (prov 5th field) and `fleet:submit`, and emits a `fleet:propose` carrying the genome (`self.systemPrompt()`) so a winning eval cell has a persona to serve.

**SDK** (`sdk/generate.py`, regenerated ts/py)
- `score(..., niche)` tags the score request (the harness stamps its own score + submit from it) and the SDK's `fleet:submit`; given the full persona text it also emits `fleet:propose` carrying the genome (deduped by `prompt_sha`).
- stdio + python-remote send the genome; ts-remote passes `niche` through the request (the edge client is self-contained, no `fleetSignal`).

**Docs** (`docs/hyperagents.md`)
- New "Driving Propose (B) yourself" section with `--eval … --niche` and `score(niche=…)` examples; signal-table and scaffold-status fixes.

## Verification

Driven against a local OTLP capture server (near-zero API spend):
- A real `--niche reviewer` eval run emitted `propose(genome)` + niche-tagged `score` + `submit`, all sharing one `prompt_sha`.
- A Python SDK `score(niche="researcher")` emitted the SDK `propose(genome)`, and the harness subprocess stamped `niche=researcher` onto its own `score` + `submit`.

Both halves produce a promotable `(niche × tier × eval_suite)` cell with a genome the worker can serve back through `pullElites`, for any role — no per-role code.