### PR TITLE
feat(repl): blank-line gutter between the submitted prompt and model output

### DIFF
--- a/scripts/test-pty-gutter.py
+++ b/scripts/test-pty-gutter.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Real-PTY test for the blank-line gutter between a submitted prompt and output (#205).
+
+Submitting a line must leave one blank line between the prompt and whatever prints
+next, so it is easy to see where the response starts. readline emits a second
+newline on Enter for this; here we drive a real terminal and assert the rendered
+transcript shows that gutter. Rendered (not raw) so the check is independent of the
+terminal's newline translation (ONLCR).
+"""
+
+import os
+import sys
+import tempfile
+
+from pty_harness import PtySession, terminal_text
+
+
+_arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
+GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="graff-pty-gutter-") as tmp:
+        env = {
+            "HOME": tmp,
+            "CODEGRAFF_API_KEY": "local-pty-test",
+            "GRAFF_FLEET": "off",
+            "GRAFF_NO_TELEMETRY": "1",
+        }
+        with PtySession(
+            GRAFF,
+            ["--model", "deepseek-v4-pro", "--no-telemetry"],
+            cwd=tmp,
+            env=env,
+            unset_env=("CODEX_HOME", "NO_COLOR"),
+            timeout=15.0,
+        ) as session:
+            session.wait_for_literal("] ›")
+
+            # A local slash command produces output without touching a backend.
+            cursor = len(session.raw)
+            session.send_line("/help")
+            end = session.wait_for_literal("/models [health]", start=cursor)
+
+            # In the isolated post-submit window the submitted line(s) render first,
+            # then the command output; the blank-line gutter (#205) must sit
+            # immediately BEFORE the first output line. The number of echoed input
+            # lines varies with redraw timing, so anchor on the output, not indices.
+            rendered = terminal_text(bytes(session.raw[cursor:end]))
+            lines = rendered.split("\n")
+            out_idx = next(
+                (i for i, ln in enumerate(lines) if ln.startswith("commands (bare")),
+                None,
+            )
+            if out_idx is None:
+                raise AssertionError(f"never saw the /help output:\n{rendered!r}")
+            if out_idx < 1 or lines[out_idx - 1].strip() != "":
+                raise AssertionError(
+                    "no blank-line gutter between the submitted prompt and its "
+                    f"output (#205); lines={lines[: out_idx + 1]!r}"
+                )
+            if not any("/help" in ln for ln in lines[:out_idx]):
+                raise AssertionError(f"submitted line missing:\n{rendered!r}")
+
+            session.send_key("ctrl-d")
+            result = session.read_until_exit(5.0)
+            if result.timed_out or result.exit_code != 0:
+                raise SystemExit(
+                    f"REPL did not exit cleanly: exit={result.exit_code} "
+                    f"timed_out={result.timed_out}"
+                )
+    print("ok    PTY prompt/output blank-line gutter (#205)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/readline.zig
+++ b/src/readline.zig
@@ -274,8 +274,11 @@ pub fn readLine(
             '\r', '\n' => {
                 // The cursor may be mid-block; step past the last input row so
                 // the submitted line and whatever prints next start cleanly.
+                // The second newline leaves a blank-line gutter between the
+                // submitted prompt and the model output, so it is easy to see
+                // where the response starts.
                 if (rstate.rows - 1 > rstate.crow) out.print("\x1b[{d}B", .{rstate.rows - 1 - rstate.crow}) catch {};
-                out.writeAll("\r\n") catch {};
+                out.writeAll("\r\n\r\n") catch {};
                 out.flush() catch {};
                 // Expand any pasted placeholders back to their full text.
                 for (pastes.items) |p| {


### PR DESCRIPTION
After Enter, `readline` wrote a single CRLF so the model's first output line butted
directly against the submitted prompt, making it hard to see where the response
started. It now emits a second newline so there is a clear blank-line gutter.

## Test
`scripts/test-pty-gutter.py` drives the real REPL in a pseudo-terminal, submits a
local `/help`, and asserts the rendered transcript has a blank line immediately
before the command output. Anchored on the output line (robust to echo-redraw
timing) and rendered rather than raw (independent of ONLCR). Deterministic across
repeated runs; the existing `scripts/test-pty-repl.py` still passes.

## Scope
TUI half only. Per the TUI-first rule the GUI transcript renderer needs the same
gutter to not diverge — tracked in #205, which stays open for that mirror.

Refs #205