### PR TITLE
fix(ci): Linux O_PATH dir-chmod panic + stale max_output_tokens PTY assertions

### DIFF
--- a/scripts/test-pty-codex-ws.py
+++ b/scripts/test-pty-codex-ws.py
@@ -278,8 +278,11 @@ def assert_midturn_requests(mock: CodexMock) -> None:
             f"midturn: expected exactly 3 model requests, got {len(requests)}: {requests!r}"
         )
     first, compact, final = requests
-    if [request.body.get("max_output_tokens") for request in requests] != [16000, 4096, 16000]:
-        raise AssertionError("midturn: expected root/compaction/root output caps 16k/4k/16k")
+    if any("max_output_tokens" in request.body for request in requests):
+        raise AssertionError(
+            "midturn: Responses requests must not carry a top-level "
+            "max_output_tokens (gpt-5.6 backend rejects it, #247)"
+        )
     transports = [request.transport for request in requests]
     if transports != ["ws", "sse", "ws"]:
         raise AssertionError(f"midturn: expected WS -> SSE -> WS, got {transports!r}")
@@ -371,8 +374,11 @@ def assert_transactional_requests(mock: CodexMock) -> None:
             f"got {len(requests)}: {requests!r}"
         )
     first, compact, final = requests
-    if [request.body.get("max_output_tokens") for request in requests] != [16000, 4096, 16000]:
-        raise AssertionError("transactional: expected root/compaction/root output caps 16k/4k/16k")
+    if any("max_output_tokens" in request.body for request in requests):
+        raise AssertionError(
+            "transactional: Responses requests must not carry a top-level "
+            "max_output_tokens (gpt-5.6 backend rejects it, #247)"
+        )
     transports = [request.transport for request in requests]
     if transports != ["ws", "sse", "ws"]:
         raise AssertionError(

--- a/scripts/test-title-parallel.py
+++ b/scripts/test-title-parallel.py
@@ -152,17 +152,20 @@ def main() -> None:
     if len(observed) != 2 or {kind for _, kind in observed} != {"title", "main"}:
         raise AssertionError(f"expected one title and one main request: {observed!r}")
     requests = mock.recorded_requests()
-    limits = {
+    caps = {
         (
             "title"
             if "You summarize what a coding session is about"
             in request.body.get("instructions", "")
             else "main"
-        ): request.body.get("max_output_tokens")
+        ): "max_output_tokens" in request.body
         for request in requests
     }
-    if limits != {"title": 64, "main": 16000}:
-        raise AssertionError(f"unexpected Responses output caps: {limits!r}")
+    if caps != {"title": False, "main": False}:
+        raise AssertionError(
+            f"Responses requests must not carry a top-level "
+            f"max_output_tokens (gpt-5.6 backend rejects it, #247): {caps!r}"
+        )
     delta_ms = (observed[1][0] - observed[0][0]) * 1000
     if delta_ms > 750:
         raise AssertionError(f"title/main requests serialized ({delta_ms:.1f}ms apart)")

--- a/src/kimi_catalog.zig
+++ b/src/kimi_catalog.zig
@@ -25,7 +25,10 @@ const private_file_permissions: Io.File.Permissions = if (Io.File.Permissions.ha
 const private_dir_permissions: Io.File.Permissions = if (Io.File.Permissions.has_executable_bit) @enumFromInt(0o700) else .default_dir;
 
 fn secureDir(io: Io, path: []const u8) void {
-    const dir = Io.Dir.cwd().openDir(io, path, .{}) catch return;
+    // iterate=true: a default openDir can yield an O_PATH handle on Linux, and
+    // fchmod on O_PATH fails EBADF — which std.Io treats as a programmer-bug
+    // panic, not a catchable error. A readable handle chmods fine everywhere.
+    const dir = Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch return;
     defer dir.close(io);
     dir.setPermissions(io, private_dir_permissions) catch {};
 }

--- a/src/oauth.zig
+++ b/src/oauth.zig
@@ -244,7 +244,9 @@ fn writeKimiAuth(io: Io, arena: Allocator, home: []const u8, access: []const u8,
     Io.Dir.cwd().createDir(io, kimi_dir, private_dir_permissions) catch {};
     Io.Dir.cwd().createDir(io, credentials_dir, private_dir_permissions) catch {};
     for ([_][]const u8{ kimi_dir, credentials_dir }) |path| {
-        const dir = Io.Dir.cwd().openDir(io, path, .{}) catch continue;
+        // iterate=true: see kimi_catalog.secureDir — a default openDir can be
+        // O_PATH on Linux, where fchmod panics EBADF instead of erroring.
+        const dir = Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch continue;
         defer dir.close(io);
         dir.setPermissions(io, private_dir_permissions) catch {};
     }


### PR DESCRIPTION
## Summary

Main's zig CI job has been red since 7e08374c, but the first failure masked two more behind it (the job stops at the first failed step):

1. **JSON live-control test (Linux-only panic):** the kimi catalog hydration added in 7e08374c made `kimi_catalog.secureDir` reachable mid-session. A default `openDir` can yield an O_PATH handle on Linux, and `fchmod` on O_PATH fails EBADF — which std.Io (0.17-dev) escalates to a programmer-bug *panic* that `catch {}` cannot swallow. Once `~/.kimi/device_id` exists, any `/model` query that may use kimi re-enters `initIdentity → secureDir` and the process dies (the test sees stdout EOF after the 8th event). macOS never hit it: its dir handles are always chmod-able. Fix: open with `.iterate = true` in both `kimi_catalog.secureDir` and the identical `oauth.zig` kimi-credentials loop.

2. **Codex WS/SSE transport test:** `test-pty-codex-ws.py` still asserted explicit top-level 16k/4k/16k `max_output_tokens` caps, but #247 intentionally dropped the field (gpt-5.6 rejects it). Assert its absence instead.

3. **Title-parallel test:** same stale caps assertion, same fix.

## Validation

- Debug branch (`debug/json-controls-main`) with these exact commits: **full CI green** (run 29715398686)
- Local (zig 0.16, macOS): `zig build test` 231/231, `test-json-controls.py` 19/19, `test-pty-codex-ws.py` 6/6 scenarios, `test-title-parallel.py` ok

Co-Authored-By: Codegraff <blackfloofie@codegraff.com>