### PR TITLE
Release v0.0.199 — codex WS readings proven on a real PTY, transport env knobs fixed, REPL reply spacing

### DIFF
--- a/scripts/codex_ws_mock.py
+++ b/scripts/codex_ws_mock.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Dependency-free fake Codex Responses backend for graff transport tests.
+
+One TCP port serves both transports graff uses for codex turns:
+
+- WebSocket (primary): a GET with ``Upgrade: websocket`` on a path ending in
+  ``/responses`` is upgraded (101 + a properly computed Sec-WebSocket-Accept,
+  even though graff's client does not check it). The mock then reads the
+  client's MASKED ``{"type":"response.create",...}`` text frame (7/16/64-bit
+  lengths, fragmentation tolerated) and answers with two UNMASKED text frames:
+  ``response.output_item.done`` carrying the assistant message item, then
+  ``response.completed`` carrying the fixed usage block.
+- SSE (fallback): a plain POST to the same path gets a 200
+  ``text/event-stream`` body carrying the SAME two events as ``data:`` lines.
+
+The assistant item is shaped exactly the way stepResponses
+(src/agent_steps.zig) surfaces reply text: a ``message`` item whose content
+array holds an ``output_text`` block. ``ws_turns``/``sse_turns`` count which
+transport actually served each turn so tests can prove no silent fallback.
+
+Importable (``CodexMock().start() -> port`` / ``stop()``) and runnable:
+``python3 scripts/codex_ws_mock.py [--port N]`` serves until Ctrl-C, tracing
+events to stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import socket
+import struct
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+
+WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+OP_CONT = 0x0
+OP_TEXT = 0x1
+OP_BINARY = 0x2
+OP_CLOSE = 0x8
+OP_PING = 0x9
+OP_PONG = 0xA
+
+# Defensive cap on one reassembled inbound message (mirrors ws.zig's 4 MiB,
+# with headroom for large request bodies).
+MESSAGE_CAP = 16 * 1024 * 1024
+
+REPLY_TEXT = "pong from the mock"
+USAGE = {
+    "input_tokens": 1200,
+    "input_tokens_details": {"cached_tokens": 0},
+    "output_tokens": 300,
+    "total_tokens": 1500,
+}
+
+
+def assistant_item() -> dict:
+    """The message item stepResponses (src/agent_steps.zig) renders as reply
+    text; role/id/status/annotations match real Responses output items so the
+    item is also valid next-turn input."""
+    return {
+        "type": "message",
+        "id": "msg_mock_1",
+        "status": "completed",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": REPLY_TEXT, "annotations": []}],
+    }
+
+
+def turn_events() -> list[dict]:
+    """The two events one mocked turn produces, in send order."""
+    return [
+        {"type": "response.output_item.done", "item": assistant_item()},
+        {"type": "response.completed", "response": {"usage": dict(USAGE)}},
+    ]
+
+
+@dataclass
+class Frame:
+    opcode: int
+    payload: bytes
+    fin: bool
+
+
+class _SockReader:
+    """Buffered exact-read wrapper so bytes recv'd past a boundary (e.g. the
+    HTTP head) still feed later frame/body reads."""
+
+    def __init__(self, sock: socket.socket) -> None:
+        self._sock = sock
+        self._buf = bytearray()
+
+    def read_exact(self, n: int) -> bytes:
+        while len(self._buf) < n:
+            chunk = self._sock.recv(65536)
+            if not chunk:
+                raise ConnectionError("peer closed mid-read")
+            self._buf.extend(chunk)
+        out = bytes(self._buf[:n])
+        del self._buf[:n]
+        return out
+
+    def read_until(self, delim: bytes) -> bytes:
+        while delim not in self._buf:
+            chunk = self._sock.recv(65536)
+            if not chunk:
+                raise ConnectionError("peer closed before delimiter")
+            self._buf.extend(chunk)
+        end = self._buf.index(delim) + len(delim)
+        out = bytes(self._buf[:end])
+        del self._buf[:end]
+        return out
+
+
+def _read_frame(reader: _SockReader) -> Frame:
+    """Read one WebSocket frame; unmasks client (masked) payloads."""
+    head = reader.read_exact(2)
+    fin = bool(head[0] & 0x80)
+    opcode = head[0] & 0x0F
+    masked = bool(head[1] & 0x80)
+    length = head[1] & 0x7F
+    if length == 126:
+        length = struct.unpack(">H", reader.read_exact(2))[0]
+    elif length == 127:
+        length = struct.unpack(">Q", reader.read_exact(8))[0]
+    if length > MESSAGE_CAP:
+        raise ConnectionError(f"frame too long ({length}b)")
+    mask = reader.read_exact(4) if masked else b""
+    payload = reader.read_exact(length) if length else b""
+    if masked and payload:
+        payload = bytes(b ^ mask[i & 3] for i, b in enumerate(payload))
+    return Frame(opcode, payload, fin)
+
+
+def _send_frame(sock: socket.socket, opcode: int, payload: bytes) -> None:
+    """Send one unmasked (server->client) frame with FIN set."""
+    n = len(payload)
+    if n < 126:
+        header = bytes([0x80 | opcode, n])
+    elif n <= 0xFFFF:
+        header = bytes([0x80 | opcode, 126]) + struct.pack(">H", n)
+    else:
+        header = bytes([0x80 | opcode, 127]) + struct.pack(">Q", n)
+    sock.sendall(header + payload)
+
+
+def _read_message(reader: _SockReader, sock: socket.socket) -> Frame:
+    """Reassemble one data message; answers ping inline, returns close as-is."""
+    opcode: int | None = None
+    parts: list[bytes] = []
+    total = 0
+    while True:
+        frame = _read_frame(reader)
+        if frame.opcode == OP_PING:
+            _send_frame(sock, OP_PONG, frame.payload)
+            continue
+        if frame.opcode == OP_PONG:
+            continue
+        if frame.opcode == OP_CLOSE:
+            return frame
+        if frame.opcode != OP_CONT:
+            opcode = frame.opcode
+        total += len(frame.payload)
+        if total > MESSAGE_CAP:
+            raise ConnectionError("message too long")
+        parts.append(frame.payload)
+        if frame.fin:
+            return Frame(opcode if opcode is not None else OP_TEXT, b"".join(parts), True)
+
+
+def ws_accept_value(key: str) -> str:
+    """RFC 6455 Sec-WebSocket-Accept for a client Sec-WebSocket-Key."""
+    digest = hashlib.sha1((key + WS_GUID).encode("ascii")).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+@dataclass
+class CodexMock:
+    """Threaded fake codex backend: start() binds and returns the real port,
+    stop() tears it down. ws_turns/sse_turns count served turns per transport."""
+
+    host: str = "127.0.0.1"
+    port: int = 0
+    verbose: bool = False
+    ws_turns: int = 0
+    sse_turns: int = 0
+    _sock: socket.socket | None = field(default=None, repr=False)
+    _threads: list[threading.Thread] = field(default_factory=list, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _stopping: bool = field(default=False, repr=False)
+
+    def start(self) -> int:
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind((self.host, self.port))
+        srv.listen(8)
+        self.port = srv.getsockname()[1]
+        self._sock = srv
+        acceptor = threading.Thread(target=self._accept_loop, daemon=True)
+        acceptor.start()
+        self._threads.append(acceptor)
+        return self.port
+
+    def stop(self) -> None:
+        self._stopping = True
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+        for thread in self._threads:
+            thread.join(timeout=1.0)
+        self._threads.clear()
+
+    # ── internals ─────────────────────────────────────────────────────────
+
+    def _log(self, message: str) -> None:
+        if self.verbose:
+            print(f"[codex-mock] {message}", file=sys.stderr, flush=True)
+
+    def _accept_loop(self) -> None:
+        srv = self._sock
+        assert srv is not None
+        while not self._stopping:
+            try:
+                conn, _addr = srv.accept()
+            except OSError:
+                return
+            handler = threading.Thread(target=self._handle, args=(conn,), daemon=True)
+            handler.start()
+            self._threads.append(handler)
+
+    def _handle(self, conn: socket.socket) -> None:
+        try:
+            conn.settimeout(60.0)
+            reader = _SockReader(conn)
+            head = reader.read_until(b"\r\n\r\n").decode("latin-1")
+            request_line, _, header_block = head.partition("\r\n")
+            parts = request_line.split()
+            method, path = (parts + ["", ""])[:2]
+            headers: dict[str, str] = {}
+            for line in header_block.split("\r\n"):
+                name, sep, value = line.partition(":")
+                if sep:
+                    headers[name.strip().lower()] = value.strip()
+            bare_path = path.split("?", 1)[0]
+            if (
+                method == "GET"
+                and headers.get("upgrade", "").lower() == "websocket"
+                and bare_path.endswith("/responses")
+            ):
+                self._serve_ws(conn, reader, headers)
+            elif method == "POST" and bare_path.endswith("/responses"):
+                self._serve_sse(conn, reader, headers)
+            else:
+                self._log(f"http 404 {method} {path}")
+                body = b"not found"
+                conn.sendall(
+                    b"HTTP/1.1 404 Not Found\r\nContent-Length: "
+                    + str(len(body)).encode("ascii")
+                    + b"\r\nConnection: close\r\n\r\n"
+                    + body
+                )
+        except (ConnectionError, OSError) as exc:
+            self._log(f"connection dropped: {exc}")
+        finally:
+            try:
+                conn.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            conn.close()
+
+    def _serve_ws(self, conn: socket.socket, reader: _SockReader, headers: dict[str, str]) -> None:
+        accept = ws_accept_value(headers.get("sec-websocket-key", ""))
+        conn.sendall(
+            (
+                "HTTP/1.1 101 Switching Protocols\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Accept: {accept}\r\n"
+                "\r\n"
+            ).encode("ascii")
+        )
+        self._log("ws upgraded")
+        while True:
+            message = _read_message(reader, conn)
+            if message.opcode == OP_CLOSE:
+                try:
+                    _send_frame(conn, OP_CLOSE, b"")
+                except OSError:
+                    pass
+                self._log("ws closed")
+                return
+            try:
+                event = json.loads(message.payload.decode("utf-8"))
+            except ValueError:
+                event = None
+            etype = event.get("type") if isinstance(event, dict) else None
+            self._log(f"ws <- {etype} ({len(message.payload)}b)")
+            if etype != "response.create":
+                continue
+            for ev in turn_events():
+                _send_frame(conn, OP_TEXT, json.dumps(ev, separators=(",", ":")).encode("utf-8"))
+                self._log(f"ws -> {ev['type']}")
+            with self._lock:
+                self.ws_turns += 1
+
+    def _serve_sse(self, conn: socket.socket, reader: _SockReader, headers: dict[str, str]) -> None:
+        length = int(headers.get("content-length", "0") or 0)
+        body = reader.read_exact(length) if length else b""
+        self._log(f"sse <- POST ({len(body)}b)")
+        events = turn_events()
+        payload = "".join(
+            f"data: {json.dumps(ev, separators=(',', ':'))}\n\n" for ev in events
+        ).encode("utf-8")
+        conn.sendall(
+            (
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: text/event-stream\r\n"
+                f"Content-Length: {len(payload)}\r\n"
+                "Connection: close\r\n"
+                "\r\n"
+            ).encode("ascii")
+            + payload
+        )
+        for ev in events:
+            self._log(f"sse -> {ev['type']}")
+        with self._lock:
+            self.sse_turns += 1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fake codex Responses backend (WebSocket + SSE) for manual debugging."
+    )
+    parser.add_argument("--port", type=int, default=0, help="TCP port to bind (default: ephemeral)")
+    args = parser.parse_args()
+    mock = CodexMock(port=args.port, verbose=True)
+    port = mock.start()
+    print(
+        f"codex mock listening on 127.0.0.1:{port} "
+        f"(GRAFF_CODEX_URL=http://127.0.0.1:{port}/backend-api/codex/responses)",
+        file=sys.stderr,
+        flush=True,
+    )
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        mock.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-pty-codex-ws.py
+++ b/scripts/test-pty-codex-ws.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Deterministic real-PTY test for codex transport: WebSocket primary, forced
+SSE fallback, and GRAFF_CODEX_WS=off — each against a local fake backend
+(codex_ws_mock) whose ws_turns/sse_turns counters prove which transport
+actually served the turn, so a silent fallback cannot fake a pass."""
+
+import json
+import os
+import sys
+import tempfile
+
+from codex_ws_mock import REPLY_TEXT, CodexMock
+from pty_harness import PtySession
+
+_arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
+GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
+
+# Mock usage total is 1500; compactTokenCount (src/agent.zig) renders that as
+# "1k" (integer division). contextFor("codex","gpt-5.6-sol") = 372_000, so the
+# prompt meter is 1500*100/372000 = 0% with compact@ 372000/10*8/1000 = 297k.
+METER = "1k/372k ctx (0% · compact@297k)"
+
+
+def run_scenario(
+    label: str,
+    tmp: str,
+    codex_home: str,
+    port: int,
+    mock: CodexMock,
+    extra_env: dict,
+    expect_ws: int,
+    expect_sse: int,
+    health: str,
+) -> None:
+    env = {
+        "HOME": tmp,
+        "CODEX_HOME": codex_home,
+        "CODEGRAFF_API_KEY": "local-pty-test",
+        "GRAFF_FLEET": "off",
+        "GRAFF_NO_TELEMETRY": "1",
+        "GRAFF_CODEX_URL": f"http://127.0.0.1:{port}/backend-api/codex/responses",
+    }
+    env.update(extra_env)
+    # PtySession builds the child env from os.environ.copy(), so ambient
+    # transport/credential knobs (an exported GRAFF_CODEX_WS=off, a leftover
+    # GRAFF_WS_FORCE_FAIL_ONCE=1, CODEX_DISABLED, ...) would leak into every
+    # scenario and flip its transport. Strip all ambient GRAFF_*/CODEX_* the
+    # scenario does not set itself; unset_env is applied AFTER env, so keys we
+    # set deliberately must be excluded.
+    ambient = tuple(
+        k
+        for k in os.environ
+        if (k.startswith("GRAFF_") or k.startswith("CODEX_") or k == "NO_COLOR")
+        and k not in env
+    )
+    with PtySession(
+        GRAFF,
+        ["--model", "codex", "--no-telemetry"],
+        cwd=tmp,
+        env=env,
+        unset_env=ambient,
+        timeout=20.0,
+    ) as session:
+        session.wait_for_literal("] ›")
+        cursor = len(session.raw)
+        session.send_line("ping")
+        session.wait_for_literal(REPLY_TEXT, start=cursor)
+        session.wait_for_literal(METER, start=cursor)
+        if mock.ws_turns != expect_ws or mock.sse_turns != expect_sse:
+            raise AssertionError(
+                f"{label}: transport mismatch — ws_turns={mock.ws_turns} "
+                f"sse_turns={mock.sse_turns}, expected ws={expect_ws} sse={expect_sse}"
+            )
+        cursor = len(session.raw)
+        session.send_line("/models health")
+        session.wait_for_literal(f"Codex transport: {health}", start=cursor)
+        session.wait_for_literal("] ›", start=cursor)
+        session.send_key("ctrl-d")
+        result = session.read_until_exit(5.0)
+        if result.timed_out or result.exit_code != 0:
+            raise SystemExit(
+                f"{label}: REPL did not exit cleanly: "
+                f"exit={result.exit_code} timed_out={result.timed_out}"
+            )
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="graff-pty-codex-") as tmp:
+        codex_home = os.path.join(tmp, "codex-home")
+        os.makedirs(codex_home, exist_ok=True)
+        with open(os.path.join(codex_home, "auth.json"), "w", encoding="utf-8") as fh:
+            json.dump(
+                {"tokens": {"access_token": "pty-mock-token", "account_id": "acct-pty-mock"}},
+                fh,
+            )
+
+        # The AI tab-titler (titleTask, src/title.zig) fires one extra quiet SSE
+        # turn on the first prompt, which would corrupt the transport counters.
+        # Disable it the same way `/title off` does: the persisted setting in
+        # the session cwd's .harness/settings.json.
+        harness_dir = os.path.join(tmp, ".harness")
+        os.makedirs(harness_dir, exist_ok=True)
+        with open(os.path.join(harness_dir, "settings.json"), "w", encoding="utf-8") as fh:
+            json.dump({"ai_title": False}, fh)
+
+        scenarios = [
+            (
+                "ws-primary",
+                {},
+                1,
+                0,
+                "WebSocket primary with automatic SSE fallback",
+                "ok    codex WS primary: mock reply + ctx meter over WebSocket",
+            ),
+            (
+                "ws-forced-fallback",
+                {"GRAFF_WS_FORCE_FAIL_ONCE": "1"},
+                0,
+                1,
+                "SSE fallback (WebSocket failed this session)",
+                "ok    codex forced WS failure: SSE fallback reply + ctx meter + latched health",
+            ),
+            (
+                "ws-off",
+                {"GRAFF_CODEX_WS": "off"},
+                0,
+                1,
+                "SSE forced (GRAFF_CODEX_WS is off)",
+                "ok    codex WS disabled: SSE reply + ctx meter + forced-off health",
+            ),
+        ]
+        for label, extra_env, expect_ws, expect_sse, health, ok_line in scenarios:
+            mock = CodexMock()
+            port = mock.start()
+            try:
+                run_scenario(
+                    label,
+                    tmp,
+                    codex_home,
+                    port,
+                    mock,
+                    extra_env,
+                    expect_ws,
+                    expect_sse,
+                    health,
+                )
+            finally:
+                mock.stop()
+            print(ok_line)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-pty-codex-ws.py
+++ b/scripts/test-pty-codex-ws.py
@@ -6,19 +6,22 @@ actually served the turn, so a silent fallback cannot fake a pass."""
 
 import json
 import os
