### PR TITLE
Release v0.0.206: Codegraff Enso CLI hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,14 @@ and blockquotes use terminal-native markers; bold and inline code drop their raw
 delimiters; tables align; and fenced code stays copyable without decorative
 prefixes on body lines.
 
+The interactive UI uses Codegraff's accent-only **Ensō** palette: vermilion
+coral marks the model, prompt, active selections, tools, and primary Markdown
+structure; ordinary text and supporting metadata stay neutral. Success,
+warning, and error colors remain semantic, the terminal background is never
+overridden, and `NO_COLOR` is respected. The quiet `enso` thinking animation is
+the stable default; `/animation random` restores per-request variety and the
+other animation names remain available.
+
 ```
 /model [name]   no arg → interactive fuzzy picker; or /model <name|provider|provider model>
 /models         list known models, context windows, compaction points
@@ -410,6 +418,7 @@ prefixes on body lines.
 /reasoning      reasoning picker: low|medium|high|xhigh|max|ultra (persists)
 /fast           toggle Codex priority service tier for lower latency
 /ultracode      toggle persistent multi-agent workflow mode
+/animation      choose a thinking animation (`/animation` lists every option)
 /goal [text]    set/show a standing objective; /goal pause|resume|status|clear
 /loop <prompt>  work autonomously toward the prompt, stopping with a named outcome when done or blocked
 /rewind [n]     list past prompts; /rewind <n> drops prompt n+after & reverts its file edits
@@ -450,8 +459,9 @@ configured provider and keeps the saved preference for a future launch. The
 prompt is a small statusline:
 `[model · Fast · Extra high · Plan · cwd /repo · 12345/800k tok (1%) · ⚡cached]`.
 Fast stays immediately beside the model. Active reasoning/workflow modes are
-visible at a glance: Low is green, Medium cyan, High yellow, Extra
-high/Ultra/Ultracode magenta, Max/Strict red, and Plan yellow. YOLO is reported
+visible at a glance: Low is green, Medium/Extra high/Ultra/Ultracode use the
+Codegraff coral accent, High/Plan are yellow, and Max/Strict are red. YOLO is
+reported
 as an explicit warning when enabled instead of occupying the compact prompt.
 Badges for unsupported settings are hidden instead of implying they apply. The
 tail shows context used vs the compaction budget, last cache hit, and (for

--- a/scripts/test-pty-markdown.py
+++ b/scripts/test-pty-markdown.py
@@ -10,6 +10,7 @@ from pty_harness import run_to_exit
 
 _arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
 GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
+CORAL = b"\x1b[38;2;196;81;61m"
 
 
 def main() -> None:
@@ -48,7 +49,7 @@ def main() -> None:
     missing = [line for line in expected if line not in result.text]
     if missing:
         raise SystemExit(f"Markdown render missing {missing!r}\n--- transcript ---\n{result.text}")
-    for ansi in (b"\x1b[36m", b"\x1b[33m", b"\x1b[32m"):
+    for ansi in (CORAL, b"\x1b[33m", b"\x1b[32m"):
         if ansi not in result.raw:
             raise SystemExit(f"Markdown render missing ANSI style {ansi!r}")
     print("ok    PTY Markdown headings, lists, tasks, quotes, inline styles, and ANSI")

--- a/scripts/test-pty-repl.py
+++ b/scripts/test-pty-repl.py
@@ -10,6 +10,8 @@ from pty_harness import PtySession, terminal_text
 
 _arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
 GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
+CORAL = b"\x1b[38;2;196;81;61m"
+RESET = b"\x1b[0m"
 
 
 def main() -> None:
@@ -52,7 +54,7 @@ def main() -> None:
                 "/effort xhigh",
                 "reasoning effort: Extra high",
                 f"[{base} · cwd {tmp}",
-                b"\x1b[35mExtra high\x1b[0m",
+                CORAL + b"Extra high" + RESET,
             )
             command(
                 "/model definitely-not-a-model",
@@ -95,7 +97,7 @@ def main() -> None:
                 "/ultracode on",
                 "ultracode mode: on",
                 f"[{base} · Plan · Strict · Ultracode · cwd {tmp}",
-                b"\x1b[35mUltracode\x1b[0m",
+                CORAL + b"Ultracode" + RESET,
             )
             command(
                 "/yolo",
@@ -143,7 +145,7 @@ def main() -> None:
             paint = bytes(session.raw[cursor:]).rsplit(b"\x1b[2J\x1b[H", 1)[-1]
             if paint.count(b"\n") != 11:
                 raise AssertionError("model picker exceeded its 12-row terminal budget")
-            if b"\x1b[7m\xe2\x96\x8c deepseek-v4-pro" not in paint:
+            if CORAL + b"\xe2\x80\xba deepseek-v4-pro" not in paint:
                 raise AssertionError("model picker did not initially select the active model")
             session.send_key("ctrl-c")
             session.wait_for_literal("] ›", start=cursor)
@@ -154,7 +156,7 @@ def main() -> None:
             session.wait_for_literal("Ultra", start=cursor)
             session.pump_for(0.1)
             paint = bytes(session.raw[cursor:]).rsplit(b"\x1b[2J\x1b[H", 1)[-1]
-            if b"\x1b[7m Extra high" not in paint:
+            if CORAL + b"\xe2\x80\xba Extra high" not in paint:
                 raise AssertionError("reasoning picker did not initially select the current level")
             session.send_key("ctrl-c")
             session.wait_for_literal("] ›", start=cursor)

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -55,11 +55,11 @@ fn reasoningPromptLabel(effort: ReasoningEffort) []const u8 {
 fn reasoningPromptColor(effort: ReasoningEffort) []const u8 {
     return switch (effort) {
         .low => style.green,
-        .medium => style.cyan,
+        .medium => style.accent,
         .high => style.yellow,
-        .xhigh => style.magenta,
+        .xhigh => style.accent,
         .max => style.red,
-        .ultra => style.magenta,
+        .ultra => style.accent,
     };
 }
 
@@ -227,24 +227,24 @@ pub const Agent = struct {
             (std.fmt.bufPrint(&kbuf, " · ⚡{s} cached", .{compactTokenCount(&kval, self.last_cache_read)}) catch "")
         else
             "";
-        try w.print("\n{s}[{s}{s}{s}{s}", .{ style.dim, style.reset, style.cyan, self.provider.model, style.reset });
+        try w.print("\n{s}[{s}{s}{s}{s}", .{ style.dim, style.reset, style.accent, self.provider.model, style.reset });
         // Fast is the most operationally important model setting, so keep it
         // immediately beside the model instead of letting permission modes
         // push it deeper into the status line.
         if (self.fast and self.provider.kind == .responses) try writePromptBadge(w, style.green, "Fast");
         if (self.effortApplies()) try writePromptBadge(w, reasoningPromptColor(self.reasoning), reasoningPromptLabel(self.reasoning));
-        try writePromptBadge(w, style.cyan, self.provider.id);
+        try writePromptBadge(w, style.accent, self.provider.id);
         if (self.fallback_active) try writePromptBadge(w, style.yellow, "Fallback");
         if (main_mod.plan_mode) try writePromptBadge(w, style.yellow, "Plan");
         if (self.strict) try writePromptBadge(w, style.red, "Strict");
-        if (self.ultracode_mode) try writePromptBadge(w, style.magenta, "Ultracode");
+        if (self.ultracode_mode) try writePromptBadge(w, style.accent, "Ultracode");
         try w.print("{s} · cwd {s}{s}{s}", .{ style.dim, style.reset, main_mod.g_cwd_display, style.dim });
         const context_tokens = self.effectiveContextTokens();
         if (self.last_context_tokens > 0) {
             const threshold = self.provider.compactAt();
             const pct = contextPercent(context_tokens, self.provider.context);
             var used_buf: [24]u8 = undefined;
-            try w.print(" · {s}/{d}k ctx ({d}% · compact@{d}k){s}{s}]{s} {s}›{s} ", .{
+            try w.print(" · {s}/{d}k ctx ({d}% · compact@{d}k){s}{s}]{s} {s}{s}›{s} ", .{
                 compactTokenCount(&used_buf, context_tokens),
                 self.provider.context / 1000,
                 pct,
@@ -253,10 +253,11 @@ pub const Agent = struct {
                 cost,
                 style.reset,
                 style.bold,
+                style.accent,
                 style.reset,
             });
         } else {
-            try w.print("{s}]{s} {s}›{s} ", .{ cost, style.reset, style.bold, style.reset });
+            try w.print("{s}]{s} {s}{s}›{s} ", .{ cost, style.reset, style.bold, style.accent, style.reset });
         }
         try w.flush();
     }

--- a/src/agent_interrupt.zig
+++ b/src/agent_interrupt.zig
@@ -20,6 +20,8 @@ const main_mod = @import("main.zig");
 const agent_mod = @import("agent.zig");
 const repl_glue = @import("repl_glue.zig");
 const Agent = agent_mod.Agent;
+const ansi = @import("ansi.zig");
+const style = &ansi.style;
 
 const terminal = @import("term.zig");
 const tty = terminal.tty;
@@ -144,7 +146,10 @@ pub fn escPressed(echo: bool) bool {
                 main_mod.g_force_interrupt = true;
                 if (echo) {
                     if (main_mod.g_steer_echoed) repl_glue.steerEcho("\n");
-                    repl_glue.steerEcho("\x1b[33m↳ force › interrupting…\x1b[0m\n");
+                    repl_glue.steerEcho(style.yellow);
+                    repl_glue.steerEcho("↳ force › interrupting…");
+                    repl_glue.steerEcho(style.reset);
+                    repl_glue.steerEcho("\n");
                 }
             }
             main_mod.g_steer_echoed = false;
@@ -166,7 +171,11 @@ pub fn escPressed(echo: bool) bool {
         if (echo) {
             if (!main_mod.g_steer_echoed) {
                 main_mod.g_steer_visible.store(true, .release);
-                repl_glue.steerEcho("\n\x1b[36m↳ steer ›\x1b[0m ");
+                repl_glue.steerEcho("\n");
+                repl_glue.steerEcho(style.accent);
+                repl_glue.steerEcho("↳ steer ›");
+                repl_glue.steerEcho(style.reset);
+                repl_glue.steerEcho(" ");
                 main_mod.g_steer_echoed = true;
             }
             repl_glue.steerEcho(buf[i .. i + 1]);

--- a/src/agent_render.zig
+++ b/src/agent_render.zig
@@ -54,7 +54,7 @@ fn taskItem(body: []const u8) ?TaskItem {
 }
 
 fn headingColor(level: usize) []const u8 {
-    return if (level == 1) style.magenta else if (level == 2) style.cyan else style.yellow;
+    return if (level <= 2) style.accent else style.yellow;
 }
 
 fn renderHeading(w: *Io.Writer, level: usize, text: []const u8) void {
@@ -156,7 +156,7 @@ pub fn mdTryClassify(self: *Agent, w: *Io.Writer) void {
                 if (taskItem(body)) |task| {
                     mdStartItem(self, w, held, lead, 6, if (task.checked) "☑" else "☐", if (task.checked) style.green else style.yellow);
                 } else {
-                    mdStartItem(self, w, held, lead, 2, if (lead == 0) "•" else "◦", style.cyan);
+                    mdStartItem(self, w, held, lead, 2, if (lead == 0) "•" else "◦", style.accent);
                 }
                 return;
             }
@@ -175,7 +175,7 @@ pub fn mdTryClassify(self: *Agent, w: *Io.Writer) void {
                     self.md_col = lead + d + 2; // "12. " — align under the text
                     self.md_indent = lead + d + 2;
                     w.writeAll(held[0..lead]) catch {};
-                    w.print("{s}{s}{c}{s} ", .{ style.cyan, body[0..d], body[d], style.reset }) catch {};
+                    w.print("{s}{s}{c}{s} ", .{ style.accent, body[0..d], body[d], style.reset }) catch {};
                     const rest = body[d + 2 ..];
                     var tmp: [8]u8 = undefined;
                     const n = @min(rest.len, tmp.len);
@@ -418,8 +418,8 @@ pub fn flushStreamTail(self: *Agent) void {
 
 /// Render one markdown line to ANSI (portable SGR only — bold/color, no
 /// italic, so iTerm/Ghostty/Terminal/Windows-Terminal all agree): code
-/// fences + fenced bodies dimmed, ATX headers bold-cyan, `-`/`*`/`+`
-/// bullets → cyan •, and inline `**bold**` / `` `code` `` spans.
+/// fences + fenced bodies dimmed, ATX headers bold-coral, `-`/`*`/`+`
+/// bullets → coral •, and inline `**bold**` / `` `code` `` spans.
 pub fn renderMdLine(self: *Agent, w: *Io.Writer, line: []const u8) void {
     var lead: usize = 0;
     while (lead < line.len and line[lead] == ' ') lead += 1;
@@ -491,7 +491,7 @@ pub fn renderMdLine(self: *Agent, w: *Io.Writer, line: []const u8) void {
     // Bullet list item.
     if (std.mem.startsWith(u8, body, "- ") or std.mem.startsWith(u8, body, "* ") or std.mem.startsWith(u8, body, "+ ")) {
         w.writeAll(line[0..lead]) catch {};
-        w.print("{s}{s}{s} ", .{ style.cyan, if (lead == 0) "•" else "◦", style.reset }) catch {};
+        w.print("{s}{s}{s} ", .{ style.accent, if (lead == 0) "•" else "◦", style.reset }) catch {};
         renderInline(w, body[2..]);
         return;
     }
@@ -500,7 +500,7 @@ pub fn renderMdLine(self: *Agent, w: *Io.Writer, line: []const u8) void {
     while (d < body.len and body[d] >= '0' and body[d] <= '9') d += 1;
     if (d >= 1 and d + 1 < body.len and (body[d] == '.' or body[d] == ')') and body[d + 1] == ' ') {
         w.writeAll(line[0..lead]) catch {};
-        w.print("{s}{s}{c}{s} ", .{ style.cyan, body[0..d], body[d], style.reset }) catch {};
+        w.print("{s}{s}{c}{s} ", .{ style.accent, body[0..d], body[d], style.reset }) catch {};
         renderInline(w, body[d + 2 ..]);
         return;
     }

--- a/src/agent_stream.zig
+++ b/src/agent_stream.zig
@@ -67,8 +67,9 @@ pub fn spinnerTask(io: Io) void {
         w.interface.writeAll("\x1b[?7h") catch return; // restore autowrap
         w.interface.flush() catch return;
         i += 1;
+        const frame_ticks = @max(@as(usize, 1), @as(usize, anim.anims[anim.g_anim_current].frame_ms) / 20);
         var t: usize = 0;
-        while (t < 4 and !Agent.g_spin_stop.load(.acquire)) : (t += 1) {
+        while (t < frame_ticks and !Agent.g_spin_stop.load(.acquire)) : (t += 1) {
             if (main_mod.g_steer_visible.load(.acquire)) break;
             io.sleep(.fromMilliseconds(20), .awake) catch break;
         }

--- a/src/agent_tools.zig
+++ b/src/agent_tools.zig
@@ -485,7 +485,7 @@ pub fn sayToolUse(self: *Agent, call: ToolCall) !void {
     const full = aw.writer.buffered();
     const shown = if (full.len > 160) full[0..160] else full;
     try self.say("{s}⚙{s} {s}{s} {s}{s}{s}{s}\n", .{
-        style.dim,   style.reset, style.cyan, call.name,
+        style.dim,   style.reset, style.accent, call.name,
         style.dim,   shown,
         if (full.len > 160) "…" else "",
         style.reset,

--- a/src/anim.zig
+++ b/src/anim.zig
@@ -27,23 +27,25 @@ const Approvals = approvals_mod.Approvals;
 pub const Anim = struct {
     name: []const u8,
     desc: []const u8,
+    frame_ms: u16,
     frame: *const fn (w: *Io.Writer, i: usize) Io.Writer.Error!void,
 };
 
 pub const anims = [_]Anim{
-    .{ .name = "braille", .desc = "classic braille spinner (default)", .frame = animBraille },
-    .{ .name = "pulse", .desc = "pulsing star", .frame = animPulse },
-    .{ .name = "orbit-dots", .desc = "dot orbiting a ring", .frame = animOrbit },
-    .{ .name = "block-wave", .desc = "unicode block wave", .frame = animBlockWave },
-    .{ .name = "shimmer", .desc = "highlight sweeping the word", .frame = animShimmer },
-    .{ .name = "matrix", .desc = "matrix rain strip", .frame = animMatrix },
-    .{ .name = "pacman", .desc = "pac-man eating dots", .frame = animPacman },
-    .{ .name = "starfield", .desc = "parallax stars", .frame = animStarfield },
-    .{ .name = "comet-tail", .desc = "streaking comet indicator", .frame = animCometTail },
+    .{ .name = "enso", .desc = "quiet brush-circle turn (default)", .frame_ms = 160, .frame = animEnso },
+    .{ .name = "braille", .desc = "classic braille spinner", .frame_ms = 80, .frame = animBraille },
+    .{ .name = "pulse", .desc = "pulsing star", .frame_ms = 100, .frame = animPulse },
+    .{ .name = "orbit-dots", .desc = "dot orbiting a ring", .frame_ms = 100, .frame = animOrbit },
+    .{ .name = "block-wave", .desc = "unicode block wave", .frame_ms = 80, .frame = animBlockWave },
+    .{ .name = "shimmer", .desc = "highlight sweeping the word", .frame_ms = 100, .frame = animShimmer },
+    .{ .name = "matrix", .desc = "matrix rain strip", .frame_ms = 80, .frame = animMatrix },
+    .{ .name = "pacman", .desc = "pac-man eating dots", .frame_ms = 100, .frame = animPacman },
+    .{ .name = "starfield", .desc = "parallax stars", .frame_ms = 100, .frame = animStarfield },
+    .{ .name = "comet-tail", .desc = "streaking comet indicator", .frame_ms = 80, .frame = animCometTail },
 };
 
 pub var g_anim_index: usize = 0; // /animation selection (index into anims)
-pub var g_anim_random = true; // default: pick a fresh spinner per request (/animation <name> to pin one)
+pub var g_anim_random = false; // the calm enso is stable by default; /animation random opts into variety
 pub var g_anim_off = false; // /animation off
 pub var g_anim_current: usize = 0; // what spinnerTask draws right now
 // 🎂 Birthday easter egg (flagged, temporary) — when graff runs from
@@ -129,32 +131,32 @@ pub fn saveThemeSetting(io: Io, gpa: Allocator, value: []const u8) bool {
     return true;
 }
 
-/// 9-stop truecolor rainbow for the `ultracode` shine (banner + live input).
-pub const ultracode_rainbow = [_][]const u8{
-    "\x1b[38;2;255;87;51m",  "\x1b[38;2;255;159;28m", "\x1b[38;2;255;222;51m",
-    "\x1b[38;2;120;255;51m", "\x1b[38;2;51;255;170m", "\x1b[38;2;51;170;255m",
-    "\x1b[38;2;120;51;255m", "\x1b[38;2;210;51;255m", "\x1b[38;2;255;51;159m",
+/// Restrained ember sweep for `ultracode`: sumi-adjacent rust through the
+/// Codegraff coral accent to warm gold, without the old full-spectrum flash.
+pub const ultracode_ember = [_][]const u8{
+    "\x1b[38;2;168;99;67m", "\x1b[38;2;179;92;73m", "\x1b[38;2;196;81;61m",
+    "\x1b[38;2;179;92;73m", "\x1b[38;2;155;106;53m", "\x1b[38;2;165;101;59m",
 };
 
-/// `ultracode` codeword banner: a rainbow shine sweeps across the word in
+/// `ultracode` codeword banner: a slow ember shine sweeps across the word in
 /// interactive (color) mode when the codeword engages multi-agent workflow
 /// mode. Truecolor ANSI; best-effort (any write failure aborts silently).
 pub fn ultracodeShine(w: *Io.Writer, io: Io) void {
     const word = "ULTRACODE";
-    const gold = "\x1b[38;2;255;215;0m";
-    const frames = 14;
+    const ember = "\x1b[38;2;155;106;53m";
+    const frames = 9;
     var f: usize = 0;
     while (f < frames) : (f += 1) {
         w.writeAll("\r\x1b[2K") catch return;
         w.writeAll(style.bold) catch return;
-        w.print("{s}✦ ", .{gold}) catch return;
+        w.print("{s}◇ ", .{ember}) catch return;
         for (word, 0..) |c, i| {
-            w.writeAll(ultracode_rainbow[(i + f) % ultracode_rainbow.len]) catch return;
+            w.writeAll(ultracode_ember[(i + f) % ultracode_ember.len]) catch return;
             w.print("{c}", .{c}) catch return;
         }
-        w.print("{s} ✦{s}", .{ gold, style.reset }) catch return;
+        w.print("{s} ◇{s}", .{ ember, style.reset }) catch return;
         w.flush() catch return;
-        io.sleep(.fromMilliseconds(70), .awake) catch {};
+        io.sleep(.fromMilliseconds(110), .awake) catch {};
     }
     w.writeAll("\n") catch {};
     w.flush() catch {};
@@ -167,6 +169,14 @@ pub fn animIndex(name: []const u8) ?usize {
 
 fn animThinking(w: *Io.Writer) Io.Writer.Error!void {
     try w.print(" {s}thinking…{s}", .{ style.dim, style.reset });
+}
+
+fn animEnso(w: *Io.Writer, i: usize) Io.Writer.Error!void {
+    // A deliberately small, unhurried brush-circle. Each pose holds for two
+    // frames so it reads as breathing rather than a busy loading indicator.
+    const frames = [_][]const u8{ "◜", "◜", "◝", "◝", "◞", "◞", "◟", "◟" };
+    try w.print("{s}{s}{s}", .{ style.accent, frames[i % frames.len], style.reset });
+    try animThinking(w);
 }
 
 fn animGlitter(w: *Io.Writer, i: usize) Io.Writer.Error!void {
@@ -206,9 +216,9 @@ fn animDragon(w: *Io.Writer, i: usize) Io.Writer.Error!void {
 }
 
 fn animCometTail(w: *Io.Writer, i: usize) Io.Writer.Error!void {
-    // A streaking comet: a bright cyan head trailing a fading dash tail.
+    // A streaking comet: a coral head trailing a fading dash tail.
     const tail = [_][]const u8{ "    ", "·   ", "-·  ", "=-· ", "≈=-·" };
-    try w.print("{s}{s}☄{s}", .{ style.cyan, tail[i % tail.len], style.reset });
+    try w.print("{s}{s}☄{s}", .{ style.accent, tail[i % tail.len], style.reset });
     try animThinking(w);
 }
 
@@ -221,7 +231,7 @@ fn animPulse(w: *Io.Writer, i: usize) Io.Writer.Error!void {
     const glyphs = [_][]const u8{ "·", "✢", "✳", "✶", "✻", "✽", "✻", "✶", "✳", "✢" };
     const g = glyphs[i % glyphs.len];
     const bright = (i % glyphs.len) >= 3 and (i % glyphs.len) <= 6;
-    try w.print("{s}{s}{s}", .{ if (bright) style.cyan else style.dim, g, style.reset });
+    try w.print("{s}{s}{s}", .{ if (bright) style.accent else style.dim, g, style.reset });
     try animThinking(w);
 }
 
@@ -231,7 +241,7 @@ fn animOrbit(w: *Io.Writer, i: usize) Io.Writer.Error!void {
     var j: usize = 0;
     while (j < slots) : (j += 1) {
         if (j == pos) {
-            try w.print("{s}●{s}", .{ style.cyan, style.reset });
+            try w.print("{s}●{s}", .{ style.accent, style.reset });
         } else {
             try w.print("{s}·{s}", .{ style.dim, style.reset });
         }
@@ -242,7 +252,7 @@ fn animOrbit(w: *Io.Writer, i: usize) Io.Writer.Error!void {
 
 fn animBlockWave(w: *Io.Writer, i: usize) Io.Writer.Error!void {
     const lvls = [_][]const u8{ "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█" };
-    try w.writeAll(style.cyan);
+    try w.writeAll(style.accent);
     var j: usize = 0;
     while (j < 10) : (j += 1) {
         const tri = @abs(@as(i64, @intCast((i + j) % 14)) - 7); // 0..7 triangle wave
@@ -257,7 +267,7 @@ fn animShimmer(w: *Io.Writer, i: usize) Io.Writer.Error!void {
     const pos = i % (chs.len + 4); // a little off-screen pause each sweep
     for (chs, 0..) |c, j| {
         if (j == pos) {
-            try w.print("{s}{s}{s}{s}", .{ style.bold, style.cyan, c, style.reset });
+            try w.print("{s}{s}{s}{s}", .{ style.bold, style.accent, c, style.reset });
         } else {
             try w.print("{s}{s}{s}", .{ style.dim, c, style.reset });
         }
@@ -295,7 +305,7 @@ fn animStarfield(w: *Io.Writer, i: usize) Io.Writer.Error!void {
     var j: usize = 0;
     while (j < 14) : (j += 1) {
         if ((j + i) % 7 == 0) {
-            try w.print("{s}✦{s}", .{ style.cyan, style.reset });
+            try w.print("{s}✦{s}", .{ style.accent, style.reset });
         } else if ((j + i * 2) % 11 == 0) {
             try w.print("{s}·{s}", .{ style.dim, style.reset });
         } else {
@@ -342,15 +352,17 @@ test "no spinner frame ever emits a supplementary-plane glyph (anti-stealth, #10
     }
 }
 
-test "spinner pool is exactly the expected 9 animations (no silent additions)" {
+test "spinner pool is exactly the expected 10 animations (no silent additions)" {
     // Lock the user-facing spinner set: adding or renaming one must be a deliberate,
     // reviewed change, not something that slips in unnoticed.
     const expected = [_][]const u8{
-        "braille", "pulse",  "orbit-dots", "block-wave", "shimmer",
-        "matrix",  "pacman", "starfield",  "comet-tail",
+        "enso",    "braille", "pulse",  "orbit-dots", "block-wave",
+        "shimmer", "matrix",  "pacman", "starfield",  "comet-tail",
     };
     try std.testing.expectEqual(expected.len, anims.len);
     for (anims, 0..) |a, k| try std.testing.expectEqualStrings(expected[k], a.name);
+    try std.testing.expectEqualStrings("enso", anims[0].name);
+    try std.testing.expectEqual(@as(u16, 160), anims[0].frame_ms);
 }
 
 /// Check .harness/settings.json for "dev_spinner": if truthy, the
@@ -410,7 +422,7 @@ pub fn selectSpinner(io: Io) void {
 }
 
 /// Persist the /animation choice, preserving every other settings key.
-/// The default ("random") removes the key. Best-effort.
+/// The default ("enso") removes the key. Best-effort.
 pub fn saveAnimationSetting(io: Io, gpa: Allocator, value: []const u8) bool {
     Io.Dir.cwd().createDir(io, Approvals.settings_dir, .default_dir) catch {};
     var arena_state = std.heap.ArenaAllocator.init(gpa);
@@ -422,7 +434,7 @@ pub fn saveAnimationSetting(io: Io, gpa: Allocator, value: []const u8) bool {
             if (v == .object) root_obj = v.object;
         } else |_| {}
     } else |_| {}
-    if (std.mem.eql(u8, value, "random")) { // random is the default → no stored key needed
+    if (std.mem.eql(u8, value, "enso")) { // enso is the default → no stored key needed
         _ = root_obj.orderedRemove("animation");
     } else {
         root_obj.put(a, "animation", .{ .string = value }) catch return false;

--- a/src/ansi.zig
+++ b/src/ansi.zig
@@ -12,6 +12,10 @@ pub const Style = struct {
     reset: []const u8 = "",
     dim: []const u8 = "",
     bold: []const u8 = "",
+    /// Codegraff's identity color: the vermilion/coral brush stroke from the
+    /// app artwork. Keep this separate from status colors so coral always
+    /// means "active/selected/Codegraff", never implicitly success or error.
+    accent: []const u8 = "",
     red: []const u8 = "",
     green: []const u8 = "",
     yellow: []const u8 = "",
@@ -22,6 +26,9 @@ pub const Style = struct {
         .reset = "\x1b[0m",
         .dim = "\x1b[2m",
         .bold = "\x1b[1m",
+        // #C4513D keeps the coral identity while clearing WCAG AA contrast
+        // against both pure-black and pure-white terminal backgrounds.
+        .accent = "\x1b[38;2;196;81;61m",
         .red = "\x1b[31m",
         .green = "\x1b[32m",
         .yellow = "\x1b[33m",
@@ -39,8 +46,10 @@ test "Style: blank by default, ansi has escape codes" {
     const blank = Style{};
     try std.testing.expectEqualStrings("", blank.reset);
     try std.testing.expectEqualStrings("", blank.bold);
+    try std.testing.expectEqualStrings("", blank.accent);
     try std.testing.expectEqualStrings("\x1b[0m", Style.ansi.reset);
     try std.testing.expectEqualStrings("\x1b[1m", Style.ansi.bold);
+    try std.testing.expectEqualStrings("\x1b[38;2;196;81;61m", Style.ansi.accent);
     try std.testing.expectEqualStrings("\x1b[35m", Style.ansi.magenta);
     try std.testing.expectEqualStrings("\x1b[36m", Style.ansi.cyan);
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -21,6 +21,11 @@ const harness_version = root.harness_version;
 pub const changelog_text =
     \\What's new
     \\──────────
+    \\0.0.206
+    \\  • The CLI now uses Codegraff's accessible vermilion-coral accent for prompts, tools, Markdown structure, and active selections
+    \\  • A quiet Ensō brush-circle is the stable thinking default; every existing animation remains selectable, including random
+    \\  • Ultracode motion is now a slower rust/coral/gold ember sweep instead of a full-spectrum rainbow
+    \\
     \\0.0.201
     \\  • A send-failed request no longer re-pools its dead connection, so one network blip can't storm every later compaction, title, and subagent call
     \\  • The "ultracode" codeword is matched only on what you actually typed (not on appended goal/todo notes), and /clear now clears the standing goal and ultracode mode

--- a/src/commands_misc.zig
+++ b/src/commands_misc.zig
@@ -151,7 +151,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             else
                 "abnormal";
             try out.print("  {s}{d:>3}{s}  {s}{s:<8}{s} {d:>7} unread B  {s}\n", .{
-                style.cyan,                               job.id,                  style.reset,
+                style.accent,                             job.id,                  style.reset,
                 if (job.done) style.dim else style.green, status,                  style.reset,
                 job.buf.items.len - job.cursor,           utf8Prefix(job.cmd, 60),
             });
@@ -213,7 +213,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
                 has_note = true;
             };
             try out.print("{s}✓{s} connected MCP server {s}{s}{s} — {d} tool(s){s}{s}\n", .{
-                style.green, style.reset, style.cyan, name, style.reset, added,
+                style.green, style.reset, style.accent, name, style.reset, added,
                 if (persisted) " · saved to .mcp.json" else " · (not persisted)",
                 if (has_note) " · restart the harness to add its context note" else "",
             });
@@ -247,7 +247,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         } else {
             try out.print("{d} MCP server(s), {d} tool(s):\n", .{ reg.servers.len, reg.tools.len });
             for (reg.servers, 0..) |srv, i| {
-                try out.print("  {s}{s}{s}  (mcp {s}, {d} tool(s))\n", .{ style.cyan, srv.name, style.reset, srv.protocol_version, reg.toolCount(i) });
+                try out.print("  {s}{s}{s}  (mcp {s}, {d} tool(s))\n", .{ style.accent, srv.name, style.reset, srv.protocol_version, reg.toolCount(i) });
             }
             for (reg.tools) |t| try out.print("    {s}{s}{s}\n", .{ style.dim, t.qualified_name, style.reset });
             try out.writeAll("  add more: /mcp add <name> <command> [args...]\n");

--- a/src/commands_model.zig
+++ b/src/commands_model.zig
@@ -139,7 +139,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
                 }
                 return true;
             }
-            try out.print("current model: {s}{s}{s} via {s}\n", .{ style.cyan, root.provider.model, style.reset, root.provider.id });
+            try out.print("current model: {s}{s}{s} via {s}\n", .{ style.accent, root.provider.model, style.reset, root.provider.id });
             try out.writeAll("switch with /model <name> or /model <provider>:\n");
             for (provider_specs) |spec| {
                 const keyed = keys.get(spec.id) != null;
@@ -200,8 +200,8 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
                     try switchProvider(root, arena, keys.build(spec, key, try arena.dupe(u8, models[0])), out);
                     return true;
                 }
-                try out.print("{s}{s} models{s} — pick with {s}/model {s} <id>{s}:\n", .{ style.bold, spec.id, style.reset, style.cyan, spec.id, style.reset });
-                for (models) |id| try out.print("  {s}{s}{s}\n", .{ style.cyan, id, style.reset });
+                try out.print("{s}{s} models{s} — pick with {s}/model {s} <id>{s}:\n", .{ style.bold, spec.id, style.reset, style.accent, spec.id, style.reset });
+                for (models) |id| try out.print("  {s}{s}{s}\n", .{ style.accent, id, style.reset });
                 try out.flush();
                 return true;
             }
@@ -263,7 +263,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
                 var snip = if (root.messages.items[idx].object.get("content")) |c| (if (c == .string) c.string else "[image]") else "";
                 if (std.mem.indexOfScalar(u8, snip, '\n')) |nl| snip = snip[0..nl];
                 const shown = if (snip.len > 70) snip[0..70] else snip;
-                try out.print("  {s}{d}{s}: {s}{s}\n", .{ style.cyan, n, style.reset, shown, if (snip.len > 70) "…" else "" });
+                try out.print("  {s}{d}{s}: {s}{s}\n", .{ style.accent, n, style.reset, shown, if (snip.len > 70) "…" else "" });
             }
             try out.print("{s}usage: /rewind <n> — drops prompt <n>+after and reverts its write_file/edit_file changes (bash edits aren't tracked){s}\n", .{ style.dim, style.reset });
             try out.flush();

--- a/src/commands_session.zig
+++ b/src/commands_session.zig
@@ -209,7 +209,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         for (fleet.g_agent_types) |t| {
             const fp = promptFingerprint(t.prompt);
             try out.print("  {s}{s:<14}{s} {s} {s}{s}{s}", .{
-                style.cyan,
+                style.accent,
                 t.name,
                 style.reset,
                 if (t.builtin) "builtin" else "file   ",
@@ -227,13 +227,13 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         const arg = std.mem.trim(u8, line["/animation".len..], " ");
         if (arg.len == 0) {
             const current: []const u8 = if (anim.g_anim_off) "off" else if (anim.g_anim_random) "random" else anim.anims[anim.g_anim_index].name;
-            try out.print("{s}thinking animations{s} (current: {s}{s}{s}) — /animation <name> picks one, persists to {s}\n", .{ style.bold, style.reset, style.cyan, current, style.reset, Approvals.settings_path });
+            try out.print("{s}thinking animations{s} (current: {s}{s}{s}) — /animation <name> picks one, persists to {s}\n", .{ style.bold, style.reset, style.accent, current, style.reset, Approvals.settings_path });
             for (anim.anims) |a| {
-                try out.print("  {s}{s:<12}{s} {s}  preview: ", .{ style.cyan, a.name, style.reset, a.desc });
+                try out.print("  {s}{s:<12}{s} {s}  preview: ", .{ style.accent, a.name, style.reset, a.desc });
                 try a.frame(out, 3);
                 try out.writeAll("\n");
             }
-            try out.print("  {s}{s:<12}{s} a different one each request\n  {s}{s:<12}{s} no animation\n", .{ style.cyan, "random", style.reset, style.cyan, "off", style.reset });
+            try out.print("  {s}{s:<12}{s} a different one each request\n  {s}{s:<12}{s} no animation\n", .{ style.accent, "random", style.reset, style.accent, "off", style.reset });
             try out.flush();
             return true;
         }
@@ -267,9 +267,9 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         const arg = std.mem.trim(u8, line["/theme".len..], " ");
         if (arg.len == 0) {
             const current: []const u8 = if (anim.g_theme) |i| anim.themes[i].name else "off";
-            try out.print("{s}color themes{s} (current: {s}{s}{s}) — /theme <name> applies + persists, /theme off resets to your terminal default\n", .{ style.bold, style.reset, style.cyan, current, style.reset });
-            for (anim.themes) |t| try out.print("  {s}{s:<12}{s} {s}\n", .{ style.cyan, t.name, style.reset, t.desc });
-            try out.print("  {s}{s:<12}{s} terminal default (no theme)\n", .{ style.cyan, "off", style.reset });
+            try out.print("{s}color themes{s} (current: {s}{s}{s}) — /theme <name> applies + persists, /theme off resets to your terminal default\n", .{ style.bold, style.reset, style.accent, current, style.reset });
+            for (anim.themes) |t| try out.print("  {s}{s:<12}{s} {s}\n", .{ style.accent, t.name, style.reset, t.desc });
+            try out.print("  {s}{s:<12}{s} terminal default (no theme)\n", .{ style.accent, "off", style.reset });
             try out.flush();
             return true;
         }
@@ -302,7 +302,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         try out.print("{s}lifecycle hooks{s} (from {s}; event JSON on stdin, pre_tool exit 2 blocks):\n", .{ style.bold, style.reset, Approvals.settings_path });
         inline for (.{ "pre_tool", "post_tool", "turn_end" }) |ev| {
             for (@field(main_mod.g_hooks, ev)) |h| {
-                try out.print("  {s}{s:<9}{s} match {s}{s:<16}{s} {d}ms  {s}\n", .{ style.cyan, ev, style.reset, style.dim, h.match, style.reset, h.timeout_ms, h.command });
+                try out.print("  {s}{s:<9}{s} match {s}{s:<16}{s} {d}ms  {s}\n", .{ style.accent, ev, style.reset, style.dim, h.match, style.reset, h.timeout_ms, h.command });
             }
         }
         try out.flush();
@@ -348,7 +348,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
                     try out.flush();
                     return true;
                 }
-                try out.print("installing {s}{s}{s}: {s}{s}{s}\n", .{ style.cyan, sk.name, style.reset, style.dim, sk.install, style.reset });
+                try out.print("installing {s}{s}{s}: {s}{s}{s}\n", .{ style.accent, sk.name, style.reset, style.dim, sk.install, style.reset });
                 try out.flush();
                 // The user typed the install command themselves — that's the
                 // consent; the installer runs with our stdio so its progress
@@ -382,7 +382,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             const disabled = skillDisabled(sk.name);
             const state: []const u8 = if (disabled) "disabled     " else if (inst) "installed    " else "not installed";
             try out.print("  {s}{s:<8}{s} {s}{s}{s}  {s}\n", .{
-                style.cyan,                                                           sk.name, style.reset,
+                style.accent,                                                         sk.name, style.reset,
                 if (disabled) style.yellow else if (inst) style.green else style.dim, state,   style.reset,
                 sk.desc,
             });
@@ -450,7 +450,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             if (!std.mem.eql(u8, S.str(o, "kind"), "turn")) continue;
             const turn_id = S.int(o, "id");
             out.print("{s}●{s} turn {d} {s} {d}ms · prompt {s}{s}{s}{s} · {s}", .{
-                style.cyan,
+                style.accent,
                 style.reset,
                 turn_id,
                 if (S.flag(o, "ok")) "✓" else "✗",
@@ -494,7 +494,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
     if (std.mem.eql(u8, line, "/plan")) {
         main_mod.plan_mode = !main_mod.plan_mode;
         if (main_mod.plan_mode) {
-            try out.print("plan mode {s}on{s} — read-only: the agent explores and proposes; writes/edits/mutating bash are denied. /plan again to execute.\n", .{ style.cyan, style.reset });
+            try out.print("plan mode {s}on{s} — read-only: the agent explores and proposes; writes/edits/mutating bash are denied. /plan again to execute.\n", .{ style.accent, style.reset });
         } else {
             try out.writeAll("plan mode off — tools may modify things again (normal gating applies)\n");
         }

--- a/src/fleet.zig
+++ b/src/fleet.zig
@@ -241,7 +241,7 @@ pub fn promoteAgents(io: Io, gpa: Allocator, out: *Io.Writer, home: ?[]const u8,
         var fw = f.writer(io, &wbuf);
         fw.interface.writeAll(content) catch continue;
         fw.interface.flush() catch {};
-        out.print("  {s}✓{s} {s}{s}{s} → {s} {s}(mean {d:.2}, n={d}){s}\n", .{ style.green, style.reset, style.cyan, champ.niche, style.reset, path, style.dim, champ_mean, champ.n, style.reset }) catch {};
+        out.print("  {s}✓{s} {s}{s}{s} → {s} {s}(mean {d:.2}, n={d}){s}\n", .{ style.green, style.reset, style.accent, champ.niche, style.reset, path, style.dim, champ_mean, champ.n, style.reset }) catch {};
         done.append(arena, champ.niche) catch {};
         promoted += 1;
     }

--- a/src/input_util.zig
+++ b/src/input_util.zig
@@ -1,6 +1,6 @@
 //! Line-editor input helpers split out of main.zig (600-line goal): tab
 //! completion (fillCompletions), line-wrap math (wrapAt/LineRender/
-//! parseDsrCol), the ultracode wave-shine palette, the `@` file picker's
+//! parseDsrCol), the ultracode ember-shine palette, the `@` file picker's
 //! binary/dir filters + file collection (codedb-backed with a walk
 //! fallback), drag-and-drop path cleanup, and the redraw + buffer-editing
 //! helpers hoisted out of readLine's body (redraw/setLine/delRange/
@@ -88,28 +88,24 @@ pub fn parseDsrCol(seq: []const u8) ?usize {
     return if (col == 0) null else col;
 }
 
-/// Raw RGB stops for the ultracode wave (mirrors ultracode_rainbow's hues).
+/// Sumi-rust → Codegraff coral → warm-gold stops for the ultracode ember wave.
 const ultracode_rgb = [_]struct { r: u8, g: u8, b: u8 }{
-    .{ .r = 255, .g = 87, .b = 51 },
-    .{ .r = 255, .g = 159, .b = 28 },
-    .{ .r = 255, .g = 222, .b = 51 },
-    .{ .r = 120, .g = 255, .b = 51 },
-    .{ .r = 51, .g = 255, .b = 170 },
-    .{ .r = 51, .g = 170, .b = 255 },
-    .{ .r = 120, .g = 51, .b = 255 },
-    .{ .r = 210, .g = 51, .b = 255 },
-    .{ .r = 255, .g = 51, .b = 159 },
+    .{ .r = 168, .g = 99, .b = 67 },
+    .{ .r = 179, .g = 92, .b = 73 },
+    .{ .r = 196, .g = 81, .b = 61 },
+    .{ .r = 179, .g = 92, .b = 73 },
+    .{ .r = 155, .g = 106, .b = 53 },
+    .{ .r = 165, .g = 101, .b = 59 },
 };
 
-/// Smoothly interpolated rainbow hue for the ultracode wave. `pos_q8` is a
-/// 0..2048 fraction across the 9-stop palette (8 bits index + 8 bits blend),
-/// so the wave glides between colors instead of snapping. A sine brightness
-/// breath (period ~2.2s at 110ms/tick) gives a rhythmic pulse rather than a
-/// mechanical scroll. Writes the SGR escape straight to the writer.
+/// Smoothly interpolated ember hue for the ultracode wave. `pos_q8` uses an
+/// 8-bit stop index + 8-bit blend, so the color glides instead of snapping.
+/// The palette stays at a steady luminance: motion comes from the slow hue
+/// drift, not a flashing brightness pulse.
 fn ultracodeWaveHue(w: *Io.Writer, pos_q8: u16, phase: usize) void {
     const pal = &ultracode_rgb;
     const len: u16 = pal.len;
-    const p: u16 = pos_q8 + @as(u16, @intCast(phase * 32));
+    const p: u16 = pos_q8 +% @as(u16, @truncate(phase *% 16));
     const idx: u16 = (p >> 8) % len;
     const frac: u16 = p & 0xff;
     const a = pal[idx];
@@ -118,34 +114,9 @@ fn ultracodeWaveHue(w: *Io.Writer, pos_q8: u16, phase: usize) void {
     const r: i32 = @as(i32, a.r) + @divTrunc((@as(i32, b.r) - @as(i32, a.r)) * @as(i32, frac), 256);
     const g: i32 = @as(i32, a.g) + @divTrunc((@as(i32, b.g) - @as(i32, a.g)) * @as(i32, frac), 256);
     const bl: i32 = @as(i32, a.b) + @divTrunc((@as(i32, b.b) - @as(i32, a.b)) * @as(i32, frac), 256);
-    // Breath: a gentle sine over phase, period 20 ticks (~2.2s @ 110ms),
-    // modulating brightness between ~81% and ~94% — a soft, subtle pulse.
-    const breath: u16 = switch (phase % 20) {
-        0 => 120,
-        1 => 120,
-        2 => 118,
-        3 => 117,
-        4 => 114,
-        5 => 112,
-        6 => 110,
-        7 => 107,
-        8 => 106,
-        9 => 104,
-        10 => 104,
-        11 => 104,
-        12 => 106,
-        13 => 107,
-        14 => 110,
-        15 => 112,
-        16 => 114,
-        17 => 117,
-        18 => 118,
-        else => 120,
-    };
-    const sc: i32 = @as(i32, breath);
-    const cr: u8 = @intCast(@max(0, @min(255, @divTrunc(r * sc, 128))));
-    const cg: u8 = @intCast(@max(0, @min(255, @divTrunc(g * sc, 128))));
-    const cb: u8 = @intCast(@max(0, @min(255, @divTrunc(bl * sc, 128))));
+    const cr: u8 = @intCast(@max(0, @min(255, r)));
+    const cg: u8 = @intCast(@max(0, @min(255, g)));
+    const cb: u8 = @intCast(@max(0, @min(255, bl)));
     w.print("\x1b[38;2;{d};{d};{d}m", .{ cr, cg, cb }) catch {};
 }
 
@@ -280,8 +251,8 @@ pub fn cleanDroppedPath(gpa: Allocator, home: []const u8, pasted: []const u8) ?[
 
 // Redraw the whole input below a fixed prompt prefix, wrapping it
 // across rows. Spans listed in `marks` (paths from the @ picker or a
-// file drop, plus "[Image]") render as a cyan chip (reverse video +
-// cyan) so they keep reading as attached files, not typed words; a
+// file drop, plus "[Image]") render as an accent chip (reverse video +
+// Codegraff coral) so they keep reading as attached files, not typed words; a
 // chip crossing a row break keeps its colour. `st` carries the row
 // count + cursor row of the previous draw so this one can clear it
 // with relative moves only — no DECSC anchor for a scroll to strand.
@@ -309,11 +280,11 @@ pub fn redraw(o: *Io.Writer, items: []const u8, c: usize, marks: []const []const
     var mark_open = false;
     const secret_start = util.sensitiveInputStart(items);
     // `ultracode` shines the input itself: each letter of every
-    // (case-insensitive) occurrence renders in a rotating rainbow hue.
+    // (case-insensitive) occurrence renders in a rotating ember hue.
     var shine_starts: [8]usize = undefined;
     var shine_ends: [8]usize = undefined;
     var nshine: usize = 0;
-    {
+    if (main_mod.use_color) {
         var si: usize = 0;
         while (si + 9 <= items.len) : (si += 1) {
             if (std.ascii.eqlIgnoreCase(items[si .. si + 9], "ultracode")) {
@@ -344,19 +315,18 @@ pub fn redraw(o: *Io.Writer, items: []const u8, c: usize, marks: []const []const
                     o.writeAll("\x1b[0m") catch {};
                     shine_active = false;
                 }
-                o.writeAll("\x1b[7;36m") catch {};
+                o.writeAll(if (main_mod.use_color) "\x1b[7;38;2;196;81;61m" else "\x1b[7m") catch {};
                 mark_end = i + best;
                 mark_open = true;
             }
         }
-        // Rainbow shine for an `ultracode` span (skipped inside a chip).
+        // Ember shine for an `ultracode` span (skipped inside a chip).
         if (!mark_open and !masked) {
             var in_shine = false;
             for (shine_starts[0..nshine], shine_ends[0..nshine]) |sstart, send| {
                 if (i >= sstart and i < send) {
-                    // Smooth interpolated hue + rhythmic brightness
-                    // breath; pos_q8 spreads the 9 letters across a
-                    // full palette pass so the wave glides.
+                    // Smooth interpolated hue; pos_q8 spreads the word across
+                    // one palette pass.
                     ultracodeWaveHue(o, @intCast((i - sstart) * 256), g_shine_phase);
                     in_shine = true;
                     break;

--- a/src/main.zig
+++ b/src/main.zig
@@ -224,7 +224,7 @@ pub var g_companion_disabled = [_]bool{false} ** companion_servers.len;
 var g_codedbpro_licensed: bool = false;
 // Thinking animations: spinner animations + color themes (+ settings persistence) live in anim.zig; spinner consumers (Agent.spinnerTask, /animation, /theme) stay here.
 const anim = @import("anim.zig");
-// Steering (Codex-style): bytes typed while a turn streams are captured (not discarded), echoed live in dim cyan, and queued to run next on Enter —
+// Steering (Codex-style): bytes typed while a turn streams are captured (not discarded), echoed live in dim coral, and queued to run next on Enter —
 // follow-ups queue without waiting for the turn to finish. TTY-only (raw-stdin esc-watch is off in --json/GUI mode); watchdog/select arms may
 // drain/echo stdin while the stream reader is blocked, so g_steer_visible pauses spinner redraws to keep the live row intact.
 pub var g_steer_buf: std.ArrayList(u8) = .empty; // in-progress line (page-alloc)

--- a/src/mainloop.zig
+++ b/src/mainloop.zig
@@ -137,7 +137,7 @@ pub fn run(ctx: *Ctx) !void {
             if (e.force) {
                 try ctx.out.print("{s}↳ force ›{s} {s}\n", .{ style.yellow, style.reset, e.text });
             } else {
-                try ctx.out.print("{s}↳ steer ›{s} {s}\n", .{ style.cyan, style.reset, e.text });
+                try ctx.out.print("{s}↳ steer ›{s} {s}\n", .{ style.accent, style.reset, e.text });
             }
             try ctx.out.flush();
             break :blk e.text;

--- a/src/picker_auth.zig
+++ b/src/picker_auth.zig
@@ -151,14 +151,14 @@ pub fn offerProviderAuth(
 
     const title = std.fmt.allocPrint(arena, "No key for {s} \xe2\x80\xba", .{pid}) catch "No key \xe2\x80\xba";
     const choice = pick(root, arena, out, title, items[0..n]) orelse {
-        try out.print("kept {s}{s}{s}\n", .{ style.cyan, root.provider.model, style.reset });
+        try out.print("kept {s}{s}{s}\n", .{ style.accent, root.provider.model, style.reset });
         try out.flush();
         return;
     };
     const picked = items[choice].name;
 
     if (std.mem.eql(u8, picked, "keep current model")) {
-        try out.print("kept {s}{s}{s}\n", .{ style.cyan, root.provider.model, style.reset });
+        try out.print("kept {s}{s}{s}\n", .{ style.accent, root.provider.model, style.reset });
         try out.flush();
         return;
     }
@@ -197,7 +197,7 @@ pub fn offerProviderAuth(
         try out.flush();
         const key = readSecret(root, arena, out) orelse "";
         if (key.len == 0) {
-            try out.print("cancelled — kept {s}{s}{s}\n", .{ style.cyan, root.provider.model, style.reset });
+            try out.print("cancelled — kept {s}{s}{s}\n", .{ style.accent, root.provider.model, style.reset });
             try out.flush();
             return;
         }
@@ -214,7 +214,7 @@ pub fn offerProviderAuth(
     else
         model;
     const provider = keys.providerById(pid, selected_model) catch {
-        try out.print("still no usable key for {s} — kept {s}{s}{s}\n", .{ pid, style.cyan, root.provider.model, style.reset });
+        try out.print("still no usable key for {s} — kept {s}{s}{s}\n", .{ pid, style.accent, root.provider.model, style.reset });
         try out.flush();
         return;
     };

--- a/src/pickers.zig
+++ b/src/pickers.zig
@@ -228,7 +228,7 @@ pub fn modelPicker(root: *Agent, keys: *Keys, arena: Allocator, out: *Io.Writer)
         }
 
         out.writeAll("\x1b[2J\x1b[H") catch {};
-        out.print("{s}Model ›{s} {s}\n", .{ style.cyan, style.reset, query.items }) catch {};
+        out.print("{s}Model ›{s} {s}\n", .{ style.accent, style.reset, query.items }) catch {};
         out.print("{s}{d}/{d}{s}\n", .{ style.dim, filtered.items.len, model_table.len, style.reset }) catch {};
         out.writeAll(style.dim) catch {};
         out.writeAll("  ") catch {};
@@ -247,8 +247,8 @@ pub fn modelPicker(root: *Agent, keys: *Keys, arena: Allocator, out: *Io.Writer)
             const cur = std.mem.eql(u8, m.name, root.provider.model) and std.mem.eql(u8, m.provider, root.provider.id);
             const keyed = keys.get(m.provider) != null;
             const context = pricing.contextFor(m.provider, m.name);
-            if (row == sel) out.writeAll("\x1b[7m") catch {};
-            out.print("{s} ", .{if (cur) "▌" else " "}) catch {};
+            if (row == sel) out.writeAll(style.accent) catch {};
+            out.print("{s} ", .{if (row == sel) "›" else if (cur) "▌" else " "}) catch {};
             writeCell(out, m.name, layout.name_width);
             out.writeByte(' ') catch {};
             writeCell(out, m.provider, layout.provider_width);
@@ -264,7 +264,7 @@ pub fn modelPicker(root: *Agent, keys: *Keys, arena: Allocator, out: *Io.Writer)
                 // Preserve the keyless warning even when CTX is hidden.
                 out.writeAll(" !") catch {};
             }
-            if (row == sel) out.writeAll("\x1b[0m") catch {};
+            if (row == sel) out.writeAll(style.reset) catch {};
             out.writeByte('\n') catch {};
         }
         out.writeAll(style.dim) catch {};
@@ -346,16 +346,16 @@ pub fn listPickerAt(root: *Agent, arena: Allocator, out: *Io.Writer, title: []co
         if (filtered.items.len == 0) sel = 0 else if (sel >= filtered.items.len) sel = filtered.items.len - 1;
 
         out.writeAll("\x1b[2J\x1b[H") catch {};
-        out.print("{s}{s}{s} {s}\n", .{ style.cyan, title, style.reset, query.items }) catch {};
+        out.print("{s}{s}{s} {s}\n", .{ style.accent, title, style.reset, query.items }) catch {};
         out.print("{s}{d}/{d}{s}\n", .{ style.dim, filtered.items.len, items.len, style.reset }) catch {};
         const off = if (sel >= layout.visible) sel - layout.visible + 1 else 0;
         var row = off;
         while (row < filtered.items.len and row < off + layout.visible) : (row += 1) {
             const item = items[filtered.items[row]];
-            if (row == sel) out.writeAll("\x1b[7m") catch {};
-            out.writeByte(' ') catch {};
-            writeCell(out, item.name, layout.name_width);
-            if (row == sel) out.writeAll("\x1b[0m") catch {};
+            if (row == sel) out.writeAll(style.accent) catch {};
+            out.print("{s} ", .{if (row == sel) "›" else " "}) catch {};
+            writeCell(out, item.name, if (layout.name_width > 1) layout.name_width - 1 else 1);
+            if (row == sel) out.writeAll(style.reset) catch {};
             if (layout.show_desc) {
                 out.print(" {s}", .{style.dim}) catch {};
                 writeCell(out, item.desc, layout.desc_width);

--- a/src/readline.zig
+++ b/src/readline.zig
@@ -239,13 +239,12 @@ pub fn readLine(
             pend_i += 1;
             break :blk b;
         } else blk: {
-            // While the input contains `ultracode`, wave the rainbow shine
-            // across the letters: poll for input with a slower 110ms timeout,
+            // While the input contains `ultracode`, drift the ember shine
+            // across the letters: poll for input with a slower 140ms timeout,
             // and on each idle tick advance the phase + redraw so the hue
-            // glides and breathes (~9fps, calm + rhythmic rather than a fast
-            // flicker).
-            while (std.ascii.indexOfIgnoreCase(buf.items, "ultracode") != null) {
-                if (inputPendingTimed(110)) break; // keystroke ready — read it below
+            // glides at ~7fps rather than flickering.
+            while (main_mod.use_color and std.ascii.indexOfIgnoreCase(buf.items, "ultracode") != null) {
+                if (inputPendingTimed(140)) break; // keystroke ready — read it below
                 input_util.g_shine_phase +%= 1;
                 redraw(out, buf.items, cur, marks.items, &rstate, prompt_col);
             }

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -1,12 +1,12 @@
-//! `graff repl` — an interactive chat REPL on the zigzag TUI, styled like
-//! Claude Code: a bordered welcome box with the `✻` accent, conversation turns
+//! `graff repl` — an interactive chat REPL on the zigzag TUI, styled in the
+//! Codegraff ink-and-coral language: a bordered welcome box, conversation turns
 //! (`>` you, `⏺` the model), a rounded input box pinned to the bottom, a status
 //! line, and `/`-style commands mirroring the harness's interactive set.
 //!
 //! Spike branch: spike/zigzag-repl. Reachable as `graff repl` (subcommand of
 //! the main binary) and the standalone `graff-repl` exe — both call `run()`.
 //!
-//! The model call runs on a background thread so the braille thinking spinner
+//! The model call runs on a background thread so the ensō thinking spinner
 //! animates while it works (the zigzag loop re-renders every frame). The whole
 //! conversation is sent each turn (multi-turn memory). Without a model wired in
 //! (standalone exe) it falls back to a pure i64 arithmetic evaluator, which
@@ -111,17 +111,18 @@ pub var g_debug: bool = false; // GRAFF_REPL_DEBUG / `/debug` → dump raw strea
 
 pub const accent = util.accent;
 
-/// `/ultracode` rainbow shine — sweeps across the input border per frame.
-pub const rainbow = [_]zz.Color{
-    zz.Color.fromRgb(0xFF, 0x5C, 0x57), zz.Color.fromRgb(0xFF, 0x9F, 0x43),
-    zz.Color.fromRgb(0xFE, 0xD3, 0x30), zz.Color.fromRgb(0x6B, 0xCB, 0x77),
-    zz.Color.fromRgb(0x4D, 0x96, 0xFF), zz.Color.fromRgb(0xB1, 0x7A, 0xFF),
+/// `/ultracode` ember shine — a slow coral/rust/gold border sweep.
+pub const ultracode_palette = [_]zz.Color{
+    zz.Color.fromRgb(0xA8, 0x63, 0x43), zz.Color.fromRgb(0xB3, 0x5C, 0x49),
+    zz.Color.fromRgb(0xC4, 0x51, 0x3D), zz.Color.fromRgb(0xB3, 0x5C, 0x49),
+    zz.Color.fromRgb(0x9B, 0x6A, 0x35), zz.Color.fromRgb(0xA5, 0x65, 0x3B),
 };
 
+pub const enso_frames = [_][]const u8{ "◜", "◝", "◞", "◟" };
 pub const braille_frames = [_][]const u8{ "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
 pub const dragon_frames = [_][]const u8{ "🐉  ", "🐉 ✦", "🐉 ✧", "🐉 ✦" };
 
-const Anim = enum { braille, dragon };
+const Anim = enum { enso, braille, dragon };
 pub const Toast = enum { none, copied, failed };
 pub const TOAST_MS: u64 = 1500; // copy-confirmation toast window (wall-clock ms), #85
 
@@ -173,7 +174,7 @@ pub const Model = struct {
     thinking_show: bool = false,
     ultracode: bool = false,
     goal: ?[]const u8 = null, // owned
-    anim: Anim = .braille,
+    anim: Anim = .enso,
     scroll: usize = 0,
     // Mouse drag-selection → auto-copy (OSC52). Screen rows, 0-based.
     sel_anchor_row: ?usize = null,
@@ -385,7 +386,7 @@ pub const HELP_CALC =
     \\Commands:
     \\  /help     this help
     \\  /clear    clear the conversation
-    \\  /animation braille|dragon   spinner style
+    \\  /animation enso|braille|dragon   spinner style
     \\  /quit     exit  (also /q, ctrl-c)
     \\
     \\Offline mode (no model): evaluates i64 arithmetic — + - * / %, parens.
@@ -411,6 +412,7 @@ test "model: offline arithmetic path (no turn_fn)" {
     var m: Model = undefined;
     m.setup(std.testing.allocator);
     defer m.deinit();
+    try std.testing.expectEqual(Anim.enso, m.anim);
 
     try std.testing.expectEqual(Effect.stay, m.applyLine("2 + 3 * 4"));
     const out = try m.render(std.testing.allocator, 60, 24, 0);
@@ -471,6 +473,8 @@ test "model: commands toggle settings" {
     try std.testing.expect(m.goal != null);
     _ = m.applyLine("/animation dragon");
     try std.testing.expectEqual(Anim.dragon, m.anim);
+    _ = m.applyLine("/animation enso");
+    try std.testing.expectEqual(Anim.enso, m.anim);
 }
 
 fn stubTurn(_: ?*anyopaque, gpa: std.mem.Allocator, history: []const Turn, params: Params, _: *StreamBuf) ?[]const u8 {

--- a/src/repl_markdown.zig
+++ b/src/repl_markdown.zig
@@ -42,7 +42,7 @@ pub fn renderMarkdown(gpa: std.mem.Allocator, src: []const u8, width_hint: usize
         }
         if (in_fence) {
             try out.appendSlice(try (zz.Style{}).fg(.brightBlack).render(a, "▏ "));
-            try out.appendSlice(try (zz.Style{}).fg(.cyan).render(a, line));
+            try out.appendSlice(line);
             continue;
         }
         if (isTableRow(t) and idx + 1 < lines.len and isTableSep(std.mem.trim(u8, lines[idx + 1], " \t"))) {

--- a/src/repl_model_commands.zig
+++ b/src/repl_model_commands.zig
@@ -90,8 +90,8 @@ pub fn runCommand(self: *Model, line: []const u8) void {
         self.setSession(arg);
         self.pushFmt(.info, "session renamed: {s}", .{self.session_name orelse "repl"}) catch {};
     } else if (std.mem.eql(u8, cmd, "/animation")) {
-        if (std.mem.eql(u8, arg, "dragon")) self.anim = .dragon else if (std.mem.eql(u8, arg, "braille")) self.anim = .braille else {
-            self.push(.info, "usage: /animation braille|dragon") catch {};
+        if (std.mem.eql(u8, arg, "enso")) self.anim = .enso else if (std.mem.eql(u8, arg, "dragon")) self.anim = .dragon else if (std.mem.eql(u8, arg, "braille")) self.anim = .braille else {
+            self.push(.info, "usage: /animation enso|braille|dragon") catch {};
             return;
         }
         self.pushFmt(.info, "spinner: {s}", .{@tagName(self.anim)}) catch {};

--- a/src/repl_model_render.zig
+++ b/src/repl_model_render.zig
@@ -17,6 +17,7 @@ const tailPreview = util.tailPreview;
 
 pub fn spinnerFrame(self: *const Model, now_ms: u64) []const u8 {
     return switch (self.anim) {
+        .enso => repl.enso_frames[(now_ms / 160) % repl.enso_frames.len],
         .braille => repl.braille_frames[(now_ms / 80) % repl.braille_frames.len],
         .dragon => repl.dragon_frames[(now_ms / 220) % repl.dragon_frames.len],
     };
@@ -49,7 +50,7 @@ pub fn render(self: *Model, gpa: std.mem.Allocator, term_width: usize, term_heig
     const a = arena_state.allocator();
 
     const inner: u16 = @intCast(@max(@as(usize, 8), term_width) - 4);
-    const border_color = if (self.ultracode) repl.rainbow[(now_ms / 90) % repl.rainbow.len] else zz.Color.brightBlack;
+    const border_color = if (self.ultracode) repl.ultracode_palette[(now_ms / 180) % repl.ultracode_palette.len] else zz.Color.brightBlack;
     const box = (zz.Style{}).borderAll(zz.Border.rounded)
         .borderForeground(border_color).paddingLeft(1).paddingRight(1).width(inner);
 

--- a/src/repl_util.zig
+++ b/src/repl_util.zig
@@ -6,7 +6,7 @@
 const std = @import("std");
 const zz = @import("zigzag");
 
-pub const accent = zz.Color.fromRgb(0xD9, 0x77, 0x57); // Claude coral
+pub const accent = zz.Color.fromRgb(0xC4, 0x51, 0x3D); // accessible Codegraff vermilion coral
 
 pub const HELP_CHAT =
     \\Commands (mirrors the graff session):
@@ -17,7 +17,7 @@ pub const HELP_CHAT =
     \\  /fast /thinking /ultracode       thinking controls (toggles)
     \\  /goal <text>                     standing objective (tracked as a checklist)
     \\  /plan /strict /yolo /keepcontext /title   modes
-    \\  /rename <name>  /animation braille|dragon
+    \\  /rename <name>  /animation enso|braille|dragon
     \\  /bash /save /resume /sessions /trace /trajectory
     \\  /agents /skills /hooks /mcp /loop /image /paste /key
     \\
@@ -31,7 +31,7 @@ pub fn renderInline(out: *std.array_list.Managed(u8), a: std.mem.Allocator, line
         const c = line[i];
         if (c == '`') {
             if (std.mem.indexOfScalarPos(u8, line, i + 1, '`')) |end| {
-                try out.appendSlice(try (zz.Style{}).fg(.cyan).render(a, line[i + 1 .. end]));
+                try out.appendSlice(try (zz.Style{}).fg(accent).render(a, line[i + 1 .. end]));
                 i = end + 1;
                 continue;
             }

