### PR TITLE
fix(#56): fail-safe the concurrency-starved SSE/WS fallbacks (Fix-B)

### DIFF
--- a/src/agent_stream.zig
+++ b/src/agent_stream.zig
@@ -261,14 +261,14 @@ pub fn postStreamWithClient(self: *Agent, client: *std.http.Client, body: []cons
         var hd_buf: [2]HeadDone = undefined;
         var hsel: Io.Select(HeadDone) = .init(self.io, &hd_buf);
         hsel.concurrent(.sent, sendHeadTask, .{ &req, body, &response }) catch {
-            // No spare concurrency: accept the hang risk (existing behavior).
-            req.transfer_encoding = .{ .content_length = body.len };
-            var bw = try req.sendBodyUnflushed(&.{});
-            try bw.writer.writeAll(body);
-            try bw.end();
-            try req.connection.?.flush();
-            response = try req.receiveHead(&.{});
-            break :head;
+            // #56 Fix-B: Io pool exhausted (deep subagent fan-out saturated the
+            // thread pool) — we can't spawn the head-stall watchdog. A bare
+            // send+receiveHead here could hang forever on a half-open socket with
+            // nothing to trip it. Nothing has streamed yet, so fail safe: poison the
+            // connection and return a retryable HungRequest so request() backs off
+            // and redials once a pool slot frees, instead of blocking the turn.
+            if (req.connection) |conn| conn.closing = true;
+            return error.HungRequest;
         };
         hsel.concurrent(.stall, headStallTask, .{ self.io, orig_tio != null }) catch {
             const r = hsel.await() catch |e| {
@@ -342,12 +342,21 @@ pub fn postStreamWithClient(self: *Agent, client: *std.http.Client, body: []cons
             var rd_buf: [2]ReadDone = undefined;
             var rsel: Io.Select(ReadDone) = .init(self.io, &rd_buf);
             rsel.concurrent(.line, streamLineTask, .{ reader, &line.writer }) catch {
-                _ = reader.streamDelimiterEnding(&line.writer, '\n') catch |e| {
-                    if (saw_done and readErrIsClose(e)) break :stream; // #134/#135: terminal event already seen — a post-completion close/reset is clean
-                    if (got_body and readErrIsClose(e)) { noteDropped(self); return error.StreamDropped; } // #133: closed before [DONE]/finish_reason — a drop, not a clean end
-                    return e;
-                }; // no spare concurrency
-                break :read;
+                // #56 Fix-B: pool exhausted — no idle-stall watchdog for this read.
+                // A bare blocking streamDelimiterEnding here is the last forever-hang:
+                // on a half-open socket it never returns and nothing can trip it. Fail
+                // safe with the SAME outcome as a watchdog deadline — if the terminal
+                // event already landed the response is complete (clean end); otherwise
+                // flush the partial, poison, and end the turn as StreamStalled (never a
+                // hang, never a mislabeled StreamDropped or user Esc).
+                if (saw_done) break :stream;
+                self.flushStreamTail();
+                if (!main_mod.json_mode) if (self.out) |o| {
+                    o.writeAll("\n⚠ stream stalled — ending turn\n") catch {};
+                    o.flush() catch {};
+                };
+                if (req.connection) |conn| conn.closing = true;
+                return error.StreamStalled;
             };
             rsel.concurrent(.stall, streamStallTask, .{ self.io, orig_tio != null }) catch {
                 const r = rsel.await() catch |e| {

--- a/src/agent_ws.zig
+++ b/src/agent_ws.zig
@@ -156,8 +156,16 @@ pub fn postResponsesWs(self: *Agent, body: []const u8) ![]u8 {
             var rd_buf: [2]ReadDone = undefined;
             var rsel: Io.Select(ReadDone) = .init(self.io, &rd_buf);
             rsel.concurrent(.msg, wsReadTask, .{ client, gpa, &fbuf }) catch {
-                _ = client.readMessage(gpa, &fbuf) catch |e| return e; // no spare concurrency
-                break :read;
+                // #56 Fix-B: pool exhausted — mirror the SSE line-read fail-safe. A bare
+                // blocking readMessage can hang forever on a half-open ws with no
+                // watchdog; end the turn as StreamStalled (never a hang, never a user
+                // Esc), exactly as the .deadline arm below does.
+                if (!main_mod.json_mode) if (self.out) |o| {
+                    o.writeAll("\n⚠ stream stalled — ending turn\n") catch {};
+                    o.flush() catch {};
+                };
+                if (self.tracer) |tr| tr.note("ws", "stall");
+                return error.StreamStalled;
             };
             rsel.concurrent(.stall, streamStallTask, .{ self.io, orig_tio != null }) catch {
                 const r = rsel.await() catch |e| {

--- a/src/http.zig
+++ b/src/http.zig
@@ -301,7 +301,7 @@ pub fn postWatched(gpa: Allocator, io: Io, client: *std.http.Client, provider: P
     var done_buf: [2]Done = undefined;
     var sel: Io.Select(Done) = .init(io, &done_buf);
     sel.concurrent(.posted, postTask, .{ gpa, client, provider, body }) catch
-        return post(gpa, client, provider, body); // no concurrency: accept the hang risk
+        return error.HungRequest; // #56 Fix-B: pool exhausted — don't fall back to a bare blocking post() that can hang a subagent turn with no Esc path; return retryable so request() retries + backs off
     sel.concurrent(.watchdog, postWatchdog, .{io}) catch {
         const r = sel.await() catch |e| { // posted is the only arm
             sel.cancelDiscard();


### PR DESCRIPTION
Closes the remaining **Fix-B** from #56 (the two headline guards + reconnect already landed; this is the last unguarded hang path).

## Problem

The stall watchdog races each blocking network read against a watchdog task on the `Io` pool. When the pool is exhausted (deep subagent fan-out → genuine OS thread exhaustion, since `concurrent_limit` is unlimited), `Io.Select.concurrent` returns `ConcurrencyUnavailable`, and the `catch` branch fell back to a **bare, unguarded blocking read** with an explicit *"accept the hang risk"* comment. On a half-open socket (server gone, no FIN/RST) that read never returns and no watchdog can trip it — the exact "stuck at thinking / reconnect doesn't reconnect" wedge #56 is about, now only reachable under pool starvation.

## Fix — make each starved fallback fail safe

Reuses error classes already fully wired downstream (no new plumbing). Treatment differs because a pre-stream failure is a clean full retry, but a mid-stream failure must not be misclassified as a provider drop:

| Site | Fallback now returns | Why |
|---|---|---|
| `agent_stream.zig` head-send (pre-stream) | `error.HungRequest` | nothing streamed yet → request()'s transport-flake retry redials cleanly |
| `agent_stream.zig` SSE line-read (mid-stream) | `error.StreamStalled` | same outcome as a watchdog deadline — terminal-event-already-seen = clean end; else flush partial, poison, end turn (honest label, preserves partial, **never** a mislabeled StreamDropped or user Esc) |
| `http.zig` `postWatched` (non-streaming POST) | `error.HungRequest` | caller re-issues the whole POST |
| `agent_ws.zig` Codex frame-read | `error.StreamStalled` | mirrors the SSE path |

Each branch mirrors an existing, **already-tested** watchdog arm (the `.stall`/`.deadline` handlers). Only reachable under genuine pool exhaustion, so steady-state behavior is unchanged.

## Test

`zig build test` **152/152**; `scripts/test-stall-drop.py` still green (the `StreamStalled`/`StreamDropped` save paths these route into are intact). The pool-exhaustion trigger isn't unit-reproducible without an env seam — consistent with how #134/#132 are verified via a seam + the e2e script rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)