### PR TITLE
feat(xai): add `graff login xai` — Grok OAuth (device-code), no API key

### DIFF
--- a/src/args.zig
+++ b/src/args.zig
@@ -35,6 +35,7 @@ pub const Flags = struct {
     refresh_flag: bool = false,
     codex_login: bool = false,
     kimi_login: bool = false,
+    xai_login: bool = false,
     help_flag: bool = false,
     version_flag: bool = false,
     print_flag: bool = false,
@@ -162,6 +163,7 @@ pub fn parse(init: std.process.Init) !Flags {
         if (flags.positionals.items.len > 0 and std.mem.eql(u8, flags.positionals.items[0], "login")) flags.login_flag = true;
         if (flags.positionals.items.len > 1 and std.mem.eql(u8, flags.positionals.items[1], "codex")) flags.codex_login = true;
         if (flags.positionals.items.len > 1 and std.mem.eql(u8, flags.positionals.items[1], "kimi")) flags.kimi_login = true;
+        if (flags.positionals.items.len > 1 and std.mem.eql(u8, flags.positionals.items[1], "xai")) flags.xai_login = true;
     }
 
     // One-shot print mode: `harness -p "prompt"` or a bare positional prompt

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -37,6 +37,7 @@ pub const usage_text =
     \\  graff login                      get a codegraff key (device-code OAuth)
     \\  graff login codex [--refresh]    ChatGPT/Codex OAuth login (PKCE)
     \\  graff login kimi                 Kimi Code OAuth login (device-code)
+    \\  graff login xai                  Grok/SuperGrok OAuth login (device-code)
     \\  graff key set <provider> <key>   store a key (macOS Keychain, else 0600 file)
     \\  graff key list                   show which providers have keys
     \\  graff models [refresh]           list the live catalog; refresh Codex + models.dev metadata

--- a/src/commands_model.zig
+++ b/src/commands_model.zig
@@ -450,6 +450,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             .{ .name = "codegraff", .desc = "free codegraff key (device-code OAuth)" },
             .{ .name = "codex", .desc = "ChatGPT / OpenAI sign-in (alias: oai)" },
             .{ .name = "kimi", .desc = "Kimi Code sign-in (device-code OAuth)" },
+            .{ .name = "xai", .desc = "Grok / SuperGrok sign-in (device-code OAuth)" },
         };
         // Bare /login: pick a provider on a TTY, else just list the options.
         if (target.len == 0) {
@@ -469,6 +470,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             std.mem.eql(u8, target, "chatgpt") or std.mem.eql(u8, target, "gpt"))
             target = "codex";
         if (std.mem.eql(u8, target, "graff")) target = "codegraff";
+        if (std.mem.eql(u8, target, "grok")) target = "xai";
 
         const home = root.home;
         try out.flush(); // hand stdout to the login flow's own writer
@@ -490,6 +492,12 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
                 try out.flush();
                 return true;
             };
+        } else if (std.mem.eql(u8, target, "xai")) {
+            oauth.xaiLogin(root.io, root.gpa, arena, home) catch |err| {
+                try out.print("\xe2\x9c\x97 xai login failed: {t}\n", .{err});
+                try out.flush();
+                return true;
+            };
         } else {
             // A pure API-key provider, or something unrecognized.
             for (provider_specs) |spec| if (std.mem.eql(u8, spec.id, target)) {
@@ -497,7 +505,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
                 try out.flush();
                 return true;
             };
-            try out.print("can't log into '{s}' \xe2\x80\x94 try /login codegraff | codex | kimi (others: /key <provider> <key>)\n", .{target});
+            try out.print("can't log into '{s}' \xe2\x80\x94 try /login codegraff | codex | kimi | xai (others: /key <provider> <key>)\n", .{target});
             try out.flush();
             return true;
         }

--- a/src/oauth.zig
+++ b/src/oauth.zig
@@ -416,6 +416,150 @@ fn fetchKimiModel(io: Io, gpa: Allocator, arena: Allocator, access: []const u8) 
     return null;
 }
 
