### PR TITLE
fix: newer-issue batch — file-mode + fs-errors (#179/#183), blank sessions (#184), subagent errors (#187)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Stream stall/drop is not a user Esc (#134/#132)
         run: python3 scripts/test-stall-drop.py zig-out/bin/graff
 
+      - name: Newer-issue E2E — blank sessions not persisted (#184)
+        run: python3 scripts/test-e2e-newer-issues.py zig-out/bin/graff
+
       - name: SDK generation drift
         run: |
           python3 sdk/generate.py --harness ./zig-out/bin/graff

--- a/scripts/test-e2e-newer-issues.py
+++ b/scripts/test-e2e-newer-issues.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""End-to-end regression for the newer-issue fixes, driving the real graff
+binary (no network — a fake key + the GRAFF_FORCE_STALL_ONCE seam short-circuit
+the turn). Covers #184: a blank draft is never persisted, while a conversation
+with meaningful state (a user message, a goal, ...) is.
+
+Usage:  scripts/test-e2e-newer-issues.py [path/to/graff]
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+_arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
+GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
+
+BASE_ENV = {
+    "CODEGRAFF_API_KEY": "fake-test-key",
+    "GRAFF_NO_TELEMETRY": "1",
+    "GRAFF_FLEET": "off",
+}
+
+
+def run(stdin, extra_env=None):
+    """Run graff once in a throwaway HOME+cwd; return every *.session.json
+    written anywhere under either."""
+    home = tempfile.mkdtemp(prefix="graff-e2e-home-")
+    cwd = tempfile.mkdtemp(prefix="graff-e2e-cwd-")
+    try:
+        env = {"HOME": home, "PATH": os.environ.get("PATH", ""), **BASE_ENV}
+        if extra_env:
+            env.update(extra_env)
+        subprocess.run([GRAFF], input=stdin, env=env, cwd=cwd,
+                       capture_output=True, text=True, timeout=60)
+        found = []
+        for root in (home, cwd):
+            for dirpath, _dirs, files in os.walk(root):
+                found += [os.path.join(dirpath, f) for f in files
+                          if f.endswith(".session.json")]
+        return found
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+        shutil.rmtree(cwd, ignore_errors=True)
+
+
+def main():
+    failures = []
+
+    # #184 negative: a blank conversation (start -> /exit, no user turn, no goal)
+    # must NOT leave a session file. Before the fix, the startup autosave wrote a
+    # session-<ts>.session.json here.
+    blank = run("/exit\n")
+    if blank:
+        failures.append("#184: blank conversation persisted %d session file(s): %s" % (len(blank), blank))
+
+    # #184 positive: one user message (force-stalled, so no network) IS meaningful
+    # and must be saved.
+    meaningful = run(
+        "/model codegraff deepseek-v4-pro\nhello there\n/save meaningful\n/exit\n",
+        {"GRAFF_FORCE_STALL_ONCE": "1"},
+    )
+    if not any(p.endswith("meaningful.session.json") for p in meaningful):
+        failures.append("#184: a conversation with a user message was NOT saved (got %s)" % (meaningful,))
+
+    if failures:
+        print("FAIL:")
+        for f in failures:
+            print("  -", f)
+        return 1
+    print("ok: #184 blank-not-persisted + meaningful-persisted")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -223,7 +223,10 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
                 if (try codedbCompactRead(gpa, io, path, start_line, end_line)) |out| return out;
             }
         }
