### PR TITLE
fix(gui): exclude trailing Markdown emphasis delimiters from autolinked URLs (#197)

### DIFF
--- a/gui/src/components/chat/utils/chatLinks.test.ts
+++ b/gui/src/components/chat/utils/chatLinks.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import { getChatLinkMatches } from "./chatLinks";
+
+function firstUrl(text: string): string | undefined {
+  return getChatLinkMatches(text).find((match) => match.kind === "url")?.value;
+}
+
+describe("getChatLinkMatches URL vs Markdown delimiters", () => {
+  test("strips trailing ** from a bold-wrapped bare URL", () => {
+    // Regression for #197: Cmd-hover underlined the closing ** and opened
+    // http://localhost:3003** instead of http://localhost:3003.
+    expect(firstUrl("**http://localhost:3003**")).toBe("http://localhost:3003");
+  });
+
+  test("strips a single trailing * from an italic-wrapped URL", () => {
+    expect(firstUrl("*https://example.com*")).toBe("https://example.com");
+  });
+
+  test("strips trailing ~~ from a strikethrough-wrapped URL", () => {
+    expect(firstUrl("~~https://example.com~~")).toBe("https://example.com");
+  });
+
+  test("strips Markdown delimiters interleaved with trailing punctuation", () => {
+    expect(firstUrl("**http://localhost:3003.**")).toBe("http://localhost:3003");
+  });
+
+  test("preserves a legitimate interior asterisk in the URL path", () => {
+    expect(firstUrl("see http://a.com/x*y here")).toBe("http://a.com/x*y");
+  });
+
+  test("preserves a legitimate tilde in the URL path", () => {
+    expect(firstUrl("https://example.com/~user")).toBe("https://example.com/~user");
+  });
+
+  test("still balances closing parens in a Wikipedia-style URL", () => {
+    expect(firstUrl("https://en.wikipedia.org/wiki/Foo_(bar)")).toBe(
+      "https://en.wikipedia.org/wiki/Foo_(bar)",
+    );
+  });
+
+  test("still trims a wrapping paren and trailing sentence punctuation", () => {
+    expect(firstUrl("(https://example.com)")).toBe("https://example.com");
+    expect(firstUrl("visit https://example.com.")).toBe("https://example.com");
+  });
+
+  test("reports the correct span end after trimming the delimiters", () => {
+    const [match] = getChatLinkMatches("**http://localhost:3003**");
+    expect(match).toMatchObject({
+      kind: "url",
+      start: 2,
+      end: 2 + "http://localhost:3003".length,
+      value: "http://localhost:3003",
+    });
+  });
+});

--- a/gui/src/components/chat/utils/chatLinks.test.ts
+++ b/gui/src/components/chat/utils/chatLinks.test.ts
@@ -29,8 +29,19 @@ describe("getChatLinkMatches URL vs Markdown delimiters", () => {
     expect(firstUrl("see http://a.com/x*y here")).toBe("http://a.com/x*y");
   });
 
-  test("preserves a legitimate tilde in the URL path", () => {
+  test("preserves legitimate trailing asterisks on unwrapped URLs", () => {
+    expect(firstUrl("https://example.com/path*")).toBe("https://example.com/path*");
+    expect(firstUrl("https://example.com/?q=*")).toBe("https://example.com/?q=*");
+  });
+
+  test("preserves legitimate tildes in unwrapped URLs", () => {
     expect(firstUrl("https://example.com/~user")).toBe("https://example.com/~user");
+    expect(firstUrl("https://example.com/~")).toBe("https://example.com/~");
+  });
+
+  test("removes only the matching closing delimiter", () => {
+    expect(firstUrl("*https://example.com/path**")).toBe("https://example.com/path*");
+    expect(firstUrl("~~https://example.com/path~~~")).toBe("https://example.com/path~");
   });
 
   test("still balances closing parens in a Wikipedia-style URL", () => {

--- a/gui/src/components/chat/utils/chatLinks.test.ts
+++ b/gui/src/components/chat/utils/chatLinks.test.ts
@@ -53,4 +53,17 @@ describe("getChatLinkMatches URL vs Markdown delimiters", () => {
       value: "http://localhost:3003",
     });
   });
+
+  test("strips stacked and mixed trailing emphasis delimiters", () => {
+    expect(firstUrl("***https://example.com***")).toBe("https://example.com");
+    expect(firstUrl("~~*https://example.com*~~")).toBe("https://example.com");
+  });
+
+  test("never splits a multi-byte trailing character (surrogate-safe)", () => {
+    // Trimming only removes ASCII markers, so a URL that legitimately ends in a
+    // multi-byte glyph (accents, emoji) is preserved byte-for-byte, never cut
+    // mid-codepoint.
+    expect(firstUrl("**https://example.com/éé**")).toBe("https://example.com/éé");
+    expect(firstUrl("see https://example.com/p\u{1F600}")).toBe("https://example.com/p\u{1F600}");
+  });
 });

--- a/gui/src/components/chat/utils/chatLinks.ts
+++ b/gui/src/components/chat/utils/chatLinks.ts
@@ -4,7 +4,6 @@ const FILE_PATH_PATTERN =
 const PATH_BOUNDARY_PATTERN = /[\s([{"'`]/u;
 const TRAILING_PUNCTUATION_PATTERN = /[.,;!?]+$/u;
 const TRAILING_CLOSERS = new Set([")", "]", "}", ">", "'", '"', "`"]);
-const TRAILING_MARKDOWN_DELIMITERS = new Set(["*", "~"]);
 const FILE_BASENAME_EXTENSION_PATTERN = /\.[A-Za-z0-9_-]+$/u;
 const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Za-z]:[\\/]/u;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\/u;
@@ -77,14 +76,6 @@ function trimLinkCandidate(candidate: string): string {
       break;
     }
 
-    // Bare URLs/paths wrapped in Markdown emphasis (**url**, *url*, ~~url~~) capture the
-    // closing delimiters; strip trailing markers so the clickable target excludes them.
-    if (TRAILING_MARKDOWN_DELIMITERS.has(lastChar)) {
-      value = value.slice(0, -1);
-      trimmed = true;
-      continue;
-    }
-
     if (TRAILING_CLOSERS.has(lastChar)) {
       const opener =
         lastChar === ")" ? "(" : lastChar === "]" ? "[" : lastChar === "}" ? "{" : null;
@@ -102,6 +93,35 @@ function trimLinkCandidate(candidate: string): string {
   }
 
   return value;
+}
+
+function markdownClosingDelimiterBefore(text: string, start: number): string | null {
+  const opening = text.slice(0, start).match(/[~*]+$/u)?.[0];
+  if (opening == null) {
+    return null;
+  }
+
+  for (let index = 0; index < opening.length; index += 1) {
+    if (opening[index] === "*") {
+      continue;
+    }
+    if (opening[index] !== "~" || opening[index + 1] !== "~") {
+      return null;
+    }
+    index += 1;
+  }
+
+  return [...opening].reverse().join("");
+}
+
+function trimMarkdownWrappedLinkCandidate(text: string, start: number, candidate: string): string {
+  const value = trimLinkCandidate(candidate);
+  const closingDelimiter = markdownClosingDelimiterBefore(text, start);
+  if (closingDelimiter == null || !value.endsWith(closingDelimiter)) {
+    return value;
+  }
+
+  return trimLinkCandidate(value.slice(0, -closingDelimiter.length));
 }
 
 function safeDecode(value: string): string {
@@ -425,7 +445,7 @@ export function getChatLinkMatches(
   URL_PATTERN.lastIndex = 0;
   let urlMatch: RegExpExecArray | null;
   while ((urlMatch = URL_PATTERN.exec(text)) !== null) {
-    const value = trimLinkCandidate(urlMatch[0]);
+    const value = trimMarkdownWrappedLinkCandidate(text, urlMatch.index, urlMatch[0]);
     if (value.length === 0) {
       continue;
     }

--- a/gui/src/components/chat/utils/chatLinks.ts
+++ b/gui/src/components/chat/utils/chatLinks.ts
@@ -4,6 +4,7 @@ const FILE_PATH_PATTERN =
 const PATH_BOUNDARY_PATTERN = /[\s([{"'`]/u;
 const TRAILING_PUNCTUATION_PATTERN = /[.,;!?]+$/u;
 const TRAILING_CLOSERS = new Set([")", "]", "}", ">", "'", '"', "`"]);
+const TRAILING_MARKDOWN_DELIMITERS = new Set(["*", "~"]);
 const FILE_BASENAME_EXTENSION_PATTERN = /\.[A-Za-z0-9_-]+$/u;
 const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Za-z]:[\\/]/u;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\/u;
@@ -58,24 +59,46 @@ export function isMailtoUrl(href: string): boolean {
 }
 
 function trimLinkCandidate(candidate: string): string {
-  let value = candidate.replace(TRAILING_PUNCTUATION_PATTERN, "");
+  let value = candidate;
 
-  while (value.length > 0) {
+  let trimmed = true;
+  while (trimmed && value.length > 0) {
+    trimmed = false;
+
+    const withoutPunctuation = value.replace(TRAILING_PUNCTUATION_PATTERN, "");
+    if (withoutPunctuation.length !== value.length) {
+      value = withoutPunctuation;
+      trimmed = true;
+      continue;
+    }
+
     const lastChar = value.at(-1);
-    if (lastChar == null || !TRAILING_CLOSERS.has(lastChar)) {
+    if (lastChar == null) {
       break;
     }
 
-    const opener = lastChar === ")" ? "(" : lastChar === "]" ? "[" : lastChar === "}" ? "{" : null;
-    if (opener != null) {
-      const openerCount = value.split(opener).length - 1;
-      const closerCount = value.split(lastChar).length - 1;
-      if (closerCount <= openerCount) {
-        break;
-      }
+    // Bare URLs/paths wrapped in Markdown emphasis (**url**, *url*, ~~url~~) capture the
+    // closing delimiters; strip trailing markers so the clickable target excludes them.
+    if (TRAILING_MARKDOWN_DELIMITERS.has(lastChar)) {
+      value = value.slice(0, -1);
+      trimmed = true;
+      continue;
     }
 
-    value = value.slice(0, -1);
+    if (TRAILING_CLOSERS.has(lastChar)) {
+      const opener =
+        lastChar === ")" ? "(" : lastChar === "]" ? "[" : lastChar === "}" ? "{" : null;
+      if (opener != null) {
+        const openerCount = value.split(opener).length - 1;
+        const closerCount = value.split(lastChar).length - 1;
+        if (closerCount <= openerCount) {
+          break;
+        }
+      }
+
+      value = value.slice(0, -1);
+      trimmed = true;
+    }
   }
 
   return value;


### PR DESCRIPTION
## Problem

Bare URLs wrapped in Markdown emphasis (`**url**`, `*url*`, `~~url~~`) captured the closing delimiters in the link target. On macOS, Cmd-hover/Cmd-click then underlined the trailing markers and tried to open an invalid destination such as `http://localhost:3003**`.

Markdown-rendered messages normally split strong spans first, but raw/plain-text paths (`ChatInlineText` / `getInlineTextSegments`) pass the markers straight into `getChatLinkMatches`.

## Fix

The matcher now recognizes a contiguous Markdown delimiter immediately before a bare URL and removes only the matching closing delimiter from the candidate. This keeps Markdown syntax outside the clickable span without stripping valid URL characters from unwrapped links.

| input | clickable target |
| --- | --- |
| `**http://localhost:3003**` | `http://localhost:3003` |
| `*https://example.com*` | `https://example.com` |
| `~~https://example.com~~` | `https://example.com` |
| `https://example.com/path*` | unchanged |
| `https://example.com/~` | unchanged |
| `*https://example.com/path**` | `https://example.com/path*` |

The delimiter handling is URL-specific, so generic file/path candidate cleanup does not accidentally remove legitimate trailing markers.

## Tests

- `bun test`: 157 passed, 0 failed.
- `bunx eslint src/components/chat/utils/chatLinks.ts src/components/chat/utils/chatLinks.test.ts`: passed.
- `bunx tsc -b`: passed.
- Added regressions for bold, italic, strikethrough, mixed delimiters, offsets, punctuation, multi-byte characters, and legitimate trailing `*` / `~` URL characters.

Repository-wide `bun run lint` remains blocked by eight pre-existing errors in unrelated GUI files. The Vite build also reaches the bundler but is blocked by the repository's existing missing `esbuild` dependency.

Closes #197
