### PR TITLE
feat(#112): graff worktree remove <name> + prune to clean up abandoned tabs

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -45,6 +45,8 @@ pub const usage_text =
     \\  graff mcp                         list configured MCP servers
     \\  graff worktree list              list the per-tab worktrees created by -w
     \\  graff worktree merge <name>      squash-land worktree-<name> onto the current branch + clean up
+    \\  graff worktree remove <name>     discard worktree-<name> (drops its scratch work) + delete the branch
+    \\  graff worktree prune             drop git registrations for worktrees whose dirs were deleted
     \\  graff sandboxes                  list your gateway sandboxes (what's burning credits)
     \\  graff sandboxes stop <id>        spin a sandbox down (stops it + settles the meter)
     \\  graff cube new                   spin up a cloud graff (sandbox + serve + preview URL)

--- a/src/jobs.zig
+++ b/src/jobs.zig
@@ -246,7 +246,50 @@ pub fn worktreeCommand(gpa: Allocator, io: Io, arena: Allocator, args: []const [
         return;
     }
 
-    try out.print("unknown worktree command '{s}' — use: graff worktree list | graff worktree merge <name>\n", .{action});
+    if (std.mem.eql(u8, action, "remove") or std.mem.eql(u8, action, "rm")) {
+        if (args.len < 2) {
+            try out.writeAll("usage: graff worktree remove <name>\n");
+            return;
+        }
+        const name = args[1];
+        const wt_path = try std.fmt.allocPrint(arena, ".graff/worktrees/{s}", .{name});
+        const wt_branch = try std.fmt.allocPrint(arena, "worktree-{s}", .{name});
+        // --force: discard any uncommitted scratch work — the whole point of
+        // `remove` is to throw away an abandoned tab (#112).
+        const rm = runCapped(gpa, io, &.{ "git", "worktree", "remove", "--force", wt_path }, 8192, 8192, 30_000) catch {
+            try out.print("✗ could not remove {s} (not a git repository, or no such worktree)\n", .{wt_path});
+            return;
+        };
+        defer {
+            gpa.free(rm.stdout);
+            gpa.free(rm.stderr);
+        }
+        if (!ranOk(rm)) {
+            try out.print("✗ couldn't remove {s}: {s}", .{ wt_path, rm.stderr });
+            return;
+        }
+        // -D (force) so an unmerged scratch branch is still deleted.
+        if (runCapped(gpa, io, &.{ "git", "branch", "-D", wt_branch }, 8192, 8192, 30_000)) |r| {
+            gpa.free(r.stdout);
+            gpa.free(r.stderr);
+        } else |_| {}
+        try out.print("✓ removed {s} and branch {s}\n", .{ wt_path, wt_branch });
+        return;
+    }
+
+    if (std.mem.eql(u8, action, "prune")) {
+        // Drop git's registrations for worktrees whose dirs were deleted out of band.
+        const r = runCapped(gpa, io, &.{ "git", "worktree", "prune" }, 8192, 8192, 30_000) catch {
+            try out.writeAll("not a git repository (nothing to prune)\n");
+            return;
+        };
+        gpa.free(r.stdout);
+        gpa.free(r.stderr);
+        try out.writeAll("✓ pruned stale worktree registrations\n");
+        return;
+    }
+
+    try out.print("unknown worktree command '{s}' — use: graff worktree list | merge <name> | remove <name> | prune\n", .{action});
 }
 
 /// One background bash job (`bash` with run_in_background:true). A pump task


### PR DESCRIPTION
Partial fix for #112 (the safe, in-repo slice).

## What

Two new `graff worktree` subcommands so a session's own accumulated per-tab worktrees can be cleaned up:

- **`remove <name>`** — `git worktree remove --force .graff/worktrees/<name>` (discards scratch work — the point of throwing away an abandoned tab) + `git branch -D worktree-<name>`.
- **`prune`** — `git worktree prune`, dropping registrations for worktrees whose dirs were deleted out of band.

Both touch only `.graff/worktrees/<name>` and `worktree-<name>` via git plumbing — never `$HOME`, never arbitrary paths. Dispatch already forwards all `worktree` args to `worktreeCommand`, so no dispatch change. Help text + the unknown-command hint updated.

## Scope note (important)

This is deliberately the **safe slice**. It does **not** touch the `$HOME` `codedb-*`/`codegraff-*` dirs that also motivated #112 — investigation confirmed graff never created those; they're external `git worktree add`/`git clone` artifacts from developing codedb+codegraff. A `graff cleanup` for those is dangerous (prefix-match + delete user dirs) and, if pursued, needs dry-run-by-default + `git worktree list --porcelain` registration validation + an age bound, in its own PR. Leaving #112 open for that decision.

## Verified

In a throwaway git repo: create a worktree → `graff worktree remove feat` prints `✓ removed .graff/worktrees/feat and branch worktree-feat`, the dir is gone, the branch is deleted, and it drops out of `worktree list`; `prune` succeeds. `zig build test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)