+// xAI (Grok) OAuth — device-code flow against auth.x.ai. The OIDC discovery
+// doc (auth.x.ai/.well-known/openid-configuration) advertises the device_code
+// grant + a public ("none") client, so no secret/PKCE is needed. `graff login
+// xai` runs the flow and writes the token to ~/.xai/credentials/graff-oauth.json;
+// loadXaiOAuth reads it at startup and refreshes near expiry. The access token
+// is sent as a plain bearer to the existing xai provider row
+// (api.x.ai/v1/chat/completions, kind=.openai). client_id is xAI's shared Grok
+// CLI client — the consent screen shows "Grok Build" — same posture as the
+// Codex/Kimi logins. NOTE: xAI gates api.x.ai per account, so a valid login can
+// still 403 on inference until the account is allowlisted (env XAI_API_KEY wins
+// and always works). User-Agent is set on all requests (Cloudflare-fronted).
+const xai_oauth_host = "https://auth.x.ai";
+const xai_device_auth_url = xai_oauth_host ++ "/oauth2/device/code";
+const xai_token_url = xai_oauth_host ++ "/oauth2/token";
+const xai_client_id = "b1a00492-073a-47ea-816f-4c329264a828";
+const xai_scope = "openid profile email offline_access grok-cli:access api:access";
+const xai_user_agent = "grok-cli/1.0";
+
+/// POST a form body to an xAI OAuth endpoint (with a CLI User-Agent); return the
+/// parsed JSON object.
+fn xaiOAuthPost(io: Io, gpa: Allocator, arena: Allocator, url: []const u8, body: []const u8) !std.json.ObjectMap {
+    var client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer client.deinit();
+    var aw: Io.Writer.Allocating = .init(arena);
+    _ = try client.fetch(.{
+        .location = .{ .url = url },
+        .method = .POST,
+        .payload = body,
+        .response_writer = &aw.writer,
+        .headers = .{
+            .content_type = .{ .override = "application/x-www-form-urlencoded" },
+            .user_agent = .{ .override = xai_user_agent },
+        },
+    });
+    const v = try std.json.parseFromSliceLeaky(Value, arena, aw.writer.buffered(), .{ .allocate = .alloc_always });
+    if (v != .object) return error.BadOAuthResponse;
+    return v.object;
+}
+
+fn xaiAuthPath(arena: Allocator, home: []const u8) []const u8 {
+    return std.fmt.allocPrint(arena, "{s}/.xai/credentials/graff-oauth.json", .{home}) catch "";
+}
+
+fn writeXaiAuth(io: Io, arena: Allocator, home: []const u8, access: []const u8, refresh: []const u8, expires_at: i64) !void {
+    Io.Dir.cwd().createDir(io, try std.fmt.allocPrint(arena, "{s}/.xai", .{home}), .default_dir) catch {};
+    Io.Dir.cwd().createDir(io, try std.fmt.allocPrint(arena, "{s}/.xai/credentials", .{home}), .default_dir) catch {};
+    var obj: std.json.ObjectMap = .empty;
+    try obj.put(arena, "access_token", .{ .string = access });
+    try obj.put(arena, "refresh_token", .{ .string = refresh });
+    try obj.put(arena, "expires_at", .{ .integer = expires_at });
+    var aw: Io.Writer.Allocating = .init(arena);
+    var st: std.json.Stringify = .{ .writer = &aw.writer };
+    try st.write(Value{ .object = obj });
+    const f = try Io.Dir.cwd().createFile(io, xaiAuthPath(arena, home), .{});
+    defer f.close(io);
+    var wbuf: [4096]u8 = undefined;
+    var fw = f.writer(io, &wbuf);
+    try fw.interface.writeAll(aw.writer.buffered());
+    try fw.interface.flush();
+}
+
+/// `graff login xai`: xAI/Grok device-code OAuth. Prints a verification URL +
+/// user code, opens the browser, polls until the user authorizes, then stores
+/// the access/refresh token. (The consent screen shows "Grok Build" — xAI's
+/// shared CLI client.)
+pub fn xaiLogin(io: Io, gpa: Allocator, arena: Allocator, home: []const u8) !void {
+    var obuf: [4096]u8 = undefined;
+    var ow = Io.File.stdout().writer(io, &obuf);
+    const out = &ow.interface;
+
+    const da_body = try std.fmt.allocPrint(arena, "client_id={s}&scope={s}", .{ xai_client_id, xai_scope });
+    const da = xaiOAuthPost(io, gpa, arena, xai_device_auth_url, da_body) catch |err| {
+        try out.print("✗ xAI device authorization failed: {t}\n", .{err});
+        try out.flush();
+        return;
+    };
+    if (da.get("error")) |e| {
+        try out.print("✗ {s}\n", .{if (e == .string) e.string else "device authorization error"});
+        try out.flush();
+        return;
+    }
+    const device_code = strFieldObj(da, "device_code") orelse return error.BadOAuthResponse;
+    const user_code = strFieldObj(da, "user_code") orelse "";
+    const verify = strFieldObj(da, "verification_uri_complete") orelse strFieldObj(da, "verification_uri") orelse "";
+    const interval: i64 = if (da.get("interval")) |iv| (if (iv == .integer) @max(iv.integer, 1) else 5) else 5;
+
+    try out.print("\nTo log in to Grok (xAI), open this URL (browser should open automatically):\n\n  {s}\n\nand confirm the code:  {s}\n\nwaiting for authorization…\n", .{ verify, user_code });
+    try out.flush();
+    openBrowser(io, verify);
+
+    const poll_body = try std.fmt.allocPrint(arena, "client_id={s}&device_code={s}&grant_type=urn:ietf:params:oauth:grant-type:device_code", .{ xai_client_id, device_code });
+    var attempts: usize = 0;
+    while (attempts < 360) : (attempts += 1) {
+        io.sleep(Io.Duration.fromSeconds(interval), .awake) catch {};
+        const resp = xaiOAuthPost(io, gpa, arena, xai_token_url, poll_body) catch continue;
+        if (resp.get("access_token")) |a| if (a == .string and a.string.len > 0) {
+            const refresh = strFieldObj(resp, "refresh_token") orelse "";
+            const expires_in: i64 = if (resp.get("expires_in")) |ei| (if (ei == .integer) ei.integer else 3600) else 3600;
+            try writeXaiAuth(io, arena, home, a.string, refresh, @divTrunc(unixMs(io), 1000) + expires_in);
+            try out.print("✓ logged into Grok (xAI) — wrote {s}. /model xai grok-4.3\n", .{xaiAuthPath(arena, home)});
+            try out.writeAll("  note: xAI gates its OpenAI-compatible API per account — if a Grok turn 403s, your account isn't allowlisted for api.x.ai yet.\n");
+            try out.flush();
+            return;
+        };
+        const msg = if (resp.get("error")) |e| (if (e == .string) e.string else "") else "";
+        if (std.mem.eql(u8, msg, "authorization_pending") or std.mem.eql(u8, msg, "slow_down")) continue;
+        if (std.mem.eql(u8, msg, "expired_token")) {
+            try out.writeAll("✗ the code expired — run `graff login xai` again\n");
+            try out.flush();
+            return;
+        }
+        if (msg.len > 0) {
+            try out.print("✗ {s}\n", .{msg});
+            try out.flush();
+            return;
+        }
+    }
+    try out.writeAll("✗ timed out waiting for authorization\n");
+    try out.flush();
+}
+
+/// Reads the stored xAI OAuth access token, refreshing in place near expiry.
+/// Returns null if not logged in. Mirrors loadKimiOAuth.
+pub fn loadXaiOAuth(io: Io, gpa: Allocator, arena: Allocator, home: []const u8) ?[]const u8 {
+    const data = Io.Dir.cwd().readFileAlloc(io, xaiAuthPath(arena, home), arena, .limited(64 * 1024)) catch return null;
+    const v = std.json.parseFromSliceLeaky(Value, arena, data, .{ .allocate = .alloc_always }) catch return null;
+    if (v != .object) return null;
+    const access = strFieldObj(v.object, "access_token") orelse return null;
+    const expires_at: i64 = if (v.object.get("expires_at")) |e| (if (e == .integer) e.integer else 0) else 0;
+    if (expires_at != 0 and @divTrunc(unixMs(io), 1000) >= expires_at - 60) {
+        if (strFieldObj(v.object, "refresh_token")) |refresh| {
+            const body = std.fmt.allocPrint(arena, "client_id={s}&grant_type=refresh_token&refresh_token={s}", .{ xai_client_id, refresh }) catch return access;
+            const resp = xaiOAuthPost(io, gpa, arena, xai_token_url, body) catch return access;
+            if (resp.get("access_token")) |a| if (a == .string and a.string.len > 0) {
+                const new_refresh = strFieldObj(resp, "refresh_token") orelse refresh;
+                const expires_in: i64 = if (resp.get("expires_in")) |ei| (if (ei == .integer) ei.integer else 3600) else 3600;
+                writeXaiAuth(io, arena, home, a.string, new_refresh, @divTrunc(unixMs(io), 1000) + expires_in) catch {};
+                return a.string;
+            };
+        }
+    }
+    return access;
+}
+
 // Codegraff device-code login — mirrors graff's CodegraffDeviceStrategy: POST
 // /v1/device/start → show verification_uri + user_code → poll /v1/device/poll
 // until status "ok" yields the cg_sk_ key, written to ~/<codegraff_key_file>.

