### PR TITLE
fix(agent): pair the Codex WS delta boundary with a fresh response id (#194)

### DIFF
--- a/src/agent_compact.zig
+++ b/src/agent_compact.zig
@@ -651,6 +651,72 @@ test "buildBody (.responses): delta while WS live; full input after closeCodexWs
     try std.testing.expect(std.mem.indexOf(u8, rebuilt_body, "third — not yet sent") != null);
 }
 
+// (#194) stepResponses must move the Codex WS delta boundary (codex_sent_upto)
+// and previous_response_id together. parseResponses accepts a response whose
+// output items carry no terminal response.id; advancing the boundary while
+// keeping the previous id would pair a stale id with a slice that id never held.
+// With a fresh id both advance in lockstep; with no id both reset so the next
+// request re-anchors with the full input.
+test "stepResponses (codex-ws): delta boundary only advances with a fresh response id (#194)" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    var dummy_ws: ws.WsClient = undefined; // stepResponses only checks codex_ws != null
+
+    // A response WITHOUT an id must reset the continuation state to a full re-anchor.
+    {
+        var msgs = std.json.Array.init(a);
+        try msgs.append(try textMessage(a, "user", "first"));
+        try msgs.append(try textMessage(a, "assistant", "second"));
+        var agent: Agent = .{
+            .gpa = std.testing.allocator,
+            .arena = a,
+            .io = undefined,
+            .client = undefined,
+            .provider = .{ .id = "codex", .kind = .responses, .auth = .bearer, .url = "https://x/responses", .api_key = "k", .model = "gpt-5", .context = 100_000 },
+            .messages = msgs,
+            .sub = true, // skip say()
+            .label = "",
+            .out = null,
+            .codex_ws = &dummy_ws,
+            .codex_prev_id = try std.testing.allocator.dupe(u8, "resp_stale"),
+            .codex_sent_upto = 2,
+        };
+        const parsed = try std.json.parseFromSliceLeaky(std.json.Value, a, "{\"output\":[{\"type\":\"reasoning\"}]}", .{});
+        _ = try agent.stepResponses(parsed.object);
+        try std.testing.expect(agent.codex_prev_id == null); // stale id freed + dropped
+        try std.testing.expectEqual(@as(usize, 0), agent.codex_sent_upto); // boundary reset
+    }
+
+    // A response WITH an id installs it and advances the boundary in lockstep.
+    {
+        var msgs = std.json.Array.init(a);
+        try msgs.append(try textMessage(a, "user", "first"));
+        try msgs.append(try textMessage(a, "assistant", "second"));
+        var agent: Agent = .{
+            .gpa = std.testing.allocator,
+            .arena = a,
+            .io = undefined,
+            .client = undefined,
+            .provider = .{ .id = "codex", .kind = .responses, .auth = .bearer, .url = "https://x/responses", .api_key = "k", .model = "gpt-5", .context = 100_000 },
+            .messages = msgs,
+            .sub = true,
+            .label = "",
+            .out = null,
+            .codex_ws = &dummy_ws,
+            .codex_prev_id = null,
+            .codex_sent_upto = 0,
+        };
+        const parsed = try std.json.parseFromSliceLeaky(std.json.Value, a, "{\"id\":\"resp_new\",\"output\":[{\"type\":\"reasoning\"}]}", .{});
+        _ = try agent.stepResponses(parsed.object);
+        try std.testing.expect(agent.codex_prev_id != null);
+        try std.testing.expectEqualStrings("resp_new", agent.codex_prev_id.?);
+        try std.testing.expectEqual(@as(usize, 3), agent.codex_sent_upto); // 2 initial + 1 appended output item
+        std.testing.allocator.free(agent.codex_prev_id.?); // gpa-owned dupe (leak-checked)
+    }
+}
+
 test "emergencyCutIndex: cuts at a clean user turn at/after the midpoint" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();

--- a/src/agent_steps.zig
+++ b/src/agent_steps.zig
@@ -70,12 +70,22 @@ pub fn stepResponses(self: *Agent, response: std.json.ObjectMap) !?[]const u8 {
     // Codex WS delta: the server now holds up to here (the output items appended
     // above). The NEXT request sends previous_response_id + only what is appended
     // after this point (the tool results below). Only while the WS session lives.
+    //
+    // The delta boundary (codex_sent_upto) and previous_response_id must move in
+    // lockstep: buildBody pairs previous_response_id with messages[codex_sent_upto..].
+    // parseResponses accepts output items without a terminal response.id (#194), so
+    // a response can lack one — advancing the boundary while keeping the OLD id
+    // would slice off history that id never held. Install the new id and boundary
+    // together; with no usable id (or a failed dup) reset both to null/0 so the
+    // next request re-anchors with the full input instead.
     if (self.codex_ws != null) {
-        self.codex_sent_upto = self.messages.items.len;
-        if (response.get("id")) |idv| if (idv == .string and idv.string.len > 0) {
-            if (self.codex_prev_id) |old| self.gpa.free(old);
-            self.codex_prev_id = self.gpa.dupe(u8, idv.string) catch null;
-        };
+        const new_id: ?[]const u8 = if (response.get("id")) |idv|
+            (if (idv == .string and idv.string.len > 0) idv.string else null)
+        else
+            null;
+        if (self.codex_prev_id) |old| self.gpa.free(old);
+        self.codex_prev_id = if (new_id) |idv| (self.gpa.dupe(u8, idv) catch null) else null;
+        self.codex_sent_upto = if (self.codex_prev_id != null) self.messages.items.len else 0;
     }
 
     if (calls.items.len > 0) {


### PR DESCRIPTION
## Problem

`stepResponses()` advances the Codex WS delta boundary (`codex_sent_upto`) whenever a WS session is live, but only replaces `codex_prev_id` when the parsed response contains a new `response.id`. `parseResponses()` accepts output items **without** a terminal response id, so a response can lack one — leaving the **old** id paired with an **advanced** boundary.

`buildBody()` then sends `previous_response_id: <old id>` + `messages[codex_sent_upto..]`, slicing off history the referenced response never held.

## Fix

Move the id and the boundary in lockstep (`agent_steps.zig`):
- New valid id → install it and advance `codex_sent_upto` together.
- No usable id (or a failed dup) → reset both to `null` / `0` so the next request re-anchors with the full input (`buildBody`'s `prev_id == null` path), instead of replaying a stale delta.

No WS teardown is needed — resetting the watermarks is enough; the next request sends the full input over the live session, exactly like the first request of any WS session.

## Test

A unit test drives a codex-WS agent through `stepResponses()`:
- **id-less response** → `codex_prev_id` is dropped and the boundary resets to 0 (full re-anchor).
- **id-bearing response** → the id installs and the boundary advances in lockstep.

Leak-checked (testing allocator). `zig build test` green, `zig fmt` clean, and `scripts/test-pty-codex-ws.py` (WS-fail → SSE fallback, WS-off) still passes.

Closes #194