-        const data = try Io.Dir.cwd().readFileAlloc(io, path, gpa, .limited(256 * 1024));
+        const data = Io.Dir.cwd().readFileAlloc(io, path, gpa, .limited(256 * 1024)) catch |err| {
+            if (fsErrorText(gpa, .read, path, err)) |t| return .{ .text = t, .is_error = true };
+            return err;
+        };
         // Binary guard: PDFs/images/archives would only poison the context
         // with mojibake — point the model at bash converters instead.
         if (binaryFileExt(path) or std.mem.indexOfScalar(u8, data[0..@min(data.len, 4096)], 0) != null) {
@@ -287,7 +290,10 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
         const all = if (input.object.get("replace_all")) |v| v == .bool and v.bool else false;
         if (old.len == 0) return .{ .text = try gpa.dupe(u8, "old_string must not be empty"), .is_error = true };
 
-        const data = try Io.Dir.cwd().readFileAlloc(io, path, gpa, .limited(1024 * 1024));
+        const data = Io.Dir.cwd().readFileAlloc(io, path, gpa, .limited(1024 * 1024)) catch |err| {
+            if (fsErrorText(gpa, .edit, path, err)) |t| return .{ .text = t, .is_error = true };
+            return err;
+        };
         defer gpa.free(data);
         const count = std.mem.count(u8, data, old);
         if (count == 0) return .{
@@ -303,6 +309,9 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
         defer gpa.free(replaced);
         _ = std.mem.replace(u8, data, old, new, replaced);
         if (ctx.snapshots) |snaps| if (!ctx.from_sub) snaps.record(path, data); // pre-edit content for /rewind
+        // #179: capture the file's mode now so the atomic rewrite below can't drop
+        // a 0755 executable bit down to the default 0644.
+        const prev_stat = Io.Dir.cwd().statFile(io, path, .{}) catch null;
         // Premium splice: when the zigrep suite is installed, zigpatch does
         // the write — an atomic tmp+rename byte-level --all splice (our count
         // checks above already enforce the uniqueness semantics). Any
@@ -318,10 +327,13 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
                 .exited => |code| code == 0,
                 else => false,
             };
-            if (ok and std.mem.indexOf(u8, run.stdout, "\"ok\":true") != null)
+            if (ok and std.mem.indexOf(u8, run.stdout, "\"ok\":true") != null) {
+                preserveMode(io, path, prev_stat); // #179: zigpatch renamed a fresh inode into place
                 return .{ .text = try std.fmt.allocPrint(gpa, "replaced {d} occurrence(s) in {s} (zigpatch)", .{ count, path }) };
+            }
         }
         try Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = replaced });
+        preserveMode(io, path, prev_stat); // #179: keep the pre-edit mode
         return .{ .text = try std.fmt.allocPrint(gpa, "replaced {d} occurrence(s) in {s}", .{ count, path }) };
     }
     if (std.mem.eql(u8, call.name, "write_file")) {
@@ -334,7 +346,14 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
             defer if (before) |b| gpa.free(b);
             snaps.record(path, before);
         };
-        try Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = content });
+        // #179: an existing file keeps its mode (e.g. 0755) across the overwrite;
+        // a brand-new file (prev_stat == null) keeps the default.
+        const prev_stat = Io.Dir.cwd().statFile(io, path, .{}) catch null;
+        Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = content }) catch |err| {
+            if (fsErrorText(gpa, .write, path, err)) |t| return .{ .text = t, .is_error = true };
+            return err;
+        };
+        preserveMode(io, path, prev_stat);
         return .{ .text = try std.fmt.allocPrint(gpa, "wrote {d} bytes to {s}", .{ content.len, path }) };
     }
     if (std.mem.eql(u8, call.name, "subagent")) return execSubagent(ctx, input);
