### PR TITLE
fix(agent): pre-send compaction gate + in-turn recovery for context-window overflow (#193)

### DIFF
--- a/src/agent.zig
+++ b/src/agent.zig
@@ -308,6 +308,28 @@ pub const Agent = struct {
                 if (!self.sub) esc_cancel.store(false, .release);
                 return error.Interrupted;
             }
+            // #193: pre-send overflow gate. A single turn's tool-output burst can
+            // push the input past the model's wall before the between-turns 80%
+            // meter (last_context_tokens, server-reported) catches up. Estimate the
+            // full input locally and compact BEFORE sending so we never ship an
+            // over-cap request (codex run_pre_sampling_compact / opencode isOverflow).
+            if (self.inputOverCompactThreshold()) {
+                // Bracket the compaction with codex-WS resets, mirroring how every
+                // other compactOrRecover call site is bookended by runTurn's
+                // closeCodexWs (299 + defer 300). Mid-turn the WS can be live with a
+                // prev_id / codex_sent_upto watermark keyed to the pre-trim history:
+                // (1) the first reset lets compact()'s own summary request (it calls
+                // request() at agent_compact.zig:267, after shrinking history at
+                // 259-260) run against a clean session — a stale prev_id makes the
+                // server re-prepend the full pre-trim context, defeating or
+                // overflowing the summary itself; (2) the second re-anchors so the
+                // next in-turn request() re-sends the trimmed full input, not a delta
+                // keyed to dropped messages (same closeCodexWs-after-trim reason as
+                // the in-turn recovery at agent_request.zig:273).
+                self.closeCodexWs();
+                self.compactOrRecover(true);
+                self.closeCodexWs();
+            }
             const root = try self.request(self.toolsJson());
             const done = switch (self.provider.kind) {
                 .anthropic => try self.stepAnthropic(root),
@@ -323,6 +345,7 @@ pub const Agent = struct {
     // 600-line goal). Member-aliased so self.request(...)/etc. resolve
     // unchanged.
     pub const request = @import("agent_request.zig").request;
+    pub const inputOverCompactThreshold = @import("agent_request.zig").inputOverCompactThreshold;
     pub const recordUsage = @import("agent_request.zig").recordUsage;
     pub const usageInt = @import("agent_request.zig").usageInt;
     pub const recordCost = @import("agent_request.zig").recordCost;

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -114,6 +114,7 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
     sanitizeMessagesUtf8(self.arena, &self.messages); // invalid UTF-8 (any source/format) -> '?' so content never serializes as a byte-int array the API rejects
     if (self.provider.kind == .responses) normalizeResponsesHistory(self.arena, &self.messages);
     if (self.provider.kind == .openai) normalizeOpenAIHistory(self.arena, &self.messages); // #99: chat-completions sibling of the above
+    var context_retried = false; // #193: at most one in-turn overflow recovery per request
     rebuild: while (true) {
         const live = !self.sub and self.out != null and !self.stream_quiet;
         self.streamed_text = false;
@@ -256,8 +257,24 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
                     // session would wedge (every retry resends the same
                     // oversized history). Pin the meter to the window so the
                     // ApiError compact-and-recover path engages.
-                    if (std.mem.indexOf(u8, msg, "exceeds the context window") != null)
+                    if (std.mem.indexOf(u8, msg, "exceeds the context window") != null) {
                         self.last_context_tokens = self.provider.context;
+                        // #193: the local pre-send gate uses a byte/4 LOWER bound, so
+                        // the backend can still reject an input it let through. A good
+                        // harness recovers the turn invisibly instead of failing it:
+                        // reclaim room in place and retry the SAME request once
+                        // (opencode compactAfterOverflow + rebuild). emergencyTrim does
+                        // no summary request, so this can't reenter request(); the guard
+                        // means a second overflow falls through to the error below, so we
+                        // never loop. closeCodexWs re-anchors so the retry sends the
+                        // trimmed full input, not a stale WS delta.
+                        if (!context_retried and self.emergencyTrim() > 0) {
+                            context_retried = true;
+                            self.closeCodexWs();
+                            if (self.tracer) |tr| tr.note("context", "input over the window — emergency-trimmed and retrying the turn");
+                            continue :rebuild;
+                        }
+                    }
                     if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, 0, 0, true);
                     try self.sayApiError("codex api error: {s}", .{msg});
                     return error.ApiError;
@@ -490,6 +507,39 @@ pub fn fullInputEstimateTokens(self: *Agent) u64 {
     var s: std.json.Stringify = .{ .writer = &d.writer };
     s.write(Value{ .array = self.messages }) catch return 0;
     return d.fullCount() / 4;
+}
+
+/// Pre-send overflow gate (#193). `last_context_tokens` only updates from the
+/// server's returned usage, so it lags tool output appended *within* a turn: a
+/// burst of large tool results can push this turn's input past the model's wall
+/// before the between-turns 80% meter ever sees it (the "input exceeds the
+/// context window" rejection on codex/gpt-5.x). Estimating the full input
+/// locally before each request lets the turn loop compact first — the analogue
+/// of codex's run_pre_sampling_compact / opencode's isOverflow-before-each-turn.
+/// Guarded on a known window (compactAt()==0 → don't compact blindly).
+pub fn inputOverCompactThreshold(self: *Agent) bool {
+    const threshold = self.provider.compactAt();
+    return threshold > 0 and fullInputEstimateTokens(self) >= threshold;
+}
+
+test "inputOverCompactThreshold (#193): local estimate gates a pre-send compact" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var msgs = std.json.Array.init(a);
+    var agent: Agent = undefined;
+    agent.messages = msgs;
+    // small window: compactAt() = 10_000/10*8 = 8_000 tokens ≈ 32_000 serialized bytes
+    agent.provider = .{ .id = "codex", .kind = .responses, .auth = .bearer, .url = "", .api_key = "", .model = "gpt-5", .context = 10_000 };
+    try std.testing.expect(!inputOverCompactThreshold(&agent)); // empty history → under
+    // one fat tool output (~40KB serialized ≈ 10k est tokens) crosses 8k in a single append
+    const big = "{\"type\":\"function_call_output\",\"output\":\"" ++ ("x" ** 40000) ++ "\"}";
+    try msgs.append(try std.json.parseFromSliceLeaky(Value, a, big, .{}));
+    agent.messages = msgs;
+    try std.testing.expect(inputOverCompactThreshold(&agent)); // burst → over → compact before send
+    // unknown window (context 0) never gates
+    agent.provider.context = 0;
+    try std.testing.expect(!inputOverCompactThreshold(&agent));
 }
 
 pub fn recordUsageResponses(self: *Agent, response: std.json.ObjectMap, req_body_len: usize) void {


### PR DESCRIPTION
## What

Fixes #193 — a single turn's tool-output burst could push the request input past the model's context window before auto-compaction ever fired, so codex / gpt-5.x rejected with `exceeds the context window` and the turn died. That makes graff a poor harness exactly when it's working hardest (many large parallel tool reads in one turn).

## Root cause

Auto-compaction was gated on `last_context_tokens`, which only updates from the server's returned usage — so it **lags** tool output appended *within* a turn. The between-turns 80% meter (`mainloop.zig`) never saw the mid-turn spike. graff already had a local estimator (`fullInputEstimateTokens`, #174) but only used it to correct the meter *after* a response, never as a pre-send gate.

## Fix (two layers, mirroring codex `run_pre_sampling_compact` and opencode `isOverflow` / `compactAfterOverflow`)

1. **Pre-send gate** (`agent.zig` `runTurn`): estimate the full input locally before every request and compact when it's already ≥ `compactAt()`, so we never ship an over-cap request. The gate **brackets** `compactOrRecover` with `closeCodexWs()` on both sides — mid-turn the codex WS holds a `prev_id` / `codex_sent_upto` watermark keyed to the pre-trim history, so the first reset lets `compact()`'s own summary request run against a clean session (a stale `prev_id` makes the server re-prepend the full pre-trim context and defeat/overflow the summary), and the second re-anchors the next in-turn `request()` to the trimmed full input instead of a delta referencing dropped messages. This matches how every other `compactOrRecover` call site is bookended by `runTurn`'s `closeCodexWs`.

2. **In-turn recovery** (`agent_request.zig`): the local estimate is a `bytes/4` lower bound, so the backend can still reject. On `exceeds the context window`, emergency-trim and retry the same request **once** (single-retry guard), then fall through to the original error — the turn recovers invisibly instead of failing.

## Verification

- `zig build test` → **176/176** (adds an `inputOverCompactThreshold` unit test), `zig fmt` clean.
- Adversarial multi-agent review of the diff — which **caught the missing `closeCodexWs` bracket** above and drove that fix, then confirmed the fixed version correct.
- End-to-end drive against a local mock: a would-be-overflow turn now emits `[compacting]` → `[history compacted]` → completes, instead of dying with `exceeds the context window`.

## Known follow-ups (documented on #193, out of scope here)

- Per-tool-output truncation at ingestion (codex `TruncationPolicy` / opencode `max_bytes`) — the in-turn recovery is codex/`.responses`-only; a dense burst on anthropic/openai that both undercounts and overflows still dies as before (same as pre-fix baseline).
- The `[compacting ~N tokens…]` line reads ~0 when the gate fires off the local estimate (the server meter is still 0). Cosmetic.
