### PR TITLE
fix: reject image paste early for non-vision models

### DIFF
--- a/src/readline.zig
+++ b/src/readline.zig
@@ -51,6 +51,19 @@ const session = @import("session.zig");
 const Agent = agent_mod.Agent;
 const saveSession = session.saveSession;
 
+const ClipboardPasteSource = union(enum) {
+    image: []const u8,
+    no_image,
+    no_vision,
+    unsupported_platform,
+};
+
+fn clipboardPasteSource(io: Io, supports_vision: bool, is_macos: bool, grabber: anytype) ClipboardPasteSource {
+    if (!supports_vision) return .no_vision;
+    if (!is_macos) return .unsupported_platform;
+    return .{ .image = grabber(io) orelse return .no_image };
+}
+
 /// History + unsent-draft navigation for the line editor (#101). Mirrors the
 /// GUI's promptHistoryNavigation.ts: stepping UP out of the fresh slot snapshots
 /// the half-typed draft; stepping DOWN past the newest entry restores it instead
@@ -323,17 +336,22 @@ pub fn readLine(
             },
             0x16 => { // Ctrl-V: attach a clipboard image (macOS) at the cursor
                 var msg: ?[]const u8 = null;
-                if (grabClipboardImage(root.io)) |p| switch (stageImagePath(root, p)) {
-                    .ok => {
-                        const marker = "[Image] ";
-                        buf.insertSlice(gpa, cur, marker) catch {};
-                        cur += marker.len;
-                        addMark(gpa, &marks, "[Image]");
-                        redraw(out, buf.items, cur, marks.items, &rstate, prompt_col);
-                    },
+                switch (clipboardPasteSource(root.io, vision.visionCapable(root.provider), builtin.os.tag == .macos, grabClipboardImage)) {
                     .no_vision => msg = "this model can't see images — /model to a vision one (claude-*, gpt-5*)",
-                    .read_fail => msg = "couldn't read the clipboard image",
-                } else msg = if (builtin.os.tag == .macos) "no image on the clipboard — copy an image first (this is Ctrl-V; ⌘V can't be captured)" else "clipboard image paste is macOS-only — use /image <path>";
+                    .unsupported_platform => msg = "clipboard image paste is macOS-only — use /image <path>",
+                    .no_image => msg = "no image on the clipboard — copy an image first (this is Ctrl-V; ⌘V can't be captured)",
+                    .image => |p| switch (stageImagePath(root, p)) {
+                        .ok => {
+                            const marker = "[Image] ";
+                            buf.insertSlice(gpa, cur, marker) catch {};
+                            cur += marker.len;
+                            addMark(gpa, &marks, "[Image]");
+                            redraw(out, buf.items, cur, marks.items, &rstate, prompt_col);
+                        },
+                        .no_vision => msg = "this model can't see images — /model to a vision one (claude-*, gpt-5*)",
+                        .read_fail => msg = "couldn't read the clipboard image",
+                    },
+                }
                 if (msg) |m| { // feedback below the input, then redraw the prompt+buffer fresh
                     if (rstate.rows - 1 > rstate.crow) out.print("\x1b[{d}B", .{rstate.rows - 1 - rstate.crow}) catch {};
                     out.print("\r\n{s}· {s}{s}", .{ style.dim, m, style.reset }) catch {};
@@ -595,4 +613,34 @@ pub fn readLine(
         history.append(gpa, dup) catch {};
     }
     return buf.items;
+}
+
+test "clipboard paste checks vision support before clipboard access" {
+    const MockGrabber = struct {
+        var calls: usize = 0;
+        var image: ?[]const u8 = "/tmp/test.png";
+
+        fn grab(_: Io) ?[]const u8 {
+            calls += 1;
+            return image;
+        }
+    };
+    const expectTag = struct {
+        fn expect(expected: std.meta.Tag(ClipboardPasteSource), actual: ClipboardPasteSource) !void {
+            try std.testing.expectEqual(expected, std.meta.activeTag(actual));
+        }
+    }.expect;
+
+    MockGrabber.calls = 0;
+    try expectTag(.no_vision, clipboardPasteSource(std.testing.io, false, true, MockGrabber.grab));
+    try expectTag(.no_vision, clipboardPasteSource(std.testing.io, false, false, MockGrabber.grab));
+    try expectTag(.unsupported_platform, clipboardPasteSource(std.testing.io, true, false, MockGrabber.grab));
+    try std.testing.expectEqual(@as(usize, 0), MockGrabber.calls);
+
+    try expectTag(.image, clipboardPasteSource(std.testing.io, true, true, MockGrabber.grab));
+    try std.testing.expectEqual(@as(usize, 1), MockGrabber.calls);
+
+    MockGrabber.image = null;
+    try expectTag(.no_image, clipboardPasteSource(std.testing.io, true, true, MockGrabber.grab));
+    try std.testing.expectEqual(@as(usize, 2), MockGrabber.calls);
 }


### PR DESCRIPTION
## Summary

- check the selected model's vision capability before attempting Ctrl-V clipboard capture
- show the model-unsupported message immediately and avoid inserting `[Image]` for non-vision models
- keep platform and empty-clipboard feedback limited to vision-capable capture attempts
- add a regression test with an injected clipboard grabber that verifies unsupported models never access the clipboard

Closes #258.

## Testing

- `zig build`
- `zig build test --summary all` — 232/232 passed
- `zig fmt --check src/main.zig src/mcp.zig src/readline.zig build.zig`
- `bash scripts/check-zig-lines.sh`
- PTY regression: non-vision Ctrl-V shows `this model can't see images`, does not show the empty-clipboard message, and does not insert `[Image]`
- passed the JSON control/live-stream, spinner, REPL, Markdown, model-preference, stall/drop, blank-session persistence, and SDK smoke checks

## Existing CI context

Current `main` is already red ([run 29633443960](https://github.com/justrach/codegraff/actions/runs/29633443960)). Two broader output-cap scripts also fail locally against current `main` behavior (`test-pty-codex-ws.py` and `test-title-parallel.py`); both exercise Codex request limits and are unrelated to this readline-only change.