--- a/src/session_start.zig
+++ b/src/session_start.zig
@@ -113,7 +113,7 @@ pub fn setupWorktreeAndBanner(
             main_mod.g_worktree_branch = wt_branch; // non-null = auto-commit each turn to this scratch branch
             if (!main_mod.json_mode) {
                 const ac: []const u8 = if (main_mod.g_worktree_autocommit) " · auto-committing each turn (`graff worktree merge` to land it)" else "";
-                out.print("{s}worktree:{s} {s}{s}{s} (branch {s}) — edits isolated from the main checkout{s}\n", .{ style.dim, style.reset, style.cyan, wt_path, style.reset, wt_branch, ac }) catch {};
+                out.print("{s}worktree:{s} {s}{s}{s} (branch {s}) — edits isolated from the main checkout{s}\n", .{ style.dim, style.reset, style.accent, wt_path, style.reset, wt_branch, ac }) catch {};
                 out.flush() catch {};
             }
         }
@@ -128,7 +128,7 @@ pub fn setupWorktreeAndBanner(
         try arena.dupe(u8, environ_map.get("PWD") orelse ".");
 
     if (!main_mod.json_mode and flags.oneshot_prompt == null) {
-        try out.print("{s}codegraff{s} · folder: {s}{s}{s} · / for commands · @ picks a file · esc interrupts · ↑/↓ history · tab completes · ctrl-d quits · trace → {s}\n", .{ style.bold, style.reset, style.cyan, main_mod.g_cwd_display, style.reset, trace_path });
+        try out.print("{s}codegraff{s} · folder: {s}{s}{s} · / for commands · @ picks a file · esc interrupts · ↑/↓ history · tab completes · ctrl-d quits · trace → {s}\n", .{ style.bold, style.reset, style.accent, main_mod.g_cwd_display, style.reset, trace_path });
         try out.flush();
         if (codex_account) |acct| {
             try out.print("logged into Codex (ChatGPT account {s}…) — /model codex\n", .{acct[0..@min(acct.len, 8)]});


### PR DESCRIPTION
## Hotfix

- Introduce an accessible Codegraff vermilion-coral accent for prompts, tools, Markdown structure, model/provider metadata, file chips, and active selections.
- Replace full-row reverse picker highlights with a quieter coral pointer that remains understandable without color.
- Make the slow Ensō brush-circle the stable thinking default while preserving every existing animation and `/animation random`.
- Replace Ultracode's full-spectrum rainbow with a slower, steady-luminance rust/coral/gold ember sweep.
- Apply the same visual language to the bordered `graff repl` surface without taking over the terminal background.
- Preserve semantic success, warning, and error colors; continue respecting `NO_COLOR` and existing saved animation choices.

## Why

The CLI was already structurally calm, but its cyan/magenta/rainbow accents did not match the sumi-ink, warm-paper, and vermilion identity of the Codegraff application artwork. This patch makes the interface feel recognizably Codegraff while reducing unnecessary motion and retaining terminal ownership and accessibility.

## Release impact

This is a presentation-only patch on top of v0.0.205. Provider behavior, model routing, tools, persistence, startup optimizations, context accounting, and JSON/SDK transports are unchanged. The v0.0.206 release notes will carry forward the comprehensive v0.0.205 notes and add this hotfix first.

After the six-target release workflow completes, both macOS archives will be Developer ID signed, notarized with the `notary-local` profile, repacked in the original archive layout, and reflected in a regenerated checksum manifest.

## Validation

- `zig build test`
- `zig build repl-test`
- default build
- real-PTY spinner rendering from the repository, home directory, and `/tmp`
- `NO_COLOR` smoke
- `git diff --check`
