### PR TITLE
fix: commits are authored by the user, not the bot (codegraff → co-author)

### DIFF
--- a/src/jobs.zig
+++ b/src/jobs.zig
@@ -14,6 +14,12 @@ const root = @import("main.zig");
 const agent_mod = @import("agent.zig");
 const tools_mod = @import("tools.zig");
 const ToolOutput = tools_mod.ToolOutput;
+
+/// Commit-message trailer that credits the harness assist. The commit AUTHOR
+/// stays the user's own git identity (their GitHub account) — graff never
+/// overrides GIT_AUTHOR_*; codegraff is recorded as a co-author instead,
+/// mirroring how Claude Code attributes commits.
+const codegraff_coauthor = "Co-Authored-By: Codegraff <blackfloofie@codegraff.com>";
 const Agent = agent_mod.Agent;
 
 const CappedRun = struct {
@@ -146,7 +152,10 @@ pub fn worktreeAutoCommit(gpa: Allocator, io: Io, msg: []const u8) void {
     }, 4096, 4096, 30_000) catch return;
     gpa.free(add.stdout);
     gpa.free(add.stderr);
-    const c = runCapped(gpa, io, &.{ "git", "commit", "--no-verify", "-m", msg }, 8192, 8192, 30_000) catch return;
+    // Author stays the user's git identity; codegraff rides as a co-author trailer.
+    const full = std.fmt.allocPrint(gpa, "{s}\n\n{s}", .{ msg, codegraff_coauthor }) catch msg;
+    defer if (full.ptr != msg.ptr) gpa.free(full);
+    const c = runCapped(gpa, io, &.{ "git", "commit", "--no-verify", "-m", full }, 8192, 8192, 30_000) catch return;
     gpa.free(c.stdout);
     gpa.free(c.stderr);
 }
@@ -219,7 +228,7 @@ pub fn worktreeCommand(gpa: Allocator, io: Io, arena: Allocator, args: []const [
         }
 
         // 2) commit the squashed result as one clean commit on the current branch.
-        const cmsg = std.fmt.allocPrint(arena, "{s}: land worktree", .{name}) catch "land worktree";
+        const cmsg = std.fmt.allocPrint(arena, "{s}: land worktree\n\n{s}", .{ name, codegraff_coauthor }) catch "land worktree";
         const c = runCapped(gpa, io, &.{ "git", "commit", "--no-verify", "-m", cmsg }, 8192, 8192, 30_000) catch {
             try out.writeAll("✗ git commit failed — worktree left intact\n");
             return;

--- a/src/prompts.zig
+++ b/src/prompts.zig
@@ -42,10 +42,12 @@ pub const main_system_prompt =
     \\issue at justrach/codegraff (`gh issue create --repo justrach/codegraff
     \\...`), never in the current working repository's issue tracker.
     \\
-    \\When making git commits on behalf of the user, always set the author
-    \\to Codegraff <blackfloofie@codegraff.com> — pass GIT_AUTHOR_NAME,
-    \\GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME, and GIT_COMMITTER_EMAIL env vars
-    \\on every git command so the bot identity is preserved in the commit log.
+    \\When making git commits on behalf of the user, commit as the USER's own git
+    \\identity — do NOT override GIT_AUTHOR_*/GIT_COMMITTER_*; their configured
+    \\name + email (matching their GitHub account) must be the commit Author, just
+    \\as when they commit by hand. Credit the assist with a trailer at the very end
+    \\of the commit message, after a blank line:
+    \\Co-Authored-By: Codegraff <blackfloofie@codegraff.com>
     \\
     \\Never run git commands that discard work — `reset --hard`, `clean -f`,
     \\`checkout --`/`restore`, force-push, or `branch -D` — unless the user


### PR DESCRIPTION
## Problem

When you commit through graff, the commit was authored by **`Codegraff <blackfloofie@codegraff.com>`** instead of you. Root cause: the system prompt (`src/prompts.zig`) told the model to set `GIT_AUTHOR_*`/`GIT_COMMITTER_*` to the bot on *every* commit "so the bot identity is preserved." So your own work landed attributed to the bot, not your GitHub account.

## Fix — mirror Claude Code's attribution

**You** are the commit Author (your local git config — which is already your GitHub identity), and the assist is credited with a **`Co-Authored-By: Codegraff <blackfloofie@codegraff.com>`** trailer.

- **`prompts.zig`** — rewrite the guidance: commit as the user's own git identity, never override `GIT_AUTHOR_*`; append the co-author trailer.
- **`jobs.zig`** — the `-w` per-turn auto-checkpoint (`worktreeAutoCommit`) and the `worktree merge` land-commit append the same shared trailer. Both already committed with the user's identity, so this just adds the co-author credit for consistency.

## Verified

In a repo inheriting the global git config (`justrach` + GitHub's noreply email), `graff worktree merge feat` produces:

```
Author:    justrach <54503978+justrach@users.noreply.github.com>
Committer: justrach <54503978+justrach@users.noreply.github.com>

feat: land worktree

Co-Authored-By: Codegraff <blackfloofie@codegraff.com>
```

That's your real GitHub identity as the Author, codegraff as co-author — never the bot as author. Build + `zig build test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)