### PR TITLE
fix(tui): AI session title survives an interrupted/stalled/dropped/errored turn

### DIFF
--- a/src/mainloop.zig
+++ b/src/mainloop.zig
@@ -76,6 +76,24 @@ pub const Ctx = struct {
     sys_strict: []const u8,
 };
 
+/// Apply the backgrounded AI session title (titleTask) to the redrawable
+/// window title + saved session filename. Called from BOTH the happy-path
+/// post-turn step and the end-of-iteration `defer`, so an interrupted /
+/// stalled / dropped / errored turn — which `continue`s before the post-turn
+/// step — still lands the title instead of generating it then throwing it away
+/// (ai_title_done is already set, so it would otherwise never regenerate and
+/// the window title stays stuck on the prompt-derived fallback). Awaits once.
+fn applyAiTitle(ctx: *Ctx, f: *Io.Future(?[]const u8)) void {
+    if (f.await(ctx.io)) |t| {
+        ctx.root.session_title = ctx.arena.dupe(u8, t) catch null;
+        ctx.gpa.free(t);
+        if (ctx.root.session_title) |st| {
+            title_mod.setTerminalTitle(ctx.out, st, main_mod.g_cwd_display);
+            session.renameSession(ctx.root, ctx.arena, session.slugifyTitle(ctx.arena, st));
+        }
+    }
+}
+
 /// The interactive-REPL / --json-protocol turn loop itself. Runs until EOF,
 /// `exit`/`quit`/`q`, or a plain `break` out of the raw-line read. main()
 /// resumes right after this returns and does its own final-save/worktree
@@ -387,15 +405,17 @@ pub fn run(ctx: *Ctx) !void {
         vision.stageGuiImageAttachment(ctx.root, msg);
 
         // Generate the AI tab-title concurrently (io.async), spawned BEFORE the
-        // header so the first-turn header can wait for the summary title; reaped
-        // after the turn (below) or by this defer on an early bail-out.
+        // header so the first-turn header can wait for the summary title. Applied
+        // after the turn on the happy path (below); the defer is the fallback for
+        // an interrupted/stalled/dropped/errored turn (those `continue` before the
+        // apply step) so the generated title is never silently discarded.
         var title_fut: ?Io.Future(?[]const u8) = null;
         if (!main_mod.json_mode and ctx.root.ai_title and !ctx.root.ai_title_done) {
             ctx.root.ai_title_done = true;
             title_fut = ctx.io.async(title_mod.titleTask, .{ ctx.gpa, ctx.io, ctx.root.client, ctx.root.provider, base_msg });
         }
         defer if (title_fut) |*f| {
-            _ = f.await(ctx.io);
+            applyAiTitle(ctx, f);
         };
 
         // TUI/session header: once the first real prompt materializes the chat,
@@ -597,14 +617,7 @@ pub fn run(ctx: *Ctx) !void {
         // the fast prompt title; the summary now lands on the redrawable window title
         // and the saved session filename. Usually already resolved by here.
         if (title_fut) |*f| {
-            if (f.await(ctx.io)) |t| {
-                ctx.root.session_title = ctx.arena.dupe(u8, t) catch null;
-                ctx.gpa.free(t);
-                if (ctx.root.session_title) |st| {
-                    title_mod.setTerminalTitle(ctx.out, st, main_mod.g_cwd_display);
-                    session.renameSession(ctx.root, ctx.arena, session.slugifyTitle(ctx.arena, st));
-                }
-            }
+            applyAiTitle(ctx, f);
             title_fut = null;
         }
         fleet.joinElites(ctx.io); // publish backgrounded fleet champions for the next turn (no-op once joined)


### PR DESCRIPTION
## Problem

The backgrounded AI tab/window title (`titleTask`, spawned via `io.async` in `mainloop.zig`) was only applied on a **cleanly-completed** turn — the post-turn step at `mainloop.zig:599`. But every error path in the turn handler ends in `continue`:

- `error.Interrupted` (Esc), `error.StreamStalled` (#134), `error.StreamDropped` (#133), `error.ApiError`, and the catch-all `else`

…each of which `continue`s **before** line 599. Meanwhile:

1. `ai_title_done` is set `true` the moment the titler is *spawned* (`mainloop.zig:394`), before the turn runs.
2. The end-of-iteration `defer` awaited the future but **discarded** the result (`_ = f.await(ctx.io)`).

So on any interrupted/stalled/dropped/errored turn, the AI title was computed and thrown away, and because `ai_title_done` was already set it never regenerated. A session whose **first** turn stalled/dropped stayed stuck on the raw prompt-derived fallback title for its entire lifetime.

This is the user-visible "why isn't the async header updating" symptom — and it's amplified by the very stream-drop/stall issues in #132/#133/#134.

## Fix

Factor the apply into `applyAiTitle(ctx, f)` and call it from **both**:
- the happy-path post-turn step (which then nulls the future, so the defer no-ops), and
- the `defer` (which now *applies* the result instead of discarding it).

The title lands **exactly once** regardless of how the turn ends.

## Verification

Built with Zig 0.16.0, codesigned, driven in a real PTY against the live gateway:

| Scenario | Result |
|---|---|
| First turn **force-stalled** (`GRAFF_FORCE_STALL_ONCE`) | window title updates `please refactor the database connection pooling logic` → `refactoring the database connection pooling logic` (AI summary lands despite the stall) ✅ |
| Normal turn | `reply with exactly: ok` → `ok`, applied once, no double-emit ✅ |

`zig build test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)