### PR TITLE
Release v0.0.202: governed /goal + /loop, clock_sleep, context-overflow follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,8 @@ prefixes on body lines.
 /reasoning      reasoning picker: low|medium|high|xhigh|max|ultra (persists)
 /fast           toggle Codex priority service tier for lower latency
 /ultracode      toggle persistent multi-agent workflow mode
+/goal [text]    set/show a standing objective; /goal pause|resume|status|clear
+/loop <prompt>  work autonomously toward the prompt, stopping with a named outcome when done or blocked
 /rewind [n]     list past prompts; /rewind <n> drops prompt n+after & reverts its file edits
 /image <path>   attach an image to your next message (vision models only)
 /paste          attach the clipboard image (macOS); also Ctrl-V (⌘V can't be captured)
@@ -426,6 +428,14 @@ exit | /exit | ctrl-d | ctrl-c(empty)   quit
 
 `/plan`, `/yolo`, and `/strict` change how the permission gate behaves for the
 session. See [Permission modes](#permission-modes).
+
+`/goal` sets a standing objective that steers every turn as a live checklist.
+`/goal pause` stops the steering without losing the objective, `/goal resume`
+turns it back on, and `/goal status` shows the objective and its current state.
+`/loop <prompt>` works autonomously toward the prompt, running turn after turn
+(plan, act, verify) and stopping on its own with a named outcome (accepted,
+blocked, cancelled, or exhausted) once the work is done, you step in, or a safety
+limit is hit, instead of pausing for confirmation between routine steps.
 
 The line editor supports ↑/↓ history (persisted to `~/.simple-harness-history`),
 Tab completion (commands, and model names after `/model `), and emacs-style

--- a/scripts/test-pty-gutter.py
+++ b/scripts/test-pty-gutter.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Real-PTY test for the blank-line gutter between a submitted prompt and output (#205).
+
+Submitting a line must leave one blank line between the prompt and whatever prints
+next, so it is easy to see where the response starts. readline emits a second
+newline on Enter for this; here we drive a real terminal and assert the rendered
+transcript shows that gutter. Rendered (not raw) so the check is independent of the
+terminal's newline translation (ONLCR).
+"""
+
+import os
+import sys
+import tempfile
+
+from pty_harness import PtySession, terminal_text
+
+
+_arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
+GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="graff-pty-gutter-") as tmp:
+        env = {
+            "HOME": tmp,
+            "CODEGRAFF_API_KEY": "local-pty-test",
+            "GRAFF_FLEET": "off",
+            "GRAFF_NO_TELEMETRY": "1",
+        }
+        with PtySession(
+            GRAFF,
+            ["--model", "deepseek-v4-pro", "--no-telemetry"],
+            cwd=tmp,
+            env=env,
+            unset_env=("CODEX_HOME", "NO_COLOR"),
+            timeout=15.0,
+        ) as session:
+            session.wait_for_literal("] ›")
+
+            # A local slash command produces output without touching a backend.
+            cursor = len(session.raw)
+            session.send_line("/help")
+            end = session.wait_for_literal("/models [health]", start=cursor)
+
+            # In the isolated post-submit window the submitted line(s) render first,
+            # then the command output; the blank-line gutter (#205) must sit
+            # immediately BEFORE the first output line. The number of echoed input
+            # lines varies with redraw timing, so anchor on the output, not indices.
+            rendered = terminal_text(bytes(session.raw[cursor:end]))
+            lines = rendered.split("\n")
+            out_idx = next(
+                (i for i, ln in enumerate(lines) if ln.startswith("commands (bare")),
+                None,
+            )
+            if out_idx is None:
+                raise AssertionError(f"never saw the /help output:\n{rendered!r}")
+            if out_idx < 1 or lines[out_idx - 1].strip() != "":
+                raise AssertionError(
+                    "no blank-line gutter between the submitted prompt and its "
+                    f"output (#205); lines={lines[: out_idx + 1]!r}"
+                )
+            if not any("/help" in ln for ln in lines[:out_idx]):
+                raise AssertionError(f"submitted line missing:\n{rendered!r}")
+
+            session.send_key("ctrl-d")
+            result = session.read_until_exit(5.0)
+            if result.timed_out or result.exit_code != 0:
+                raise SystemExit(
+                    f"REPL did not exit cleanly: exit={result.exit_code} "
+                    f"timed_out={result.timed_out}"
+                )
+    print("ok    PTY prompt/output blank-line gutter (#205)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-pty-overflow.py
+++ b/scripts/test-pty-overflow.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""End-to-end real-PTY test for anthropic/openai context-overflow handling (#201-#203).
+
+Points graff at a local OpenAI-compatible backend (the built-in `lmstudio` provider,
+http://127.0.0.1:1234) whose only reply is an injected error, and drives a real turn
+through the terminal. Two scenarios prove the overflow detection is BOTH correct and
+precise:
+
+  A. error.code = context_length_exceeded with a message that matches none of the
+     English substrings (Dutch). graff must still detect the overflow via the
+     STRUCTURED code (#203/G2), pin the meter to the window, and stay responsive
+     rather than wedge (#201/#202). Observable: the prompt's ctx meter reads
+     "<W>k/<W>k ctx (100% ...)".
+  B. error.code = rate_limit_exceeded with a non-overflow message. graff must NOT
+     mistake it for an overflow: the meter must not pin. Proves detection is precise.
+
+Requires 127.0.0.1:1234 to be free (the lmstudio provider URL is fixed); skips if a
+real LM Studio (or anything) already holds it.
+"""
+
+import http.server
+import json
+import os
+import re
+import socket
+import sys
+import tempfile
+import threading
+
+from pty_harness import PtySession, terminal_text
+
+
+_arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
+GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
+
+# "<used>k/<window>k ctx (<pct>% · compact@<X>k)" — the "·" is U+00B7.
+METER_RE = re.compile(r"(\d+)k/(\d+)k ctx \((\d+)% · compact@(\d+)k\)")
+PINNED_RE = re.compile(r"(\d+)k/(\d+)k ctx \(100% · compact@\d+k\)")
+
+
+class OpenAiErrorMock:
+    """Serves one fixed OpenAI-style error envelope for every /v1/chat/completions."""
+
+    def __init__(self, error_obj: dict) -> None:
+        self.body = json.dumps({"error": error_obj}).encode()
+        self.hits = 0
+        parent = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802
+                parent.hits += 1
+                length = int(self.headers.get("content-length", 0))
+                if length:
+                    self.rfile.read(length)
+                self.send_response(200)
+                self.send_header("content-type", "application/json")
+                self.send_header("content-length", str(len(parent.body)))
+                self.end_headers()
+                self.wfile.write(parent.body)
+
+            def do_GET(self) -> None:  # noqa: N802 (e.g. a /v1/models probe)
+                self.send_response(404)
+                self.end_headers()
+
+            def log_message(self, *_a) -> None:  # silence the default stderr logging
+                pass
+
+        self.httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 1234), Handler)
+
+    def start(self) -> None:
+        threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
+
+    def stop(self) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+def _run(error_obj: dict, tmp: str):
+    """Run one turn against a mock returning error_obj; return (rendered_text, hits)."""
+    mock = OpenAiErrorMock(error_obj)
+    mock.start()
+    try:
+        env = {
+            "HOME": tmp,
+            "LMSTUDIO_API_KEY": "local-pty-test",
+            "GRAFF_FLEET": "off",
+            "GRAFF_NO_TELEMETRY": "1",
+        }
+        ambient = tuple(
+            k for k in os.environ
+            if (k.startswith("GRAFF_") or k.startswith("CODEX_") or k == "NO_COLOR")
+            and k not in env
+        )
+        with PtySession(
+            GRAFF,
+            ["--model", "lmstudio", "--no-telemetry"],
+            cwd=tmp,
+            env=env,
+            unset_env=ambient,
+            timeout=20.0,
+        ) as session:
+            session.wait_for_literal("] ›")
+            cursor = len(session.raw)
+            session.send_line("hello")
+            # The turn ends with an api error either way; wait for it, then settle.
+            session.wait_for_literal("api error:", start=cursor)
+            session.pump_for(1.5)
+            rendered = terminal_text(bytes(session.raw[cursor:]))
+
+            # Session must remain usable after the failed turn (no wedge): a local
+            # command still works and the REPL exits cleanly.
+            c2 = len(session.raw)
+            session.send_line("/help")
+            session.wait_for_literal("/models [health]", start=c2)
+            session.send_key("ctrl-d")
+            result = session.read_until_exit(5.0)
+            if result.timed_out or result.exit_code != 0:
+                raise SystemExit(
+                    f"REPL did not exit cleanly: exit={result.exit_code} "
+                    f"timed_out={result.timed_out}"
+                )
+            return rendered, mock.hits
+    finally:
+        mock.stop()
+
+
+def main() -> None:
+    # The lmstudio provider URL is hardcoded to :1234; bail cleanly if it's taken.
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # SO_REUSEADDR binds over a TIME_WAIT port left by a prior run, but still fails
+    # against a real LISTENing server — so back-to-back runs work, a live LM Studio skips.
+    probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        probe.bind(("127.0.0.1", 1234))
+    except OSError:
+        print("skip  127.0.0.1:1234 is in use (real LM Studio?) — overflow PTY test skipped")
+        return
+    finally:
+        probe.close()
+
+    with tempfile.TemporaryDirectory(prefix="graff-pty-overflow-") as tmp:
+        # Disable the AI tab-titler so it doesn't fire an extra quiet turn.
+        harness = os.path.join(tmp, ".harness")
+        os.makedirs(harness, exist_ok=True)
+        with open(os.path.join(harness, "settings.json"), "w", encoding="utf-8") as fh:
+            json.dump({"ai_title": False}, fh)
+
+        # Scenario A: structured overflow code, message matches NO English substring.
+        dutch = "de aanvraag overschrijdt het maximale vensterformaat van dit model"
+        rendered, hits = _run(
+            {"message": dutch, "type": "invalid_request_error", "code": "context_length_exceeded"},
+            tmp,
+        )
+        if hits < 1:
+            raise AssertionError("A: graff never reached the backend")
+        if "api error" not in rendered or dutch not in rendered:
+            raise AssertionError(f"A: overflow error was not surfaced:\n{rendered}")
+        pinned = PINNED_RE.search(rendered)
+        if not pinned:
+            raise AssertionError(
+                "A: meter did not pin to the window — the structured error.code "
+                f"(context_length_exceeded) was not detected as overflow (#203/G2):\n{rendered}"
+            )
+        m = METER_RE.search(rendered)
+        if m.group(1) != m.group(2):
+            raise AssertionError(f"A: meter used != window despite pin: {m.group(0)!r}")
+        print(f"ok    overflow-by-code detected end to end; meter pinned to {m.group(2)}k (100%)")
+
+        # Scenario B: a non-overflow code + non-overflow message must NOT pin.
+        rendered, _ = _run(
+            {"message": "too many requests", "type": "rate_limit_error", "code": "rate_limit_exceeded"},
+            tmp,
+        )
+        if "too many requests" not in rendered:
+            raise AssertionError(f"B: rate-limit error was not surfaced:\n{rendered}")
+        stray = PINNED_RE.search(rendered)
+        if stray:
+            raise AssertionError(
+                "B: meter pinned on a NON-overflow error — detection is not precise "
+                f"({stray.group(0)!r}):\n{rendered}"
+            )
+        print("ok    non-overflow error did not pin the meter (detection is precise)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -346,6 +346,7 @@ pub const Agent = struct {
     // unchanged.
     pub const request = @import("agent_request.zig").request;
     pub const inputOverCompactThreshold = @import("agent_request.zig").inputOverCompactThreshold;
+    pub const fullInputEstimateTokens = @import("agent_request.zig").fullInputEstimateTokens;
     pub const recordUsage = @import("agent_request.zig").recordUsage;
     pub const usageInt = @import("agent_request.zig").usageInt;
     pub const recordCost = @import("agent_request.zig").recordCost;

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -407,6 +407,7 @@ pub const Agent = struct {
     pub const emergencyCutIndex = @import("agent_compact.zig").emergencyCutIndex;
     pub const emergencyTrim = @import("agent_compact.zig").emergencyTrim;
     pub const compactOrRecover = @import("agent_compact.zig").compactOrRecover;
+    pub const capOversizedToolOutputs = @import("agent_compact.zig").capOversizedToolOutputs;
 
     // The live streaming path (thinking spinner, live "Thinking" reasoning
     // block, and postStream itself — the root agent's streaming POST) lives

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -77,6 +77,21 @@ pub const TodoItem = struct {
     status: []const u8,
 };
 
+/// Governed-run status for a standing /goal (#223). Frozen enum — `budget_limited`
+/// is reserved for #224's per-goal budget accounting. Only `.active` steers turns.
+pub const GoalStatus = enum { active, paused, blocked, complete, budget_limited };
+
+/// A structured standing objective: the /goal text plus its lifecycle status and
+/// created/updated timestamps. Replaces the bare `?[]const u8` so /goal can
+/// pause/resume/report and persist a real state machine across resumes. The
+/// `objective` string is owned by the session arena (like the old goal string).
+pub const Goal = struct {
+    objective: []const u8,
+    status: GoalStatus = .active,
+    created_ms: i64 = 0,
+    updated_ms: i64 = 0,
+};
+
 /// One agent: a message history plus the POST/tool-dispatch loop. The root
 /// agent prints to stdout; subagents (sub = true) run on pool threads and
 /// log through std.debug.print, which locks stderr and is thread-safe.
@@ -135,7 +150,7 @@ pub const Agent = struct {
     ultracode_mode: bool = false, // persistent ultracode (multi-agent workflow) mode (/ultracode)
     show_thinking: bool = true, // stream the model's reasoning live in the TUI (/thinking); off = spinner only
     ai_title: bool = true, // AI-generate the tab/session title from the first prompt (/title)
-    goal: ?[]const u8 = null, // persistent objective steering (/goal)
+    goal: ?Goal = null, // structured objective + status lifecycle (/goal, #223)
     session_name: []const u8 = "last", // autosave/resume target (<name>.session.json)
     session_title: ?[]const u8 = null, // human-readable title/rename metadata
     sys_strict: []const u8 = prompts.main_system_prompt_strict,

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -77,9 +77,9 @@ pub const TodoItem = struct {
     status: []const u8,
 };
 
-/// Governed-run status for a standing /goal (#223). Frozen enum — `budget_limited`
-/// is reserved for #224's per-goal budget accounting. Only `.active` steers turns.
-pub const GoalStatus = enum { active, paused, blocked, complete, budget_limited };
+/// Governed-run status for a standing /goal (#223). Only `.active` steers turns;
+/// pause/resume and the /loop continuation gate (#226) key off the others.
+pub const GoalStatus = enum { active, paused, blocked, complete };
 
 /// A structured standing objective: the /goal text plus its lifecycle status and
 /// created/updated timestamps. Replaces the bare `?[]const u8` so /goal can

--- a/src/agent_compact.zig
+++ b/src/agent_compact.zig
@@ -400,30 +400,32 @@ fn isToolOutputMsg(m: Value) bool {
     return false;
 }
 
-fn truncateStrField(arena: Allocator, o: *std.json.ObjectMap, key: []const u8, cap: usize) usize {
+fn truncateStrField(arena: Allocator, o: *std.json.ObjectMap, key: []const u8, cap: usize, note: []const u8) usize {
     const v = o.get(key) orelse return 0;
     if (v != .string or v.string.len <= cap) return 0;
     const orig = v.string.len;
-    const stub = std.fmt.allocPrint(arena, "{s}\n[old tool output truncated to recover context (#163)]", .{utf8Prefix(v.string, cap)}) catch return 0;
+    // Keep the prefix short enough that prefix + '\n' + note <= cap, so the marker
+    // never grows an output that was only barely over the cap.
+    const stub = std.fmt.allocPrint(arena, "{s}\n{s}", .{ utf8Prefix(v.string, cap -| (note.len + 1)), note }) catch return 0;
     o.put(arena, key, .{ .string = stub }) catch return 0;
     return orig -| stub.len;
 }
 
 /// Truncate an over-large tool-output payload in `m` in place to ~`cap` bytes,
 /// preserving the message and its call/output pairing. Returns bytes reclaimed.
-fn truncateToolOutput(arena: Allocator, m: *Value, cap: usize) usize {
+fn truncateToolOutput(arena: Allocator, m: *Value, cap: usize, note: []const u8) usize {
     if (m.* != .object) return 0;
     if (m.object.get("type")) |t| if (t == .string and std.mem.eql(u8, t.string, "function_call_output"))
-        return truncateStrField(arena, &m.object, "output", cap);
+        return truncateStrField(arena, &m.object, "output", cap, note);
     if (m.object.get("role")) |r| if (r == .string) {
-        if (std.mem.eql(u8, r.string, "tool")) return truncateStrField(arena, &m.object, "content", cap);
+        if (std.mem.eql(u8, r.string, "tool")) return truncateStrField(arena, &m.object, "content", cap, note);
         if (std.mem.eql(u8, r.string, "user")) if (m.object.get("content")) |c| if (c == .array) {
             var saved: usize = 0;
             for (m.object.get("content").?.array.items) |*blk| {
                 if (blk.* != .object) continue;
                 const bt = blk.object.get("type") orelse continue;
                 if (bt == .string and std.mem.eql(u8, bt.string, "tool_result"))
-                    saved += truncateStrField(arena, &blk.object, "content", cap);
+                    saved += truncateStrField(arena, &blk.object, "content", cap, note);
             }
             return saved;
         };
@@ -451,7 +453,28 @@ pub fn trimOldestToolOutputs(self: *Agent) usize {
         if (!isToolOutputMsg(m.*)) continue;
         seen += 1;
         if (seen > total - keep_recent) break; // keep the most recent verbatim
-        reclaimed += truncateToolOutput(self.arena, m, stub_cap);
+        reclaimed += truncateToolOutput(self.arena, m, stub_cap, "[old tool output truncated to recover context (#163)]");
+    }
+    if (reclaimed > 0) self.last_context_tokens = 0; // force a re-measure next turn
+    return reclaimed;
+}
+
+/// #193 follow-up: bound ANY single tool output to `cap` serialized bytes before
+/// send, in place, across every wire format (responses `function_call_output`,
+/// openai `role:"tool"`, anthropic `tool_result` blocks). normalizeResponsesHistory
+/// already hard-caps the responses output at the Responses API limit, but
+/// anthropic/openai tool results had no per-output bound: one uncapped result (a
+/// runaway MCP tool, a big fetch on a small-window model) could alone push the
+/// input past the window — and past what emergencyTrim can reclaim, since it keeps
+/// the most-recent outputs verbatim. Cap is window-proportional (Provider.perOutputCap)
+/// so large-context models keep full results untouched. Preserves every call/output
+/// pairing (shrinks strings, never drops a message). Returns bytes reclaimed.
+pub fn capOversizedToolOutputs(self: *Agent, cap: usize) usize {
+    if (cap == 0) return 0;
+    var reclaimed: usize = 0;
+    for (self.messages.items) |*m| {
+        if (isToolOutputMsg(m.*))
+            reclaimed += truncateToolOutput(self.arena, m, cap, "[tool output truncated: over this model's per-result cap — read/fetch a smaller range (#193)]");
     }
     if (reclaimed > 0) self.last_context_tokens = 0; // force a re-measure next turn
     return reclaimed;
@@ -542,6 +565,70 @@ test "trimOldestToolOutputs recovers a runaway tool-loop history (#163)" {
     try std.testing.expectEqual(@as(usize, 6), truncated); // 10 outputs, oldest 6 truncated
     try std.testing.expectEqual(@as(usize, 4), full); // 4 most-recent kept verbatim
     try std.testing.expectEqual(@as(usize, 11), agent.messages.items.len); // no message dropped
+}
+
+test "capOversizedToolOutputs (#193): bounds an oversized output in every wire format, leaves small ones + non-tool msgs" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    const cap: usize = 1024;
+    const big = try a.alloc(u8, 8192);
+    @memset(big, 'x');
+
+    var msgs = std.json.Array.init(a);
+    // responses function_call_output (oversized)
+    var fco: std.json.ObjectMap = .empty;
+    try fco.put(a, "type", .{ .string = "function_call_output" });
+    try fco.put(a, "call_id", .{ .string = "c1" });
+    try fco.put(a, "output", .{ .string = big });
+    try msgs.append(.{ .object = fco });
+    // openai role:"tool" (oversized)
+    var tool: std.json.ObjectMap = .empty;
+    try tool.put(a, "role", .{ .string = "tool" });
+    try tool.put(a, "tool_call_id", .{ .string = "c2" });
+    try tool.put(a, "content", .{ .string = big });
+    try msgs.append(.{ .object = tool });
+    // anthropic user turn carrying a tool_result block (oversized)
+    var user: std.json.ObjectMap = .empty;
+    try user.put(a, "role", .{ .string = "user" });
+    var blocks = std.json.Array.init(a);
+    var tr: std.json.ObjectMap = .empty;
+    try tr.put(a, "type", .{ .string = "tool_result" });
+    try tr.put(a, "tool_use_id", .{ .string = "c3" });
+    try tr.put(a, "content", .{ .string = big });
+    try blocks.append(.{ .object = tr });
+    try user.put(a, "content", .{ .array = blocks });
+    try msgs.append(.{ .object = user });
+    // a small tool output (within cap) — must be left untouched
+    var small: std.json.ObjectMap = .empty;
+    try small.put(a, "type", .{ .string = "function_call_output" });
+    try small.put(a, "output", .{ .string = "ok" });
+    try msgs.append(.{ .object = small });
+    // a plain assistant text message — never a tool output, left untouched
+    try msgs.append(try textMessage(a, "assistant", "hello"));
+
+    var agent: Agent = undefined;
+    agent.arena = a;
+    agent.messages = msgs;
+    agent.last_context_tokens = 42;
+
+    const reclaimed = capOversizedToolOutputs(&agent, cap);
+    try std.testing.expect(reclaimed > 0);
+    try std.testing.expectEqual(@as(usize, 0), agent.last_context_tokens); // forces a re-measure
+
+    // every oversized tool output is now within the cap, with a marker
+    const out0 = agent.messages.items[0].object.get("output").?.string;
+    try std.testing.expect(out0.len <= cap);
+    try std.testing.expect(std.mem.indexOf(u8, out0, "truncated") != null);
+    const out1 = agent.messages.items[1].object.get("content").?.string;
+    try std.testing.expect(out1.len <= cap);
+    const block = agent.messages.items[2].object.get("content").?.array.items[0];
+    try std.testing.expect(block.object.get("content").?.string.len <= cap);
+    // within-cap output and the non-tool message are untouched
+    try std.testing.expectEqualStrings("ok", agent.messages.items[3].object.get("output").?.string);
+    try std.testing.expectEqualStrings("hello", agent.messages.items[4].object.get("content").?.string);
+    // cap == 0 disables the cap entirely (unknown window)
+    try std.testing.expectEqual(@as(usize, 0), capOversizedToolOutputs(&agent, 0));
 }
 
 test "cleanUserTurn: plain user text yes; assistant/tool_result no" {

--- a/src/agent_compact.zig
+++ b/src/agent_compact.zig
@@ -455,7 +455,8 @@ pub fn trimOldestToolOutputs(self: *Agent) usize {
         if (seen > total - keep_recent) break; // keep the most recent verbatim
         reclaimed += truncateToolOutput(self.arena, m, stub_cap, "[old tool output truncated to recover context (#163)]");
     }
-    if (reclaimed > 0) self.last_context_tokens = 0; // force a re-measure next turn
+    // #202: reflect the trimmed size instead of blinding the meter to 0.
+    if (reclaimed > 0) self.last_context_tokens = self.fullInputEstimateTokens();
     return reclaimed;
 }
 
@@ -476,7 +477,9 @@ pub fn capOversizedToolOutputs(self: *Agent, cap: usize) usize {
         if (isToolOutputMsg(m.*))
             reclaimed += truncateToolOutput(self.arena, m, cap, "[tool output truncated: over this model's per-result cap — read/fetch a smaller range (#193)]");
     }
-    if (reclaimed > 0) self.last_context_tokens = 0; // force a re-measure next turn
+    // #202: reflect the trimmed size instead of blinding the meter to 0, so the
+    // between-turns gate keeps working and an overflow recover-pin isn't clobbered.
+    if (reclaimed > 0) self.last_context_tokens = self.fullInputEstimateTokens();
     return reclaimed;
 }
 
@@ -554,7 +557,9 @@ test "trimOldestToolOutputs recovers a runaway tool-loop history (#163)" {
     try std.testing.expect(emergencyCutIndex(agent.messages.items) == null);
     const reclaimed = trimOldestToolOutputs(&agent);
     try std.testing.expect(reclaimed > 0); // recovered instead of wedging
-    try std.testing.expectEqual(@as(usize, 0), agent.last_context_tokens); // forces a re-measure
+    // #202: re-measured to the trimmed size instead of blinding the meter to 0
+    try std.testing.expect(agent.last_context_tokens > 0);
+    try std.testing.expectEqual(agent.fullInputEstimateTokens(), agent.last_context_tokens);
     var truncated: usize = 0;
     var full: usize = 0;
     for (agent.messages.items) |m| {
@@ -614,7 +619,9 @@ test "capOversizedToolOutputs (#193): bounds an oversized output in every wire f
 
     const reclaimed = capOversizedToolOutputs(&agent, cap);
     try std.testing.expect(reclaimed > 0);
-    try std.testing.expectEqual(@as(usize, 0), agent.last_context_tokens); // forces a re-measure
+    // #202: re-measured to the trimmed size instead of blinding the meter to 0
+    try std.testing.expect(agent.last_context_tokens > 0);
+    try std.testing.expectEqual(agent.fullInputEstimateTokens(), agent.last_context_tokens);
 
     // every oversized tool output is now within the cap, with a marker
     const out0 = agent.messages.items[0].object.get("output").?.string;

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -126,6 +126,33 @@ test "isContextOverflow (#193): matches every provider's overflow phrasing, not 
     try std.testing.expect(!isContextOverflow("model not found"));
 }
 
+test "recordUsage (#202): floors the meter from the local estimate when usage is absent" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    var msgs = std.json.Array.init(a);
+    var m: std.json.ObjectMap = .empty;
+    try m.put(a, "role", .{ .string = "user" });
+    try m.put(a, "content", .{ .string = "the quick brown fox jumps over the lazy dog" });
+    try msgs.append(.{ .object = m });
+
+    var agent: Agent = undefined;
+    agent.arena = a;
+    agent.messages = msgs;
+    agent.last_context_tokens = 0;
+
+    // a response body with NO usage object previously froze the meter at its stale
+    // value; now it floors to max(full-input estimate, req_body_len/4) so the
+    // between-turns compaction gate can still fire.
+    const root: std.json.ObjectMap = .empty;
+    recordUsage(&agent, root, 4000);
+
+    try std.testing.expect(agent.last_context_tokens > 0);
+    const expected = @max(fullInputEstimateTokens(&agent), @as(u64, 1000)); // 4000/4
+    try std.testing.expectEqual(expected, agent.last_context_tokens);
+}
+
 test "recoverContextOverflow (#193): overflow trims + retries once; guard and non-overflow fall through" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
@@ -217,7 +244,14 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
     // window past what the in-turn recovery below can reclaim (it keeps the most
     // recent outputs verbatim). Window-proportional, so large-context models keep
     // full tool results untouched.
-    _ = self.capOversizedToolOutputs(self.provider.perOutputCap());
+    const capped = self.capOversizedToolOutputs(self.provider.perOutputCap());
+    if (capped > 0) {
+        // #202: don't truncate silently. The model already sees an inline marker;
+        // surface it to the trace and (interactively) to the user too.
+        if (self.tracer) |tr| tr.note("context", "capped an oversized tool output before send");
+        if (!main_mod.json_mode and !self.sub)
+            self.say("[tool output over this model's per-result cap — truncated {d} bytes before send (#193)]\n", .{capped}) catch {};
+    }
     var context_retried = false; // #193: at most one in-turn overflow recovery per request
     rebuild: while (true) {
         const live = !self.sub and self.out != null and !self.stream_quiet;
@@ -401,7 +435,7 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
                     try self.sayApiError("api error ({s}): {s}", .{ etype, emsg });
                     return error.ApiError;
                 };
-                self.recordUsage(root);
+                self.recordUsage(root, body.len);
                 if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, self.last_context_tokens, self.last_cache_read, false);
                 if (main_mod.json_mode and !self.sub) self.emit(.{ .type = "model_call_finished", .provider = self.provider.id, .model = self.provider.model, .ok = true, .ms = ms });
                 return root;
@@ -464,18 +498,22 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
             return error.ApiError;
         }
 
-        self.recordUsage(root);
+        self.recordUsage(root, body.len);
         if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, self.last_context_tokens, self.last_cache_read, false);
         if (main_mod.json_mode and !self.sub) self.emit(.{ .type = "model_call_finished", .provider = self.provider.id, .model = self.provider.model, .ok = true, .ms = ms });
         return root;
     }
 }
 
-pub fn recordUsage(self: *Agent, root: std.json.ObjectMap) void {
-    const usage = root.get("usage") orelse return;
-    if (usage != .object) return;
-    const u = usage.object;
+pub fn recordUsage(self: *Agent, root: std.json.ObjectMap, req_body_len: usize) void {
     self.last_cache_read = 0;
+    // #202: keep the context meter live when the provider omits usage — otherwise
+    // the between-turns compaction gate freezes at a stale value and a long session
+    // can wedge. Mirror the codex/.responses fallback (req_body_len/4, floored at the
+    // full-input estimate) that recordUsageResponses already applies (#174).
+    const usage = root.get("usage") orelse return floorContextTokens(self, req_body_len / 4);
+    if (usage != .object) return floorContextTokens(self, req_body_len / 4);
+    const u = usage.object;
     switch (self.provider.kind) {
         .anthropic => {
             var total: i64 = 0;
@@ -504,6 +542,14 @@ pub fn recordUsage(self: *Agent, root: std.json.ObjectMap) void {
         // codex uses recordUsageResponses on its own path.
         .responses => {},
     }
+}
+
+/// #202: floor the context meter at the local estimate (full-input byte/4, or the
+/// request-body byte/4 when the history isn't serialized yet) when the API omits
+/// usage, so auto-compaction still triggers. Never lowers an existing higher count.
+fn floorContextTokens(self: *Agent, est: u64) void {
+    const floor = @max(self.fullInputEstimateTokens(), est);
+    if (floor > self.last_context_tokens) self.last_context_tokens = floor;
 }
 
 /// An integer usage field, or 0 if absent / wrong type.

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -78,7 +78,14 @@ test "isAuthError (#148): auth failures only, not credits/rate/other" {
 /// too long", "exceed context limit"). Drives the in-turn emergency-trim + retry
 /// recovery symmetrically for every provider (#193) — before it, only the codex
 /// path recovered and anthropic/openai died on an over-window turn.
-fn isContextOverflow(msg: []const u8) bool {
+fn isContextOverflow(msg: []const u8, code: ?[]const u8) bool {
+    // #203: match the structured error code first (openai/codex parity — a local or
+    // non-English provider whose message text differs still recovers), then fall back
+    // to the human-readable phrasing.
+    if (code) |c| {
+        const codes = [_][]const u8{ "context_length_exceeded", "context_window_exceeded" };
+        for (codes) |k| if (std.mem.eql(u8, c, k)) return true;
+    }
     const needles = [_][]const u8{
         "context window", // codex/responses: "exceeds the context window"
         "context length", // openai: "maximum context length is N tokens"
@@ -103,8 +110,8 @@ fn isContextOverflow(msg: []const u8) bool {
 /// `context_retried` shared across every branch of a request) so a second overflow
 /// falls through and never loops. These wire formats send the full input each
 /// rebuild, so — unlike the codex branch — no closeCodexWs re-anchor is needed.
-fn recoverContextOverflow(self: *Agent, msg: []const u8, retried: *bool) bool {
-    if (!isContextOverflow(msg)) return false;
+fn recoverContextOverflow(self: *Agent, msg: []const u8, code: ?[]const u8, retried: *bool) bool {
+    if (!isContextOverflow(msg, code)) return false;
     self.last_context_tokens = self.provider.context;
     if (retried.* or self.emergencyTrim() == 0) return false;
     retried.* = true;
@@ -112,18 +119,23 @@ fn recoverContextOverflow(self: *Agent, msg: []const u8, retried: *bool) bool {
     return true;
 }
 
-test "isContextOverflow (#193): matches every provider's overflow phrasing, not unrelated errors" {
+test "isContextOverflow (#193/#203): matches structured code + every provider's phrasing, not unrelated errors" {
     // codex/responses, openai, anthropic wire-format rejections all recover in-turn
-    try std.testing.expect(isContextOverflow("Your input exceeds the context window of 272000 tokens"));
-    try std.testing.expect(isContextOverflow("This model's maximum context length is 128000 tokens. However, you requested 130000"));
-    try std.testing.expect(isContextOverflow("context_length_exceeded"));
-    try std.testing.expect(isContextOverflow("prompt is too long: 219373 tokens > 200000 maximum"));
-    try std.testing.expect(isContextOverflow("input length and max_tokens exceed context limit"));
-    // unrelated API errors must NOT trigger a trim + retry
-    try std.testing.expect(!isContextOverflow("The API Key appears to be invalid or may have expired."));
-    try std.testing.expect(!isContextOverflow("tool_choice is not supported"));
-    try std.testing.expect(!isContextOverflow("rate limit exceeded"));
-    try std.testing.expect(!isContextOverflow("model not found"));
+    try std.testing.expect(isContextOverflow("Your input exceeds the context window of 272000 tokens", null));
+    try std.testing.expect(isContextOverflow("This model's maximum context length is 128000 tokens. However, you requested 130000", null));
+    try std.testing.expect(isContextOverflow("context_length_exceeded", null));
+    try std.testing.expect(isContextOverflow("prompt is too long: 219373 tokens > 200000 maximum", null));
+    try std.testing.expect(isContextOverflow("input length and max_tokens exceed context limit", null));
+    // #203: a structured error code recovers even when the message text is unfamiliar
+    // (a local / non-English provider whose phrasing we don't match on)
+    try std.testing.expect(isContextOverflow("de invoerlengte overschrijdt het venster", "context_length_exceeded"));
+    try std.testing.expect(isContextOverflow("", "context_window_exceeded"));
+    // unrelated API errors must NOT trigger a trim + retry, by message or by code
+    try std.testing.expect(!isContextOverflow("The API Key appears to be invalid or may have expired.", null));
+    try std.testing.expect(!isContextOverflow("tool_choice is not supported", null));
+    try std.testing.expect(!isContextOverflow("rate limit exceeded", null));
+    try std.testing.expect(!isContextOverflow("model not found", null));
+    try std.testing.expect(!isContextOverflow("some unrelated failure", "rate_limit_exceeded"));
 }
 
 test "recordUsage (#202): floors the meter from the local estimate when usage is absent" {
@@ -183,15 +195,15 @@ test "recoverContextOverflow (#193): overflow trims + retries once; guard and no
 
     // overflow + trimmable history -> recovers (retry the turn), guard flips
     var retried = false;
-    try std.testing.expect(recoverContextOverflow(&agent, "prompt is too long: 999 tokens > 100 maximum", &retried));
+    try std.testing.expect(recoverContextOverflow(&agent, "prompt is too long: 999 tokens > 100 maximum", null, &retried));
     try std.testing.expect(retried);
     // a second overflow this request -> guard blocks a re-trim (no loop), but the
     // meter stays pinned to the window so the between-turns compaction still engages
-    try std.testing.expect(!recoverContextOverflow(&agent, "prompt is too long", &retried));
+    try std.testing.expect(!recoverContextOverflow(&agent, "prompt is too long", null, &retried));
     try std.testing.expectEqual(agent.provider.context, agent.last_context_tokens);
     // an unrelated error never recovers, regardless of the guard
     var retried2 = false;
-    try std.testing.expect(!recoverContextOverflow(&agent, "invalid api key", &retried2));
+    try std.testing.expect(!recoverContextOverflow(&agent, "invalid api key", null, &retried2));
     try std.testing.expect(!retried2);
 }
 
@@ -395,7 +407,7 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
                     // session would wedge (every retry resends the same
                     // oversized history). Pin the meter to the window so the
                     // ApiError compact-and-recover path engages.
-                    if (isContextOverflow(msg)) {
+                    if (isContextOverflow(msg, null)) {
                         self.last_context_tokens = self.provider.context;
                         // #193: the local pre-send gate uses a byte/4 LOWER bound, so
                         // the backend can still reject an input it let through. A good
@@ -430,7 +442,8 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
                     const eo = if (root.get("error")) |ev| (if (ev == .object) ev.object else null) else null;
                     const etype = if (eo) |e| (if (e.get("type")) |tv| (if (tv == .string) tv.string else "error") else "error") else "error";
                     const emsg = if (eo) |e| (if (e.get("message")) |mv| (if (mv == .string) mv.string else "") else "") else "";
-                    if (recoverContextOverflow(self, emsg, &context_retried)) continue; // #193: streamed error event that is an overflow → trim + retry
+                    const ecode = if (eo) |e| (if (e.get("code")) |cv| (if (cv == .string) cv.string else null) else null) else null;
+                    if (recoverContextOverflow(self, emsg, ecode, &context_retried)) continue; // #193/#203: streamed error event overflow (by code or phrasing) → trim + retry
                     if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, 0, 0, true);
                     try self.sayApiError("api error ({s}): {s}", .{ etype, emsg });
                     return error.ApiError;
@@ -454,7 +467,8 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
             const eo = if (root.get("error")) |ev| (if (ev == .object) ev.object else null) else null;
             const etype = if (eo) |e| (if (e.get("type")) |tv| (if (tv == .string) tv.string else "error") else "error") else "error";
             const emsg = if (eo) |e| (if (e.get("message")) |mv| (if (mv == .string) mv.string else "") else "") else "";
-            if (recoverContextOverflow(self, emsg, &context_retried)) continue; // #193: anthropic {"type":"error"} overflow → trim + retry
+            const ecode = if (eo) |e| (if (e.get("code")) |cv| (if (cv == .string) cv.string else null) else null) else null;
+            if (recoverContextOverflow(self, emsg, ecode, &context_retried)) continue; // #193/#203: {"type":"error"} overflow (by code or phrasing) → trim + retry
             if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, 0, 0, true);
             try self.sayApiError("api error ({s}): {s}", .{ etype, emsg });
             return error.ApiError;
@@ -492,7 +506,7 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
             // #193 follow-up: recover an anthropic/openai context-window rejection
             // in-turn instead of failing the turn (before this only codex recovered;
             // anthropic and openai died). Shared with the two error branches above.
-            if (recoverContextOverflow(self, msg, &context_retried)) continue;
+            if (recoverContextOverflow(self, msg, null, &context_retried)) continue;
             if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, 0, 0, true);
             try self.sayApiError("api error: {s}", .{msg});
             return error.ApiError;
@@ -675,7 +689,15 @@ pub fn fullInputEstimateTokens(self: *Agent) u64 {
 /// Guarded on a known window (compactAt()==0 → don't compact blindly).
 pub fn inputOverCompactThreshold(self: *Agent) bool {
     const threshold = self.provider.compactAt();
-    return threshold > 0 and fullInputEstimateTokens(self) >= threshold;
+    if (threshold == 0) return false;
+    // #203: fullInputEstimateTokens omits the ever-present system prompt + tool
+    // schemas, so it undercounts the real input and this gate under-fires. Add a
+    // baseline for that fixed prefill, clamped to 1/8 of the window so it can never
+    // dominate a small (local) window. (Kept out of fullInputEstimateTokens itself,
+    // which must stay pure over self.messages for the unit tests.)
+    const prefill_baseline_tokens: u64 = 8000;
+    const prefill = @min(prefill_baseline_tokens, self.provider.context / 8);
+    return fullInputEstimateTokens(self) + prefill >= threshold;
 }
 
 test "inputOverCompactThreshold (#193): local estimate gates a pre-send compact" {

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -72,6 +72,102 @@ test "isAuthError (#148): auth failures only, not credits/rate/other" {
     try std.testing.expect(!isAuthError("context length exceeded"));
 }
 
+/// True if `msg` is a provider's "input is over the context window" rejection,
+/// across wire formats: codex/responses ("exceeds the context window"), openai
+/// ("maximum context length", "context_length_exceeded"), anthropic ("prompt is
+/// too long", "exceed context limit"). Drives the in-turn emergency-trim + retry
+/// recovery symmetrically for every provider (#193) — before it, only the codex
+/// path recovered and anthropic/openai died on an over-window turn.
+fn isContextOverflow(msg: []const u8) bool {
+    const needles = [_][]const u8{
+        "context window", // codex/responses: "exceeds the context window"
+        "context length", // openai: "maximum context length is N tokens"
+        "context_length_exceeded", // openai error code echoed into the message
+        "context limit", // anthropic: "input length and max_tokens exceed context limit"
+        "prompt is too long", // anthropic: "prompt is too long: N tokens > M maximum"
+        "maximum context", // defensive: "maximum context ... exceeded"
+    };
+    for (needles) |n| if (std.mem.indexOf(u8, msg, n) != null) return true;
+    return false;
+}
+
+/// #193 follow-up: shared in-turn context-overflow recovery for the three
+/// anthropic/openai error branches (streamed error event, non-streamed
+/// `{"type":"error"}` envelope, and the generic apiErrorMessage path). Before
+/// this, only the codex/.responses branch recovered — anthropic/openai died on an
+/// over-window turn. Returns true if the caller should `continue` the rebuild loop
+/// (emergency-trimmed, retry the same request once); false to fall through to the
+/// normal error. Pins the meter to the window FIRST so the between-turns
+/// compaction engages even when we can't recover here (the rejected request
+/// returns no usage to correct the lagging meter). Guarded by `retried` (one
+/// `context_retried` shared across every branch of a request) so a second overflow
+/// falls through and never loops. These wire formats send the full input each
+/// rebuild, so — unlike the codex branch — no closeCodexWs re-anchor is needed.
+fn recoverContextOverflow(self: *Agent, msg: []const u8, retried: *bool) bool {
+    if (!isContextOverflow(msg)) return false;
+    self.last_context_tokens = self.provider.context;
+    if (retried.* or self.emergencyTrim() == 0) return false;
+    retried.* = true;
+    if (self.tracer) |tr| tr.note("context", "input over the window — emergency-trimmed and retrying the turn");
+    return true;
+}
+
+test "isContextOverflow (#193): matches every provider's overflow phrasing, not unrelated errors" {
+    // codex/responses, openai, anthropic wire-format rejections all recover in-turn
+    try std.testing.expect(isContextOverflow("Your input exceeds the context window of 272000 tokens"));
+    try std.testing.expect(isContextOverflow("This model's maximum context length is 128000 tokens. However, you requested 130000"));
+    try std.testing.expect(isContextOverflow("context_length_exceeded"));
+    try std.testing.expect(isContextOverflow("prompt is too long: 219373 tokens > 200000 maximum"));
+    try std.testing.expect(isContextOverflow("input length and max_tokens exceed context limit"));
+    // unrelated API errors must NOT trigger a trim + retry
+    try std.testing.expect(!isContextOverflow("The API Key appears to be invalid or may have expired."));
+    try std.testing.expect(!isContextOverflow("tool_choice is not supported"));
+    try std.testing.expect(!isContextOverflow("rate limit exceeded"));
+    try std.testing.expect(!isContextOverflow("model not found"));
+}
+
+test "recoverContextOverflow (#193): overflow trims + retries once; guard and non-overflow fall through" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    // a runaway tool-loop history emergencyTrim can reclaim (mirrors the #163 shape:
+    // one clean user turn then only tool outputs, so trimOldestToolOutputs recovers)
+    var msgs = std.json.Array.init(a);
+    var um: std.json.ObjectMap = .empty;
+    try um.put(a, "role", .{ .string = "user" });
+    try um.put(a, "content", .{ .string = "do a thing" });
+    try msgs.append(.{ .object = um });
+    const big = try a.alloc(u8, 5000);
+    @memset(big, 'x');
+    var i: usize = 0;
+    while (i < 10) : (i += 1) {
+        var o: std.json.ObjectMap = .empty;
+        try o.put(a, "type", .{ .string = "function_call_output" });
+        try o.put(a, "call_id", .{ .string = "c" });
+        try o.put(a, "output", .{ .string = big });
+        try msgs.append(.{ .object = o });
+    }
+    var agent: Agent = undefined;
+    agent.arena = a;
+    agent.messages = msgs;
+    agent.tracer = null;
+    agent.provider = .{ .id = "anthropic", .kind = .anthropic, .auth = .x_api_key, .url = "", .api_key = "", .model = "claude", .context = 100000 };
+    agent.last_context_tokens = 0;
+
+    // overflow + trimmable history -> recovers (retry the turn), guard flips
+    var retried = false;
+    try std.testing.expect(recoverContextOverflow(&agent, "prompt is too long: 999 tokens > 100 maximum", &retried));
+    try std.testing.expect(retried);
+    // a second overflow this request -> guard blocks a re-trim (no loop), but the
+    // meter stays pinned to the window so the between-turns compaction still engages
+    try std.testing.expect(!recoverContextOverflow(&agent, "prompt is too long", &retried));
+    try std.testing.expectEqual(agent.provider.context, agent.last_context_tokens);
+    // an unrelated error never recovers, regardless of the guard
+    var retried2 = false;
+    try std.testing.expect(!recoverContextOverflow(&agent, "invalid api key", &retried2));
+    try std.testing.expect(!retried2);
+}
+
 test "fullInputEstimateTokens (#174): counts retained reasoning the chained usage never reports" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
@@ -114,6 +210,14 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
     sanitizeMessagesUtf8(self.arena, &self.messages); // invalid UTF-8 (any source/format) -> '?' so content never serializes as a byte-int array the API rejects
     if (self.provider.kind == .responses) normalizeResponsesHistory(self.arena, &self.messages);
     if (self.provider.kind == .openai) normalizeOpenAIHistory(self.arena, &self.messages); // #99: chat-completions sibling of the above
+    // #193 follow-up: bound any single oversized tool output (an uncapped MCP
+    // result, a huge fetch on a small-window model) before send. The responses
+    // path already hard-caps output above (normalizeResponsesHistory); this is the
+    // provider-agnostic sibling so one pathological result can't alone overflow the
+    // window past what the in-turn recovery below can reclaim (it keeps the most
+    // recent outputs verbatim). Window-proportional, so large-context models keep
+    // full tool results untouched.
+    _ = self.capOversizedToolOutputs(self.provider.perOutputCap());
     var context_retried = false; // #193: at most one in-turn overflow recovery per request
     rebuild: while (true) {
         const live = !self.sub and self.out != null and !self.stream_quiet;
@@ -257,7 +361,7 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
                     // session would wedge (every retry resends the same
                     // oversized history). Pin the meter to the window so the
                     // ApiError compact-and-recover path engages.
-                    if (std.mem.indexOf(u8, msg, "exceeds the context window") != null) {
+                    if (isContextOverflow(msg)) {
                         self.last_context_tokens = self.provider.context;
                         // #193: the local pre-send gate uses a byte/4 LOWER bound, so
                         // the backend can still reject an input it let through. A good
@@ -292,6 +396,7 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
                     const eo = if (root.get("error")) |ev| (if (ev == .object) ev.object else null) else null;
                     const etype = if (eo) |e| (if (e.get("type")) |tv| (if (tv == .string) tv.string else "error") else "error") else "error";
                     const emsg = if (eo) |e| (if (e.get("message")) |mv| (if (mv == .string) mv.string else "") else "") else "";
+                    if (recoverContextOverflow(self, emsg, &context_retried)) continue; // #193: streamed error event that is an overflow → trim + retry
                     if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, 0, 0, true);
                     try self.sayApiError("api error ({s}): {s}", .{ etype, emsg });
                     return error.ApiError;
@@ -315,6 +420,7 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
             const eo = if (root.get("error")) |ev| (if (ev == .object) ev.object else null) else null;
             const etype = if (eo) |e| (if (e.get("type")) |tv| (if (tv == .string) tv.string else "error") else "error") else "error";
             const emsg = if (eo) |e| (if (e.get("message")) |mv| (if (mv == .string) mv.string else "") else "") else "";
+            if (recoverContextOverflow(self, emsg, &context_retried)) continue; // #193: anthropic {"type":"error"} overflow → trim + retry
             if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, 0, 0, true);
             try self.sayApiError("api error ({s}): {s}", .{ etype, emsg });
             return error.ApiError;
@@ -349,6 +455,10 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
                     continue;
                 }
             }
+            // #193 follow-up: recover an anthropic/openai context-window rejection
+            // in-turn instead of failing the turn (before this only codex recovered;
+            // anthropic and openai died). Shared with the two error branches above.
+            if (recoverContextOverflow(self, msg, &context_retried)) continue;
             if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, 0, 0, true);
             try self.sayApiError("api error: {s}", .{msg});
             return error.ApiError;

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -98,6 +98,22 @@ fn isContextOverflow(msg: []const u8, code: ?[]const u8) bool {
     return false;
 }
 
+/// The structured error code from a parsed error envelope, if any: openai / lmstudio /
+/// deepseek put it at root.error.code; some providers use a top-level root.code (#203).
+fn errorCode(root: std.json.ObjectMap) ?[]const u8 {
+    if (root.get("error")) |ev| {
+        if (ev == .object) {
+            if (ev.object.get("code")) |cv| {
+                if (cv == .string) return cv.string;
+            }
+        }
+    }
+    if (root.get("code")) |cv| {
+        if (cv == .string) return cv.string;
+    }
+    return null;
+}
+
 /// #193 follow-up: shared in-turn context-overflow recovery for the three
 /// anthropic/openai error branches (streamed error event, non-streamed
 /// `{"type":"error"}` envelope, and the generic apiErrorMessage path). Before
@@ -136,6 +152,26 @@ test "isContextOverflow (#193/#203): matches structured code + every provider's 
     try std.testing.expect(!isContextOverflow("rate limit exceeded", null));
     try std.testing.expect(!isContextOverflow("model not found", null));
     try std.testing.expect(!isContextOverflow("some unrelated failure", "rate_limit_exceeded"));
+}
+
+test "errorCode (#203): pulls root.error.code (openai/lmstudio), falls back to root.code, else null" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    // openai/lmstudio/deepseek shape: {"error":{"code":"context_length_exceeded",...}}
+    var err: std.json.ObjectMap = .empty;
+    try err.put(a, "code", .{ .string = "context_length_exceeded" });
+    var root1: std.json.ObjectMap = .empty;
+    try root1.put(a, "error", .{ .object = err });
+    try std.testing.expectEqualStrings("context_length_exceeded", errorCode(root1).?);
+    // top-level code fallback
+    var root2: std.json.ObjectMap = .empty;
+    try root2.put(a, "code", .{ .string = "context_window_exceeded" });
+    try std.testing.expectEqualStrings("context_window_exceeded", errorCode(root2).?);
+    // neither present → null (falls back to substring detection)
+    var root3: std.json.ObjectMap = .empty;
+    try root3.put(a, "message", .{ .string = "hi" });
+    try std.testing.expect(errorCode(root3) == null);
 }
 
 test "recordUsage (#202): floors the meter from the local estimate when usage is absent" {
@@ -506,7 +542,10 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
             // #193 follow-up: recover an anthropic/openai context-window rejection
             // in-turn instead of failing the turn (before this only codex recovered;
             // anthropic and openai died). Shared with the two error branches above.
-            if (recoverContextOverflow(self, msg, null, &context_retried)) continue;
+            // #203: openai-compatible errors arrive here (no top-level "type":"error"),
+            // so pull the structured code from root.error.code for isContextOverflow — a
+            // local provider whose message text we don't match on still recovers.
+            if (recoverContextOverflow(self, msg, errorCode(root), &context_retried)) continue;
             if (self.tracer) |tr| tr.api(self.label, self.provider.model, ms, body.len, resp_body.len, 0, 0, true);
             try self.sayApiError("api error: {s}", .{msg});
             return error.ApiError;

--- a/src/agent_tools.zig
+++ b/src/agent_tools.zig
@@ -45,6 +45,8 @@ const ToolOutput = tools_mod.ToolOutput;
 const exec = @import("exec.zig");
 const execTool = exec.execTool;
 
+const util = @import("util.zig"); // #225: unixMs, for the clock_sleep interrupted-elapsed measurement
+
 // escWatchTask/drainStdin/rawNonblockStdin live in agent_interrupt.zig;
 // Agent.esc_watch_done is a struct-level pub var that STAYS declared inside the
 // Agent struct in main.zig (never alias a var — see esc_cancel/
@@ -314,6 +316,38 @@ pub fn firstWord(cmd: []const u8) []const u8 {
     return cmd[0..end];
 }
 
+/// #225: clock_sleep meta tool — root-only, feature-flagged (main.zig
+/// g_clock_sleep / --clock-sleep / GRAFF_CLOCK_SLEEP=1). Mirrors codex's
+/// clock.sleep: capped at 12h, cancelled by user input like any other
+/// backoff (sleepInterruptible), and an interruption is reported as a
+/// normal (non-error) outcome, not a tool failure.
+pub const clock_sleep_max_ms: i64 = 43_200_000; // 12h, mirrors codex MAX_SLEEP_DURATION_MS
+
+const ClockSleepMs = struct { ms: i64, clamped: bool };
+
+/// Pure `ms`-field validation/clamping, split out of the handleMeta arm so
+/// the reject/clamp paths are unit-testable without a live Agent/Io.
+/// `input` must be `{"ms": <non-negative integer>}` — anything else
+/// (missing, negative, non-integer, wrong shape) is a normal rejection,
+/// never a crash. A value over the 12h cap clamps instead of rejecting.
+fn parseClockSleepMs(input: Value) error{InvalidMs}!ClockSleepMs {
+    if (input != .object) return error.InvalidMs;
+    const raw = input.object.get("ms") orelse return error.InvalidMs;
+    if (raw != .integer or raw.integer < 0) return error.InvalidMs;
+    if (raw.integer > clock_sleep_max_ms) return .{ .ms = clock_sleep_max_ms, .clamped = true };
+    return .{ .ms = raw.integer, .clamped = false };
+}
+
+fn clockSleepSuccessText(arena: std.mem.Allocator, ms: i64, clamped: bool) ![]const u8 {
+    if (clamped) return std.fmt.allocPrint(arena, "clock_sleep: requested ms exceeded the 12h cap, clamped to {d} ms; slept {d} ms", .{ clock_sleep_max_ms, ms });
+    return std.fmt.allocPrint(arena, "slept {d} ms", .{ms});
+}
+
+fn clockSleepInterruptedText(arena: std.mem.Allocator, elapsed_ms: i64) ![]const u8 {
+    return std.fmt.allocPrint(arena, "sleep interrupted after {d} ms by user input", .{elapsed_ms});
+}
+
+
 /// Handle a meta tool inline on the agent's own thread.
 pub fn handleMeta(self: *Agent, call: ToolCall) !ExecResult {
     if (std.mem.eql(u8, call.name, "attempt_completion")) {
@@ -344,6 +378,26 @@ pub fn handleMeta(self: *Agent, call: ToolCall) !ExecResult {
         const rendered = self.renderTodos();
         if (!self.sub) try self.say("{s}\n", .{rendered});
         return .{ .text = rendered, .is_error = false };
+    }
+    if (std.mem.eql(u8, call.name, "clock_sleep")) {
+        const parsed = parseClockSleepMs(call.input) catch return .{
+            .text = "clock_sleep: ms must be a non-negative integer",
+            .is_error = true,
+        };
+        if (parsed.ms == 0) {
+            // Nothing to wait out — skip the sleep call (and the Io clock
+            // reads below) entirely rather than round-tripping a zero-length
+            // sleep through sleepInterruptible.
+            return .{ .text = try clockSleepSuccessText(self.arena, 0, parsed.clamped), .is_error = false };
+        }
+        const start_ms = util.unixMs(self.io);
+        self.sleepInterruptible(@intCast(parsed.ms)) catch |err| switch (err) {
+            error.Interrupted => {
+                const elapsed_ms = util.unixMs(self.io) - start_ms;
+                return .{ .text = try clockSleepInterruptedText(self.arena, elapsed_ms), .is_error = false };
+            },
+        };
+        return .{ .text = try clockSleepSuccessText(self.arena, parsed.ms, parsed.clamped), .is_error = false };
     }
     if (std.mem.eql(u8, call.name, "ask_user")) return self.askUser(call);
     // todo_read
@@ -478,4 +532,122 @@ test "firstWord: splits the command on the first whitespace" {
     try std.testing.expectEqualStrings("cat", firstWord("cat\tfile")); // tab delimiter
     try std.testing.expectEqualStrings("", firstWord(""));
     try std.testing.expectEqualStrings("", firstWord(" leading"));
+}
+
+test "parseClockSleepMs: valid ms passes through, missing/negative/non-integer reject, over-cap clamps (#225)" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    const valid = std.json.parseFromSliceLeaky(Value, a, "{\"ms\":200}", .{}) catch unreachable;
+    const parsed = try parseClockSleepMs(valid);
+    try std.testing.expectEqual(@as(i64, 200), parsed.ms);
+    try std.testing.expect(!parsed.clamped);
+
+    const zero = std.json.parseFromSliceLeaky(Value, a, "{\"ms\":0}", .{}) catch unreachable;
+    try std.testing.expectEqual(@as(i64, 0), (try parseClockSleepMs(zero)).ms);
+
+    const missing = std.json.parseFromSliceLeaky(Value, a, "{}", .{}) catch unreachable;
+    try std.testing.expectError(error.InvalidMs, parseClockSleepMs(missing));
+
+    const negative = std.json.parseFromSliceLeaky(Value, a, "{\"ms\":-1}", .{}) catch unreachable;
+    try std.testing.expectError(error.InvalidMs, parseClockSleepMs(negative));
+
+    const string_ms = std.json.parseFromSliceLeaky(Value, a, "{\"ms\":\"soon\"}", .{}) catch unreachable;
+    try std.testing.expectError(error.InvalidMs, parseClockSleepMs(string_ms));
+
+    const float_ms = std.json.parseFromSliceLeaky(Value, a, "{\"ms\":200.5}", .{}) catch unreachable;
+    try std.testing.expectError(error.InvalidMs, parseClockSleepMs(float_ms));
+
+    const over_cap = std.json.parseFromSliceLeaky(Value, a, "{\"ms\":99999999999}", .{}) catch unreachable;
+    const clamped = try parseClockSleepMs(over_cap);
+    try std.testing.expectEqual(clock_sleep_max_ms, clamped.ms);
+    try std.testing.expect(clamped.clamped);
+}
+
+test "clockSleepSuccessText/clockSleepInterruptedText: exact result strings (#225 acceptance)" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    try std.testing.expectEqualStrings("slept 200 ms", try clockSleepSuccessText(a, 200, false));
+    try std.testing.expectEqualStrings(
+        "clock_sleep: requested ms exceeded the 12h cap, clamped to 43200000 ms; slept 43200000 ms",
+        try clockSleepSuccessText(a, clock_sleep_max_ms, true),
+    );
+    try std.testing.expectEqualStrings("sleep interrupted after 150 ms by user input", try clockSleepInterruptedText(a, 150));
+}
+
+test "handleMeta clock_sleep: ms=0 completes for real end-to-end, bad ms rejects without touching Io" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var agent: Agent = .{
+        .gpa = a,
+        .arena = a,
+        // ms=0 never reaches sleepInterruptible's self.io.sleep() call (its
+        // while loop is skipped at left=0), and the ms-error paths below
+        // return before sleepInterruptible is even called — undefined Io is
+        // safe for exactly these cases (a real Io backend has no unit-test
+        // seam in this codebase; see agent_argstream.zig's own `.io =
+        // undefined` test for the established precedent).
+        .io = undefined,
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = null,
+    };
+    const zero_call: ToolCall = .{ .id = "1", .name = "clock_sleep", .input = std.json.parseFromSliceLeaky(Value, a, "{\"ms\":0}", .{}) catch unreachable };
+    const zero_result = try handleMeta(&agent, zero_call);
+    try std.testing.expectEqualStrings("slept 0 ms", zero_result.text);
+    try std.testing.expect(!zero_result.is_error);
+
+    inline for (.{ "{}", "{\"ms\":-1}", "{\"ms\":\"soon\"}", "{\"ms\":200.5}" }) |bad_json| {
+        const bad_call: ToolCall = .{ .id = "1", .name = "clock_sleep", .input = std.json.parseFromSliceLeaky(Value, a, bad_json, .{}) catch unreachable };
+        const bad_result = try handleMeta(&agent, bad_call);
+        try std.testing.expect(bad_result.is_error);
+        try std.testing.expectEqualStrings("clock_sleep: ms must be a non-negative integer", bad_result.text);
+    }
+}
+
+test "clock_sleep counts against --max-tool-calls and --dedupe-tool-calls like any other call (#225 rails, no bypass)" {
+    const saved_max = main_mod.max_tool_calls;
+    const saved_dedupe = main_mod.dedupe_tool_calls;
+    defer {
+        main_mod.max_tool_calls = saved_max;
+        main_mod.dedupe_tool_calls = saved_dedupe;
+    }
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var agent: Agent = .{
+        .gpa = a,
+        .arena = a,
+        .io = undefined, // rejectToolCall never touches self.io
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = null,
+    };
+    const call: ToolCall = .{ .id = "1", .name = "clock_sleep", .input = std.json.parseFromSliceLeaky(Value, a, "{\"ms\":0}", .{}) catch unreachable };
+
+    main_mod.max_tool_calls = 1;
+    main_mod.dedupe_tool_calls = false;
+    try std.testing.expect((try rejectToolCall(&agent, call)) == null); // 1st call clears the budget gate
+    const budget_denied = try rejectToolCall(&agent, call);
+    try std.testing.expect(budget_denied != null);
+    try std.testing.expect(budget_denied.?.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, budget_denied.?.text, "budget") != null);
+
+    agent.tool_calls_this_turn = 0;
+    main_mod.max_tool_calls = null;
+    main_mod.dedupe_tool_calls = true;
+    try std.testing.expect((try rejectToolCall(&agent, call)) == null); // 1st identical call clears the dedupe gate
+    const dupe_denied = try rejectToolCall(&agent, call);
+    try std.testing.expect(dupe_denied != null);
+    try std.testing.expect(dupe_denied.?.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, dupe_denied.?.text, "duplicate") != null);
 }

--- a/src/args.zig
+++ b/src/args.zig
@@ -108,6 +108,8 @@ pub fn parse(init: std.process.Init) !Flags {
                     main_mod.max_tool_calls = std.fmt.parseInt(u64, mv, 10) catch std.process.fatal("--max-tool-calls needs a non-negative integer, got '{s}'", .{mv});
                 } else if (std.mem.eql(u8, arg, "--dedupe-tool-calls")) {
                     main_mod.dedupe_tool_calls = true;
+                } else if (std.mem.eql(u8, arg, "--clock-sleep")) {
+                    main_mod.g_clock_sleep = true; // #225: opt in to the root-only clock_sleep meta tool (also GRAFF_CLOCK_SLEEP=1)
                 } else if (std.mem.eql(u8, arg, "--no-autocommit")) {
                     main_mod.g_worktree_autocommit = false;
                 } else if (std.mem.eql(u8, arg, "--schema")) {

--- a/src/command_catalog.zig
+++ b/src/command_catalog.zig
@@ -26,7 +26,7 @@ pub const commands = [_]Item{
     .{ .name = "/clear", .desc = "wipe the conversation and start fresh" },
     .{ .name = "/new", .desc = "start a fresh autosaved session" },
     .{ .name = "/rename", .usage = "/rename <title>", .desc = "set the current session title" },
-    .{ .name = "/goal", .usage = "/goal [text]", .desc = "set/show a standing objective (tracked as a checklist); /goal clear clears" },
+    .{ .name = "/goal", .usage = "/goal [text|pause|resume|status|clear]", .desc = "set/show a standing objective (tracked as a checklist); pause/resume steering, status shows state, clear removes it" },
     .{ .name = "/loop", .usage = "/loop <prompt>", .desc = "run an autonomous plan->act->verify pass" },
     .{ .name = "/plan", .desc = "toggle plan mode: read-only explore + propose; writes/edits denied" },
     .{ .name = "/ultracode", .desc = "toggle persistent workflow mode; bare opens an on/off picker, or /ultracode on|off" },

--- a/src/commands_misc.zig
+++ b/src/commands_misc.zig
@@ -40,6 +40,7 @@ const serde = @import("serde.zig");
 const schema = @import("schema.zig");
 const renderRootTools = schema.renderRootTools;
 const root_specs = schema.root_specs;
+const effectiveRootSpecs = schema.effectiveRootSpecs; // #225: gate clock_sleep on the flag when re-rendering the tool lists
 
 const mcp_cli = @import("mcp_cli.zig");
 const persistMcpServer = mcp_cli.persistMcpServer;
@@ -205,9 +206,10 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
                 return true;
             };
             // Re-render the tool lists so the new tools reach the model.
-            root.tools_anthropic = try renderRootTools(arena, .anthropic, &root_specs, reg.tools);
-            root.tools_openai = try renderRootTools(arena, .openai, &root_specs, reg.tools);
-            root.tools_responses = try renderRootTools(arena, .responses, &root_specs, reg.tools);
+            const root_tool_specs = try effectiveRootSpecs(arena); // #225: gate clock_sleep on the flag
+            root.tools_anthropic = try renderRootTools(arena, .anthropic, root_tool_specs, reg.tools);
+            root.tools_openai = try renderRootTools(arena, .openai, root_tool_specs, reg.tools);
+            root.tools_responses = try renderRootTools(arena, .responses, root_tool_specs, reg.tools);
             const persisted = persistMcpServer(root.io, arena, name, command, args.items);
             var has_note = false;
             for (mcp_notes) |mn| if (std.mem.eql(u8, mn.server, name)) {
@@ -233,9 +235,10 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
                 try out.writeAll("no untrusted workspace MCP server(s) to connect.\n");
             } else {
                 // Re-render the tool lists so the new tools reach the model.
-                root.tools_anthropic = try renderRootTools(arena, .anthropic, &root_specs, reg.tools);
-                root.tools_openai = try renderRootTools(arena, .openai, &root_specs, reg.tools);
-                root.tools_responses = try renderRootTools(arena, .responses, &root_specs, reg.tools);
+                const root_tool_specs = try effectiveRootSpecs(arena); // #225: gate clock_sleep on the flag
+                root.tools_anthropic = try renderRootTools(arena, .anthropic, root_tool_specs, reg.tools);
+                root.tools_openai = try renderRootTools(arena, .openai, root_tool_specs, reg.tools);
+                root.tools_responses = try renderRootTools(arena, .responses, root_tool_specs, reg.tools);
                 try out.print("{s}✓{s} trusted workspace — connected {d} MCP server(s); {d} tool(s) total\n", .{ style.green, style.reset, n, reg.tools.len });
             }
             try out.flush();

--- a/src/commands_session.zig
+++ b/src/commands_session.zig
@@ -63,7 +63,7 @@ fn resetConversationSteering(root: *Agent) void {
 
 test "/clear + /new reset conversation steering — goal and ultracode_mode don't survive (#178)" {
     var root: Agent = undefined;
-    root.goal = "ultracode: index the statutes";
+    root.goal = .{ .objective = "ultracode: index the statutes" };
     root.ultracode_mode = true;
     resetConversationSteering(&root);
     try std.testing.expect(root.goal == null);
@@ -122,16 +122,34 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
     }
     if (std.mem.startsWith(u8, line, "/goal")) {
         const text = std.mem.trim(u8, line["/goal".len..], " \t");
-        if (text.len == 0) {
-            if (root.goal) |goal| try out.print("Current goal: {s}\nClear it with /goal clear.\n", .{goal}) else try out.writeAll("No active goal. Set one with /goal <objective>.\n");
+        if (text.len == 0 or std.ascii.eqlIgnoreCase(text, "status")) {
+            // bare /goal or /goal status: report the objective + lifecycle state.
+            if (root.goal) |g| {
+                try out.print("\xf0\x9f\x8e\xaf Goal: {s}\nStatus: {s}. Commands: /goal pause | resume | clear.\n", .{ g.objective, @tagName(g.status) });
+            } else try out.writeAll("No active goal. Set one with /goal <objective>.\n");
         } else if (std.ascii.eqlIgnoreCase(text, "clear") or std.ascii.eqlIgnoreCase(text, "off")) {
             root.goal = null;
             saveSession(root, arena, root.session_name) catch {};
             try out.writeAll("Goal cleared. Future turns will not get goal steering.\n");
+        } else if (std.ascii.eqlIgnoreCase(text, "pause")) {
+            if (root.goal) |*g| {
+                g.status = .paused;
+                g.updated_ms = unixMs(root.io);
+                saveSession(root, arena, root.session_name) catch {};
+                try out.print("Goal paused: {s} - turns no longer get goal steering. /goal resume to continue.\n", .{g.objective});
+            } else try out.writeAll("No active goal to pause. Set one with /goal <objective>.\n");
+        } else if (std.ascii.eqlIgnoreCase(text, "resume")) {
+            if (root.goal) |*g| {
+                g.status = .active;
+                g.updated_ms = unixMs(root.io);
+                saveSession(root, arena, root.session_name) catch {};
+                try out.print("\xf0\x9f\x8e\xaf Goal resumed: {s} - steering every turn again.\n", .{g.objective});
+            } else try out.writeAll("No goal to resume. Set one with /goal <objective>.\n");
         } else {
-            root.goal = try arena.dupe(u8, text);
+            const now = unixMs(root.io);
+            root.goal = .{ .objective = try arena.dupe(u8, text), .status = .active, .created_ms = now, .updated_ms = now };
             saveSession(root, arena, root.session_name) catch {};
-            try out.print("\xf0\x9f\x8e\xaf Goal set: {s} \xe2\x80\x94 starting now (tracked as a live checklist; it steers every turn until /goal clear).\n", .{text});
+            try out.print("\xf0\x9f\x8e\xaf Goal set: {s} \xe2\x80\x94 starting now (tracked as a live checklist; it steers every turn until /goal pause or /goal clear).\n", .{text});
         }
         try out.flush();
         return true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -58,6 +58,7 @@ pub var show_timing = false;
 pub var show_cost = false;
 pub var json_mode = false; // --json: structured JSONL events on stdout instead of human text
 pub var g_codex_ws = true; // root Codex turns use the WebSocket transport (Responses API over wss) with SSE fallback; GRAFF_CODEX_WS=off|0 forces SSE
+pub var g_clock_sleep: bool = false; // #225: root-only clock_sleep meta tool, off by default; --clock-sleep / GRAFF_CLOCK_SLEEP=1 turns it on (gates advertising in renderRootTools, mirrors g_codex_ws)
 pub var g_force_stall_once: bool = false; // #134 test seam (GRAFF_FORCE_STALL_ONCE=1): the next live turn returns error.StreamStalled — proves the stall path is never labeled a user Esc
 pub var g_force_drop_once: bool = false; // #132/#133 test seam (GRAFF_FORCE_DROP_ONCE=1): the next live turn returns error.StreamDropped
 pub var max_tool_calls: ?u64 = null; // --max-tool-calls: hard per-turn root tool budget

--- a/src/mainloop.zig
+++ b/src/mainloop.zig
@@ -135,7 +135,7 @@ pub fn run(ctx: *Ctx) !void {
         // just recording it. Bare /goal (show) and /goal clear/off stay commands.
         const goal_prompt: ?[]const u8 = if (!main_mod.json_mode and std.mem.startsWith(u8, line, "/goal ")) gblk: {
             const g = std.mem.trim(u8, line["/goal".len..], " \t");
-            if (g.len == 0 or std.ascii.eqlIgnoreCase(g, "clear") or std.ascii.eqlIgnoreCase(g, "off")) break :gblk null;
+            if (g.len == 0 or std.ascii.eqlIgnoreCase(g, "clear") or std.ascii.eqlIgnoreCase(g, "off") or std.ascii.eqlIgnoreCase(g, "pause") or std.ascii.eqlIgnoreCase(g, "resume") or std.ascii.eqlIgnoreCase(g, "status")) break :gblk null;
             break :gblk g;
         } else null;
         if (!main_mod.json_mode) {

--- a/src/mainloop.zig
+++ b/src/mainloop.zig
@@ -94,6 +94,15 @@ fn applyAiTitle(ctx: *Ctx, f: *Io.Future(?[]const u8)) void {
     }
 }
 
+/// #226: true only when the model has a live checklist and every item is marked
+/// completed — a "work asserted done" signal for the /loop continuation gate
+/// (alongside attempt_completion / root.completed). An empty checklist is NOT done.
+fn allTodosDone(root: *agent_mod.Agent) bool {
+    if (root.todos.items.len == 0) return false;
+    for (root.todos.items) |t| if (!std.mem.eql(u8, t.status, "completed")) return false;
+    return true;
+}
+
 /// The interactive-REPL / --json-protocol turn loop itself. Runs until EOF,
 /// `exit`/`quit`/`q`, or a plain `break` out of the raw-line read. main()
 /// resumes right after this returns and does its own final-save/worktree
@@ -104,6 +113,14 @@ pub fn run(ctx: *Ctx) !void {
     var prev_turn_id: u64 = 0;
     var prev_prompt_fp: [16]u8 = scoring.promptFingerprint(ctx.root.systemPrompt());
 
+    // #226: /loop controller-authorized continuation state. `loop_continue_armed`
+    // is set only after a CLEANLY-COMPLETED autonomous /loop turn and consumed at
+    // the next readline — so any interrupt/error (which `continue`s past the arming
+    // site) auto-stops the loop with no per-error-branch handling.
+    const loop_iter_cap: u32 = 25; // hard per-/loop iteration bound (never-completing-model guard)
+    var loop_iters_left: u32 = 0; // continuation turns still authorized this /loop run
+    var loop_continue_armed = false; // a continuation turn is queued for the next readline
+
     while (true) {
         // Steering drain: prompts typed while the previous turn streamed
         // were captured into g_steer_queue. Run them now, one after
@@ -112,7 +129,10 @@ pub fn run(ctx: *Ctx) !void {
         repl_glue.resetSteerPartial();
         const steer_entry: ?repl_glue.SteerEntry = repl_glue.popSteer();
         defer if (steer_entry) |e| std.heap.page_allocator.free(e.text);
+        var is_loop_continuation = false; // #226: this iteration is an autonomous /loop continuation turn
         const raw_line: []const u8 = if (steer_entry) |e| blk: {
+            loop_iters_left = 0; // #226: a user steer/force cancels the autonomous /loop run
+            loop_continue_armed = false;
             if (e.force) {
                 try ctx.out.print("{s}↳ force ›{s} {s}\n", .{ style.yellow, style.reset, e.text });
             } else {
@@ -120,6 +140,15 @@ pub fn run(ctx: *Ctx) !void {
             }
             try ctx.out.flush();
             break :blk e.text;
+        } else if (loop_continue_armed) blk: {
+            // #226: autonomous /loop continuation — synthesize the next turn from the
+            // continuation steering note instead of reading a new user line. Consumed
+            // here, so an interrupted/errored turn does not resume the loop.
+            loop_continue_armed = false;
+            is_loop_continuation = true;
+            const todos_render = if (ctx.root.todos.items.len > 0) ctx.root.renderTodos() else "";
+            const note = try repl_glue.continuationSteeringNote(ctx.arena, todos_render);
+            break :blk try std.fmt.allocPrint(ctx.arena, "/loop {s}", .{note});
         } else if (ctx.interactive) blk: {
             try ctx.root.prompt();
             break :blk (try readline.readLine(ctx.root, ctx.in, ctx.out, ctx.gpa, ctx.history, ctx.linebuf)) orelse break;
@@ -707,6 +736,35 @@ pub fn run(ctx: *Ctx) !void {
             // 80–95% a transient compaction failure can recover next turn.
             const near_cap = ctx.root.provider.context > 0 and ctx.root.last_context_tokens * 100 >= ctx.root.provider.context * 95;
             ctx.root.compactOrRecover(near_cap);
+        }
+
+        // #226: /loop controller-authorized continuation. After a cleanly-
+        // completed autonomous /loop turn the CONTROLLER decides whether to run
+        // another turn — not the model merely stopping. Keep going while the goal
+        // is active and the work isn't asserted done (attempt_completion set
+        // root.completed, or the checklist is finished); otherwise stop with a
+        // NAMED terminal outcome. `loop_continue_armed` is consumed at the next
+        // readline, so an interrupted/errored turn (which `continue`s past here)
+        // never resumes the loop.
+        if (loop_prompt != null and !main_mod.json_mode) {
+            if (!is_loop_continuation) loop_iters_left = loop_iter_cap; // fresh /loop run: arm the bound
+            const model_done = ctx.root.completed != null or allTodosDone(ctx.root);
+            const gstatus: agent_mod.GoalStatus = if (ctx.root.goal) |g| g.status else .active;
+            switch (repl_glue.continuationDecision(gstatus, model_done, loop_iters_left)) {
+                .continue_turn => {
+                    loop_iters_left -= 1; // consume one credit for the queued continuation
+                    loop_continue_armed = true;
+                },
+                .stop => |outcome| {
+                    loop_iters_left = 0;
+                    loop_continue_armed = false;
+                    if (outcome == .accepted) if (ctx.root.goal) |*g| {
+                        if (g.status == .active) g.status = .complete; // the loop drove the goal to done
+                    };
+                    try ctx.out.print("{s}↩ /loop stopped — {s}{s}\n", .{ style.dim, @tagName(outcome), style.reset });
+                    try ctx.out.flush();
+                },
+            }
         }
         // opencode-style continuous autosave: persist after every turn so a
         // crash or quit never loses the thread — last.session.json, the same

--- a/src/pricing.zig
+++ b/src/pricing.zig
@@ -303,6 +303,23 @@ pub fn contextFor(provider_id: []const u8, model: []const u8) u64 {
     return default_context;
 }
 
+/// Whether a model has a catalogued context window (baked row or fresh overlay),
+/// as opposed to falling through to default_context. Mirrors contextFor's lookup so
+/// a caller can tell an unknown/local model from a known 200k one (#203) — needed
+/// because contextFor returns default_context for both.
+pub fn isKnownModel(provider_id: []const u8, model: []const u8) bool {
+    for (models()) |m| {
+        if (std.mem.eql(u8, m.provider, provider_id) and std.mem.eql(u8, m.name, model)) return true;
+    }
+    for (context_overlay) |m| {
+        if (std.mem.eql(u8, m.name, model)) return true;
+    }
+    for (models()) |m| {
+        if (std.mem.eql(u8, m.name, model)) return true;
+    }
+    return false;
+}
+
 /// Fuzzy model selection for `/model <query>` (graff-style). Exact name wins;
 /// otherwise case-insensitive substring, preferring a model whose provider has
 /// a key/login available so `/model sonnet` lands on a usable provider. Returns

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -85,6 +85,19 @@ pub const Provider = struct {
     pub fn compactAt(p: Provider) u64 {
         return p.context / 10 * 8;
     }
+
+    /// #193 follow-up: the largest a SINGLE tool output may be, in serialized
+    /// bytes, before it is truncated at send time (capOversizedToolOutputs).
+    /// Window-proportional — ~50% of the window in estimated tokens (~4 bytes /
+    /// token) — so large-context models keep full tool results untouched and only
+    /// a result big enough to threaten the window on its own is bounded. This
+    /// guarantees no single output can alone overflow past what the in-turn
+    /// emergency-trim recovery can reclaim (it keeps the most-recent outputs
+    /// verbatim). 0 (unknown window) disables the cap.
+    pub fn perOutputCap(p: Provider) usize {
+        if (p.context == 0) return 0;
+        return @intCast(p.context * 2);
+    }
 };
 
 /// One optional API key per provider_specs entry, read from the environment.

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -86,17 +86,26 @@ pub const Provider = struct {
         return p.context / 10 * 8;
     }
 
-    /// #193 follow-up: the largest a SINGLE tool output may be, in serialized
-    /// bytes, before it is truncated at send time (capOversizedToolOutputs).
-    /// Window-proportional — ~50% of the window in estimated tokens (~4 bytes /
-    /// token) — so large-context models keep full tool results untouched and only
-    /// a result big enough to threaten the window on its own is bounded. This
-    /// guarantees no single output can alone overflow past what the in-turn
-    /// emergency-trim recovery can reclaim (it keeps the most-recent outputs
-    /// verbatim). 0 (unknown window) disables the cap.
+    /// #201: absolute ceiling for a single tool output regardless of window size,
+    /// so a huge-context model still bounds one pathological result.
+    const abs_output_cap_bytes: usize = 256 * 1024;
+
+    /// #193 follow-up / #201: the largest a SINGLE tool output may be, in serialized
+    /// bytes, before it is truncated at send time (capOversizedToolOutputs). It must
+    /// stay small enough that `keep_recent` (=4) such outputs — which
+    /// trimOldestToolOutputs keeps VERBATIM during in-turn recovery — still leave
+    /// room for the trimmed remainder + system prompt to fit on retry. At the old
+    /// `context * 2` (~50% of the window each) four recent outputs pinned ~2x the
+    /// window, past what recovery could reclaim → wedge (#201). Now window-proportional
+    /// at ~1/8 of the window in estimated tokens (context/2 bytes at ~4 bytes/token),
+    /// so 4 recent outputs occupy ~50% of the window, plus an absolute ceiling for
+    /// very large windows. Large-context models still keep normal tool results
+    /// untouched; only a result big enough to threaten the window is bounded.
+    /// 0 (unknown window) disables the cap.
     pub fn perOutputCap(p: Provider) usize {
         if (p.context == 0) return 0;
-        return @intCast(p.context * 2);
+        const proportional: usize = @intCast(p.context / 2);
+        return @min(proportional, abs_output_cap_bytes);
     }
 };
 
@@ -246,4 +255,20 @@ test "Keys.build: g_codex_url_override rewires only the codex endpoint" {
     try std.testing.expectEqualStrings("http://127.0.0.1:8765/responses", codex.url);
     const anthropic = try all.providerById("anthropic", "claude-opus-4-8");
     try std.testing.expectEqualStrings("https://api.anthropic.com/v1/messages", anthropic.url);
+}
+
+test "perOutputCap (#201): window-proportional with an absolute ceiling, keep_recent-safe" {
+    var p: Provider = undefined;
+    // ~1/8 of the window in tokens (context/2 bytes at ~4 bytes/token)
+    p.context = 270_000;
+    try std.testing.expectEqual(@as(usize, 135_000), p.perOutputCap());
+    // #201 invariant: keep_recent (=4) verbatim outputs must stay reclaimable —
+    // 4 * cap (in estimated tokens) < the window.
+    try std.testing.expect(4 * (p.perOutputCap() / 4) < p.context);
+    // absolute ceiling bounds a huge window so one result can't dominate
+    p.context = 4_000_000;
+    try std.testing.expectEqual(@as(usize, 256 * 1024), p.perOutputCap());
+    // unknown window disables the cap
+    p.context = 0;
+    try std.testing.expectEqual(@as(usize, 0), p.perOutputCap());
 }

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -14,6 +14,26 @@ const std = @import("std");
 const pricing = @import("pricing.zig");
 const contextFor = pricing.contextFor;
 
+/// #203: declare the context window (tokens) for an unknown/local model whose real
+/// window graff cannot look up, replacing the conservative default. Applied only
+/// when contextFor falls back to default_context (see contextWindowFor) so it can
+/// never shrink a known/catalogued window. Set from GRAFF_CONTEXT / GRAFF_CONTEXT_WINDOW.
+pub var g_context_override: ?u64 = null;
+
+/// #204: override the auto-compaction threshold as a percent of the window
+/// (default 80). null → 80. Unlike codex we allow lowering AND raising (1..100).
+pub var g_compact_pct_override: ?u8 = null;
+
+/// The context window for a provider+model, honoring g_context_override for an
+/// unknown/local model — i.e. only when contextFor returns the conservative default,
+/// never overriding a known window (#203).
+fn contextWindowFor(provider_id: []const u8, model: []const u8) u64 {
+    // Only an unknown/local model (no catalogued window) takes the override, so a
+    // global GRAFF_CONTEXT can never shrink a known model that happens to be 200k.
+    if (g_context_override) |ov| if (!pricing.isKnownModel(provider_id, model)) return ov;
+    return contextFor(provider_id, model);
+}
+
 /// Wire format + auth style + endpoint per provider. Base URLs and env-var
 /// names from models.dev/api.json (snapshot 2026-06-10); the anthropic and
 /// openai bases are the canonical ones (models.dev lists them as null).
@@ -81,9 +101,12 @@ pub const Provider = struct {
     pub const Kind = enum { anthropic, openai, responses };
     pub const Auth = enum { x_api_key, bearer };
 
-    /// Auto-compact past 80% of the model's context window.
+    /// Auto-compact past a percentage (default 80%) of the model's context window.
+    /// GRAFF_COMPACT_PCT overrides the percentage, clamped to 1..100 (#204). Unlike
+    /// codex's one-directional clamp, the override may lower OR raise the threshold.
     pub fn compactAt(p: Provider) u64 {
-        return p.context / 10 * 8;
+        const pct: u64 = if (g_compact_pct_override) |o| @min(o, 100) else 80;
+        return p.context / 100 * pct;
     }
 
     /// #201: absolute ceiling for a single tool output regardless of window size,
@@ -156,7 +179,7 @@ pub const Keys = struct {
             .url = if (is_codex) g_codex_url_override orelse spec.url else spec.url,
             .api_key = key,
             .model = model,
-            .context = contextFor(spec.id, model),
+            .context = contextWindowFor(spec.id, model),
             .account = if (is_codex) keys.codex_account else "",
             .source = keys.source(spec.id),
         };
@@ -271,4 +294,25 @@ test "perOutputCap (#201): window-proportional with an absolute ceiling, keep_re
     // unknown window disables the cap
     p.context = 0;
     try std.testing.expectEqual(@as(usize, 0), p.perOutputCap());
+}
+
+test "contextWindowFor (#203): GRAFF_CONTEXT overrides only an unknown/local model" {
+    g_context_override = 8192;
+    defer g_context_override = null;
+    // unknown/local model (no catalogued window) → the override applies
+    try std.testing.expectEqual(@as(u64, 8192), contextWindowFor("lmstudio", "some-local-gguf"));
+    // a known, catalogued model keeps its real window even with the override set
+    try std.testing.expect(pricing.isKnownModel("anthropic", "claude-opus-4-8"));
+    try std.testing.expect(contextWindowFor("anthropic", "claude-opus-4-8") != 8192);
+}
+
+test "compactAt (#204): GRAFF_COMPACT_PCT overrides the 80% default, both directions" {
+    var p: Provider = undefined;
+    p.context = 100_000;
+    try std.testing.expectEqual(@as(u64, 80_000), p.compactAt()); // default 80%
+    g_compact_pct_override = 70;
+    defer g_compact_pct_override = null;
+    try std.testing.expectEqual(@as(u64, 70_000), p.compactAt()); // lowered
+    g_compact_pct_override = 95;
+    try std.testing.expectEqual(@as(u64, 95_000), p.compactAt()); // raised — no codex-style clamp to 90
 }

--- a/src/providers.zig
+++ b/src/providers.zig
@@ -86,6 +86,12 @@ fn applyProviderInner(root: *Agent, arena: Allocator, p: Provider, persist: bool
     root.effort_rejected = false; // new model may accept reasoning_effort; relearn
     root.ws_off = false; // a previous Codex WS fallback must not leak across switches
     root.provider = p;
+    // #204: a provider switch changes the window; don't carry the previous model's
+    // absolute token count against it. Re-estimate from the (kept or translated)
+    // history so the meter + compaction gate stay consistent until the next response
+    // returns real usage. (The cross-format history-clear above already set 0;
+    // fullInputEstimateTokens over an empty history is 0.)
+    root.last_context_tokens = root.fullInputEstimateTokens();
     root.fallback_active = !persist;
     root.fallback_blocked = false;
     if (persist) saveModel(root.io, root.home, p.id, p.model);

--- a/src/readline.zig
+++ b/src/readline.zig
@@ -274,8 +274,11 @@ pub fn readLine(
             '\r', '\n' => {
                 // The cursor may be mid-block; step past the last input row so
                 // the submitted line and whatever prints next start cleanly.
+                // The second newline leaves a blank-line gutter between the
+                // submitted prompt and the model output, so it is easy to see
+                // where the response starts.
                 if (rstate.rows - 1 > rstate.crow) out.print("\x1b[{d}B", .{rstate.rows - 1 - rstate.crow}) catch {};
-                out.writeAll("\r\n") catch {};
+                out.writeAll("\r\n\r\n") catch {};
                 out.flush() catch {};
                 // Expand any pasted placeholders back to their full text.
                 for (pastes.items) |p| {

--- a/src/repl_glue.zig
+++ b/src/repl_glue.zig
@@ -94,13 +94,14 @@ pub const ReplStreamSink = struct {
 /// current checklist render when one exists. Returns "" when goal is null so the
 /// caller can skip the append. Pass todos_render="" when there are no todos — do
 /// NOT pass renderTodos()'s "(no todos)" placeholder, which would leak into the prompt.
-pub fn goalSteeringNote(arena: Allocator, goal: ?[]const u8, todos_render: []const u8) ![]const u8 {
+pub fn goalSteeringNote(arena: Allocator, goal: ?agent_mod.Goal, todos_render: []const u8) ![]const u8 {
     const g = goal orelse return "";
+    if (g.status != .active) return ""; // paused/blocked/complete/budget_limited never steer (#223)
     const progress: []const u8 = if (todos_render.len > 0)
         try std.fmt.allocPrint(arena, "\n\nChecklist so far:\n{s}", .{todos_render})
     else
         "";
-    return std.fmt.allocPrint(arena, "[standing goal: {s} - track this as a todo_write checklist and work through it, marking each item in_progress when you start and completed when done.]{s}", .{ g, progress });
+    return std.fmt.allocPrint(arena, "[standing goal: {s} - track this as a todo_write checklist and work through it, marking each item in_progress when you start and completed when done.]{s}", .{ g.objective, progress });
 }
 
 /// Extract a 0-100 score from an eval command's output: a `score` key (JSON or
@@ -146,7 +147,7 @@ pub fn evalSteeringNote(arena: Allocator, eval_cmd: ?[]const u8, target: u8, has
     return std.fmt.allocPrint(arena, "[eval-driven loop active. A scoring command is configured. Work it as a scored improvement loop: (1) call the `eval` tool to score the current state - the harness runs the command and logs to .graff/eval-log.tsv, so do NOT run it yourself via bash; (2) read the score, best-so-far, and output; (3) find the SINGLE biggest failure (inspect any artifacts or images directly); (4) make ONE focused change targeting it; (5) call `eval` again. Continue until `eval` reports the target ({d}/100) is met.{s} Do not stop at the first passing result, and do not revert unless `eval` shows a clear regression. After each `eval`, briefly note what you changed.]", .{ target, gate });
 }
 
-test "goalSteeringNote: goal + checklist assembly, no (no todos) leak" {
+test "goalSteeringNote: active-only gate + checklist assembly, no (no todos) leak" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const ar = arena.allocator();
@@ -154,14 +155,17 @@ test "goalSteeringNote: goal + checklist assembly, no (no todos) leak" {
     // No goal -> empty note, caller skips the append.
     try std.testing.expectEqualStrings("", try goalSteeringNote(ar, null, ""));
 
-    // Goal, no todos -> bracket note, no checklist, and never the "(no todos)" placeholder.
-    const n1 = try goalSteeringNote(ar, "close all issues", "");
+    // A paused (non-active) goal never steers (#223): empty note.
+    try std.testing.expectEqualStrings("", try goalSteeringNote(ar, .{ .objective = "close all issues", .status = .paused }, ""));
+
+    // Active goal, no todos -> bracket note, no checklist, and never the "(no todos)" placeholder.
+    const n1 = try goalSteeringNote(ar, .{ .objective = "close all issues" }, "");
     try std.testing.expect(std.mem.startsWith(u8, n1, "[standing goal: close all issues - track this as a todo_write checklist"));
     try std.testing.expect(std.mem.indexOf(u8, n1, "Checklist so far") == null);
     try std.testing.expect(std.mem.indexOf(u8, n1, "(no todos)") == null);
 
-    // Goal + live todos -> the rendered checklist is appended verbatim.
-    const n2 = try goalSteeringNote(ar, "ship 0.0.177", "[x] wire steering\n[ ] add test");
+    // Active goal + live todos -> the rendered checklist is appended verbatim.
+    const n2 = try goalSteeringNote(ar, .{ .objective = "ship 0.0.177" }, "[x] wire steering\n[ ] add test");
     try std.testing.expect(std.mem.indexOf(u8, n2, "Checklist so far:\n[x] wire steering\n[ ] add test") != null);
 }
 

--- a/src/repl_glue.zig
+++ b/src/repl_glue.zig
@@ -169,6 +169,77 @@ test "goalSteeringNote: active-only gate + checklist assembly, no (no todos) lea
     try std.testing.expect(std.mem.indexOf(u8, n2, "Checklist so far:\n[x] wire steering\n[ ] add test") != null);
 }
 
+/// #226 continuation gate — the outcome when a /loop turn finishes: the loop
+/// either runs another turn or stops with a NAMED terminal state (surfaced in
+/// the transcript so #219's ledger can later record it verbatim). Budget-free.
+pub const ContinuationOutcome = enum {
+    accepted, // the goal's checklist is complete (or the goal itself is complete)
+    exhausted, // hit the hard per-/loop iteration bound with work still open
+    blocked, // the goal is blocked and needs the user
+    cancelled, // the goal was paused — the user stepped in
+};
+
+pub const ContinuationDecision = union(enum) {
+    continue_turn, // run another /loop turn without reading a new user line
+    stop: ContinuationOutcome, // return control to the prompt with this named outcome
+};
+
+/// Pure controller decision for /loop continuation (#226): continuation is
+/// authorized by CONTROLLER STATE, never by the model merely stopping. An active
+/// goal with the checklist still open and iterations left keeps going; a
+/// completed checklist, a paused/blocked/complete goal, or a spent iteration
+/// bound each yield the matching named terminal outcome. No budgets.
+pub fn continuationDecision(
+    goal_status: agent_mod.GoalStatus,
+    todos_all_completed: bool,
+    iters_left: u32,
+) ContinuationDecision {
+    if (todos_all_completed) return .{ .stop = .accepted };
+    switch (goal_status) {
+        .paused => return .{ .stop = .cancelled },
+        .blocked => return .{ .stop = .blocked },
+        .complete => return .{ .stop = .accepted },
+        .active => {},
+    }
+    if (iters_left == 0) return .{ .stop = .exhausted };
+    return .continue_turn;
+}
+
+/// The steering appended to each autonomous /loop continuation turn (the
+/// continuation_steering_item analog): keep working the checklist, verify, and
+/// stop only when done or blocked — not a per-turn user note.
+pub fn continuationSteeringNote(arena: Allocator, todos_render: []const u8) ![]const u8 {
+    if (todos_render.len == 0)
+        return "[continuing autonomously (/loop): make the next concrete step toward the goal, then verify it. Do not ask for confirmation between routine steps. Stop only when the work is complete or you hit a blocker that needs the user.]";
+    return std.fmt.allocPrint(arena, "[continuing autonomously (/loop): keep working the checklist below — do the next incomplete item, mark it in_progress then completed, and verify. Do not ask for confirmation between routine steps. Stop only when every item is done or you are blocked.\n\nChecklist so far:\n{s}]", .{todos_render});
+}
+
+test "continuationDecision: one assertion per branch (#226)" {
+    // todos all complete -> accepted, regardless of status/iters.
+    try std.testing.expectEqual(ContinuationOutcome.accepted, continuationDecision(.active, true, 5).stop);
+    // active + open todos + iterations left -> continue.
+    try std.testing.expect(std.meta.activeTag(continuationDecision(.active, false, 5)) == .continue_turn);
+    // active + open todos + iteration bound spent -> exhausted.
+    try std.testing.expectEqual(ContinuationOutcome.exhausted, continuationDecision(.active, false, 0).stop);
+    // paused -> cancelled (the user stepped in).
+    try std.testing.expectEqual(ContinuationOutcome.cancelled, continuationDecision(.paused, false, 5).stop);
+    // blocked -> blocked.
+    try std.testing.expectEqual(ContinuationOutcome.blocked, continuationDecision(.blocked, false, 5).stop);
+    // complete -> accepted.
+    try std.testing.expectEqual(ContinuationOutcome.accepted, continuationDecision(.complete, false, 5).stop);
+}
+
+test "continuationSteeringNote: renders checklist when present, generic otherwise (#226)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+    const empty = try continuationSteeringNote(ar, "");
+    try std.testing.expect(std.mem.indexOf(u8, empty, "Checklist so far") == null);
+    try std.testing.expect(std.mem.indexOf(u8, empty, "continuing autonomously") != null);
+    const withlist = try continuationSteeringNote(ar, "[ ] add test");
+    try std.testing.expect(std.mem.indexOf(u8, withlist, "Checklist so far:\n[ ] add test") != null);
+}
+
 /// repl.TurnFn — run a full ROOT agent turn (tools + MCP) for `graff repl`, so
 /// the model can read files, run bash, search the codebase, etc. — not a bare
 /// completion. Auto-approves tools (yolo: the chat repl has no permission UI),

--- a/src/schema.zig
+++ b/src/schema.zig
@@ -189,6 +189,13 @@ const meta_specs = [_]ToolSpec{
         \\{"type": "object", "properties": {"result": {"type": "string", "description": "Final answer to present to the user"}}, "required": ["result"]}
         ,
     },
+    .{
+        .name = "clock_sleep",
+        .desc = "Pause the current turn for up to 12 hours of wall-clock time; interruptible by user input, and reported as a normal (non-error) result either way. For autonomous /loop runs that need to wait before re-checking something (e.g. a long external job). Root-only; off unless --clock-sleep/GRAFF_CLOCK_SLEEP=1 is set.",
+        .schema =
+        \\{"type": "object", "properties": {"ms": {"type": "integer", "description": "Milliseconds to sleep (0 returns immediately; clamped to the 12h/43200000ms cap)"}, "reason": {"type": "string", "description": "Optional: why you're sleeping, for the trace/UX"}}, "required": ["ms"]}
+        ,
+    },
 };
 
 const subagent_spec = ToolSpec{
@@ -214,7 +221,8 @@ pub fn isMetaName(name: []const u8) bool {
         std.mem.eql(u8, name, "todo_read") or
         std.mem.eql(u8, name, "ask_user") or
         std.mem.eql(u8, name, "eval") or
-        std.mem.eql(u8, name, "attempt_completion");
+        std.mem.eql(u8, name, "attempt_completion") or
+        std.mem.eql(u8, name, "clock_sleep");
 }
 
 // Comptime-rendered tool lists for subagents (base only, both formats).
@@ -275,6 +283,21 @@ pub fn renderRootTools(
     for (mcp_tools) |m| try writeToolEntry(&s, kind, m.qualified_name, m.description, .{ .value = m.input_schema });
     try s.endArray();
     return aw.toOwnedSlice();
+}
+
+/// Root tool catalog for the current session: drops clock_sleep unless the
+/// root-only feature flag is on (--clock-sleep / GRAFF_CLOCK_SLEEP=1, see
+/// main.zig g_clock_sleep) so the model never even sees a tool it can't
+/// call while the flag is off (#225). Subagents are unaffected — they
+/// build their tool lists from base_specs only (tools_*_sub above), which
+/// never included meta_specs/clock_sleep in the first place.
+pub fn effectiveRootSpecs(arena: Allocator) ![]const ToolSpec {
+    if (root.g_clock_sleep) return &root_specs;
+    var out: std.ArrayList(ToolSpec) = .empty;
+    for (root_specs) |t| {
+        if (!std.mem.eql(u8, t.name, "clock_sleep")) try out.append(arena, t);
+    }
+    return out.items;
 }
 
 const Schema = union(enum) { raw: []const u8, value: Value };
@@ -459,14 +482,37 @@ test "providerDisplayName & providerLoginKind: id mapping with sane fallbacks" {
     try std.testing.expectEqualStrings("codex_device", providerLoginKind("codex"));
     try std.testing.expectEqualStrings("api_key", providerLoginKind("openai"));
 }
-test "isMetaName: the four orchestrator-handled meta tools" {
+test "isMetaName: the five orchestrator-handled meta tools" {
     try std.testing.expect(isMetaName("todo_write"));
     try std.testing.expect(isMetaName("todo_read"));
     try std.testing.expect(isMetaName("ask_user"));
     try std.testing.expect(isMetaName("attempt_completion"));
+    try std.testing.expect(isMetaName("clock_sleep"));
     try std.testing.expect(!isMetaName("bash"));
     try std.testing.expect(!isMetaName("subagent"));
     try std.testing.expect(!isMetaName("codedb"));
+}
+
+test "effectiveRootSpecs: drops clock_sleep from the root tool catalog unless the flag is on (#225)" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    const saved = root.g_clock_sleep;
+    defer root.g_clock_sleep = saved;
+
+    root.g_clock_sleep = false;
+    const off_specs = try effectiveRootSpecs(a);
+    try std.testing.expectEqual(root_specs.len - 1, off_specs.len);
+    for (off_specs) |t| try std.testing.expect(!std.mem.eql(u8, t.name, "clock_sleep"));
+
+    root.g_clock_sleep = true;
+    const on_specs = try effectiveRootSpecs(a);
+    try std.testing.expectEqual(root_specs.len, on_specs.len);
+    var found = false;
+    for (on_specs) |t| {
+        if (std.mem.eql(u8, t.name, "clock_sleep")) found = true;
+    }
+    try std.testing.expect(found);
 }
 test "providerTakesEffort: effort-honoring providers, but never for grok models" {
     try std.testing.expect(providerTakesEffort(.responses, "codex", "gpt-5.5"));

--- a/src/session.zig
+++ b/src/session.zig
@@ -229,7 +229,18 @@ pub fn saveSession(root: *Agent, arena: Allocator, name: []const u8) !void {
     try s.objectField("ultracode_mode");
     try s.write(root.ultracode_mode);
     try s.objectField("goal");
-    if (root.goal) |goal| try s.write(goal) else try s.write(null);
+    if (root.goal) |g| {
+        try s.beginObject();
+        try s.objectField("objective");
+        try s.write(g.objective);
+        try s.objectField("status");
+        try s.write(@tagName(g.status));
+        try s.objectField("created_ms");
+        try s.write(g.created_ms);
+        try s.objectField("updated_ms");
+        try s.write(g.updated_ms);
+        try s.endObject();
+    } else try s.write(null);
     try s.objectField("title");
     if (root.session_title) |title| try s.write(title) else try s.write(sessionTitle(root));
     try s.objectField("updated_ms");
@@ -244,6 +255,56 @@ pub fn saveSession(root: *Agent, arena: Allocator, name: []const u8) !void {
     try Io.Dir.cwd().writeFile(root.io, .{ .sub_path = path, .data = aw.writer.buffered() });
 }
 
+/// Parse the persisted `goal` field into a structured Goal (#223). A bare string
+/// is a legacy session -> load as .active stamped with `now_ms`; an object carries
+/// objective + status + created/updated timestamps (an unknown/missing status
+/// falls back to .active). Pure (no Io) so it round-trips in unit tests. Returns
+/// null for an empty/absent objective.
+fn goalFromValue(v: Value, now_ms: i64) ?agent_mod.Goal {
+    if (v == .string) {
+        if (v.string.len == 0) return null;
+        return .{ .objective = v.string, .status = .active, .created_ms = now_ms, .updated_ms = now_ms };
+    }
+    if (v == .object) {
+        const go = v.object;
+        const txt = if (go.get("objective")) |o| (if (o == .string and o.string.len > 0) o.string else null) else null;
+        const objective = txt orelse return null;
+        const st: agent_mod.GoalStatus = if (go.get("status")) |s| (if (s == .string) (std.meta.stringToEnum(agent_mod.GoalStatus, s.string) orelse .active) else .active) else .active;
+        const cms: i64 = if (go.get("created_ms")) |c| (if (c == .integer) c.integer else 0) else 0;
+        const ums: i64 = if (go.get("updated_ms")) |u| (if (u == .integer) u.integer else 0) else 0;
+        return .{ .objective = objective, .status = st, .created_ms = cms, .updated_ms = ums };
+    }
+    return null;
+}
+
+test "goalFromValue: legacy string -> active; object round-trips; paused stays paused (#223)" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    // Legacy bare string -> active, stamped with now_ms (backward compat).
+    const legacy = try std.json.parseFromSliceLeaky(Value, a, "\"ship 0.0.202\"", .{ .allocate = .alloc_always });
+    const g1 = goalFromValue(legacy, 4242).?;
+    try std.testing.expectEqualStrings("ship 0.0.202", g1.objective);
+    try std.testing.expectEqual(agent_mod.GoalStatus.active, g1.status);
+    try std.testing.expectEqual(@as(i64, 4242), g1.created_ms);
+
+    // New object with a paused status round-trips as paused (survives resume).
+    const paused = try std.json.parseFromSliceLeaky(Value, a, "{\"objective\":\"land #223\",\"status\":\"paused\",\"created_ms\":10,\"updated_ms\":20}", .{ .allocate = .alloc_always });
+    const g2 = goalFromValue(paused, 999).?;
+    try std.testing.expectEqualStrings("land #223", g2.objective);
+    try std.testing.expectEqual(agent_mod.GoalStatus.paused, g2.status);
+    try std.testing.expectEqual(@as(i64, 10), g2.created_ms);
+    try std.testing.expectEqual(@as(i64, 20), g2.updated_ms);
+
+    // Empty string -> null (no goal).
+    const empty = try std.json.parseFromSliceLeaky(Value, a, "\"\"", .{ .allocate = .alloc_always });
+    try std.testing.expect(goalFromValue(empty, 1) == null);
+
+    // An unknown status string falls back to active (forward-compat with future variants).
+    const unknown = try std.json.parseFromSliceLeaky(Value, a, "{\"objective\":\"x\",\"status\":\"zzz\"}", .{ .allocate = .alloc_always });
+    try std.testing.expectEqual(agent_mod.GoalStatus.active, goalFromValue(unknown, 1).?.status);
+}
 /// Restore a saved session: parse the file (arena-owned), rebuild the
 /// provider, and replace the live history. The wire format must still match
 /// the restored provider's kind — same provider id guarantees it.
@@ -262,7 +323,7 @@ pub fn loadSession(root: *Agent, keys: Keys, arena: Allocator, name: []const u8)
     const msgs = if (obj.get("messages")) |v| (if (v == .array) v.array else return error.BadSession) else return error.BadSession;
     const strict = if (obj.get("strict")) |v| (v == .bool and v.bool) else false;
     const ultracode_mode = if (obj.get("ultracode_mode")) |v| (v == .bool and v.bool) else false;
-    const goal = if (obj.get("goal")) |v| (if (v == .string and v.string.len > 0) v.string else null) else null;
+    const goal: ?agent_mod.Goal = if (obj.get("goal")) |v| goalFromValue(v, unixMs(root.io)) else null;
     const title = if (obj.get("title")) |v| (if (v == .string and v.string.len > 0) v.string else null) else null;
 
     root.provider = try keys.providerById(pid, model);
@@ -323,7 +384,7 @@ test "hasMeaningfulState gates the blank-draft write (#184)" {
     try std.testing.expect(!hasMeaningfulState(&root));
 
     // A standing /goal alone is meaningful (goal-only sessions are still saved).
-    root.goal = "ship the release";
+    root.goal = .{ .objective = "ship the release" };
     try std.testing.expect(hasMeaningfulState(&root));
 
     // One user message alone is meaningful.

--- a/src/session_run.zig
+++ b/src/session_run.zig
@@ -200,6 +200,9 @@ pub fn buildRootAgent(
     flags: args.Flags,
     telem_endpoint: []const u8,
 ) !agent_mod.Agent {
+    // #225: clock_sleep only appears in the model's tool catalog when the
+    // root-only feature flag is on (--clock-sleep / GRAFF_CLOCK_SLEEP=1).
+    const root_tool_specs = try schema.effectiveRootSpecs(arena);
     var root: agent_mod.Agent = .{
         .snapshots = snaps,
         .gpa = gpa,
@@ -218,9 +221,9 @@ pub fn buildRootAgent(
         .tracer = tracer,
         .sys_normal = sys_normal,
         .sys_strict = sys_strict,
-        .tools_anthropic = try schema.renderRootTools(arena, .anthropic, &schema.root_specs, mcp_tools),
-        .tools_openai = try schema.renderRootTools(arena, .openai, &schema.root_specs, mcp_tools),
-        .tools_responses = try schema.renderRootTools(arena, .responses, &schema.root_specs, mcp_tools),
+        .tools_anthropic = try schema.renderRootTools(arena, .anthropic, root_tool_specs, mcp_tools),
+        .tools_openai = try schema.renderRootTools(arena, .openai, root_tool_specs, mcp_tools),
+        .tools_responses = try schema.renderRootTools(arena, .responses, root_tool_specs, mcp_tools),
     };
     const fresh_session_name = try std.fmt.allocPrint(arena, "session-{d}", .{util.unixMs(io)});
     root.session_name = if (flags.resume_flag) |name| (if (!flags.new_session_flag and !flags.no_resume_flag) name else fresh_session_name) else fresh_session_name;
@@ -358,6 +361,14 @@ pub fn setupSkillsAndTheme(io: Io, arena: Allocator, environ_map: anytype, out: 
     // be silently overwritten here, since setupSkillsAndTheme runs later.
     if (environ_map.get("GRAFF_CODEX_WS")) |v| {
         main_mod.g_codex_ws = !(std.ascii.eqlIgnoreCase(v, "off") or std.mem.eql(u8, v, "0") or std.ascii.eqlIgnoreCase(v, "false") or std.ascii.eqlIgnoreCase(v, "no"));
+    }
+    // #225: GRAFF_CLOCK_SLEEP=1|true|on|yes arms the root-only clock_sleep
+    // meta tool (in addition to --clock-sleep). Affirmative-only, like
+    // GRAFF_WS_FORCE_FAIL_ONCE below — OR'd onto the CLI flag so a
+    // conflicting/absent env value never silently turns --clock-sleep back
+    // off; default stays off.
+    if (environ_map.get("GRAFF_CLOCK_SLEEP")) |v| {
+        main_mod.g_clock_sleep = main_mod.g_clock_sleep or std.mem.eql(u8, v, "1") or std.ascii.eqlIgnoreCase(v, "true") or std.ascii.eqlIgnoreCase(v, "on") or std.ascii.eqlIgnoreCase(v, "yes");
     }
     // (#codex-ws) GRAFF_CODEX_WS_IDLE_SECS raises/lowers the held-WS idle limit
     // (default 4 min — the backend killed ours within 8.5 min idle; opencode

--- a/src/session_run.zig
+++ b/src/session_run.zig
@@ -368,6 +368,23 @@ pub fn setupSkillsAndTheme(io: Io, arena: Allocator, environ_map: anytype, out: 
             if (secs > 0) agent_ws.codex_ws_idle_ms = @intCast(@min(secs, 86_400) * 1000);
         } else |_| {}
     }
+    // #203: GRAFF_CONTEXT / GRAFF_CONTEXT_WINDOW declares the context window (in
+    // tokens) for an unknown/local model whose real window graff can't look up,
+    // replacing the conservative 200k fallback so the compaction gate + per-output
+    // cap are sized correctly. Only affects models that fall back to the default
+    // (see provider.contextWindowFor). Ignored if unparseable or 0.
+    if (environ_map.get("GRAFF_CONTEXT") orelse environ_map.get("GRAFF_CONTEXT_WINDOW")) |v| {
+        if (std.fmt.parseInt(u64, std.mem.trim(u8, v, " \t"), 10)) |n| {
+            if (n > 0) provider_mod.g_context_override = n;
+        } else |_| {}
+    }
+    // #204: GRAFF_COMPACT_PCT overrides the auto-compaction threshold as a percent
+    // of the window (default 80). Clamped to 1..100; ignored if unparseable or 0.
+    if (environ_map.get("GRAFF_COMPACT_PCT")) |v| {
+        if (std.fmt.parseInt(u8, std.mem.trim(u8, v, " \t"), 10)) |pct| {
+            if (pct > 0) provider_mod.g_compact_pct_override = @min(pct, 100);
+        } else |_| {}
+    }
     ws.g_debug = environ_map.get("GRAFF_WS_DEBUG") != null;
     // GRAFF_WS_FORCE_FAIL_ONCE=1|true|on|yes arms the one-shot forced WS
     // connect failure (integration-test seam for the SSE fallback + ws_off

--- a/src/session_run.zig
+++ b/src/session_run.zig
@@ -225,7 +225,7 @@ pub fn buildRootAgent(
     const fresh_session_name = try std.fmt.allocPrint(arena, "session-{d}", .{util.unixMs(io)});
     root.session_name = if (flags.resume_flag) |name| (if (!flags.new_session_flag and !flags.no_resume_flag) name else fresh_session_name) else fresh_session_name;
     repl_glue.loadThinkingSettings(io, arena, &root); // {"effort":...,"fast":...} persisted by /effort and /fast
-    if (flags.goal_flag) |g| root.goal = try arena.dupe(u8, g); // --goal applies to every turn (incl. --json/-p/SDK)
+    if (flags.goal_flag) |g| root.goal = .{ .objective = try arena.dupe(u8, g), .status = .active, .created_ms = util.unixMs(io), .updated_ms = util.unixMs(io) }; // --goal applies to every turn (incl. --json/-p/SDK)
     if (flags.eval_cmd_flag) |c| root.eval_cmd = try arena.dupe(u8, c);
     if (flags.eval_target_flag) |t| root.eval_target = t;
     if (flags.eval_niche_flag) |n| root.eval_niche = try arena.dupe(u8, n);


### PR DESCRIPTION
Cuts **v0.0.202** to `main`. Two bodies of work:

### Governed `/goal` + `/loop` (new)
- **#223** — structured goal state + `/goal pause | resume | status` (only active goals steer; paused goals go quiet; persists with legacy-string upgrade).
- **#225** — `clock_sleep` agent tool: interruptible, 12h-capped, feature-flagged (`--clock-sleep` / `GRAFF_CLOCK_SLEEP=1`), root-only.
- **#226** — controller-authorized `/loop` continuation replacing the old `[harness note]` string: runs autonomously and stops with a **named** outcome (`accepted`/`blocked`/`cancelled`/`exhausted`) on real completion (`attempt_completion` or finished checklist), with a 25-turn safety cap; Esc/steer cancels.
- Per-goal token budgets were intentionally **not** included (kept `/goal` lightweight).
- README updated; full `zig build test` green; live-verified end-to-end (goal lifecycle + `/loop` stopping "accepted" and marking the goal complete).

### Context-overflow follow-ups (release/v0.0.202)
- #196/#207/#201-#205: per-tool-output cap, recovery-path parity, local-model window override + structured overflow detection, blank-line prompt/output gutter, E2E PTY tests.

Tagging `v0.0.202` after merge triggers the release build (all 6 desktop targets); the macOS CLI binaries are then notarized locally.