@@ -404,4 +423,79 @@ test "sliceLines: byte-exact 1-based inclusive window (#66)" {
     try std.testing.expect(sliceLines(data, 99, 100) == null); // start past EOF
     try std.testing.expectEqualStrings("y", sliceLines("x\ny", 2, 2).?); // no trailing newline
     try std.testing.expect(std.mem.indexOf(u8, data, sliceLines(data, 2, 3).?) != null); // literal substring
+}
+
+/// The three native file tools, used to shape a filesystem-error message with
+/// the tool's own name and the right recovery hint (#183).
+const FileOp = enum {
+    read,
+    edit,
+    write,
+    fn tool(self: FileOp) []const u8 {
+        return switch (self) {
+            .read => "read_file",
+            .edit => "edit_file",
+            .write => "write_file",
+        };
+    }
+};
+
+/// Maps an EXPECTED filesystem error from a native file tool to a clear message
+/// naming the tool, the supplied path, and the failure — so the model sees
+/// "read_file: foo.zig does not exist" instead of a bare "error: FileNotFound"
+/// (#183). Returns null for anything outside the usual path/permission set, so
+/// the caller re-throws it onto the generic harness-failure path. Confinement,
+/// symlink, and validation errors are already handled before the fs call and
+/// never reach here. Caller owns the returned slice.
+fn fsErrorText(gpa: Allocator, op: FileOp, path: []const u8, err: anyerror) ?[]u8 {
+    return (switch (err) {
+        // A missing target, or a non-directory used as a path component.
+        error.FileNotFound, error.NotDir => switch (op) {
+            .read => std.fmt.allocPrint(gpa, "read_file: {s} does not exist (paths are relative to the cwd) — check the name, or list the directory with bash `ls`", .{path}),
+            .edit => std.fmt.allocPrint(gpa, "edit_file: {s} does not exist — edit_file only rewrites an existing file; use write_file to create it", .{path}),
+            .write => std.fmt.allocPrint(gpa, "write_file: cannot create {s} — its parent directory does not exist; create it first with bash `mkdir -p`", .{path}),
+        },
+        error.IsDir => std.fmt.allocPrint(gpa, "{s}: {s} is a directory, not a file", .{ op.tool(), path }),
+        error.AccessDenied, error.PermissionDenied => std.fmt.allocPrint(gpa, "{s}: permission denied for {s}", .{ op.tool(), path }),
+        error.NoSpaceLeft => std.fmt.allocPrint(gpa, "write_file: no space left on device writing {s}", .{path}),
+        else => return null,
+    }) catch null;
+}
+
+/// Re-apply a file's saved permission bits after a rewrite. edit_file's atomic
+/// zigpatch splice — and write_file overwriting an existing file — land the new
+/// content on a fresh inode with the default 0644, silently dropping a 0755
+/// executable bit; restore it (#179). `prev` is null for a brand-new file (keep
+/// the default) or when the pre-write stat failed. Best-effort: a chmod failure
+/// never fails the write itself.
+fn preserveMode(io: Io, path: []const u8, prev: ?Io.Dir.Stat) void {
+    const st = prev orelse return;
+    Io.Dir.cwd().setFilePermissions(io, path, st.permissions, .{}) catch {};
+}
+
+test "fsErrorText names the tool, path, and failure (#183)" {
+    const gpa = std.testing.allocator;
+
+    const nf = fsErrorText(gpa, .read, "src/foo.zig", error.FileNotFound).?;
+    defer gpa.free(nf);
+    try std.testing.expect(std.mem.indexOf(u8, nf, "read_file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, nf, "src/foo.zig") != null);
+
+    const ed = fsErrorText(gpa, .edit, "src/bar.zig", error.FileNotFound).?;
+    defer gpa.free(ed);
+    try std.testing.expect(std.mem.indexOf(u8, ed, "edit_file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ed, "write_file") != null); // points at creation
+
+    const wr = fsErrorText(gpa, .write, "nope/out.txt", error.FileNotFound).?;
+    defer gpa.free(wr);
+    try std.testing.expect(std.mem.indexOf(u8, wr, "write_file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, wr, "parent") != null); // distinguishes a missing parent dir
+
+    const perm = fsErrorText(gpa, .edit, "p", error.AccessDenied).?;
+    defer gpa.free(perm);
+    try std.testing.expect(std.mem.indexOf(u8, perm, "edit_file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, perm, "permission") != null);
+
+    // Errors outside the usual path/permission set fall through to the generic handler.
+    try std.testing.expect(fsErrorText(gpa, .read, "p", error.OutOfMemory) == null);
 }

--- a/src/session.zig
+++ b/src/session.zig
@@ -186,10 +186,36 @@ pub fn sessionTitle(root: *Agent) []const u8 {
     return "Untitled session";
 }
 
+/// A conversation is "meaningful" — worth persisting to disk — once it holds any
+/// durable state a resume would want back. Concretely, at least one of:
+///   - a user message (>= 1 message with role "user"),
+///   - a non-null standing goal (/goal steering),
+///   - a non-empty todo list, or
+///   - recorded tool activity this session.
+/// A truly blank draft (no user turn, no goal, no todos, no tools) is NOT
+/// meaningful, so saveSession skips it rather than leaving an "Untitled
+/// session" file on disk (#184). Callers that only want to avoid the blank-draft
+/// write get this for free by going through saveSession.
+pub fn hasMeaningfulState(root: *Agent) bool {
+    if (root.goal != null) return true;
+    if (root.todos.items.len > 0) return true;
+    if (root.tools_used.entries.items.len > 0) return true;
+    for (root.messages.items) |m| {
+        if (m != .object) continue;
+        const role = if (m.object.get("role")) |v| (if (v == .string) v.string else "") else "";
+        if (std.mem.eql(u8, role, "user")) return true;
+    }
+    return false;
+}
+
 /// Save the conversation (messages + provider id/model + strict flag) to
 /// <name>.session.json in the cwd. The JSON message array is already the
 /// provider-native wire shape, so resume is a verbatim restore.
 pub fn saveSession(root: *Agent, arena: Allocator, name: []const u8) !void {
+    // #184: delay durable session creation until the conversation has meaningful
+    // state — never leave a blank draft as an "Untitled session" on disk. Existing
+    // files are untouched (we skip the write, we do not delete).
+    if (!hasMeaningfulState(root)) return;
     var aw: Io.Writer.Allocating = .init(root.gpa);
     defer aw.deinit();
     var s: std.json.Stringify = .{ .writer = &aw.writer };
@@ -279,4 +305,32 @@ test "slugifyTitle makes a filesystem-safe slug from an AI title" {
     try std.testing.expectEqualStrings("add-dark-mode", slugifyTitle(a, "Add dark mode!!"));
     try std.testing.expectEqualStrings("planning-v2", slugifyTitle(a, "  Planning — v2  ")); // trim + collapse
     try std.testing.expectEqualStrings("", slugifyTitle(a, "🎉 ✨")); // symbol-only → "" (keeps the session-<ts> name)
+}
+
+test "hasMeaningfulState gates the blank-draft write (#184)" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // Only the fields hasMeaningfulState reads are set; the rest stay untouched.
+    var root: Agent = undefined;
+    root.goal = null;
+    root.todos = .empty;
+    root.tools_used = .{};
+    root.messages = std.json.Array.init(arena);
+
+    // Truly blank: no user turn, no goal, no todos, no tools → not persisted.
+    try std.testing.expect(!hasMeaningfulState(&root));
+
+    // A standing /goal alone is meaningful (goal-only sessions are still saved).
+    root.goal = "ship the release";
+    try std.testing.expect(hasMeaningfulState(&root));
+
+    // One user message alone is meaningful.
+    root.goal = null;
+    var obj: std.json.ObjectMap = .empty;
+    try obj.put(arena, "role", .{ .string = "user" });
+    try obj.put(arena, "content", .{ .string = "hi" });
+    try root.messages.append(.{ .object = obj });
+    try std.testing.expect(hasMeaningfulState(&root));
 }

--- a/src/subagent.zig
+++ b/src/subagent.zig
@@ -68,6 +68,86 @@ fn guiEmit(io: Io, ev: anytype) void {
     w.flush() catch return;
 }
 
+/// Coarse classification of a subagent's underlying API/transport failure, so
+/// the tool result can tell the orchestrator what actually broke and whether a
+/// retry is worth it — the bare `error.ApiError` propagation carried none of it.
+const FailKind = enum {
+    quota, // rate limit / out of credits / overloaded
+    transport, // network drop / stream stall — usually transient
+    model, // model missing / decommissioned / unavailable
+    invalid, // bad arguments / unsupported param / context too long
+    auth, // key invalid / expired / unauthorized
+    unknown, // no detail to classify against
+
+    fn label(self: FailKind) []const u8 {
+        return switch (self) {
+            .quota => "quota/rate-limit",
+            .transport => "transport",
+            .model => "model-availability",
+            .invalid => "invalid-arguments",
+            .auth => "auth",
+            .unknown => "unknown",
+        };
+    }
+
+    /// Is re-running the identical task likely to succeed? Transient failures
+    /// (quota backoff, transport flake) yes; a bad model / argument / credential
+    /// just fails again until the cause is fixed.
+    fn retrySafe(self: FailKind) bool {
+        return switch (self) {
+            .quota, .transport, .unknown => true,
+            .model, .invalid, .auth => false,
+        };
+    }
+};
+
+fn containsAnyCI(hay: []const u8, needles: []const []const u8) bool {
+    for (needles) |n| if (std.ascii.indexOfIgnoreCase(hay, n) != null) return true;
+    return false;
+}
+
+/// Classify a child turn's failure from its error kind and the child agent's
+/// captured `last_api_error` detail (the provider's error type + message, or a
+/// transport reason). The detail is the authoritative signal; the error kind
+/// only distinguishes a stream stall/drop, whose stale envelope would mislead.
+/// Order matters: quota/auth/model phrases are checked before the broad
+/// `invalid_request_error` type so a rate-limit or missing-model envelope isn't
+/// swallowed as a generic "invalid" just because that type string contains it.
+fn classifyFailure(err: anyerror, detail: ?[]const u8) FailKind {
+    switch (err) {
+        error.StreamStalled, error.StreamDropped => return .transport,
+        else => {},
+    }
+    const msg = detail orelse return .unknown;
+    if (containsAnyCI(msg, &.{ "network error", "stream stalled", "stream dropped", "timed out", "connection reset", "connection closed" })) return .transport;
+    if (containsAnyCI(msg, &.{ "rate limit", "rate_limit", "quota", "429", "overloaded", "out of credits", "credits", "billing", "too many requests" })) return .quota;
+    if (containsAnyCI(msg, &.{ "api key", "unauthorized", "expired", "authentication", "invalid_api_key", "401" })) return .auth;
+    if (containsAnyCI(msg, &.{ "does not exist", "not found", "no such model", "decommission", "no longer", "model_not_found", "unavailable", "404" })) return .model;
+    if (containsAnyCI(msg, &.{ "context length", "context window", "invalid", "unsupported", "not supported", "must be", "too long", "400", "parameter", "max_tokens", "bad request" })) return .invalid;
+    return .unknown;
+}
+
+/// Build the is_error tool result for a subagent whose child turn failed at the
+/// API/transport layer. Threads the child's own diagnostic — provider status /
+/// message, a coarse category, and whether a retry is worth it — up to the
+/// orchestrator instead of collapsing to an opaque bare `error: ApiError`.
+/// `detail` is the child agent's `last_api_error`; formatted into `gpa` before
+/// the child arena that owns it is freed on return.
+fn subagentFailure(gpa: Allocator, sub_id: []const u8, err: anyerror, detail: ?[]const u8) ToolOutput {
+    const kind = classifyFailure(err, detail);
+    const cause = detail orelse @errorName(err);
+    const retry = if (kind.retrySafe())
+        "retry is likely safe — re-run the same task (after a short backoff for quota/transport)"
+    else
+        "retry is NOT safe as-is — fix the cause first (switch model, correct arguments, or re-auth)";
+    const text = std.fmt.allocPrint(
+        gpa,
+        "subagent {s} failed before producing a report: {s} [{s} failure]. {s}",
+        .{ sub_id, cause, kind.label(), retry },
+    ) catch return .{ .is_error = true };
+    return .{ .text = text, .is_error = true };
+}
+
 /// Run one isolated subagent to completion: fresh arena, fresh history,
 /// same shared http client and provider. Runs entirely on this pool thread;
 /// its own tool calls fan out further via io.async. `sys_override` swaps the
@@ -149,7 +229,13 @@ pub fn runSub(ctx: ToolCtx, kind: []const u8, label: []const u8, prompt: []const
         });
     }
     if (telemetry.g_telem) |t| t.runEvent(&fp, sys_override != null, run_ok, run_ms, used_tools);
-    const text = try report;
+    // A child API/transport failure used to collapse to a bare "error: ApiError"
+    // once execTool's catch ran failure() on the propagated error. Instead
+    // surface the child's own diagnostic (provider status/message + a coarse
+    // category + retry guidance) as an is_error result, duped into gpa before
+    // the child arena that owns last_api_error is freed on return.
+    const text = report catch |err|
+        return subagentFailure(gpa, sub_id, err, agent.last_api_error);
     const empty = text.len == 0;
     const report_body = if (empty) "subagent finished without a report" else text;
     // Persist the full report + metadata so it can be inspected from the
@@ -316,4 +402,29 @@ test "variantJudgePrompt: bounded, names the phase, keeps the score contract" {
     try std.testing.expect(std.mem.indexOf(u8, p, "score: <N>") != null);
     // …and it round-trips: a judge tail like this parses back to the score.
     try std.testing.expectEqual(@as(?f64, 87), repl_glue.parseEvalScore("ok\nscore: 87"));
+}
+
+test "classifyFailure: maps the child's api-error detail to a category + retry-safety" {
+    // A stream stall/drop names itself via the error kind — its stale envelope
+    // (if any) must not override the transport verdict.
+    try std.testing.expectEqual(FailKind.transport, classifyFailure(error.StreamStalled, null));
+    try std.testing.expectEqual(FailKind.transport, classifyFailure(error.StreamDropped, "api error (some_error): stale"));
+    // No detail to go on → unknown (and a retry is still allowed to be tried).
+    try std.testing.expectEqual(FailKind.unknown, classifyFailure(error.ApiError, null));
+    // Real provider envelopes (the shapes sayApiError formats into last_api_error).
+    try std.testing.expectEqual(FailKind.quota, classifyFailure(error.ApiError, "api error (rate_limit_error): Number of requests exceeded"));
+    try std.testing.expectEqual(FailKind.quota, classifyFailure(error.ApiError, "api error: You have run out of credits or need a Grok subscription."));
+    try std.testing.expectEqual(FailKind.auth, classifyFailure(error.ApiError, "api error: The API Key appears to be invalid or may have expired."));
+    // invalid_request_error carries "invalid", but a missing-model message is
+    // classified as model-availability because that phrase is checked first.
+    try std.testing.expectEqual(FailKind.model, classifyFailure(error.ApiError, "api error (invalid_request_error): The model `gpt-foo` does not exist or you do not have access to it."));
+    try std.testing.expectEqual(FailKind.invalid, classifyFailure(error.ApiError, "api error (invalid_request_error): This model's maximum context length is 8192 tokens."));
+    try std.testing.expectEqual(FailKind.transport, classifyFailure(error.ApiError, "network error: HttpConnectionClosing (gave up after 6 attempts)"));
+
+    // Retry-safety contract: transient failures may retry, structural ones must not.
+    try std.testing.expect(FailKind.quota.retrySafe());
+    try std.testing.expect(FailKind.transport.retrySafe());
+    try std.testing.expect(!FailKind.model.retrySafe());
+    try std.testing.expect(!FailKind.invalid.retrySafe());
+    try std.testing.expect(!FailKind.auth.retrySafe());
 }


### PR DESCRIPTION
Four newer issues, implemented in isolated worktrees (each gated on `zig build test` green) and reviewed before landing.

## Fixes
- **#179** — `edit_file` (and `write_file` overwriting an existing file) dropped a `0755` executable bit to `0644` because the atomic zigpatch splice lands new content on a fresh inode. Capture the mode before the rewrite and re-apply it after (best-effort; a brand-new file keeps the default).
- **#183** — `read_file`/`edit_file`/`write_file` surfaced bare `error: FileNotFound`. Expected fs errors are now mapped at the operation site to a message naming the tool, the path, and the failure (edit points at `write_file` for creation; write distinguishes a missing parent dir). Unexpected errors still route to the generic failure path; confinement/symlink checks are untouched.
- **#184** — a blank draft was persisted at startup as an `Untitled session`. `saveSession` now skips the write until the conversation has meaningful state (a user message, a goal, todos, or tool activity). No existing files are deleted.
- **#187** — a child turn failing at the API/transport layer collapsed to an opaque `error: ApiError`. The subagent tool now surfaces the child's `last_api_error` (provider status/message), a coarse category (quota/transport/model/invalid/auth), and whether retry is safe.

## Verification
- `zig build test`: **174/174** (4 new unit tests: `fsErrorText`, `hasMeaningfulState`, `classifyFailure`, plus existing).
- **New E2E** (`scripts/test-e2e-newer-issues.py`, CI-wired): drives the real binary to prove #184 end-to-end — a blank conversation leaves no session file, a meaningful one is saved. Confirmed to **fail on the pre-fix binary**, so it's a real regression guard.

Fixes #179
Fixes #183
Fixes #184
Fixes #187