### PR TITLE
fix(http): pre-warm CA bundle to stop concurrent-subagent TLS races (#131)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -18,6 +18,19 @@
 //! as the conversation grows.
 const std = @import("std");
 const Io = std.Io;
+
+/// #131: pre-load the shared HTTP client's CA bundle single-threaded, so the
+/// parallel subagents that share this client (on pool threads) never race the
+/// lazy CA-bundle rescan on their first concurrent HTTPS connect. Zig std flags
+/// that race itself ("TODO data race here on ca_bundle"): when two threads both
+/// rescan+swap+deinit the bundle, a handshake reading it mid-swap fails instantly
+/// with error.TlsInitializationFailed (ms=0, resp_bytes=0 — see #131). Warming it
+/// here sets client.now, so every later connect skips the rescan entirely.
+fn prewarmCaBundle(client: *std.http.Client, gpa: std.mem.Allocator, io: Io) void {
+    const now = Io.Clock.real.now(io);
+    client.ca_bundle.rescan(gpa, io, now) catch return;
+    client.now = now;
+}
 const Value = std.json.Value;
 const Allocator = std.mem.Allocator;
 const mcp = @import("mcp.zig");
@@ -241,6 +254,7 @@ pub fn main(init: std.process.Init) !void {
     const codex_account = resolved_keys.codex_account;
     var client: std.http.Client = .{ .allocator = gpa, .io = io };
     defer client.deinit();
+    prewarmCaBundle(&client, gpa, io);
     var stdin_buf: [64 * 1024]u8 = undefined;
     var stdin_reader = Io.File.stdin().reader(io, &stdin_buf);
     const in = &stdin_reader.interface;
@@ -569,6 +583,7 @@ test "/bash slash command runs the bash tool and frees its gpa-allocated result"
 
     var client: std.http.Client = .{ .allocator = gpa, .io = io };
     defer client.deinit();
+    prewarmCaBundle(&client, gpa, io);
 
     var root: Agent = .{
         .gpa = gpa,


### PR DESCRIPTION
Closes #131.

## Root cause — a CA-bundle data race in `std.http.Client`, triggered by concurrent subagents
Her evidence: 4 **gpt-5.5 subagent** calls failed with `is_error:true, ms:0, resp_bytes:0`; #132 names the actual error — `network error: TlsInitializationFailed (gave up after 6 attempts)`. `ms:0` = failure at the transport layer *before any network round-trip*, and it only happens on **concurrent** subagent calls, never the sequential main agent.

Parallel subagents (workflow/judge) share **one** `std.http.Client` across pool threads (`subagent.zig` `.client = ctx.client`; `http.zig` even notes it *assumes* `fetch` is thread-safe). On the first HTTPS connect, `std.http.Client` **lazily rescans** the CA bundle:

```zig
// std/http/Client.zig
if (client.now != null) break :tls;      // skip once loaded
… bundle.rescan(...);
client.now = now;
std.mem.swap(&client.ca_bundle, &bundle); // defer bundle.deinit() frees the old one
```
and the TLS handshake reads `&client.ca_bundle`:
```zig
// TODO data race here on ca_bundle          ← Zig std's own comment
.client = std.crypto.tls.Client.init(…, .ca = .{ .bundle = .{ .bundle = &client.ca_bundle, … } }, .realtime_now = client.now.?, …)
```
When several pool threads make their first HTTPS connect **simultaneously** on a cold client, two both see `client.now == null` and both rescan → `swap` → `deinit`. One thread's swap/deinit yanks the bundle another thread is mid-handshake with → instant `error.TlsInitializationFailed`. Once `client.now` is set the path is skipped, so it only bites the first concurrent burst — exactly the intermittent subagent failures she saw.

## Fix
`prewarmCaBundle()` loads the bundle **single-threaded** right after each client is created (session + oneshot paths), setting `client.now`. Every later connect — including all concurrent subagents — then skips the rescan and just reads the stable, immutable bundle. No race window, regardless of which client the subagents share.

## Verified
`zig build` · `zig build test` **152/152** · a normal HTTPS turn still works (the pre-warm is transparent).

## Related
#132/#134 (the stall/drop-mislabeled-as-Esc issues) are a *separate* path already addressed by the #133/#134 stream work; this PR is only the `TlsInitializationFailed` root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