--- a/src/pickers.zig
+++ b/src/pickers.zig
@@ -484,6 +484,11 @@ pub fn reloadLoginKey(root: *Agent, keys: *Keys, arena: Allocator, provider_id: 
                 value.* = k;
                 source.* = .login;
             }
+        } else if (std.mem.eql(u8, provider_id, "xai")) {
+            if (oauth.loadXaiOAuth(root.io, root.gpa, arena, home)) |k| {
+                value.* = k;
+                source.* = .login;
+            }
         } else if (std.mem.eql(u8, provider_id, "codex")) {
             if (oauth.loadCodexAuth(root.io, arena, home)) |auth| {
                 value.* = auth.token;
@@ -543,7 +548,7 @@ pub fn offerProviderAuth(root: *Agent, keys: *Keys, arena: Allocator, out: *Io.W
         try out.flush();
         return;
     };
-    const can_login = std.mem.eql(u8, pid, "codegraff") or std.mem.eql(u8, pid, "codex") or std.mem.eql(u8, pid, "kimi");
+    const can_login = std.mem.eql(u8, pid, "codegraff") or std.mem.eql(u8, pid, "codex") or std.mem.eql(u8, pid, "kimi") or std.mem.eql(u8, pid, "xai");
 
     // Non-interactive (one-shot / no TTY): no picker — print the hint and bail.
     if (!main_mod.use_color or root.in == null) {
@@ -599,6 +604,12 @@ pub fn offerProviderAuth(root: *Agent, keys: *Keys, arena: Allocator, out: *Io.W
         } else if (std.mem.eql(u8, pid, "kimi")) {
             oauth.kimiLogin(root.io, root.gpa, arena, home) catch |err| {
                 try out.print("\xe2\x9c\x97 kimi login failed: {t}\n", .{err});
+                try out.flush();
+                return;
+            };
+        } else if (std.mem.eql(u8, pid, "xai")) {
+            oauth.xaiLogin(root.io, root.gpa, arena, home) catch |err| {
+                try out.print("\xe2\x9c\x97 xai login failed: {t}\n", .{err});
                 try out.flush();
                 return;
             };

--- a/src/startup.zig
+++ b/src/startup.zig
@@ -100,6 +100,12 @@ pub fn resolveKeys(io: Io, gpa: Allocator, arena: Allocator, environ_map: anytyp
                     source.* = .login;
                 }
             }
+            if (std.mem.eql(u8, spec.id, "xai") and value.* == null) {
+                if (oauth.loadXaiOAuth(io, gpa, arena, home)) |key| {
+                    value.* = key;
+                    source.* = .login;
+                }
+            }
         }
     }
     // Stored keys (macOS Keychain / 0600 file via `harness key set`): fill any
@@ -290,7 +296,7 @@ pub fn runSubcommand(io: Io, gpa: Allocator, arena: Allocator, init: std.process
     // `codex` (or --refresh) runs the ChatGPT PKCE/refresh flow → ~/.codex/auth.json.
     if (flags.login_flag) {
         const home = keys_cli.homeEnv(init.environ_map) orelse std.process.fatal("no HOME/USERPROFILE", .{});
-        if (flags.kimi_login) try oauth.kimiLogin(io, gpa, arena, home) else if (flags.codex_login or flags.refresh_flag) try oauth.codexLogin(io, gpa, arena, home, flags.refresh_flag) else try oauth.codegraffLogin(io, gpa, arena, home);
+        if (flags.xai_login) try oauth.xaiLogin(io, gpa, arena, home) else if (flags.kimi_login) try oauth.kimiLogin(io, gpa, arena, home) else if (flags.codex_login or flags.refresh_flag) try oauth.codexLogin(io, gpa, arena, home, flags.refresh_flag) else try oauth.codegraffLogin(io, gpa, arena, home);
         return true;
     }
 


### PR DESCRIPTION
Adds `graff login xai` — sign into Grok via x.ai's OAuth, no `XAI_API_KEY` to paste (the way [openclaw](https://deepwiki.com/openclaw/openclaw) does it).

## Why it's feasible
x.ai exposes a **real, public device-code OAuth server** — `auth.x.ai/.well-known/openid-configuration` advertises the `urn:ietf:params:oauth:grant-type:device_code` grant and a public (`none`) client. So codegraff can mirror its existing **Kimi device-code flow** exactly; no PKCE/secret needed.

## What's added
- **`oauth.zig`**: `xaiLogin` (POST `auth.x.ai/oauth2/device/code` → show `verification_uri` + `user_code` → open browser → poll `auth.x.ai/oauth2/token`) and `loadXaiOAuth` (reads `~/.xai/credentials/graff-oauth.json`, refreshes in place near expiry). `client_id` is xAI's shared Grok CLI client (consent screen shows **"Grok Build"**) — the same posture as the existing Codex/Kimi logins. A CLI `User-Agent` is sent on all requests (Cloudflare-fronted host).
- **Wiring** mirrors kimi: `args.zig` (`login xai` flag), `startup.zig` (dispatch + startup token loader), `commands_model.zig` (`/login xai` + `grok` alias), `pickers.zig` (`/model xai` offer-to-login + live reload), `cli.zig` (help).
- **`provider.zig` unchanged**: the OAuth access token flows into the existing `xai` row (`kind=.openai`, `api.x.ai/v1/chat/completions`) as the bearer. `XAI_API_KEY` still wins if set.

## Verified live
- `graff login xai` → device-code flow → browser authorize → wrote the credential.
- A **`grok-4.3` turn streamed a real reply** via the OAuth token — **no 403** on this account.
- `zig build` · `zig build test` **150/150** · `zig fmt` clean.

## Caveat
xAI **gates `api.x.ai` per account** (same shape as the gpt-5.6 codex entitlement rollout). It worked on my account, but a different account may complete login and still 403 on inference until allowlisted — the login prints a note to that effect. `client_id` is reverse-engineered (consistent with the codex/kimi logins already shipped); xAI could rotate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
