### PR TITLE
feat(repl): /goal <objective> starts the loop immediately (like codex/opencode)

### DIFF
--- a/src/commands_session.zig
+++ b/src/commands_session.zig
@@ -110,7 +110,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         } else {
             root.goal = try arena.dupe(u8, text);
             saveSession(root, arena, root.session_name) catch {};
-            try out.print("Goal set: {s}\nI'll track it as a live checklist (todo_write) and work through it across turns.\n", .{text});
+            try out.print("\xf0\x9f\x8e\xaf Goal set: {s} \xe2\x80\x94 starting now (tracked as a live checklist; it steers every turn until /goal clear).\n", .{text});
         }
         try out.flush();
         return true;

--- a/src/mainloop.zig
+++ b/src/mainloop.zig
@@ -112,12 +112,20 @@ pub fn run(ctx: *Ctx) !void {
             std.mem.trim(u8, line["/loop".len..], " \t")
         else
             null;
+        // /goal <objective>: set the standing goal AND run it as the first turn
+        // right away — codex/opencode both start the loop on a goal instead of
+        // just recording it. Bare /goal (show) and /goal clear/off stay commands.
+        const goal_prompt: ?[]const u8 = if (!main_mod.json_mode and std.mem.startsWith(u8, line, "/goal ")) gblk: {
+            const g = std.mem.trim(u8, line["/goal".len..], " \t");
+            if (g.len == 0 or std.ascii.eqlIgnoreCase(g, "clear") or std.ascii.eqlIgnoreCase(g, "off")) break :gblk null;
+            break :gblk g;
+        } else null;
         if (!main_mod.json_mode) {
             const l = if (line.len > 0 and line[0] == '/') line[1..] else line;
             if (std.mem.eql(u8, l, "exit") or std.mem.eql(u8, l, "quit") or std.mem.eql(u8, l, "q")) break;
         }
 
-        if (!main_mod.json_mode and repl_glue.isSlashCommandLine(line) and loop_prompt == null) {
+        if (!main_mod.json_mode and repl_glue.isSlashCommandLine(line) and loop_prompt == null and goal_prompt == null) {
             // Bare "/" on a TTY: open the filterable command menu.
             if (ctx.interactive and line.len == 1) {
                 if (pickers.listPicker(ctx.root, ctx.arena, ctx.out, "Command ›", &pickers.command_menu)) |idx| {
@@ -129,6 +137,10 @@ pub fn run(ctx: *Ctx) !void {
             continue;
         }
 
+        // /goal <objective>: apply the goal (handleCommand sets root.goal, saves,
+        // and prints), then fall through to run a turn on it immediately.
+        if (goal_prompt != null) try main_mod.handleCommand(ctx.root, ctx.keys, ctx.arena, line, ctx.out);
+
         // The user message for this turn. In --json mode each input line is a
         // {"type":"user","text":"..."} request; {"type":"set_system_prompt",
         // "text":"...","append":bool} mutates the root system prompt between
@@ -137,7 +149,7 @@ pub fn run(ctx: *Ctx) !void {
         // {"type":"score","prompt_sha":"...","score":0.7,"notes":"..."}
         // appends an evaluation record for an agent variant to the
         // trajectory archive (the DGM evaluation phase writing back).
-        const base_msg: []const u8 = if (loop_prompt) |lp| lp else if (main_mod.json_mode) blk: {
+        const base_msg: []const u8 = if (loop_prompt) |lp| lp else if (goal_prompt) |gp| gp else if (main_mod.json_mode) blk: {
             const parsed = std.json.parseFromSliceLeaky(Value, ctx.arena, line, .{ .allocate = .alloc_always }) catch {
                 ctx.root.emit(.{ .type = "error", .message = "invalid JSON (expect {\"type\":\"user\",\"text\":\"...\"})" });
                 continue;


### PR DESCRIPTION
`/goal <text>` used to just record a standing objective and return to the prompt — you had to type again to make anything happen. Per how **codex** (task → `Op::UserTurn` → `run_turn`, GoalExtension steers each turn) and **opencode** (`SessionPrompt.loop`) work, a goal should *start the loop immediately*.

Now `/goal <objective>` **sets the goal and runs it as the first turn right away** (the goal still persists + steers every later turn until `/goal clear`). Bare `/goal` (show) and `/goal clear|off` stay pure commands. Mirrors the existing `/loop <prompt>` immediate-run path in the mainloop.

**Verified:** `zig build` · **152/152** · live — `/goal reply with one word: started` → "🎯 Goal set … starting now" → runs the turn → replies; show/clear run no turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)