### PR TITLE
Recover legacy iOS session sign-ins

### DIFF
--- a/apps/ios/Graff/Sources/GraffAccount.swift
+++ b/apps/ios/Graff/Sources/GraffAccount.swift
@@ -106,8 +106,16 @@ struct AppSessionFull: Decodable {
 
 enum GatewayError: LocalizedError {
     case http(Int, String)
+
     var errorDescription: String? {
         switch self { case .http(let c, let m): return "gateway HTTP \(c): \(m)" }
+    }
+
+    var isInsufficientSessionScope: Bool {
+        switch self {
+        case .http(403, let message): return message.localizedCaseInsensitiveContains("sessions")
+        default: return false
+        }
     }
 }
 

--- a/apps/ios/Graff/Sources/SessionsListView.swift
+++ b/apps/ios/Graff/Sources/SessionsListView.swift
@@ -6,12 +6,23 @@ struct SessionsListView: View {
     @State private var showAccount = false
     @State private var showNewSession = false
     @State private var loadNote = ""
+    @State private var needsSessionRelogin = false
 
     var body: some View {
         NavigationStack {
             List {
                 if !loadNote.isEmpty {
-                    Text(loadNote).font(.footnote).foregroundStyle(.secondary)
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(loadNote).font(.footnote).foregroundStyle(.secondary)
+                        if needsSessionRelogin {
+                            Button("Sign in again") {
+                                Gateway.signOut()
+                                sessions = []
+                                showAccount = true
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+                    }
                 }
                 ForEach($sessions) { $session in
                     NavigationLink {
@@ -85,9 +96,17 @@ struct SessionsListView: View {
                 }
                 return s
             }
+            needsSessionRelogin = false
             loadNote = sessions.isEmpty ? "No sessions yet — tap + to build something." : ""
         } catch {
-            loadNote = error.localizedDescription
+            if let gatewayError = error as? GatewayError,
+               gatewayError.isInsufficientSessionScope {
+                needsSessionRelogin = true
+                loadNote = "This sign-in predates session sync. Sign in again to renew access."
+            } else {
+                needsSessionRelogin = false
+                loadNote = error.localizedDescription
+            }
         }
     }
 


### PR DESCRIPTION
## What changed

- Recognize the session API's insufficient-scope response.
- Replace the raw 403 row with a clear **Sign in again** recovery action.
- Clear only the stale local gateway credential before reopening the existing device login.

## Why

Keys issued before the backend scope fix remain API-only. Without an app recovery path, those users stay on the Sessions screen with a raw gateway error even after new sign-ins are fixed.

## Impact

Affected users can renew their sign-in directly from Sessions. Normal session loading and signed-out demo behavior are unchanged.

## Validation

- Swift 6 / iOS 26 simulator compilation
- installed and launched on iPhone 17 Pro simulator
- visual smoke check of the Sessions screen
- `git diff --check`
