### PR TITLE
fix: make parallel bash cancellation terminal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: PTY Markdown rendering test
         run: python3 scripts/test-pty-markdown.py zig-out/bin/graff
 
+      - name: Parallel bash Esc cancellation test (#266)
+        run: python3 scripts/test-pty-parallel-cancel.py zig-out/bin/graff
+
       - name: PTY model preference and fallback test
         run: python3 scripts/test-model-preference.py zig-out/bin/graff
 

--- a/scripts/test-pty-parallel-cancel.py
+++ b/scripts/test-pty-parallel-cancel.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Real-PTY regression for parallel bash interruption and process-group cleanup."""
+
+import http.server
+import json
+import os
+import shlex
+import socket
+import sys
+import tempfile
+import threading
+import time
+
+from pty_harness import PtySession
+
+
+_arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
+GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
+
+
+class ToolMock:
+    def __init__(self, commands: list[str]) -> None:
+        self.commands = commands
+        self.hits = 0
+        parent = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802
+                length = int(self.headers.get("content-length", 0))
+                if length:
+                    self.rfile.read(length)
+                parent.hits += 1
+                if parent.hits == 1:
+                    tool_calls = []
+                    for i, command in enumerate(parent.commands):
+                        tool_calls.append({
+                            "index": i,
+                            "id": f"cancel-{i}",
+                            "type": "function",
+                            "function": {
+                                "name": "bash",
+                                "arguments": json.dumps({"command": command}),
+                            },
+                        })
+                    chunk = {
+                        "choices": [{
+                            "delta": {"role": "assistant", "tool_calls": tool_calls},
+                            "finish_reason": "tool_calls",
+                        }]
+                    }
+                else:
+                    chunk = {
+                        "choices": [{
+                            "delta": {"role": "assistant", "content": "done"},
+                            "finish_reason": "stop",
+                        }]
+                    }
+                body = ("data: " + json.dumps(chunk) + "\n\ndata: [DONE]\n\n").encode()
+                self.send_response(200)
+                self.send_header("content-type", "text/event-stream")
+                self.send_header("content-length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self) -> None:  # noqa: N802
+                self.send_response(404)
+                self.end_headers()
+
+            def log_message(self, *_args) -> None:
+                pass
+
+        self.httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 1234), Handler)
+
+    def start(self) -> None:
+        threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
+
+    def stop(self) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+def wait_for_pid_files(session: PtySession, paths: list[str]) -> None:
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        session.pump(0.05)
+        if all(os.path.exists(path) and os.path.getsize(path) > 0 for path in paths):
+            return
+    raise AssertionError(f"parallel commands did not start: {paths}")
+
+
+def assert_processes_gone(paths: list[str]) -> None:
+    pids = [int(open(path, encoding="utf-8").read().strip()) for path in paths]
+    deadline = time.monotonic() + 2
+    alive = pids
+    while alive and time.monotonic() < deadline:
+        next_alive = []
+        for pid in alive:
+            try:
+                os.kill(pid, 0)
+                next_alive.append(pid)
+            except ProcessLookupError:
+                pass
+        alive = next_alive
+        if alive:
+            time.sleep(0.05)
+    if alive:
+        for pid in alive:
+            try:
+                os.kill(pid, 9)
+            except ProcessLookupError:
+                pass
+        raise AssertionError(f"cancelled command descendants survived: {alive}")
+
+
+def main() -> None:
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        probe.bind(("127.0.0.1", 1234))
+    except OSError:
+        print("skip  127.0.0.1:1234 is in use — parallel-cancel PTY test skipped")
+        return
+    finally:
+        probe.close()
+
+    with tempfile.TemporaryDirectory(prefix="graff-parallel-cancel-") as tmp:
+        harness = os.path.join(tmp, ".harness")
+        os.makedirs(harness, exist_ok=True)
+        with open(os.path.join(harness, "settings.json"), "w", encoding="utf-8") as fh:
+            json.dump({"ai_title": False}, fh)
+        pid_paths = [os.path.join(tmp, f"child-{i}.pid") for i in range(2)]
+        commands = [f"sleep 30 & echo $! > {shlex.quote(path)}; wait" for path in pid_paths]
+        mock = ToolMock(commands)
+        mock.start()
+        try:
+            env = {
+                "HOME": tmp,
+                "LMSTUDIO_API_KEY": "local-pty-test",
+                "GRAFF_FLEET": "off",
+                "GRAFF_NO_TELEMETRY": "1",
+            }
+            with PtySession(GRAFF, ["--model", "lmstudio", "--no-telemetry"], cwd=tmp, env=env, timeout=20) as session:
+                session.wait_for_literal("] ›")
+                session.send_line("/yolo")
+                session.wait_for_literal("yolo mode ON")
+                cursor = len(session.raw)
+                session.send_line("run both checks")
+                session.wait_for_literal("running 2 tools in parallel", start=cursor)
+                wait_for_pid_files(session, pid_paths)
+                session.send_key("esc")
+                session.wait_for_literal("[cancelled by user; local process group killed]", start=cursor)
+                session.wait_for_literal("parallel tools finished: 0 completed, 0 failed, 2 cancelled", start=cursor)
+                session.wait_for_literal("interrupted (esc)", start=cursor)
+                assert_processes_gone(pid_paths)
+                session.send_key("ctrl-d")
+                result = session.read_until_exit(5)
+                if result.timed_out or result.exit_code != 0:
+                    raise AssertionError(f"REPL exit={result.exit_code} timed_out={result.timed_out}")
+        finally:
+            mock.stop()
+    print("ok    parallel Esc reports terminal states and kills command descendants")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -466,10 +466,8 @@ pub const Agent = struct {
     pub const assembleAnthropic = @import("agent_steps.zig").assembleAnthropic;
     pub const assembleOpenAI = @import("agent_steps.zig").assembleOpenAI;
 
-    // Tool-call dispatch (runTools, the human-approval gate, meta-tool
-    // handling, tool-call/result UX lines) lives in agent_tools.zig (#123,
-    // 600-line goal). Member-aliased so self.runTools(...)/etc. resolve
-    // unchanged.
+    // Tool dispatch/gating and user-facing UX are split between
+    // agent_tools.zig and agent_tool_ui.zig; aliases keep call sites stable.
     pub const runTools = @import("agent_tools.zig").runTools;
     pub const rejectToolCall = @import("agent_tools.zig").rejectToolCall;
     pub const toolDedupeKey = @import("agent_tools.zig").toolDedupeKey;
@@ -477,10 +475,10 @@ pub const Agent = struct {
     pub const gateTool = @import("agent_tools.zig").gateTool;
     pub const firstWord = @import("agent_tools.zig").firstWord;
     pub const handleMeta = @import("agent_tools.zig").handleMeta;
-    pub const askUser = @import("agent_tools.zig").askUser;
-    pub const emitAskUser = @import("agent_tools.zig").emitAskUser;
-    pub const sayToolUse = @import("agent_tools.zig").sayToolUse;
-    pub const sayToolResult = @import("agent_tools.zig").sayToolResult;
+    pub const askUser = @import("agent_tool_ui.zig").askUser;
+    pub const emitAskUser = @import("agent_tool_ui.zig").emitAskUser;
+    pub const sayToolUse = @import("agent_tool_ui.zig").sayToolUse;
+    pub const sayToolResult = @import("agent_tool_ui.zig").sayToolResult;
     pub fn renderTodos(self: *Agent) []const u8 {
         if (self.todos.items.len == 0) return "(no todos)";
         var aw: Io.Writer.Allocating = .init(self.arena);

--- a/src/agent_tool_ui.zig
+++ b/src/agent_tool_ui.zig
@@ -1,0 +1,131 @@
+//! User-facing tool-call UX and ask_user handling, split from agent_tools.zig
+//! to keep the dispatcher focused and within the repository line limit.
+
+const std = @import("std");
+const Io = std.Io;
+const Value = std.json.Value;
+
+const main_mod = @import("main.zig");
+const Agent = @import("agent.zig").Agent;
+const tools = @import("tools.zig");
+const ToolCall = tools.ToolCall;
+const ExecResult = tools.ExecResult;
+const answerParseError = tools.answerParseError;
+const parseAnswerRequest = tools.parseAnswerRequest;
+const isMetaName = @import("schema.zig").isMetaName;
+const style = &@import("ansi.zig").style;
+
+/// The "user message as a tool" half of the loop: block for a typed reply and
+/// return it as the tool result. Only the root agent has stdin.
+pub fn askUser(self: *Agent, call: ToolCall) !ExecResult {
+    const in = self.in orelse return .{
+        .text = "no human is attached — make a reasonable assumption and continue",
+        .is_error = true,
+    };
+    const w = self.out.?;
+    const question = if (call.input.object.get("question")) |q| q.string else "(no question)";
+    if (main_mod.json_mode) {
+        const call_id = if (call.id.len > 0) call.id else blk: {
+            const id = try std.fmt.allocPrint(self.arena, "ask_user-{d}", .{self.next_ask_id});
+            self.next_ask_id += 1;
+            break :blk id;
+        };
+        try self.emitAskUser(call_id, question, call.input);
+        const raw = (try in.takeDelimiter('\n')) orelse return .{ .text = "user ended input without answering", .is_error = true };
+        const parsed = std.json.parseFromSliceLeaky(Value, self.arena, std.mem.trim(u8, raw, " \t\r"), .{ .allocate = .alloc_always }) catch return .{
+            .text = "invalid answer JSON for ask_user",
+            .is_error = true,
+        };
+        const answer = parseAnswerRequest(parsed, call_id) catch |err| return .{ .text = answerParseError(err), .is_error = true };
+        if (answer.cancelled) return .{ .text = "user cancelled the follow-up", .is_error = true };
+        return .{ .text = try self.arena.dupe(u8, answer.text), .is_error = false };
+    }
+    if (!self.argStreamedFully(call)) try w.print("\n❓ {s}\n", .{question});
+    if (call.input.object.get("options")) |opts| if (opts == .array) {
+        for (opts.array.items, 1..) |opt, n| try w.print("   {d}) {s}\n", .{ n, opt.string });
+    };
+    try w.writeAll("   your answer › ");
+    try w.flush();
+    const raw = (try in.takeDelimiter('\n')) orelse return .{ .text = "user ended input without answering", .is_error = true };
+    return .{ .text = try self.arena.dupe(u8, std.mem.trim(u8, raw, " \t\r")), .is_error = false };
+}
+
+pub fn emitAskUser(self: *Agent, call_id: []const u8, question: []const u8, input: Value) !void {
+    const w = self.out orelse return;
+    var s: std.json.Stringify = .{ .writer = w };
+    try s.beginObject();
+    try s.objectField("type");
+    try s.write("ask_user");
+    try s.objectField("call_id");
+    try s.write(call_id);
+    try s.objectField("question");
+    try s.write(question);
+    try s.objectField("input");
+    try s.write(input);
+    try s.endObject();
+    try w.writeByte('\n');
+    try w.flush();
+}
+
+pub fn sayToolUse(self: *Agent, call: ToolCall) !void {
+    if (main_mod.json_mode) {
+        if (std.mem.eql(u8, call.name, "ask_user")) return;
+        self.emit(.{ .type = "tool_call", .name = call.name, .input = call.input });
+        self.emit(.{ .type = "tool_call_started", .name = call.name, .input = call.input });
+        return;
+    }
+    if (self.argStreamedFully(call)) return;
+    var aw: Io.Writer.Allocating = .init(self.gpa);
+    defer aw.deinit();
+    var s: std.json.Stringify = .{ .writer = &aw.writer };
+    try s.write(call.input);
+    const full = aw.writer.buffered();
+    const shown = if (full.len > 160) full[0..160] else full;
+    try self.say("{s}⚙{s} {s}{s} {s}{s}{s}{s}\n", .{
+        style.dim,   style.reset, style.accent, call.name, style.dim, shown,
+        if (full.len > 160) "…" else "",
+        style.reset,
+    });
+}
+
+/// Compact result feedback for one finished tool call.
+pub fn sayToolResult(self: *Agent, name: []const u8, r: ExecResult) void {
+    const w = self.out orelse return;
+    if (main_mod.json_mode) {
+        if (isMetaName(name) and !std.mem.eql(u8, name, "ask_user")) return;
+        self.emit(.{ .type = "tool_result", .name = name, .is_error = r.is_error, .text = r.text });
+        self.emit(.{ .type = "tool_call_finished", .name = name, .is_error = r.is_error, .ms = r.ms });
+        return;
+    }
+    if (isMetaName(name)) return;
+    const all = std.mem.trim(u8, r.text, " \t\r\n");
+    var preview = all;
+    if (std.mem.indexOfScalar(u8, preview, '\n')) |nl| preview = preview[0..nl];
+    preview = std.mem.trim(u8, preview, " \t\r");
+    const shown = if (preview.len > 100) preview[0..100] else preview;
+    const mark = if (r.cancelled) "⊘" else if (r.is_error) "✗" else "✓";
+    const mc = if (r.cancelled) style.yellow else if (r.is_error) style.red else style.green;
+    var tbuf: [24]u8 = undefined;
+    const timing = if (main_mod.show_timing and r.ms > 0) (std.fmt.bufPrint(&tbuf, " ({d}ms)", .{r.ms}) catch "") else "";
+    w.print("  {s}{s}{s}{s}{s}{s} {s}{s}{s}{s}\n", .{
+        mc,          mark, style.reset, style.dim, timing, style.reset, style.dim, shown,
+        if (shown.len < all.len) "…" else "",
+        style.reset,
+    }) catch return;
+    w.flush() catch return;
+}
+
+/// One terminal line closes a parallel group so the UI cannot remain visually
+/// stuck on its earlier "running" state after every future has joined.
+pub fn sayParallelSummary(self: *Agent, indices: []const usize, results: []const ExecResult) void {
+    var completed: usize = 0;
+    var failed: usize = 0;
+    var cancelled: usize = 0;
+    for (indices) |i| {
+        if (results[i].cancelled) cancelled += 1 else if (results[i].is_error) failed += 1 else completed += 1;
+    }
+    if (main_mod.json_mode) return; // each JSON tool_result already carries its terminal text
+    self.say("  {s}↯ parallel tools finished: {d} completed, {d} failed, {d} cancelled{s}\n", .{
+        style.dim, completed, failed, cancelled, style.reset,
+    }) catch {};
+}

--- a/src/agent_tools.zig
+++ b/src/agent_tools.zig
@@ -3,7 +3,7 @@
 //! the human-approval gate for bash/write_file/edit_file/MCP calls
 //! (gateTool), meta-tool handling (attempt_completion/eval/todo_write/
 //! todo_read/ask_user, on the agent's own thread — handleMeta/askUser),
-//! and the tool-call/tool-result UX lines (sayToolUse/sayToolResult).
+//! Tool UX and ask_user handling live in agent_tool_ui.zig.
 //! Split out of the Agent struct (#123, 600-line goal).
 
 const std = @import("std");
@@ -15,10 +15,6 @@ const agent_mod = @import("agent.zig");
 const Agent = agent_mod.Agent;
 const ToolCall = tools_mod.ToolCall;
 const ExecResult = tools_mod.ExecResult;
-
-const AnswerRequest = tools_mod.AnswerRequest;
-const answerParseError = tools_mod.answerParseError;
-const parseAnswerRequest = tools_mod.parseAnswerRequest;
 
 const ansi = @import("ansi.zig");
 const style = &ansi.style;
@@ -41,6 +37,7 @@ const isMetaName = schema.isMetaName;
 const tools_mod = @import("tools.zig");
 const ToolCtx = tools_mod.ToolCtx;
 const ToolOutput = tools_mod.ToolOutput;
+const tool_ui = @import("agent_tool_ui.zig");
 
 const exec = @import("exec.zig");
 const execTool = exec.execTool;
@@ -156,11 +153,12 @@ pub fn runTools(self: *Agent, calls: []const ToolCall) ![]ExecResult {
             // Keep the model-facing history compact. The exact output remains
             // inspectable on disk and the short preview carries its pointer.
             const detail = persistToolResult(self, output.text);
-            results[i] = .{ .text = try toolPreviewText(self.arena, output.text, detail), .is_error = output.is_error, .ms = output.ms };
+            results[i] = .{ .text = try toolPreviewText(self.arena, output.text, detail), .is_error = output.is_error, .cancelled = output.cancelled, .ms = output.ms };
         }
     }
     // Show a compact ✓/✗ + preview for each non-meta call (no-op for subs).
     for (calls, results) |call, r| self.sayToolResult(call.name, r);
+    if (ext_idx.items.len > 1) tool_ui.sayParallelSummary(self, ext_idx.items, results);
     return results;
 }
 
@@ -441,128 +439,6 @@ pub fn handleMeta(self: *Agent, call: ToolCall) !ExecResult {
     if (std.mem.eql(u8, call.name, "ask_user")) return self.askUser(call);
     // todo_read
     return .{ .text = self.renderTodos(), .is_error = false };
-}
-
-/// The "user message as a tool" half of the loop: the agent calls
-/// ask_user, we block for a typed reply, and hand it back as the tool
-/// result. Only the root agent has stdin; subagents must self-decide.
-pub fn askUser(self: *Agent, call: ToolCall) !ExecResult {
-    const in = self.in orelse return .{
-        .text = "no human is attached — make a reasonable assumption and continue",
-        .is_error = true,
-    };
-    const w = self.out.?;
-    const question = if (call.input.object.get("question")) |q| q.string else "(no question)";
-    if (main_mod.json_mode) {
-        const call_id = if (call.id.len > 0) call.id else blk: {
-            const id = try std.fmt.allocPrint(self.arena, "ask_user-{d}", .{self.next_ask_id});
-            self.next_ask_id += 1;
-            break :blk id;
-        };
-        try self.emitAskUser(call_id, question, call.input);
-        const raw = (try in.takeDelimiter('\n')) orelse return .{
-            .text = "user ended input without answering",
-            .is_error = true,
-        };
-        const parsed = std.json.parseFromSliceLeaky(Value, self.arena, std.mem.trim(u8, raw, " \t\r"), .{ .allocate = .alloc_always }) catch return .{
-            .text = "invalid answer JSON for ask_user",
-            .is_error = true,
-        };
-        const answer = parseAnswerRequest(parsed, call_id) catch |err| return .{
-            .text = answerParseError(err),
-            .is_error = true,
-        };
-        if (answer.cancelled) return .{ .text = "user cancelled the follow-up", .is_error = true };
-        return .{ .text = try self.arena.dupe(u8, answer.text), .is_error = false };
-    }
-    // Skip the re-print only when the question streamed live in full.
-    if (!self.argStreamedFully(call)) try w.print("\n❓ {s}\n", .{question});
-    if (call.input.object.get("options")) |opts| if (opts == .array) {
-        for (opts.array.items, 1..) |opt, n| try w.print("   {d}) {s}\n", .{ n, opt.string });
-    };
-    try w.writeAll("   your answer › ");
-    try w.flush();
-
-    const raw = (try in.takeDelimiter('\n')) orelse return .{
-        .text = "user ended input without answering",
-        .is_error = true,
-    };
-    const answer = std.mem.trim(u8, raw, " \t\r");
-    return .{ .text = try self.arena.dupe(u8, answer), .is_error = false };
-}
-
-pub fn emitAskUser(self: *Agent, call_id: []const u8, question: []const u8, input: Value) !void {
-    const w = self.out orelse return;
-    var s: std.json.Stringify = .{ .writer = w };
-    try s.beginObject();
-    try s.objectField("type");
-    try s.write("ask_user");
-    try s.objectField("call_id");
-    try s.write(call_id);
-    try s.objectField("question");
-    try s.write(question);
-    try s.objectField("input");
-    try s.write(input);
-    try s.endObject();
-    try w.writeByte('\n');
-    try w.flush();
-}
-
-pub fn sayToolUse(self: *Agent, call: ToolCall) !void {
-    if (main_mod.json_mode) {
-        if (std.mem.eql(u8, call.name, "ask_user")) return;
-        self.emit(.{ .type = "tool_call", .name = call.name, .input = call.input });
-        self.emit(.{ .type = "tool_call_started", .name = call.name, .input = call.input });
-        return;
-    }
-    // The ⚙ line would just repeat prose that already streamed live.
-    if (self.argStreamedFully(call)) return;
-    var aw: Io.Writer.Allocating = .init(self.gpa);
-    defer aw.deinit();
-    var s: std.json.Stringify = .{ .writer = &aw.writer };
-    try s.write(call.input);
-    const full = aw.writer.buffered();
-    const shown = if (full.len > 160) full[0..160] else full;
-    try self.say("{s}⚙{s} {s}{s} {s}{s}{s}{s}\n", .{
-        style.dim,   style.reset, style.accent, call.name,
-        style.dim,   shown,
-        if (full.len > 160) "…" else "",
-        style.reset,
-    });
-}
-
-/// Compact result feedback for one finished tool call: a green ✓ / red ✗
-/// and a one-line preview of what it returned. Root only (subagents have
-/// no writer); meta tools render their own UX, so skip them.
-pub fn sayToolResult(self: *Agent, name: []const u8, r: ExecResult) void {
-    const w = self.out orelse return;
-    if (main_mod.json_mode) {
-        if (isMetaName(name) and !std.mem.eql(u8, name, "ask_user")) return;
-        self.emit(.{ .type = "tool_result", .name = name, .is_error = r.is_error, .text = r.text });
-        self.emit(.{ .type = "tool_call_finished", .name = name, .is_error = r.is_error, .ms = r.ms });
-        return;
-    }
-    if (isMetaName(name)) return;
-    const all = std.mem.trim(u8, r.text, " \t\r\n");
-    var preview = all;
-    if (std.mem.indexOfScalar(u8, preview, '\n')) |nl| preview = preview[0..nl];
-    preview = std.mem.trim(u8, preview, " \t\r");
-    const shown = if (preview.len > 100) preview[0..100] else preview;
-    const truncated = shown.len < all.len; // more content (extra lines or >100 chars)
-    const mark = if (r.is_error) "✗" else "✓";
-    const mc = if (r.is_error) style.red else style.green;
-    var tbuf: [24]u8 = undefined;
-    const timing = if (main_mod.show_timing and r.ms > 0)
-        (std.fmt.bufPrint(&tbuf, " ({d}ms)", .{r.ms}) catch "")
-    else
-        "";
-    w.print("  {s}{s}{s}{s}{s}{s} {s}{s}{s}{s}\n", .{
-        mc,          mark,  style.reset, style.dim, timing, style.reset,
-        style.dim,   shown,
-        if (truncated) "…" else "",
-        style.reset,
-    }) catch return;
-    w.flush() catch return;
 }
 
 test "firstWord: splits the command on the first whitespace" {

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -51,18 +51,44 @@ const spawnJob = jobs.spawnJob;
 const jobOutput = jobs.jobOutput;
 const jobKill = jobs.jobKill;
 const shellArgv = jobs.shellArgv;
+const isSshCommand = jobs.isSshCommand;
 const skills = @import("skills.zig");
 const input_util = @import("input_util.zig");
 const binaryFileExt = input_util.binaryFileExt;
 const hooks = @import("hooks.zig");
 const telemetry = @import("telemetry.zig");
 
-/// Wall-clock ceiling for one *subagent* bash command. Subagents run on pool
-/// threads with no TTY, so there is no Esc to kill a runaway command — without
-/// this, a codedb refusal that pushes a subagent onto an unfiltered `grep ~/`
-/// hangs the whole workflow for ~48 min (#93). The root keeps its Esc-only,
-/// no-deadline behavior (a human is watching and may want a long build).
+/// Every foreground shell has a deadline. SSH gets a shorter default because
+/// a dead connection otherwise looks identical to useful remote work.
 const subagent_bash_deadline_ms: u64 = 120 * 1000;
+const ssh_bash_deadline_ms: u64 = 120 * 1000;
+const root_bash_deadline_ms: u64 = 10 * 60 * 1000;
+const max_bash_deadline_ms: u64 = 60 * 60 * 1000;
+
+fn bashDeadline(input: Value, cmd: []const u8, from_sub: bool) !u64 {
+    if (input == .object) if (input.object.get("timeout_ms")) |v| {
+        if (v != .integer or v.integer < 1000 or v.integer > max_bash_deadline_ms) return error.InvalidBashTimeout;
+        return @intCast(v.integer);
+    };
+    if (from_sub) return subagent_bash_deadline_ms;
+    return if (isSshCommand(cmd)) ssh_bash_deadline_ms else root_bash_deadline_ms;
+}
+
+test "bash deadlines are bounded and SSH defaults shorter" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const empty = try std.json.parseFromSliceLeaky(Value, arena, "{}", .{});
+    try std.testing.expectEqual(root_bash_deadline_ms, try bashDeadline(empty, "zig build", false));
+    try std.testing.expectEqual(ssh_bash_deadline_ms, try bashDeadline(empty, "ssh host status", false));
+    try std.testing.expectEqual(subagent_bash_deadline_ms, try bashDeadline(empty, "zig build", true));
+    const explicit = try std.json.parseFromSliceLeaky(Value, arena, "{\"timeout_ms\":45000}", .{});
+    try std.testing.expectEqual(@as(u64, 45_000), try bashDeadline(explicit, "ssh host status", false));
+    inline for (.{ "{\"timeout_ms\":0}", "{\"timeout_ms\":999}", "{\"timeout_ms\":3600001}", "{\"timeout_ms\":\"soon\"}" }) |json| {
+        const invalid = try std.json.parseFromSliceLeaky(Value, arena, json, .{});
+        try std.testing.expectError(error.InvalidBashTimeout, bashDeadline(invalid, "sleep 1", false));
+    }
+}
 
 /// Runs on a pool thread; never throws — failures become is_error results.
 /// Every execution is timed (out.ms) and traced.
@@ -144,10 +170,19 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
                     try std.fmt.allocPrint(gpa, "could not start background job ({t}) — run it in the foreground instead", .{err}),
                 .is_error = true,
             };
-            return .{ .text = try std.fmt.allocPrint(gpa, "[job {d} started: {s}]\nIt keeps running across turns. Poll new output with bash_output (id {d}, optional wait_ms), stop it with bash_kill.", .{ job.id, job.cmd, job.id }) };
+            return .{ .text = try std.fmt.allocPrint(gpa, "[job {d} started: {s}]\nIt keeps running across turns. Poll new output with bash_output (id {d}, optional wait_ms), stop it with bash_kill.{s}", .{
+                job.id,
+                job.cmd,
+                job.id,
+                if (isSshCommand(cmd)) " Killing the local SSH job cannot prove a detached remote process stopped; verify the remote host." else "",
+            }) };
         }
+        const deadline_ms = bashDeadline(input, cmd, ctx.from_sub) catch return .{
+            .text = try gpa.dupe(u8, "timeout_ms must be an integer from 1000 to 3600000"),
+            .is_error = true,
+        };
         const sh = shellArgv(cmd);
-        const run = try runCapped(gpa, io, &sh, bash_stdout_cap, bash_stderr_cap, if (ctx.from_sub) subagent_bash_deadline_ms else 0);
+        const run = try runCapped(gpa, io, &sh, bash_stdout_cap, bash_stderr_cap, deadline_ms);
         defer gpa.free(run.stdout);
         defer gpa.free(run.stderr);
 
@@ -162,13 +197,23 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
         if (run.stdout_truncated) try w.print("\n[stdout truncated at {d} KB]", .{bash_stdout_cap / 1024});
         if (run.stderr.len > 0) try w.print("\n[stderr]\n{s}", .{run.stderr});
         if (run.stderr_truncated) try w.print("\n[stderr truncated at {d} KB]", .{bash_stderr_cap / 1024});
-        if (run.timed_out) {
-            try w.print("\n[timed out after {d}s and was killed — too long for a subagent. Don't retry as-is: scope it to specific paths or globs instead of scanning the whole directory, or report back what you need run.]", .{subagent_bash_deadline_ms / 1000});
+        if (run.cancelled) {
+            try w.writeAll("\n[cancelled by user; local process group killed]");
+        } else if (run.timed_out) {
+            try w.print("\n[timed out after {d} ms; local process group killed]", .{deadline_ms});
+            if (ctx.from_sub) try w.writeAll(" Don't retry as-is: scope the command to specific paths or globs.");
         } else if (exit_code) |code| {
             if (code != 0) try w.print("\n[exit code {d}]", .{code});
         } else try w.writeAll("\n[terminated abnormally]");
+        if ((run.cancelled or run.timed_out) and isSshCommand(cmd)) {
+            try w.writeAll("\n[ssh note: the local SSH client was terminated, but a detached or disconnect-resistant remote process may survive; verify it on the remote host]");
+        }
         if (run.stdout.len == 0 and run.stderr.len == 0 and exit_code == 0) try w.writeAll("(no output)");
-        return .{ .text = try aw.toOwnedSlice(), .is_error = exit_code == null or exit_code.? != 0 };
+        return .{
+            .text = try aw.toOwnedSlice(),
+            .is_error = run.cancelled or run.timed_out or exit_code == null or exit_code.? != 0,
+            .cancelled = run.cancelled,
+        };
     }
     if (std.mem.eql(u8, call.name, "bash_output")) {
         const id = intField(input, "id") orelse return missingArg(gpa, "id");

--- a/src/jobs.zig
+++ b/src/jobs.zig
@@ -1,9 +1,5 @@
-//! Subprocess execution: the capped-output runner (runCapped), git-worktree
-//! management (`graff worktree` add/merge/remove + the -w auto-checkpoint
-//! commits), and the background bash-job pool (spawn/output/kill/reap). Split
-//! out of main.zig (600-line goal). Back-imports main for ToolOutput (the job
-//! tools' result shape). main re-exports runCapped (hooks.zig back-imports it)
-//! and aliases the worktree + job entry points back.
+//! Capped subprocess execution, git-worktree management, and background bash
+//! jobs. Split from main.zig to keep process lifecycle logic together.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -29,27 +25,19 @@ const CappedRun = struct {
     stdout_truncated: bool,
     stderr_truncated: bool,
     timed_out: bool,
+    cancelled: bool,
 };
 
-/// Like `std.process.run`, but hitting an output cap *truncates* instead of
-/// failing the call: the first `cap` bytes are kept, the rest is discarded
-/// as it streams (retained memory never exceeds the caps), and the child
-/// still runs to completion so its exit code is real. A chatty `python`
-/// (or an accidental `cat` of something huge) costs the child's own
-/// process memory, never the harness's.
-///
-/// `deadline_ms` is a wall-clock kill switch: 0 means "no deadline" (the
-/// root's Esc is the only stop), non-zero kills the child once it has run
-/// that long and reports `timed_out`. Subagents pass a real deadline since
-/// they have no Esc (#93).
+/// Capture capped output; a deadline or root Esc terminates the process group.
 pub fn runCapped(gpa: Allocator, io: Io, argv: []const []const u8, stdout_cap: usize, stderr_cap: usize, deadline_ms: u64) !CappedRun {
     var child = try std.process.spawn(io, .{
         .argv = argv,
+        .pgid = if (builtin.os.tag == .windows) null else 0,
         .stdin = .ignore,
         .stdout = .pipe,
         .stderr = .pipe,
     });
-    defer child.kill(io);
+    defer killChildTree(&child, io);
 
     var multi_reader_buffer: Io.File.MultiReader.Buffer(2) = undefined;
     var multi_reader: Io.File.MultiReader = undefined;
@@ -82,12 +70,12 @@ pub fn runCapped(gpa: Allocator, io: Io, argv: []const []const u8, stdout_cap: u
         }
         if (Agent.esc_cancel.load(.acquire)) {
             esc_killed = true;
-            child.kill(io);
+            killChildTree(&child, io);
             break :loop;
         }
         if (deadline_ms > 0 and t0.untilNow(io, .awake).toMilliseconds() >= deadline_ms) {
             timed_out = true;
-            child.kill(io);
+            killChildTree(&child, io);
             break :loop;
         }
     }
@@ -105,7 +93,18 @@ pub fn runCapped(gpa: Allocator, io: Io, argv: []const []const u8, stdout_cap: u
         .stdout_truncated = saved[0] != null,
         .stderr_truncated = saved[1] != null,
         .timed_out = timed_out,
+        .cancelled = esc_killed,
     };
+}
+
+/// Shell commands use their own POSIX process group so cancelling /bin/sh also
+/// terminates grandchildren such as ssh. Windows currently falls back to the
+/// direct child until job-object support is added.
+fn killChildTree(child: *std.process.Child, io: Io) void {
+    if (builtin.os.tag != .windows) {
+        if (child.id) |pid| std.posix.kill(-pid, .KILL) catch {};
+    }
+    child.kill(io);
 }
 
 /// True if a CappedRun child exited cleanly (status 0).
@@ -315,6 +314,7 @@ const Job = struct {
     exit_code: ?u8 = null, // meaningful once done
     done: bool = false,
     killed: bool = false, // ended via bash_kill rather than naturally
+    remote_ssh: bool = false, // local kill cannot prove the remote command ended
     kill_requested: bool = false, // pump notices within one 200ms tick
     dropped: bool = false, // unread output overflowed job_unread_cap
     future: Io.Future(void) = undefined, // the pump; awaited only by jobsReap
@@ -382,7 +382,7 @@ fn jobPump(job: *Job, gpa: Allocator, io: Io) void {
     g_jobs.mutex.unlock(io);
     var code: ?u8 = null;
     if (killed) {
-        job.child.kill(io); // also reaps (wait would assert afterwards)
+        killChildTree(&job.child, io); // also reaps (wait would assert afterwards)
     } else if (job.child.wait(io)) |term| {
         code = switch (term) {
             .exited => |c| c,
@@ -406,6 +406,12 @@ pub fn shellArgv(cmd: []const u8) [3][]const u8 {
         .{ "/bin/sh", "-c", cmd };
 }
 
+pub fn isSshCommand(cmd: []const u8) bool {
+    var it = std.mem.tokenizeAny(u8, cmd, " \t\r\n");
+    const first = it.next() orelse return false;
+    return std.mem.eql(u8, std.fs.path.basename(first), "ssh");
+}
+
 /// Spawn a background job and its pump. Uses io.concurrent (NOT io.async,
 /// which may run inline and block this tool forever on a long-lived child);
 /// no spare concurrency cleans up and surfaces the error to the model.
@@ -413,20 +419,21 @@ pub fn spawnJob(gpa: Allocator, io: Io, cmd: []const u8) !*Job {
     const argv = shellArgv(cmd);
     var child = try std.process.spawn(io, .{
         .argv = &argv,
+        .pgid = if (builtin.os.tag == .windows) null else 0,
         .stdin = .ignore,
         .stdout = .pipe,
         .stderr = .pipe,
     });
     const cmd_copy = gpa.dupe(u8, cmd) catch |e| {
-        child.kill(io);
+        killChildTree(&child, io);
         return e;
     };
     const job = gpa.create(Job) catch |e| {
         gpa.free(cmd_copy);
-        child.kill(io);
+        killChildTree(&child, io);
         return e;
     };
-    job.* = .{ .id = 0, .cmd = cmd_copy, .child = child };
+    job.* = .{ .id = 0, .cmd = cmd_copy, .child = child, .remote_ssh = isSshCommand(cmd) };
     g_jobs.mutex.lockUncancelable(io);
     job.id = g_jobs.next_id;
     g_jobs.next_id += 1;
@@ -436,7 +443,7 @@ pub fn spawnJob(gpa: Allocator, io: Io, cmd: []const u8) !*Job {
     };
     g_jobs.mutex.unlock(io);
     if (!appended) {
-        job.child.kill(io);
+        killChildTree(&job.child, io);
         gpa.free(job.cmd);
         gpa.destroy(job);
         return error.OutOfMemory;
@@ -450,7 +457,7 @@ pub fn spawnJob(gpa: Allocator, io: Io, cmd: []const u8) !*Job {
             }
         }
         g_jobs.mutex.unlock(io);
-        job.child.kill(io);
+        killChildTree(&job.child, io);
         gpa.free(job.cmd);
         gpa.destroy(job);
         return e;
@@ -477,7 +484,7 @@ pub fn jobOutput(gpa: Allocator, io: Io, id: u32, wait_ms: u64) !ToolOutput {
             if (!job.done) {
                 try w.print("[job {d}: running]", .{id});
             } else if (job.killed) {
-                try w.print("[job {d}: killed]", .{id});
+                try w.print("[job {d}: killed locally{s}]", .{ id, if (job.remote_ssh) "; remote SSH process status unknown" else "" });
             } else if (job.exit_code) |c| {
                 try w.print("[job {d}: exited with code {d}]", .{ id, c });
             } else {
@@ -493,9 +500,10 @@ pub fn jobOutput(gpa: Allocator, io: Io, id: u32, wait_ms: u64) !ToolOutput {
             } else {
                 try w.writeAll("\n(no new output)");
             }
+            const is_error = job.done and (job.killed or job.exit_code == null or job.exit_code.? != 0);
             job.cursor = job.buf.items.len;
             g_jobs.mutex.unlock(io);
-            return .{ .text = try aw.toOwnedSlice() };
+            return .{ .text = try aw.toOwnedSlice(), .is_error = is_error };
         }
         g_jobs.mutex.unlock(io);
         if (Agent.esc_cancel.load(.acquire)) {
@@ -520,7 +528,7 @@ pub fn jobKill(gpa: Allocator, io: Io, id: u32) !ToolOutput {
         const job = g_jobs.find(id) orelse return .{ .text = try std.fmt.allocPrint(gpa, "no background job {d} — /jobs lists them", .{id}), .is_error = true };
         if (job.done) {
             const unread = job.buf.items.len - job.cursor;
-            return .{ .text = try std.fmt.allocPrint(gpa, "job {d} already finished ({d} unread byte(s) — bash_output reads them)", .{ id, unread }) };
+            return .{ .text = try std.fmt.allocPrint(gpa, "job {d} already finished (killed={any}, exit_code={any}; {d} unread byte(s) — bash_output reads them)", .{ id, job.killed, job.exit_code, unread }) };
         }
         job.kill_requested = true;
     }
@@ -533,13 +541,42 @@ pub fn jobKill(gpa: Allocator, io: Io, id: u32) !ToolOutput {
         if (done) {
             g_jobs.mutex.lockUncancelable(io);
             defer g_jobs.mutex.unlock(io);
-            const unread = if (g_jobs.find(id)) |job| job.buf.items.len - job.cursor else 0;
-            return .{ .text = try std.fmt.allocPrint(gpa, "job {d} killed ({d} unread byte(s) — bash_output reads them)", .{ id, unread }) };
+            const found = g_jobs.find(id);
+            const unread = if (found) |job| job.buf.items.len - job.cursor else 0;
+            const remote_ssh = if (found) |job| job.remote_ssh else false;
+            return .{ .text = try std.fmt.allocPrint(gpa, "job {d} local process group killed ({d} unread byte(s) — bash_output reads them){s}", .{
+                id,
+                unread,
+                if (remote_ssh) "; the remote SSH process may survive a disconnect, so verify it on the remote host" else "",
+            }) };
         }
         io.sleep(.fromMilliseconds(100), .awake) catch break;
         waited += 100;
     }
     return .{ .text = try std.fmt.allocPrint(gpa, "job {d}: kill requested (still shutting down — check bash_output)", .{id}) };
+}
+
+test "isSshCommand recognizes direct ssh executables" {
+    try std.testing.expect(isSshCommand("ssh host command"));
+    try std.testing.expect(isSshCommand("  /usr/bin/ssh host"));
+    try std.testing.expect(!isSshCommand("printf ssh"));
+}
+
+test "runCapped distinguishes timeout from user cancellation" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const timeout = try runCapped(std.testing.allocator, std.testing.io, &.{ "/bin/sh", "-c", "sleep 5 & wait" }, 1024, 1024, 50);
+    defer std.testing.allocator.free(timeout.stdout);
+    defer std.testing.allocator.free(timeout.stderr);
+    try std.testing.expect(timeout.timed_out);
+    try std.testing.expect(!timeout.cancelled);
+
+    Agent.esc_cancel.store(true, .release);
+    defer Agent.esc_cancel.store(false, .release);
+    const cancelled = try runCapped(std.testing.allocator, std.testing.io, &.{ "/bin/sh", "-c", "sleep 5 & wait" }, 1024, 1024, 0);
+    defer std.testing.allocator.free(cancelled.stdout);
+    defer std.testing.allocator.free(cancelled.stderr);
+    try std.testing.expect(cancelled.cancelled);
+    try std.testing.expect(!cancelled.timed_out);
 }
 
 /// Session end: kill every job, await the pumps (sole owner of the futures),

--- a/src/schema.zig
+++ b/src/schema.zig
@@ -98,9 +98,9 @@ const empty_schema =
 const base_specs = [_]ToolSpec{
     .{
         .name = "bash",
-        .desc = "Run a shell command via /bin/sh -c in the current working directory. Returns stdout, stderr, and the exit code. For long-running commands (dev servers, watchers) set run_in_background true: it returns a job id immediately; poll output with bash_output and stop it with bash_kill.",
+        .desc = "Run a shell command via /bin/sh -c in the current working directory. Returns stdout, stderr, and terminal status. Foreground commands have a wall-clock timeout (10 minutes by default, 2 minutes for SSH); override with timeout_ms. Esc cancels the local process group, but an SSH remote process may survive a disconnect. For long-running commands set run_in_background true: it returns a job id for bash_output/bash_kill.",
         .schema =
-        \\{"type": "object", "properties": {"command": {"type": "string", "description": "Shell command to execute"}, "run_in_background": {"type": "boolean", "description": "Start as a background job and return its id immediately instead of waiting (default false)"}}, "required": ["command"]}
+        \\{"type": "object", "properties": {"command": {"type": "string", "description": "Shell command to execute"}, "timeout_ms": {"type": "integer", "minimum": 1000, "maximum": 3600000, "description": "Foreground wall-clock timeout in milliseconds (default 600000, or 120000 for SSH/subagents)"}, "run_in_background": {"type": "boolean", "description": "Start as a background job and return its id immediately instead of waiting (default false); timeout_ms does not apply"}}, "required": ["command"]}
         ,
     },
     .{

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -30,6 +30,7 @@ pub const ToolCall = struct {
 pub const ExecResult = struct {
     text: []const u8,
     is_error: bool,
+    cancelled: bool = false,
     ms: i64 = 0, // wall-clock of the tool exec (external tools only; --timing)
 };
 
@@ -75,6 +76,7 @@ const run_budget_mod = @import("run_budget.zig");
 pub const ToolOutput = struct {
     text: []u8 = &.{}, // gpa-owned
     is_error: bool = false,
+    cancelled: bool = false,
     ms: i64 = 0, // set by execTool
 };
 


### PR DESCRIPTION
## Summary

- give every foreground bash call a bounded wall-clock deadline: 10 minutes by default, 2 minutes for direct SSH and subagents, with a validated timeout_ms override
- launch shell commands in their own POSIX process group so Esc, timeout, bash_kill, and session cleanup terminate descendants such as ssh rather than only /bin/sh
- report cancelled, timed out, exited, killed, and abnormal terminal states explicitly
- explain that killing a local SSH client cannot prove a detached or disconnect-resistant remote process stopped
- close parallel UI groups with completed/failed/cancelled counts
- retain explicit IDs and stronger terminal states for background jobs
- add a real PTY regression that starts two child processes, interrupts the group, and proves neither descendant survives

## Validation

- zig build test --summary all: 247/247
- zig build
- zig build -Dtarget=x86_64-windows
- all JSON, PTY, transport, title, stall/drop, and newer-issue CI scripts
- SDK generation drift clean
- new parallel Esc PTY regression passes

## Stack

This PR is intentionally based on the branch for #264 because current main has pre-existing failing Responses expectation tests. Once #264 lands, the base can move to main without changing this patch.

Closes #266