### PR TITLE
fix: refresh --version changelog

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -5444,13 +5444,9 @@ const harness_version: []const u8 = @import("build_options").version;
 const changelog_text =
     \\What's new
     \\──────────
-    \\0.0.166
-    \\  • Trace/trajectory JSONL never corrupts on a failed write (#86)
-    \\  • Auto-compaction recovers instead of wedging on huge context (#88)
-    \\  • New providers: Sakana AI (fugu) + Fireworks AI (deepseek, kimi, glm…)
-    \\0.0.165
-    \\  • TUI: live /thinking reasoning stream, AI /title, session headers
-    \\  • GUI: /ultracode toggle, prompt-history image fix, segmented borders
+    \\0.0.187
+    \\  • Fleet eval-loop and SDK scores carry niche metadata
+    \\  • Elite selection rides the genome with niche-aware scoring
     \\
 ;
 


### PR DESCRIPTION
## Summary
- update the embedded `graff --version` / `-V` What's new text to the latest release, v0.0.187
- remove stale v0.0.166/v0.0.165 notes from the version output

## Validation
- `zig build -Dversion=0.0.187`
- `./zig-out/bin/graff -V`
- `zig build test`

Reviewed by local reviewer subagent: no findings.