### PR TITLE
fix(#129): one submit can't flush as N steer-queue entries

### DIFF
--- a/src/agent_interrupt.zig
+++ b/src/agent_interrupt.zig
@@ -117,9 +117,19 @@ pub fn escPressed(echo: bool) bool {
             if (main_mod.g_steer_buf.items.len > 0) {
                 // Flush the typed line to the queue as a regular
                 // follow-up (runs after the current turn finishes).
+                // Under steerLock so concurrent drainers serialize; skip an empty
+                // flush (another arm drained it first) or one byte-identical to the
+                // tail, so one submit can't enqueue as N copies each re-steered with
+                // its own harness note (#129).
+                repl_glue.steerLock();
                 if (main_mod.g_steer_buf.toOwnedSlice(std.heap.page_allocator)) |dup| {
-                    main_mod.g_steer_queue.append(std.heap.page_allocator, .{ .text = dup, .force = false }) catch std.heap.page_allocator.free(dup);
+                    if (repl_glue.steerFlushRedundant(main_mod.g_steer_queue.items, dup)) {
+                        std.heap.page_allocator.free(dup);
+                    } else {
+                        main_mod.g_steer_queue.append(std.heap.page_allocator, .{ .text = dup, .force = false }) catch std.heap.page_allocator.free(dup);
+                    }
                 } else |_| main_mod.g_steer_buf.clearRetainingCapacity();
+                repl_glue.steerUnlock();
                 if (echo and main_mod.g_steer_echoed) {
                     var qbuf: [64]u8 = undefined;
                     const qmsg = std.fmt.bufPrint(&qbuf, "  \x1b[2m[queued · {d} waiting]\x1b[0m\n", .{main_mod.g_steer_queue.items.len}) catch "\n";

--- a/src/main.zig
+++ b/src/main.zig
@@ -206,6 +206,7 @@ const SteerEntry = repl_glue.SteerEntry; // struct { text: []const u8, force: bo
 pub var g_steer_queue: std.ArrayList(SteerEntry) = .empty; // completed lines
 pub var g_steer_echoed = false; // "↳ steer ›" prefix shown for the current line
 pub var g_steer_visible: std.atomic.Value(bool) = .init(false); // visible live steering row; pauses spinner redraws
+pub var g_steer_lock: std.atomic.Value(bool) = .init(false); // spin-guards g_steer_queue/g_steer_buf mutations across concurrent drainers (main reader + pool esc-watch/watchdog arms) so one submit never flushes as N entries (#129); acquire via repl_glue.steerLock
 pub var g_out: ?*Io.Writer = null; // stdout writer for steer echo (set in main)
 pub var g_gui_mu: Io.Mutex = .init; // serializes --json stdout across pool-thread subagent emits (guiEmit + printDelta)
 pub var g_force_interrupt = false; // Force-prompt path caused the last interrupt (Ctrl-F/double-enter).

--- a/src/repl_glue.zig
+++ b/src/repl_glue.zig
@@ -284,8 +284,44 @@ pub fn replCancelCb(ctx_ptr: ?*anyopaque) void {
 
 pub const SteerEntry = struct { text: []const u8, force: bool };
 
+/// Spin-lock guarding g_steer_buf/g_steer_queue mutations. The concurrent steer
+/// drainers (the main reader + pool esc-watch/watchdog arms, #129) hold it only
+/// for the tiny queue/buffer critical sections — never across a stdin read/poll
+/// — so it stays uncontended and needs no Io handle (unlike the Io.Mutex used
+/// elsewhere, which the io-less escPressed cannot reach).
+pub fn steerLock() void {
+    while (main_mod.g_steer_lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) std.atomic.spinLoopHint();
+}
+pub fn steerUnlock() void {
+    main_mod.g_steer_lock.store(false, .release);
+}
+
+/// #129: a completed steer line should be DROPPED (not queued) when it is empty
+/// (another drainer emptied the buffer first) or byte-identical to the entry
+/// already at the tail of the queue — exactly the shape a racing double-flush or
+/// a paste burst produces, which is what enqueued one submit as N re-steered
+/// copies. Pure so it can be unit-tested away from the io-bound escPressed.
+pub fn steerFlushRedundant(queue: []const SteerEntry, text: []const u8) bool {
+    return text.len == 0 or (queue.len > 0 and std.mem.eql(u8, queue[queue.len - 1].text, text));
+}
+
+test "steerFlushRedundant drops empty + consecutive-identical flushes (#129)" {
+    const E = SteerEntry;
+    const none: []const E = &.{};
+    try std.testing.expect(steerFlushRedundant(none, "")); // empty flush
+    try std.testing.expect(!steerFlushRedundant(none, "hello")); // first real line queues
+    const one = [_]E{.{ .text = "hello", .force = false }};
+    try std.testing.expect(steerFlushRedundant(&one, "hello")); // identical to tail -> drop
+    try std.testing.expect(!steerFlushRedundant(&one, "hello world")); // different -> queue
+    const two = [_]E{ .{ .text = "a", .force = false }, .{ .text = "b", .force = false } };
+    try std.testing.expect(steerFlushRedundant(&two, "b")); // identical to TAIL -> drop
+    try std.testing.expect(!steerFlushRedundant(&two, "a")); // matches head not tail -> queue
+}
+
 /// Pops the next queued steering prompt (FIFO), or null if none.
 pub fn popSteer() ?SteerEntry {
+    steerLock();
+    defer steerUnlock();
     if (main_mod.g_steer_queue.items.len == 0) return null;
     return main_mod.g_steer_queue.orderedRemove(0);
 }
@@ -294,6 +330,8 @@ pub fn popSteer() ?SteerEntry {
 /// of each REPL iteration so a partial mid-turn draft never leaks into the
 /// next prompt.
 pub fn resetSteerPartial() void {
+    steerLock();
+    defer steerUnlock();
     main_mod.g_steer_buf.clearRetainingCapacity();
     main_mod.g_steer_echoed = false;
     main_mod.g_steer_visible.store(false, .release);


### PR DESCRIPTION
Fixes #129.

## Root cause

During a streaming turn the steering drainer `escPressed` runs from **several places concurrently** — the main SSE read loop (`agent_stream.zig:231`), the ws loop (`agent_ws.zig:129`), the head/stall **watchdog arms** (`http.zig:250,268`), and the pool **esc-watch task** — all mutating `g_steer_buf`/`g_steer_queue` with **no synchronization**. The globals' own comment says it: *"watchdog/select arms may drain/echo stdin while the stream reader is blocked."*

In an `ultracode` session (many subagents streaming at once) those racing drainers could flush one typed submit as **several byte-identical queue entries**. Each is later popped and re-steered into its own user turn — and `applyUltracodeSteering` appends a `[harness note: ultracode…]` suffix to each — which is exactly the "~8× duplicated message, each with its own harness note" reported in #129.

## Fix

Two cheap guards:

1. **Serialize the drainers.** A tiny atomic spin-lock (`g_steer_lock` + `repl_glue.steerLock`/`steerUnlock`) held only across the queue/buffer critical section — never across a stdin read/poll — so concurrent drainers can't interleave. It needs no `Io` handle, unlike the `Io.Mutex` used elsewhere, which the io-less `escPressed` can't reach.
2. **Dedup the flush.** `steerFlushRedundant()` drops a flush that is empty (another arm drained it first) or byte-identical to the tail entry — collapsing any duplicate burst (race *or* paste) to one entry. Pure function, unit-tested.

## Test

`zig build test` passes, including the new `steerFlushRedundant drops empty + consecutive-identical flushes (#129)` test. The underlying race isn't deterministically reproducible, so coverage is on the pure dedup rule plus the serialization guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)