### PR TITLE
feat(#85): copy-confirmation toast on drag-select in graff repl

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -119,6 +119,8 @@ pub const braille_frames = [_][]const u8{ "⠋", "⠙", "⠹", "⠸", "⠼", "�
 pub const dragon_frames = [_][]const u8{ "🐉  ", "🐉 ✦", "🐉 ✧", "🐉 ✦" };
 
 const Anim = enum { braille, dragon };
+pub const Toast = enum { none, copied, failed };
+pub const TOAST_MS: u64 = 1500; // copy-confirmation toast window (wall-clock ms), #85
 
 const POLL_NS: u64 = 50 * std.time.ns_per_ms;
 
@@ -175,6 +177,9 @@ pub const Model = struct {
     sel_cur_row: ?usize = null,
     view_start: usize = 0,
     view_rows: usize = 0,
+    // Copy-confirmation toast (time-based; auto-dismisses, no tick plumbing), #85.
+    toast: Toast = .none,
+    toast_until_ms: u64 = 0,
     last_term_width: usize = 0, // cached each frame for post-hoc markdown layout
     visible_text: std.array_list.Managed([]const u8) = undefined, // owned plaintext of visible rows
     dump_next: bool = false,
@@ -370,6 +375,7 @@ pub const Model = struct {
     }
 
     pub const copySelection = model_render.copySelection;
+    pub const selectionText = model_render.selectionText;
 };
 
 pub const HELP_CALC =
@@ -735,6 +741,37 @@ test "model: offline arithmetic path (no turn_fn)" {
     _ = m.applyLine("/clear");
     try std.testing.expectEqual(@as(usize, 1), m.history.items.len);
     try std.testing.expectEqual(Effect.quit, m.applyLine("/quit"));
+}
+
+test "model: copy toast shows within window then auto-dismisses (#85)" {
+    g_turn_fn = null;
+    var m: Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    m.toast = .copied;
+    m.toast_until_ms = 1000;
+    const shown = try m.render(std.testing.allocator, 60, 24, 500);
+    defer std.testing.allocator.free(shown);
+    try std.testing.expect(std.mem.indexOf(u8, shown, "Copied to clipboard") != null);
+    const gone = try m.render(std.testing.allocator, 60, 24, 2000);
+    defer std.testing.allocator.free(gone);
+    try std.testing.expect(std.mem.indexOf(u8, gone, "Copied to clipboard") == null);
+}
+
+test "model: selectionText joins non-empty rows and ignores whitespace-only (#85)" {
+    g_turn_fn = null;
+    var m: Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    try m.visible_text.append(try std.testing.allocator.dupe(u8, "hello"));
+    try m.visible_text.append(try std.testing.allocator.dupe(u8, "world"));
+    try m.visible_text.append(try std.testing.allocator.dupe(u8, "   "));
+    m.view_rows = 3;
+    const joined = m.selectionText(std.testing.allocator, 0, 1).?;
+    defer std.testing.allocator.free(joined);
+    try std.testing.expectEqualStrings("hello\nworld", joined);
+    try std.testing.expect(m.selectionText(std.testing.allocator, 2, 2) == null); // whitespace-only
+    try std.testing.expect(m.toast == .none and m.toast_until_ms == 0); // no toast raised
 }
 
 test "model: commands toggle settings" {

--- a/src/repl_model_render.zig
+++ b/src/repl_model_render.zig
@@ -109,7 +109,15 @@ pub fn render(self: *Model, gpa: std.mem.Allocator, term_width: usize, term_heig
     var bottom = std.array_list.Managed(u8).init(a);
     try bottom.appendSlice(try box.render(a, try self.input.view(a)));
     try bottom.append('\n');
-    try bottom.appendSlice(try (zz.Style{}).dim(true).render(a, try self.statusLine(a)));
+    // A live copy toast takes over the status row (same height — the conversation
+    // viewport doesn't jump); otherwise the normal status line (#85).
+    if (now_ms < self.toast_until_ms and self.toast != .none) {
+        const msg = if (self.toast == .failed) "⚠ Clipboard copy failed" else "✓ Copied to clipboard";
+        const color: zz.Color = if (self.toast == .failed) .red else .green;
+        try bottom.appendSlice(try (zz.Style{}).fg(color).bold(true).render(a, msg));
+    } else {
+        try bottom.appendSlice(try (zz.Style{}).dim(true).render(a, try self.statusLine(a)));
+    }
 
     // The conversation is a scrollable viewport above the pinned input box.
     // scroll = lines scrolled up from the bottom (0 = latest). Clamped here.
@@ -157,28 +165,41 @@ pub fn render(self: *Model, gpa: std.mem.Allocator, term_width: usize, term_heig
     return gpa.dupe(u8, out.items);
 }
 
-/// Copy the conversation lines spanned by a drag-selection (screen rows
-/// r0..r1 inclusive, 0-based) to the clipboard via OSC52. Line-granular —
-/// restores copy after mouse mode disabled native terminal selection (#91).
-pub fn copySelection(self: *Model, ctx: *zz.Context, r0: usize, r1: usize) void {
-    if (self.view_rows == 0 or self.visible_text.items.len == 0) return;
+/// Extract the trimmed text spanned by visible screen rows r0..r1 (inclusive,
+/// 0-based) from the current per-frame snapshot. Returns null for an empty,
+/// out-of-range, or whitespace-only selection. Pure — no ctx/clipboard, so it is
+/// unit-testable without a terminal (#85).
+pub fn selectionText(self: *Model, a: std.mem.Allocator, r0: usize, r1: usize) ?[]const u8 {
+    if (self.view_rows == 0 or self.visible_text.items.len == 0) return null;
     const lo = @min(r0, r1);
     var hi = @max(r0, r1);
-    if (lo >= self.view_rows) return; // selection started below the conversation
+    if (lo >= self.view_rows) return null; // selection started below the conversation
     if (hi >= self.view_rows) hi = self.view_rows - 1;
     if (hi >= self.visible_text.items.len) hi = self.visible_text.items.len - 1;
 
-    var buf = std.array_list.Managed(u8).init(self.alloc);
+    var buf = std.array_list.Managed(u8).init(a);
     defer buf.deinit();
     var r = lo;
     while (r <= hi) : (r += 1) {
         const ln = std.mem.trimEnd(u8, self.visible_text.items[r], " \t");
-        buf.appendSlice(ln) catch return;
-        if (r != hi) buf.append('\n') catch return;
+        buf.appendSlice(ln) catch return null;
+        if (r != hi) buf.append('\n') catch return null;
     }
-    const text = std.mem.trim(u8, buf.items, " \t\r\n");
-    if (text.len == 0) return;
-    _ = ctx.setClipboard(text) catch false;
+    const trimmed = std.mem.trim(u8, buf.items, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    return a.dupe(u8, trimmed) catch null;
+}
+
+/// Copy the drag-selected lines (screen rows r0..r1 inclusive, 0-based) to the
+/// clipboard via OSC52 and raise a confirmation toast. Empty selections write
+/// nothing and raise no toast. Restores copy after mouse mode disabled native
+/// terminal selection (#91, #85).
+pub fn copySelection(self: *Model, ctx: *zz.Context, r0: usize, r1: usize) void {
+    const text = self.selectionText(self.alloc, r0, r1) orelse return;
+    defer self.alloc.free(text);
+    const ok = ctx.setClipboard(text) catch false;
     // render() is hash-gated and may skip its flush; push the OSC52 out now.
     if (ctx._terminal) |term| term.flush() catch {};
+    self.toast = if (ok) .copied else .failed;
+    self.toast_until_ms = (ctx.elapsed / std.time.ns_per_ms) + repl.TOAST_MS;
 }


### PR DESCRIPTION
Partial fix for #85 (the `graff repl` slice).

## What

`graff repl` (the zigzag TUI) already auto-copies a mouse drag-selection to the clipboard via OSC52 (landed for #91) but gave **no visual feedback**. This adds a confirmation toast on the bottom status row:

- Green **`✓ Copied to clipboard`** on success, red **`⚠ Clipboard copy failed`** when OSC52 is unavailable (non-TTY / disabled).
- Time-based, auto-dismisses after ~1.5s. No Cmd/tick plumbing needed — the zigzag runtime calls `render()` every frame with a fresh `now_ms`, so the toast appears next frame and vanishes the frame after it expires.
- Swaps the status row **in place** (same height), so the conversation viewport never jumps.

Also refactors the copy path into a pure, testable **`selectionText`** (row-range → trimmed text; null for empty/out-of-range/whitespace-only) plus a thin clipboard+toast wrapper — same selection semantics as before.

## Scope note

This is the `graff repl` slice. The **main harness deliberately does not grab the mouse** (it leaves native terminal copy-on-select alone — `agent_stream.zig:223-228`), so it can't show an in-app toast and is intentionally untouched here.

## Test

`zig build repl-test` — **18/18 pass**, including two new tests: the toast shows within its window then auto-dismisses (drives `render()` at two `now_ms` values), and `selectionText` joins non-empty rows and drops whitespace-only selections without raising a toast. Leak-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)