### PR TITLE
fix(trace): record transport-flake retries in the session trace

### DIFF
--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -172,6 +172,10 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
                             // (#86). 250ms·2ⁿ, capped at 4s over 6 tries; Esc cancels.
                             const delay_ms = RetryPlan.delayMs(throttled, attempt);
                             try self.say("[network error: {t} — retrying in {d}ms ({d}/{d})]\n", .{ err, delay_ms, attempt + 1, max_attempts });
+                            // Same trace breadcrumb the 429/5xx branch leaves: a
+                            // transport-flake retry is otherwise invisible in the
+                            // session trace, hiding how flaky a provider really is.
+                            if (self.tracer) |tr| tr.note("retry", @errorName(err));
                             self.sleepInterruptible(delay_ms) catch return error.Interrupted;
                         }
                         continue;


### PR DESCRIPTION
## What

One breadcrumb: the transport-flake retry branch (`HttpConnectionClosing`, resets, truncated TLS reads) now leaves the same `{ev:"retry", detail:<error>}` note in `harness.trace.jsonl` that the 429/5xx branch already leaves.

## Why

A flaky provider was invisible in the session trace — the retries printed to the screen but left no trace record, so post-hoc diagnosis of a slow/flaky session couldn't see how many transport retries a turn ate.

## Verification

Pointed graff at an accept-then-close socket: all 6 flake retries appear as `{ev:retry, detail:HttpConnectionClosing}` with backoff-spaced timestamps (41ms, 318ms, 851ms, 1.9s, 4.1s, 8.4s). `zig build` + `zig build test` clean.