+import re
 import sys
 import tempfile
 
 from codex_ws_mock import REPLY_TEXT, CodexMock
-from pty_harness import PtySession
+from pty_harness import PtySession, terminal_text
 
 _arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
 GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
 
 # Mock usage total is 1500; compactTokenCount (src/agent.zig) renders that as
-# "1k" (integer division). contextFor("codex","gpt-5.6-sol") = 372_000, so the
-# prompt meter is 1500*100/372000 = 0% with compact@ 372000/10*8/1000 = 297k.
-METER = "1k/372k ctx (0% · compact@297k)"
+# "1k" (integer division), and 1500 tokens is 0% of any realistic window. The
+# window itself tracks the baked codex catalog (pricing.zig), which moves
+# between releases — so assert the meter SHAPE plus the compactAt invariant
+# (compact = context/10*8, src/provider.zig) instead of a frozen window size.
+METER_RE = re.compile(r"1k/(\d+)k ctx \(0% · compact@(\d+)k\)")
 
 
 def run_scenario(
@@ -65,7 +68,13 @@ def run_scenario(
         cursor = len(session.raw)
         session.send_line("ping")
         session.wait_for_literal(REPLY_TEXT, start=cursor)
-        session.wait_for_literal(METER, start=cursor)
+        session.wait_for(METER_RE, start=cursor)
+        meter = METER_RE.search(terminal_text(bytes(session.raw[cursor:])))
+        ctx_k, compact_k = int(meter.group(1)), int(meter.group(2))
+        if compact_k != ctx_k * 8 // 10:
+            raise AssertionError(
+                f"{label}: meter compact@{compact_k}k is not 80% of {ctx_k}k ctx"
+            )
         if mock.ws_turns != expect_ws or mock.sse_turns != expect_sse:
             raise AssertionError(
                 f"{label}: transport mismatch — ws_turns={mock.ws_turns} "

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -201,7 +201,7 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
             };
             switch (r) {
                 .ok => |obj| {
-                    self.recordUsageResponses(obj);
+                    self.recordUsageResponses(obj, body.len);
                     if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, self.last_context_tokens, self.last_cache_read, false);
                     if (main_mod.json_mode and !self.sub) self.emit(.{ .type = "model_call_finished", .provider = self.provider.id, .model = self.provider.model, .ok = true, .ms = ms });
                     return obj;
@@ -409,10 +409,20 @@ pub fn errorMessage(obj: std.json.ObjectMap) ?[]const u8 {
     return null;
 }
 
-pub fn recordUsageResponses(self: *Agent, response: std.json.ObjectMap) void {
+pub fn recordUsageResponses(self: *Agent, response: std.json.ObjectMap, req_body_len: usize) void {
     self.last_cache_read = 0;
-    const usage = response.get("usage") orelse return;
-    if (usage != .object) return;
+    // Fallback estimate (~4 bytes/token) from the serialized request body,
+    // which holds the full conversation — keeps the ctx meter and the
+    // compact@ trigger live when codex omits usage counts entirely.
+    const est: u64 = req_body_len / 4;
+    const usage = response.get("usage") orelse {
+        if (est > 0) self.last_context_tokens = est;
+        return;
+    };
+    if (usage != .object) {
+        if (est > 0) self.last_context_tokens = est;
+        return;
+    }
     const u = usage.object;
     const in_tokens = usageInt(u, "input_tokens");
     const out_tokens = usageInt(u, "output_tokens");
@@ -424,7 +434,11 @@ pub fn recordUsageResponses(self: *Agent, response: std.json.ObjectMap) void {
         // Still surface the prompt token counter instead of leaving the
         // prompt stuck at "model · sub" with no context usage.
         const computed_total = in_tokens + out_tokens;
-        if (computed_total > 0) self.last_context_tokens = @intCast(computed_total);
+        if (computed_total > 0) {
+            self.last_context_tokens = @intCast(computed_total);
+        } else if (est > 0) {
+            self.last_context_tokens = est;
+        }
     }
     var cached: i64 = 0;
     if (u.get("input_tokens_details")) |d| if (d == .object) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -249,6 +249,12 @@ pub fn main(init: std.process.Init) !void {
     if (builtin.os.tag == .windows) tty.enableVtOutput();
     // CLI flags: the Flags struct + parsing loop live in args.zig; downstream code reads flags.<name> in place of ~27 locals this block used to declare.
     const flags = try args.parse(init);
+    // GRAFF_CODEX_URL: override the codex responses endpoint (localhost mocks / integration tests). Parsed BEFORE subcommand dispatch and
+    // resolveKeys — `graff models [refresh]` fetches the catalog inside runSubcommand and the initial Keys.build runs inside resolveKeys.
+    // environ_map slices are process-lifetime (resolveKeys stores them into Keys the same way), so the value is kept as-is without duping.
+    if (init.environ_map.get("GRAFF_CODEX_URL")) |cu| {
+        if (cu.len > 0) provider_mod.g_codex_url_override = cu;
+    }
     // --help / --version: handled before any subcommand dispatch, so `harness login --help` prints usage instead of starting an OAuth flow.
     if (try startup.runSubcommand(io, gpa, arena, init, flags)) return;
     // Credential/model resolution (env vars → on-disk logins → `harness key set` store, env always wins; then --model or the last-saved model) lives

--- a/src/mainloop.zig
+++ b/src/mainloop.zig
@@ -475,6 +475,13 @@ pub fn run(ctx: *Ctx) !void {
         ctx.root.tool_calls_this_turn = 0;
         ctx.root.seen_tool_keys.clearRetainingCapacity();
         if (main_mod.json_mode) ctx.root.emit(.{ .type = "started", .provider = ctx.root.provider.id, .model = ctx.root.provider.model });
+        // Breathing room between the submitted input and the turn's first
+        // output — without it the reply starts on the very next line and
+        // reads as a continuation of what the user typed.
+        if (ctx.interactive and !main_mod.json_mode) {
+            try ctx.out.writeAll("\n");
+            try ctx.out.flush();
+        }
         const turn_started = Io.Timestamp.now(ctx.io, .awake);
         // A failed turn must never kill the session: ApiError is already
         // reported inside request(); anything else is surfaced here. Either

--- a/src/models_cache.zig
+++ b/src/models_cache.zig
@@ -31,6 +31,7 @@ const Allocator = std.mem.Allocator;
 const pricing = @import("pricing.zig");
 const util = @import("util.zig");
 const strFieldObj = util.strFieldObj;
+const provider = @import("provider.zig"); // g_codex_url_override: keep /models discovery on the same origin as the overridden responses endpoint
 
 const models_dev_url = "https://models.dev/api.json";
 const codex_models_url = "https://chatgpt.com/backend-api/codex/models";
@@ -201,9 +202,21 @@ fn snapshotMatchesVersion(snapshot: CodexSnapshot, version: []const u8) bool {
     return std.mem.eql(u8, snapshot.client_version, version);
 }
 
+/// The /models discovery endpoint: chatgpt.com by default; when GRAFF_CODEX_URL
+/// overrides the responses endpoint, discovery follows that origin
+/// (scheme://host[:port] + /backend-api/codex/models) so a localhost mock is
+/// never bypassed for a live chatgpt.com fetch — a mock without /models just
+/// falls back to cache/baked rows via the non-200 path.
+fn codexModelsUrl(arena: Allocator) []const u8 {
+    const override = provider.g_codex_url_override orelse return codex_models_url;
+    const scheme_end = std.mem.indexOf(u8, override, "://") orelse return codex_models_url;
+    const path_start = std.mem.indexOfScalarPos(u8, override, scheme_end + 3, '/') orelse override.len;
+    return std.fmt.allocPrint(arena, "{s}/backend-api/codex/models", .{override[0..path_start]}) catch codex_models_url;
+}
+
 fn fetchCodexSnapshot(io: Io, gpa: Allocator, arena: Allocator, token: []const u8, account: []const u8, version: []const u8) ?CodexSnapshot {
     if (token.len == 0 or account.len == 0 or version.len == 0) return null;
-    const url = std.fmt.allocPrint(arena, "{s}?client_version={s}", .{ codex_models_url, version }) catch return null;
+    const url = std.fmt.allocPrint(arena, "{s}?client_version={s}", .{ codexModelsUrl(arena), version }) catch return null;
     const bearer = std.fmt.allocPrint(arena, "Bearer {s}", .{token}) catch return null;
     const user_agent = std.fmt.allocPrint(arena, "codex_cli_rs/{s} (graff)", .{version}) catch return null;
     var client: std.http.Client = .{ .allocator = gpa, .io = io };
@@ -269,7 +282,12 @@ pub fn loadCodexCatalog(io: Io, gpa: Allocator, arena: Allocator, home: []const 
     const native_data = readSmall(io, arena, nativeCodexPath(arena, codex_home));
     const native = if (native_data) |data| parseCodexSnapshot(arena, data) else null;
     const version = effectiveCodexVersion(installedCodexVersion(io, arena), native);
-    const cached_data = readSmall(io, arena, codexDirPath(arena, home)) orelse readSmall(io, arena, codexFlatPath(arena, home));
+    // GRAFF_CODEX_URL runs are hermetic w.r.t. the shared per-HOME cache in
+    // BOTH directions: a fresh real-origin cache must not shadow the override
+    // (read skip here), and an override-origin snapshot is never written back
+    // (see below). The CODEX_HOME-scoped native cache stays available — the
+    // caller controls that path explicitly.
+    const cached_data = if (provider.g_codex_url_override != null) null else readSmall(io, arena, codexDirPath(arena, home)) orelse readSmall(io, arena, codexFlatPath(arena, home));
     const cached = if (cached_data) |data| parseCodexSnapshot(arena, data) else null;
     const now = util.unixMs(io);
     if (!force_refresh) if (cached) |snapshot| {
@@ -282,7 +300,10 @@ pub fn loadCodexCatalog(io: Io, gpa: Allocator, arena: Allocator, home: []const 
     if (fetchCodexSnapshot(io, gpa, arena, token, account, version)) |snapshot| {
         if (pricing.activateCodexModels(arena, snapshot.models)) {
             codex_catalog_source = "live account catalog";
-            writeCodexCache(io, arena, home, version, snapshot.models);
+            // Never persist an override-origin snapshot: a later default run
+            // would activate a mock's rows as a genuine chatgpt.com catalog
+            // (the cache is unkeyed by origin and stamped with the real URL).
+            if (provider.g_codex_url_override == null) writeCodexCache(io, arena, home, version, snapshot.models);
             return;
         }
     }

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -59,6 +59,12 @@ pub const provider_specs = [_]ProviderSpec{
     .{ .id = "codex", .kind = .responses, .auth = .bearer, .url = "https://chatgpt.com/backend-api/codex/responses", .env_key = "CODEX_DISABLED", .default_model = "gpt-5.6-sol" },
 };
 
+/// Codex responses-endpoint override (GRAFF_CODEX_URL, parsed in main.zig at
+/// startup — localhost mocks / integration tests). Lives here because every
+/// provider (re)build path (startup, /model switches, session restore) goes
+/// through Keys.build; both the WS and SSE transports read provider.url.
+pub var g_codex_url_override: ?[]const u8 = null;
+
 pub const Provider = struct {
     id: []const u8,
     kind: Kind,
@@ -120,15 +126,16 @@ pub const Keys = struct {
     }
 
     pub fn build(keys: Keys, spec: ProviderSpec, key: []const u8, model: []const u8) Provider {
+        const is_codex = std.mem.eql(u8, spec.id, "codex");
         return .{
             .id = spec.id,
             .kind = spec.kind,
             .auth = spec.auth,
-            .url = spec.url,
+            .url = if (is_codex) g_codex_url_override orelse spec.url else spec.url,
             .api_key = key,
             .model = model,
             .context = contextFor(spec.id, model),
-            .account = if (std.mem.eql(u8, spec.id, "codex")) keys.codex_account else "",
+            .account = if (is_codex) keys.codex_account else "",
             .source = keys.source(spec.id),
         };
     }
@@ -216,4 +223,14 @@ test "Keys.defaultProvider: first keyed provider on its default model" {
     try std.testing.expectEqualStrings("claude-opus-4-8", p.model);
     const none = Keys{ .values = [_]?[]const u8{null} ** provider_specs.len };
     try std.testing.expectError(error.MissingKey, none.defaultProvider());
+}
+
+test "Keys.build: g_codex_url_override rewires only the codex endpoint" {
+    const all = Keys{ .values = [_]?[]const u8{"k"} ** provider_specs.len };
+    g_codex_url_override = "http://127.0.0.1:8765/responses";
+    defer g_codex_url_override = null;
+    const codex = try all.providerById("codex", "gpt-5.6-sol");
+    try std.testing.expectEqualStrings("http://127.0.0.1:8765/responses", codex.url);
+    const anthropic = try all.providerById("anthropic", "claude-opus-4-8");
+    try std.testing.expectEqualStrings("https://api.anthropic.com/v1/messages", anthropic.url);
 }

--- a/src/session_run.zig
+++ b/src/session_run.zig
@@ -350,13 +350,21 @@ pub fn setupSkillsAndTheme(io: Io, arena: Allocator, environ_map: anytype, out: 
             if (secs > 0) http.stream_stall_ms = @min(secs, 86_400) * 1000; // clamp: <=1 day, no u64 overflow
         } else |_| {}
     }
-    // #codex-ws: GRAFF_CODEX_WS=off|0|false|no forces the SSE transport for
-    // codex; GRAFF_WS_DEBUG=1 dumps the ws handshake + frames to stderr.
+    // #codex-ws: GRAFF_CODEX_WS=off|0|false|no (case-insensitive, the
+    // GRAFF_FLEET predicate) forces the SSE transport for codex;
+    // GRAFF_WS_DEBUG=1 dumps the ws handshake + frames to stderr. This is the
+    // SOLE parse site for the codex transport knobs — a copy in main() would
+    // be silently overwritten here, since setupSkillsAndTheme runs later.
     if (environ_map.get("GRAFF_CODEX_WS")) |v| {
-        main_mod.g_codex_ws = !(std.mem.eql(u8, v, "off") or std.mem.eql(u8, v, "0") or std.mem.eql(u8, v, "false") or std.mem.eql(u8, v, "no"));
+        main_mod.g_codex_ws = !(std.ascii.eqlIgnoreCase(v, "off") or std.mem.eql(u8, v, "0") or std.ascii.eqlIgnoreCase(v, "false") or std.ascii.eqlIgnoreCase(v, "no"));
     }
     ws.g_debug = environ_map.get("GRAFF_WS_DEBUG") != null;
-    ws.g_force_connect_failure_once = environ_map.get("GRAFF_WS_FORCE_FAIL_ONCE") != null;
+    // GRAFF_WS_FORCE_FAIL_ONCE=1|true|on|yes arms the one-shot forced WS
+    // connect failure (integration-test seam for the SSE fallback + ws_off
+    // latch). Only affirmative values arm it — =0 must leave it disarmed.
+    if (environ_map.get("GRAFF_WS_FORCE_FAIL_ONCE")) |v| {
+        ws.g_force_connect_failure_once = std.mem.eql(u8, v, "1") or std.ascii.eqlIgnoreCase(v, "true") or std.ascii.eqlIgnoreCase(v, "on") or std.ascii.eqlIgnoreCase(v, "yes");
+    }
     skills.loadSkillSettings(io, arena); // per-skill opt-outs, also gates the auto-connect
     anim.loadAnimationSetting(io, arena); // {"animation": "..."} → thinking spinner choice
     anim.loadThemeSetting(io, arena); // {"theme": "<name>"} → opt-in terminal color theme


### PR DESCRIPTION
## What

**Codex WebSocket usage readings, proven end-to-end on a real PTY.** The WS transport shares `parseResponses` with SSE so `response.completed` usage always fed the ctx meter — but nothing could prove it, and the env knobs around the transport were broken:

- **`GRAFF_CODEX_URL`** (new): overrides the codex responses endpoint for localhost mocks / integration tests. Parsed before subcommand dispatch so `graff models refresh` honors it; `/models` discovery follows the override origin; override runs are hermetic w.r.t. the shared per-HOME catalog cache in both directions (no stale-cache shadowing, no poisoning later default runs with mock rows).
- **`GRAFF_CODEX_WS`**: now case-insensitive (the `GRAFF_FLEET` predicate), single parse site in `session_run.zig` — a duplicate parse in `main()` would be silently overwritten later.
- **`GRAFF_WS_FORCE_FAIL_ONCE`**: armed only by affirmative values (`1|true|on|yes`) — `=0` used to force-fail the next WS connect on mere presence.
- **ctx meter**: `recordUsageResponses` falls back to a request-size estimate when codex omits usage counts, keeping the meter and the `compact@` trigger live.

**New test infra**: `scripts/codex_ws_mock.py` (stdlib fake codex backend speaking real RFC6455 WS + SSE with per-transport turn counters) and `scripts/test-pty-codex-ws.py` — three real-PTY scenarios (WS primary / forced SSE fallback / WS off), each asserting reply text, the prompt meter (shape + compact@=80% invariant), `/models health`, and server-side transport counters so a silent fallback cannot fake a pass. Ambient `GRAFF_*`/`CODEX_*` env is stripped for determinism.

**REPL UX**: one blank line between the submitted input and the turn's first output (interactive non-JSON sessions only — piped/`--json`/oneshot output stays byte-identical).

## Verification (on this branch, macOS)

- `zig build` + `zig build test` (incl. new `g_codex_url_override` unit test)
- `scripts/test-pty-codex-ws.py`: passes clean AND with hostile ambient env (`GRAFF_CODEX_WS=off GRAFF_WS_FORCE_FAIL_ONCE=1` exported) — works against the #166 delta transport (WS connection reuse)
- `scripts/test-pty-repl.py`, `scripts/test-stall-drop.py`: pass
- Targeted probes: `GRAFF_WS_FORCE_FAIL_ONCE=0` stays on WS; `GRAFF_CODEX_WS=OFF` (uppercase) forces SSE; `graff models refresh` fetches the catalog from the override origin; blank line confirmed from raw PTY bytes

Multi-agent workflow build: 2 implementers + e2e verifier + 3 adversarial reviewers; all 4 review findings fixed and probe-verified.