### PR TITLE
fix(#64): plan mode can read user-approved sibling repos (read-only)

### DIFF
--- a/src/agent_tools.zig
+++ b/src/agent_tools.zig
@@ -207,11 +207,32 @@ pub fn gateTool(self: *Agent, call: ToolCall) !?ExecResult {
             const cmd_val = call.input.object.get("command") orelse return null;
             if (cmd_val != .string) return null;
             const cmd = std.mem.trim(u8, cmd_val.string, " \t");
-            if (!Approvals.readOnlyAllowed(cmd)) return .{
+            // Safe, cwd-confined read-only commands auto-run (unchanged).
+            if (Approvals.readOnlyAllowed(cmd)) return null;
+            // A read-only verb reading OUTSIDE cwd is the sibling-repo case (#64):
+            // allow once the user approves those paths this session, else prompt.
+            // Mutating verbs / metacharacter smuggling fall through to the deny.
+            if (Approvals.readOnlyExternal(cmd)) {
+                if (approvals.planReadAllowed(self.io, cmd)) return null;
+                if (self.in) |in| if (self.out) |w| {
+                    try w.print("  ⚠ plan mode — read outside the project: {s}\n  [a]llow read-only access to these paths this session · [n]o › ", .{cmd});
+                    try w.flush();
+                    const raw: []const u8 = (try in.takeDelimiter('\n')) orelse "";
+                    const answer = std.mem.trim(u8, raw, " \t\r");
+                    if (answer.len > 0 and (answer[0] == 'a' or answer[0] == 'A' or answer[0] == 'y' or answer[0] == 'Y')) {
+                        try approvals.approvePlanRead(self.io, self.gpa, cmd);
+                        return null;
+                    }
+                };
+                return .{
+                    .text = try self.arena.dupe(u8, "plan mode — read-only access outside the project was declined; describe what you need read in the plan instead"),
+                    .is_error = true,
+                };
+            }
+            return .{
                 .text = try self.arena.dupe(u8, "plan mode is on — only read-only commands run (ls/cat/grep/git status…). Put this command in the plan instead."),
                 .is_error = true,
             };
-            return null;
         }
     }
 

--- a/src/approvals.zig
+++ b/src/approvals.zig
@@ -18,6 +18,9 @@ const Allocator = std.mem.Allocator;
 pub const Approvals = struct {
     mutex: Io.Mutex = .init,
     prefixes: std.ArrayList([]const u8) = .empty,
+    /// Session-only (never persisted) path roots the user OK'd for read-only
+    /// plan-mode exploration outside cwd (#64); freed alongside prefixes.
+    plan_read_roots: std.ArrayList([]const u8) = .empty,
     yolo: bool = false,
 
     /// Read-only basics plus the build, so subagents are useful out of the
@@ -31,6 +34,15 @@ pub const Approvals = struct {
         "wc",      "grep",     "rg",         "pwd",
         "which",   "file",     "git status", "git diff",
         "git log", "git show", "zig build",  "zig fmt",
+    };
+
+    /// Verbs that only ever read — a strict subset of `seed`, used to decide what
+    /// plan mode may run OUTSIDE cwd. `zig build`/`zig fmt` are omitted (they run
+    /// build.zig / rewrite files) so the external-read hatch can never mutate a
+    /// sibling repo (#64).
+    const read_only_seed = [_][]const u8{
+        "ls",  "cat",   "head", "tail",       "wc",       "grep",    "rg",
+        "pwd", "which", "file", "git status", "git diff", "git log", "git show",
     };
 
     pub fn allowed(self: *Approvals, io: Io, cmd: []const u8) bool {
@@ -128,6 +140,81 @@ pub const Approvals = struct {
         if (!isSimple(c) or escapesCwd(c)) return false;
         for (seed) |p| if (matchesPrefix(c, p)) return true;
         return false;
+    }
+
+    fn isReadOnlyVerb(cmd: []const u8) bool {
+        for (read_only_seed) |p| if (matchesPrefix(cmd, p)) return true;
+        return false;
+    }
+
+    /// A simple read-only-verb command that reads OUTSIDE cwd — the sibling-repo
+    /// exploration case. readOnlyAllowed handles the in-cwd case; plan mode
+    /// prompts on this instead of hard-denying. Mutating verbs and metacharacter
+    /// smuggling are NOT read-only-external (#64).
+    pub fn readOnlyExternal(cmd: []const u8) bool {
+        const c = std.mem.trim(u8, cmd, " \t");
+        return isSimple(c) and escapesCwd(c) and isReadOnlyVerb(c);
+    }
+
+    /// The escaping path a token carries, or null if it stays in cwd. Mirrors
+    /// escapesCwd's token classification exactly so cwd tokens are skipped.
+    fn flaggedPath(tok: []const u8) ?[]const u8 {
+        if (tok.len == 0) return null;
+        if (tok[0] == '/' or tok[0] == '~') return tok;
+        if (std.mem.indexOf(u8, tok, "=/")) |i| return tok[i + 1 ..];
+        if (std.mem.indexOf(u8, tok, "=~")) |i| return tok[i + 1 ..];
+        var pit = std.mem.tokenizeScalar(u8, tok, '/');
+        while (pit.next()) |comp| if (std.mem.eql(u8, comp, "..")) return tok;
+        return null;
+    }
+
+    /// True if `path` sits at or under one approved root (with a '/' boundary).
+    /// Any `..` component fails outright — blocks `<root>/../../etc` smuggling.
+    fn pathUnderRoots(path: []const u8, roots: []const []const u8) bool {
+        var pit = std.mem.tokenizeScalar(u8, path, '/');
+        while (pit.next()) |comp| if (std.mem.eql(u8, comp, "..")) return false;
+        for (roots) |root| {
+            if (root.len == 0 or !std.mem.startsWith(u8, path, root)) continue;
+            if (path.len == root.len or path[root.len] == '/') return true;
+        }
+        return false;
+    }
+
+    /// Pure core of planReadAllowed: a simple read-only-verb command whose every
+    /// escaping token sits under an approved root.
+    fn planReadMatch(cmd: []const u8, roots: []const []const u8) bool {
+        const c = std.mem.trim(u8, cmd, " \t");
+        if (!isSimple(c) or !isReadOnlyVerb(c)) return false;
+        var it = std.mem.tokenizeAny(u8, c, " \t");
+        while (it.next()) |tok| {
+            const p = flaggedPath(tok) orelse continue;
+            if (!pathUnderRoots(p, roots)) return false;
+        }
+        return true;
+    }
+
+    /// Plan mode: whether `cmd` is a read-only command cleared to run outside cwd
+    /// by a session approval. Thread-safe (called from the tool-exec pool).
+    pub fn planReadAllowed(self: *Approvals, io: Io, cmd: []const u8) bool {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        if (self.yolo) return true;
+        return planReadMatch(cmd, self.plan_read_roots.items);
+    }
+
+    /// Record every escaping path in `cmd` as an approved read root for the rest
+    /// of the session. Skips `..` tokens (never approvable) and duplicates.
+    pub fn approvePlanRead(self: *Approvals, io: Io, gpa: Allocator, cmd: []const u8) !void {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        var it = std.mem.tokenizeAny(u8, cmd, " \t");
+        outer: while (it.next()) |tok| {
+            const p = flaggedPath(tok) orelse continue;
+            var pit = std.mem.tokenizeScalar(u8, p, '/');
+            while (pit.next()) |comp| if (std.mem.eql(u8, comp, "..")) continue :outer;
+            for (self.plan_read_roots.items) |r| if (std.mem.eql(u8, r, p)) continue :outer;
+            try self.plan_read_roots.append(gpa, try gpa.dupe(u8, p));
+        }
     }
 
     pub fn toggleYolo(self: *Approvals, io: Io) bool {
@@ -308,6 +395,31 @@ test "Approvals.readOnlyAllowed: only simple, in-cwd, seed-listed commands pass 
     try std.testing.expect(!Approvals.readOnlyAllowed("cat /etc/passwd")); // escapes cwd
     try std.testing.expect(!Approvals.readOnlyAllowed("ls; rm x")); // not simple
     try std.testing.expect(!Approvals.readOnlyAllowed("git push")); // mutating git verb, not seeded
+}
+
+test "Approvals.readOnlyExternal: read-only verb reading outside cwd, simple only (#64)" {
+    try std.testing.expect(Approvals.readOnlyExternal("ls ~/projects/merjs"));
+    try std.testing.expect(Approvals.readOnlyExternal("cat /abs/file"));
+    try std.testing.expect(!Approvals.readOnlyExternal("cat src/main.zig")); // in cwd
+    try std.testing.expect(!Approvals.readOnlyExternal("rm -rf /x")); // mutating verb
+    try std.testing.expect(!Approvals.readOnlyExternal("zig fmt /x.zig")); // not read-only-seeded
+    try std.testing.expect(!Approvals.readOnlyExternal("ls /x; rm y")); // not simple
+}
+
+test "Approvals.planReadMatch: reads under an approved root pass; escapes/mutations/smuggling do not (#64)" {
+    const roots = [_][]const u8{ "~/projects/merjs", "/opt/data" };
+    const r: []const []const u8 = &roots;
+    try std.testing.expect(Approvals.planReadMatch("ls ~/projects/merjs", r));
+    try std.testing.expect(Approvals.planReadMatch("ls ~/projects/merjs/src", r));
+    try std.testing.expect(Approvals.planReadMatch("cat ~/projects/merjs/README.md", r));
+    try std.testing.expect(Approvals.planReadMatch("grep foo /opt/data/x.txt", r));
+    try std.testing.expect(Approvals.planReadMatch("grep foo ~/projects/merjs/a src/b.zig", r)); // cwd token ok alongside
+    try std.testing.expect(!Approvals.planReadMatch("cat /etc/passwd", r)); // outside every root
+    try std.testing.expect(!Approvals.planReadMatch("ls ~/secrets", r));
+    try std.testing.expect(!Approvals.planReadMatch("cat ~/projects/merjs/../../etc/passwd", r)); // .. smuggling
+    try std.testing.expect(!Approvals.planReadMatch("rm -rf ~/projects/merjs", r)); // mutating verb
+    try std.testing.expect(!Approvals.planReadMatch("ls ~/projects/merjs; rm x", r)); // metachar
+    try std.testing.expect(!Approvals.planReadMatch("ls ~/projects/merjs", &.{})); // nothing approved
 }
 
 test "Approvals.isInterpreter: flags first words that grant arbitrary code execution" {

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -102,9 +102,14 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
             .is_error = true,
         };
         if (std.mem.eql(u8, call.name, "bash")) {
-            if (strField(call.input, "command")) |cmd| if (!Approvals.readOnlyAllowed(cmd)) return .{
-                .text = try gpa.dupe(u8, "plan mode is on — only read-only commands run; describe this command in the plan instead"),
-                .is_error = true,
+            if (strField(call.input, "command")) |cmd| if (!Approvals.readOnlyAllowed(cmd)) {
+                // The root may have approved this external read-only path this
+                // session (#64); subagents (from_sub) never get the external hatch.
+                const ext_ok = !ctx.from_sub and if (ctx.approvals) |ap| ap.planReadAllowed(ctx.io, cmd) else false;
+                if (!ext_ok) return .{
+                    .text = try gpa.dupe(u8, "plan mode is on — only read-only commands run; describe this command in the plan instead"),
+                    .is_error = true,
+                };
             };
         }
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -341,6 +341,8 @@ pub fn main(init: std.process.Init) !void {
     defer {
         for (approvals.prefixes.items) |p| gpa.free(p);
         approvals.prefixes.deinit(gpa);
+        for (approvals.plan_read_roots.items) |p| gpa.free(p);
+        approvals.plan_read_roots.deinit(gpa);
     }
 
     // Root system-prompt layering (base + AGENTS.md/HARNESS.md/CLAUDE.md + --append-system-prompt + active-skill lines + connected-MCP notes) lives


### PR DESCRIPTION
Fixes #64.

## Problem

Plan-mode bash was gated purely by `Approvals.readOnlyAllowed`, whose `escapesCwd` check hard-rejects any token that is absolute (`/x`), home (`~`), or contains `..`. So even a read-only seed verb against a user-named sibling repo — `ls ~/projects/merjs`, `cat ~/repo/README` — was **denied outright** with no escape hatch, blocking legitimate read-only exploration during planning.

## Fix — a session-scoped, path-scoped read-only hatch

- **`readOnlyExternal(cmd)`** — a *simple* (no metacharacters) read-only-verb command reading **outside** cwd. Verbs come from a strict read-only subset of the seed that deliberately **excludes `zig build`/`zig fmt`** (they run build.zig / rewrite files), so the hatch can never mutate an outside repo. Plan mode **prompts** on this instead of hard-denying.
- On approval, **`approvePlanRead`** records the escaping path roots for the rest of the session (**never persisted** — plan mode is transient). **`planReadAllowed`** then auto-clears later reads under an approved root.
- Always denied: `..`-smuggling under an approved root, mutating verbs, and metacharacter chaining (`;`/`|`/`` ` ``/`$`/…).
- The **exec.zig backstop** honors the root's approval (via `ctx.approvals`) so it doesn't silently re-deny the just-approved read; **subagents (`from_sub`) never get the external hatch**.

Behavior: `ls ~/projects/merjs` → prompt → `a` → that root is approved, so `cat ~/projects/merjs/README` and `ls ~/projects/merjs/src` auto-run. `cat /etc/passwd` (unapproved) still prompts; `cat ~/projects/merjs/../../etc/passwd`, `rm -rf ~/projects/merjs`, and `ls ~/x; rm y` are hard-denied.

## Test

Pure classifiers (`readOnlyExternal`, `planReadMatch`, `pathUnderRoots`) are unit-tested next to the existing `escapesCwd`/`readOnlyAllowed` tests — **154/154 pass**. Normal-mode gating, subagent gating, and cwd auto-allow are untouched. The interactive prompt path mirrors the existing (untested) y/a/n approval prompt.

Scope notes (from investigation): approved roots are stored verbatim as typed (an `ls DIR`-first flow is most ergonomic); `~` and the absolute form of the same dir are distinct roots (kept pure/testable, no HOME expansion). Cross-restart persistence was intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)