### PR TITLE
fix(agent): don't peek past a completed stream on a half-open socket (#56)

### DIFF
--- a/src/agent_stream.zig
+++ b/src/agent_stream.zig
@@ -398,9 +398,6 @@ pub fn postStreamWithClient(self: *Agent, client: *std.http.Client, body: []cons
                 },
             }
         }
-        // End of stream leaves the reader empty; otherwise the '\n' is
-        // still buffered (and consumed below, after the line is handled).
-        const more = if (reader.peekByte()) |_| true else |_| false;
         try full.writer.writeAll(line.writer.buffered());
         try full.writer.writeByte('\n');
         got_body = true; // #134: response bytes are in `full`; a later read error is a clean close
@@ -434,6 +431,13 @@ pub fn postStreamWithClient(self: *Agent, client: *std.http.Client, body: []cons
             if (req.connection) |conn| conn.closing = true;
             return error.Interrupted;
         }
+        // "Is there more?" — peek the next byte, then consume the buffered '\n'.
+        // Deliberately AFTER the terminal-event break above (#56): once
+        // [DONE]/response.completed has landed the turn is complete and we break
+        // there, so this peek never runs on a finished response. Peeking then would
+        // fill-block forever on a half-open socket (server gone, no FIN) and hang
+        // the completed turn — the exact wedge the idle-stall watchdog can't see.
+        const more = if (reader.peekByte()) |_| true else |_| false;
         if (!more) break;
         reader.toss(1);
     }


### PR DESCRIPTION
## Problem

The SSE streaming reader's post-line probe, `reader.peekByte()` (`agent_stream.zig`), ran **before** the terminal-event check that breaks on `[DONE]` / `response.completed`. On the final line of a response the peek's result is discarded anyway (the loop breaks at the terminal check), but its *fill* can block **forever** on a half-open socket — server gone, no FIN/RST — which the idle-stall watchdog does not guard. That hangs an already-complete turn: part of #56's "reconnect doesn't reconnect".

## Fix

Move the peek to **after** the terminal-event break, which matches this loop's own documented intent — *"stop instead of waiting for the socket to close"*. A completed response now breaks before it ever peeks; the non-terminal path is byte-for-byte unchanged (`peek → if (!more) break → toss the buffered '\n'`).

**Safe by inspection:** on a terminal line the loop already broke at the `isStreamEnd` check, so `more` was never read there — moving the peek only removes a useless, hang-prone fill on completed responses.

## Verification

- `zig build test` green.
- Streaming PTY suite green — `test-pty-codex-ws`, `test-pty-repl`, `test-pty-markdown`, `test-pty-spinner` (these stream model output through this exact reader), so **no regression in the hot read path**.

I explored a mock hang-test but it can't reliably distinguish old-from-new: a complete SSE line always leaves its terminating `\n` buffered (that's the byte `reader.toss(1)` consumes), so the old `peekByte` reads from the buffer without blocking in every reproducible case. A test both versions pass isn't a meaningful guard, so I rely on the inspection argument + regression suite instead.

## Scope (honest)

- **This PR** closes the **post-completion** subcase (the documented "don't wait on the socket" intent).
- The **mid-stream** half-open subcase — `peekByte` blocking on a *non-terminal* line — still needs a watchdog-guarded peek (a `streamPeekTask` select-arm) **plus** a half-open-socket mock harness (accept, send partial SSE, then network-drop without closing) to verify. Left as a follow-up.
- **Fix-B** from the issue (retryable stalls via `watchdogError`: Esc→`Interrupted`, deadline→`HungRequest`/`StreamStalled`) is already implemented and tested (#134).

Pre-existing `zig fmt` debt in this file (unrelated one-liners) left untouched to avoid churn.

Refs #56
