### PR TITLE
fix(tools): raise the open-file limit at startup + actionable fd-quota errors (#122)

### DIFF
--- a/src/exec.zig
+++ b/src/exec.zig
@@ -135,7 +135,13 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
         const bg = if (input == .object) (if (input.object.get("run_in_background")) |v| v == .bool and v.bool else false) else false;
         if (bg) {
             const job = spawnJob(gpa, io, cmd) catch |err| return .{
-                .text = try std.fmt.allocPrint(gpa, "could not start background job ({t}) — run it in the foreground instead", .{err}),
+                // #122: backgrounding costs MORE fds (pipes + pump task), so the
+                // generic "run it in the foreground" advice is right for every
+                // error except the fd-quota one — special-case that.
+                .text = if (err == error.ProcessFdQuotaExceeded)
+                    try gpa.dupe(u8, "could not start background job (ProcessFdQuotaExceeded) — graff hit its open-file limit. Wait for running jobs/tools to finish, then retry with less parallel fan-out; if it recurs, raise the limit (`ulimit -n 4096`) before starting graff.")
+                else
+                    try std.fmt.allocPrint(gpa, "could not start background job ({t}) — run it in the foreground instead", .{err}),
                 .is_error = true,
             };
             return .{ .text = try std.fmt.allocPrint(gpa, "[job {d} started: {s}]\nIt keeps running across turns. Poll new output with bash_output (id {d}, optional wait_ms), stop it with bash_kill.", .{ job.id, job.cmd, job.id }) };

--- a/src/main.zig
+++ b/src/main.zig
@@ -241,6 +241,11 @@ pub fn main(init: std.process.Init) !void {
     const gpa = init.gpa;
     const io = init.io;
     const arena = init.arena.allocator();
+    // #122: raise the open-file soft limit to the OS hard cap (Darwin defaults
+    // to 256) so parallel tool/subagent/MCP fan-out in one turn doesn't blow up
+    // shell tools with ProcessFdQuotaExceeded. Best-effort, no-op where rlimits
+    // don't exist.
+    std.process.raiseFileDescriptorLimit();
     // #124: a per-turn scratch arena for the root agent's transient parse garbage,
     // reset each request() so a long REPL/--json/serve session's RSS stays flat.
     var scratch_state = std.heap.ArenaAllocator.init(gpa);

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -350,6 +350,12 @@ fn companionNativeFallback(bare: []const u8) []const u8 {
 }
 
 pub fn failure(gpa: Allocator, err: anyerror) ToolOutput {
+    // #122: the bare error name is useless advice for an open-file-limit hit —
+    // say what it means and what actually helps.
+    if (err == error.ProcessFdQuotaExceeded) {
+        const text = gpa.dupe(u8, "error: ProcessFdQuotaExceeded — graff hit its open-file limit, usually from many parallel tools/subagents/MCP servers in one turn. Retry the failed calls sequentially (less parallel fan-out); if it recurs, raise the limit (`ulimit -n 4096`) before starting graff.") catch return .{ .is_error = true };
+        return .{ .text = text, .is_error = true };
+    }
     const text = std.fmt.allocPrint(gpa, "error: {t}", .{err}) catch return .{ .is_error = true };
     return .{ .text = text, .is_error = true };
 }


### PR DESCRIPTION
## What

- `std.process.raiseFileDescriptorLimit()` in `main()` before subcommand dispatch: lifts the soft NOFILE cap to the OS hard cap (Darwin: `OPEN_MAX` 10240 vs the 256 default). Zig 0.16.0 std ships this with correct Darwin clamping, so the fix is the one-liner discussed on the issue.
- `tools.failure()` special-cases `ProcessFdQuotaExceeded` with an actionable message (what it means, retry sequentially, `ulimit -n 4096`) instead of the bare error name.
- The background-job spawn path no longer suggests "run it in the foreground instead" for an fd-quota hit — backgrounding costs *more* fds, so that advice was actively wrong for this error.

## Why

The audit on #122 disproved the FD-leak theory (graff's own FD count is flat at 11 across turns; 150 sequential bash spawns under `ulimit -n 256` all succeed) — the failure mode is parallel tool/subagent/MCP fan-out pressure against the 256 default. Raising the limit at startup defuses it.

## Verification (end-to-end A/B)

Scripted lmstudio-slot mock orders a `bash: ulimit -n` tool call through a real `--json` turn, parent shell capped at `ulimit -n 256`:

| binary | child sees |
|---|---|
| this branch | **10240** |
| installed v0.0.200 | 256 |

`zig build` + `zig build test` clean.

Closes #122 (remaining items on that issue — fan-out caps — are follow-up material; the limit raise + error message were the actionable core).