### PR TITLE
release/v0.0.217: ultracode shape catalog, MAP-Elites slot axis, provider-routing fix

### DIFF
--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -109,7 +109,7 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
     // ~1-2KB) are scratch (#124); only the token itself is duped to survive
     // future requests.
     if (self.provider.source == .login) {
-        if (oauth.refreshOAuthKey(self.io, self.gpa, self.scratchAlloc(), self.home, self.provider.id, false)) |fresh| {
+        if (oauth.refreshOAuthKey(self.io, self.gpa, self.scratchAlloc(), self.home, self.provider.id, false, null)) |fresh| {
             self.provider.api_key = self.arena.dupe(u8, fresh) catch self.provider.api_key;
         }
     }
@@ -417,7 +417,7 @@ pub fn request(self: *Agent, tools: ?[]const u8) !std.json.ObjectMap {
             // invalid/expired"; force a refresh and retry once (kimi-code's
             // buildAuth(true)). Give up only if the fresh token also fails.
             if (!auth_refreshed and self.provider.source == .login and isAuthError(msg)) {
-                if (oauth.refreshOAuthKey(self.io, self.gpa, self.scratchAlloc(), self.home, self.provider.id, true)) |fresh| {
+                if (oauth.refreshOAuthKey(self.io, self.gpa, self.scratchAlloc(), self.home, self.provider.id, true, self.provider.api_key)) |fresh| {
                     auth_refreshed = true;
                     // #124: dupe off the scratch refresh internals — the key must
                     // survive every later request of the session.

--- a/src/main.zig
+++ b/src/main.zig
@@ -591,4 +591,7 @@ const exec = @import("exec.zig");
 test { // pull in tests from imported modules (mcp.zig)
     _ = mcp;
     _ = @import("main_test.zig");
+    // A module referenced only from a test file is NOT analyzed otherwise, so
+    // its tests silently compile to nothing and the suite still reports green.
+    _ = @import("scoring_slot_test.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -591,4 +591,8 @@ const exec = @import("exec.zig");
 test { // pull in tests from imported modules (mcp.zig)
     _ = mcp;
     _ = @import("main_test.zig");
+    // readline.zig imports HistoryNav, but a type-only reference is not enough to
+    // pull the module's own `test {}` blocks into the binary — without this line
+    // its two tests silently compile to nothing and the suite still reports green.
+    _ = @import("readline_history.zig");
 }

--- a/src/oauth.zig
+++ b/src/oauth.zig
@@ -325,14 +325,39 @@ pub fn kimiLogin(io: Io, gpa: Allocator, arena: Allocator, home: []const u8) !vo
     try out.flush();
 }
 
+/// #245 single-flight guard: has the token that just 401'd already been replaced
+/// on disk by another concurrent refresher?
+///
+/// `force` means "the access token I was holding just failed with a 401". The
+/// refresh mutex serializes concurrent refreshers but does NOT dedupe them, so a
+/// fleet of subagents that all 401 on the same expired token would each re-mint
+/// in turn. Kimi (and xAI) rotate refresh tokens and INVALIDATE the superseded
+/// access token, so refresher N+1 kills the token refresher N just adopted — the
+/// 401 cascade that wipes out a whole fleet.
+///
+/// If the on-disk token already differs from the one that failed, the 401 was
+/// about the OLD token and somebody else has already done the work: adopt theirs
+/// instead of minting another. `stale == null` keeps the previous behaviour for
+/// callers that cannot say which token failed.
+fn supersededToken(force: bool, on_disk: []const u8, stale: ?[]const u8) bool {
+    if (!force) return false;
+    const failed = stale orelse return false;
+    return !std.mem.eql(u8, on_disk, failed);
+}
+
 /// Reads the stored Kimi OAuth access token, refreshing it in place when within
 /// 60s of expiry. Returns null if not logged in. Mirrors loadCodexAuth.
-pub fn loadKimiOAuth(io: Io, gpa: Allocator, arena: Allocator, home: []const u8, force: bool) ?[]const u8 {
+/// `stale` is the token that just 401'd (null when not recovering from one) —
+/// see supersededToken.
+pub fn loadKimiOAuth(io: Io, gpa: Allocator, arena: Allocator, home: []const u8, force: bool, stale: ?[]const u8) ?[]const u8 {
     const data = Io.Dir.cwd().readFileAlloc(io, kimiAuthPath(arena, home), arena, .limited(64 * 1024)) catch return null;
     const v = std.json.parseFromSliceLeaky(Value, arena, data, .{ .allocate = .alloc_always }) catch return null;
     if (v != .object) return null;
     const access = strFieldObj(v.object, "access_token") orelse return null;
     const expires_at: i64 = if (v.object.get("expires_at")) |e| (if (e == .integer) e.integer else 0) else 0;
+    // #245: another concurrent refresher may already have replaced the token that
+    // 401'd; re-minting would rotate-kill theirs. Adopt what is on disk instead.
+    if (supersededToken(force, access, stale)) return access;
     if (force or (expires_at != 0 and @divTrunc(unixMs(io), 1000) >= expires_at - oauth_refresh_margin_s)) {
         if (strFieldObj(v.object, "refresh_token")) |refresh| {
             const body = std.fmt.allocPrint(arena, "client_id={s}&grant_type=refresh_token&refresh_token={s}", .{ kimi_client_id, refresh }) catch return access;
@@ -354,13 +379,13 @@ pub fn loadKimiOAuth(io: Io, gpa: Allocator, arena: Allocator, home: []const u8,
 /// e.g. after a 401). Returns null for providers with no auto-refresh flow
 /// (env keys, and the long-lived codex/codegraff tokens), so the caller keeps
 /// the key it has. Mutex-guarded so concurrent subagents don't double-refresh.
-pub fn refreshOAuthKey(io: Io, gpa: Allocator, arena: Allocator, home: []const u8, provider_id: []const u8, force: bool) ?[]const u8 {
+pub fn refreshOAuthKey(io: Io, gpa: Allocator, arena: Allocator, home: []const u8, provider_id: []const u8, force: bool, stale: ?[]const u8) ?[]const u8 {
     const is_kimi = std.mem.eql(u8, provider_id, "kimi");
     const is_xai = std.mem.eql(u8, provider_id, "xai");
     if (!is_kimi and !is_xai) return null;
     oauth_refresh_mutex.lockUncancelable(io);
     defer oauth_refresh_mutex.unlock(io);
-    return if (is_kimi) loadKimiOAuth(io, gpa, arena, home, force) else loadXaiOAuth(io, gpa, arena, home, force);
+    return if (is_kimi) loadKimiOAuth(io, gpa, arena, home, force, stale) else loadXaiOAuth(io, gpa, arena, home, force, stale);
 }
 
 // xAI (Grok) OAuth — device-code flow against auth.x.ai. The OIDC discovery
@@ -486,12 +511,15 @@ pub fn xaiLogin(io: Io, gpa: Allocator, arena: Allocator, home: []const u8) !voi
 
 /// Reads the stored xAI OAuth access token, refreshing in place near expiry.
 /// Returns null if not logged in. Mirrors loadKimiOAuth.
-pub fn loadXaiOAuth(io: Io, gpa: Allocator, arena: Allocator, home: []const u8, force: bool) ?[]const u8 {
+pub fn loadXaiOAuth(io: Io, gpa: Allocator, arena: Allocator, home: []const u8, force: bool, stale: ?[]const u8) ?[]const u8 {
     const data = Io.Dir.cwd().readFileAlloc(io, xaiAuthPath(arena, home), arena, .limited(64 * 1024)) catch return null;
     const v = std.json.parseFromSliceLeaky(Value, arena, data, .{ .allocate = .alloc_always }) catch return null;
     if (v != .object) return null;
     const access = strFieldObj(v.object, "access_token") orelse return null;
     const expires_at: i64 = if (v.object.get("expires_at")) |e| (if (e == .integer) e.integer else 0) else 0;
+    // #245: another concurrent refresher may already have replaced the token that
+    // 401'd; re-minting would rotate-kill theirs. Adopt what is on disk instead.
+    if (supersededToken(force, access, stale)) return access;
     if (force or (expires_at != 0 and @divTrunc(unixMs(io), 1000) >= expires_at - oauth_refresh_margin_s)) {
         if (strFieldObj(v.object, "refresh_token")) |refresh| {
             const body = std.fmt.allocPrint(arena, "client_id={s}&grant_type=refresh_token&refresh_token={s}", .{ xai_client_id, refresh }) catch return access;
@@ -537,4 +565,27 @@ test "accountFromIdToken: extracts chatgpt_account_id from a JWT payload" {
     try std.testing.expectEqualStrings("acc_test_123", accountFromIdToken(a, token));
     try std.testing.expectEqualStrings("", accountFromIdToken(a, "not-a-jwt")); // no payload segment
     try std.testing.expectEqualStrings("", accountFromIdToken(a, "a.b.c")); // payload not valid base64/json
+}
+
+test "supersededToken (#245): a concurrent refresher's token is adopted, not re-minted" {
+    const failed = "access-token-A";
+    const replaced = "access-token-B";
+
+    // The proactive (near-expiry) path never short-circuits — it is not recovering
+    // from a 401, so there is no "failed token" to compare against.
+    try std.testing.expect(!supersededToken(false, failed, failed));
+    try std.testing.expect(!supersededToken(false, replaced, failed));
+
+    // Recovering from a 401 while the on-disk token is STILL the one that failed:
+    // nobody else has refreshed, so this caller must do it.
+    try std.testing.expect(!supersededToken(true, failed, failed));
+
+    // Recovering from a 401 but disk already holds a DIFFERENT token: another child
+    // won the race. Re-minting here would rotate-kill their token and cascade the
+    // 401s across the fleet, which is the whole bug.
+    try std.testing.expect(supersededToken(true, replaced, failed));
+
+    // A caller that cannot say which token failed keeps the old behaviour.
+    try std.testing.expect(!supersededToken(true, replaced, null));
+    try std.testing.expect(!supersededToken(false, replaced, null));
 }

--- a/src/picker_auth.zig
+++ b/src/picker_auth.zig
@@ -47,12 +47,12 @@ pub fn reloadLoginKey(root: *Agent, keys: *Keys, arena: Allocator, provider_id: 
                 source.* = .login;
             }
         } else if (std.mem.eql(u8, provider_id, "kimi")) {
-            if (oauth.loadKimiOAuth(root.io, root.gpa, arena, home, false)) |k| {
+            if (oauth.loadKimiOAuth(root.io, root.gpa, arena, home, false, null)) |k| {
                 value.* = k;
                 source.* = .login;
             }
         } else if (std.mem.eql(u8, provider_id, "xai")) {
-            if (oauth.loadXaiOAuth(root.io, root.gpa, arena, home, false)) |k| {
+            if (oauth.loadXaiOAuth(root.io, root.gpa, arena, home, false, null)) |k| {
                 value.* = k;
                 source.* = .login;
             }

--- a/src/pickers.zig
+++ b/src/pickers.zig
@@ -25,6 +25,7 @@ const Keys = provider_mod.Keys;
 const command_catalog = @import("command_catalog.zig");
 const picker_auth = @import("picker_auth.zig");
 const util = @import("util.zig");
+const shapes = @import("shapes.zig");
 
 /// Case-insensitive subsequence match (fzf-style): every char of `needle`
 /// appears in `hay` in order, gaps allowed — so "gpt5.5" matches "gpt-5.5".
@@ -402,27 +403,31 @@ pub const UltracodeMessage = struct {
     explicit: bool,
 };
 
-const ultracode_explicit_note =
+const ultracode_explicit_head =
     \\[harness note: the user invoked the "ultracode" codeword, opting
     \\this turn into multi-agent orchestration. Fulfill the request with
-    \\the workflow tool: decompose it into sequential phases of parallel
-    \\subagents — fan out for coverage first, then a synthesis phase.
+    \\the workflow tool.
     \\Tell code-exploration subagents to go through the repo with the
     \\codedb tool (search / symbol / callers / outline / context) before
     \\reaching for bash grep — it is indexed and structural.
     \\Use the workflow even if you could do the work solo; skip it only
-    \\if the message needs a purely conversational reply.]
+    \\if the message needs a purely conversational reply.
 ;
 
-const ultracode_persistent_note =
+const ultracode_persistent_head =
     \\[harness note: ultracode mode is enabled for this session. Use the
-    \\workflow tool for coding tasks: decompose the work into sequential
-    \\phases with parallel subagents for exploration/review where helpful,
-    \\then synthesize and implement. Tell code-exploration subagents to go
+    \\workflow tool for coding tasks. Tell code-exploration subagents to go
     \\through the repo with the codedb tool (search / symbol / callers /
     \\outline / context) before reaching for bash grep — it is indexed and
-    \\structural.]
+    \\structural.
 ;
+
+// Both steering notes carry the shape catalog (#293), so an ultracode turn
+// instantiates one of the five known shapes under canonical slot names instead
+// of inventing a fresh structure each run — scores from differently-shaped runs
+// are not comparable, which is what kept the fleet from accruing real fitness.
+const ultracode_explicit_note = ultracode_explicit_head ++ "\n\n" ++ shapes.shape_catalog_note ++ "]";
+const ultracode_persistent_note = ultracode_persistent_head ++ "\n\n" ++ shapes.shape_catalog_note ++ "]";
 
 /// `raw` is what the user actually typed this turn; `msg` is the assembled
 /// turn message (goal/eval/loop/plan notes may already be appended). The
@@ -578,4 +583,14 @@ test "applyUltracodeSteering handles explicit and persistent modes" {
     try std.testing.expect(explicit.explicit);
     try std.testing.expect(std.mem.indexOf(u8, explicit.text, "user invoked the \"ultracode\" codeword") != null);
     try std.testing.expect(std.mem.indexOf(u8, explicit.text, "ultracode mode is enabled") == null);
+
+    // #293: BOTH steering paths must carry the shape catalog — a turn steered
+    // into orchestration without it is exactly the free-form case the catalog
+    // exists to remove. Check a slot word and the closing bracket, so a broken
+    // concatenation (dropped catalog, or a note left unterminated) fails here.
+    for ([_][]const u8{ explicit.text, persistent.text }) |steered| {
+        try std.testing.expect(std.mem.indexOf(u8, steered, "Pick ONE shape") != null);
+        try std.testing.expect(std.mem.indexOf(u8, steered, "synthesize") != null);
+        try std.testing.expect(std.mem.endsWith(u8, steered, "]"));
+    }
 }

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -146,6 +146,22 @@ pub const Provider = struct {
     }
 };
 
+/// The catalogued provider ids that serve `model`, in spec order, written into
+/// `buf`. Lets a caller turn a bare MissingKey into a message naming the login
+/// that actually needs repair (#294) — "codex has no credential" rather than
+/// the old "see /models", which sent people looking at the wrong thing after an
+/// expired ~/.codex/auth.json silently rerouted them to the gateway.
+pub fn catalogProvidersFor(buf: [][]const u8, model: []const u8) [][]const u8 {
+    var n: usize = 0;
+    for (provider_specs) |spec| {
+        if (n >= buf.len) break;
+        if (!pricing.providerModelInTable(spec.id, model)) continue;
+        buf[n] = spec.id;
+        n += 1;
+    }
+    return buf[0..n];
+}
+
 /// One optional API key per provider_specs entry, read from the environment.
 pub const Keys = struct {
     pub const CredentialSource = enum {
@@ -218,6 +234,18 @@ pub const Keys = struct {
                 }
             }
         }
+        // #294: a model the catalog assigns to specific providers is NOT unknown.
+        // If none of those providers has a credential, the user's LOGIN is what
+        // broke — rerouting to the gateway turns "codex login expired" into a
+        // gateway error about a model codex was supposed to serve. Concretely:
+        // gpt-5.6-sol exists only under provider `codex`, so an expired
+        // ~/.codex/auth.json used to route it to gateway.codegraff.com, which
+        // answers with a 404 or an out-of-credits error — and the user sees a
+        // CodeGraff balance problem while trying to use Codex.
+        //
+        // Only genuinely uncatalogued models keep the gateway fallback below,
+        // which is what that fallback was always for ("any other unknown model").
+        if (pricing.modelInTable(model)) return error.MissingKey;
         const fallback_id: []const u8 = if (std.mem.startsWith(u8, model, "claude")) "anthropic" else "codegraff";
         for (provider_specs, keys.values) |spec, value| {
             if (!std.mem.eql(u8, spec.id, fallback_id)) continue;
@@ -275,6 +303,39 @@ test "Keys.providerFor: known model, claude/gateway fallbacks, missing key" {
     try std.testing.expectEqualStrings("codegraff", (try all.providerFor("totally-made-up-model")).id);
     try std.testing.expectEqualStrings("gpt-5.5", (try all.providerFor("gpt-5.5")).model);
     try std.testing.expectError(error.MissingKey, none.providerFor("claude-opus-4-8"));
+}
+
+test "providerFor (#294): a catalogued model with no keyed provider fails instead of routing to the gateway" {
+    // The reported symptom: an expired ~/.codex/auth.json made a Codex-only
+    // model resolve to the CodeGraff gateway, so the user saw a balance/credits
+    // error while trying to use Codex. gpt-5.6-sol is catalogued ONLY under
+    // provider `codex`, which makes it the exact reproduction.
+    try std.testing.expect(pricing.providerModelInTable("codex", "gpt-5.6-sol"));
+    try std.testing.expect(!pricing.providerModelInTable("openai", "gpt-5.6-sol"));
+    try std.testing.expect(!pricing.providerModelInTable("codegraff", "gpt-5.6-sol"));
+
+    // Everything keyed EXCEPT codex — i.e. the login expired mid-session.
+    var values: [provider_specs.len]?[]const u8 = @splat("k");
+    for (provider_specs, 0..) |spec, i| {
+        if (std.mem.eql(u8, spec.id, "codex")) values[i] = null;
+    }
+    const no_codex = Keys{ .values = values };
+    // Before the fix this returned the codegraff gateway carrying gpt-5.6-sol.
+    try std.testing.expectError(error.MissingKey, no_codex.providerFor("gpt-5.6-sol"));
+
+    // With the codex credential present it still routes to codex, unchanged.
+    const all = Keys{ .values = @splat("k") };
+    try std.testing.expectEqualStrings("codex", (try all.providerFor("gpt-5.6-sol")).id);
+
+    // A model served by several providers still falls through to whichever is
+    // keyed — losing one credential must not break a model another can serve.
+    try std.testing.expectEqualStrings("openai", (try no_codex.providerFor("gpt-5.6-terra")).id);
+
+    // The gateway fallback survives for genuinely UNCATALOGUED models, which is
+    // all it was ever meant to cover.
+    try std.testing.expect(!pricing.modelInTable("totally-made-up-model"));
+    try std.testing.expectEqualStrings("codegraff", (try no_codex.providerFor("totally-made-up-model")).id);
+    try std.testing.expectEqualStrings("anthropic", (try no_codex.providerFor("claude-does-not-exist")).id);
 }
 
 test "Keys.providerById: exact id wins, unknown id falls back to model routing" {

--- a/src/readline.zig
+++ b/src/readline.zig
@@ -50,84 +50,7 @@ const agent_mod = @import("agent.zig");
 const session = @import("session.zig");
 const Agent = agent_mod.Agent;
 const saveSession = session.saveSession;
-
-const ClipboardPasteSource = union(enum) {
-    image: []const u8,
-    no_image,
-    no_vision,
-    unsupported_platform,
-};
-
-fn clipboardPasteSource(io: Io, supports_vision: bool, is_macos: bool, grabber: anytype) ClipboardPasteSource {
-    if (!supports_vision) return .no_vision;
-    if (!is_macos) return .unsupported_platform;
-    return .{ .image = grabber(io) orelse return .no_image };
-}
-
-/// History + unsent-draft navigation for the line editor (#101). Mirrors the
-/// GUI's promptHistoryNavigation.ts: stepping UP out of the fresh slot snapshots
-/// the half-typed draft; stepping DOWN past the newest entry restores it instead
-/// of clearing the line. `idx == history.len` is the fresh (editing) slot.
-const HistoryNav = struct {
-    idx: usize,
-    draft: ?[]const u8 = null, // owned snapshot of the unsent line; freed by the caller
-
-    fn init(history_len: usize) HistoryNav {
-        return .{ .idx = history_len };
-    }
-
-    /// UP / older. `current` is the live buffer. Returns the text the buffer
-    /// should show next, or null to leave it unchanged (already at the oldest).
-    /// Leaving the fresh slot snapshots `current` as the draft to restore later.
-    fn up(self: *HistoryNav, gpa: Allocator, history: []const []const u8, current: []const u8) ?[]const u8 {
-        if (self.idx == 0) return null;
-        if (self.idx == history.len) { // leaving the fresh slot: keep the draft
-            if (self.draft) |d| gpa.free(d);
-            self.draft = gpa.dupe(u8, current) catch null;
-        }
-        self.idx -= 1;
-        return history[self.idx];
-    }
-
-    /// DOWN / newer. Returns the text to show next, or null to leave it
-    /// unchanged (already at the fresh slot). Past the newest entry, restores the
-    /// snapshotted draft (or "" when there was none) instead of clearing it.
-    fn down(self: *HistoryNav, history: []const []const u8) ?[]const u8 {
-        if (self.idx >= history.len) return null;
-        self.idx += 1;
-        if (self.idx == history.len) return self.draft orelse "";
-        return history[self.idx];
-    }
-};
-
-test "HistoryNav: up snapshots the draft, down past newest restores it (#101)" {
-    const gpa = std.testing.allocator;
-    const history = [_][]const u8{ "first", "second" };
-    var nav: HistoryNav = .init(history.len);
-    defer if (nav.draft) |d| gpa.free(d);
-
-    // up from the fresh slot → newest entry, draft snapshotted
-    try std.testing.expectEqualStrings("second", nav.up(gpa, &history, "draft in progress").?);
-    // up again → older entry
-    try std.testing.expectEqualStrings("first", nav.up(gpa, &history, "second").?);
-    // up at the oldest → no change
-    try std.testing.expect(nav.up(gpa, &history, "first") == null);
-    // down → back to newest
-    try std.testing.expectEqualStrings("second", nav.down(&history).?);
-    // down past newest → the draft is restored, NOT cleared (the bug)
-    try std.testing.expectEqualStrings("draft in progress", nav.down(&history).?);
-    // down at the fresh slot → no change
-    try std.testing.expect(nav.down(&history) == null);
-}
-
-test "HistoryNav: no draft → fresh slot returns empty, no leak (#101)" {
-    const gpa = std.testing.allocator;
-    const history = [_][]const u8{"only"};
-    var nav: HistoryNav = .init(history.len);
-    defer if (nav.draft) |d| gpa.free(d);
-    try std.testing.expectEqualStrings("only", nav.up(gpa, &history, "").?);
-    try std.testing.expectEqualStrings("", nav.down(&history).?); // empty draft → empty line, as today
-}
+const HistoryNav = @import("readline_history.zig").HistoryNav;
 
 /// Read one input line with a tiny raw-mode editor: ↑/↓ walk history,
 /// Tab completes/cycles (models, providers, slash commands), backspace edits,
@@ -336,10 +259,7 @@ pub fn readLine(
             },
             0x16 => { // Ctrl-V: attach a clipboard image (macOS) at the cursor
                 var msg: ?[]const u8 = null;
-                switch (clipboardPasteSource(root.io, vision.visionCapable(root.provider), builtin.os.tag == .macos, grabClipboardImage)) {
-                    .no_vision => msg = "this model can't see images — /model to a vision one (claude-*, gpt-5*)",
-                    .unsupported_platform => msg = "clipboard image paste is macOS-only — use /image <path>",
-                    .no_image => msg = "no image on the clipboard — copy an image first (this is Ctrl-V; ⌘V can't be captured)",
+                switch (vision.clipboardPasteSource(root.io, vision.visionCapable(root.provider), builtin.os.tag == .macos, grabClipboardImage)) {
                     .image => |p| switch (stageImagePath(root, p)) {
                         .ok => {
                             const marker = "[Image] ";
@@ -348,9 +268,10 @@ pub fn readLine(
                             addMark(gpa, &marks, "[Image]");
                             redraw(out, buf.items, cur, marks.items, &rstate, prompt_col);
                         },
-                        .no_vision => msg = "this model can't see images — /model to a vision one (claude-*, gpt-5*)",
+                        .no_vision => msg = vision.no_vision_message,
                         .read_fail => msg = "couldn't read the clipboard image",
                     },
+                    else => |s| msg = vision.pasteMessage(s),
                 }
                 if (msg) |m| { // feedback below the input, then redraw the prompt+buffer fresh
                     if (rstate.rows - 1 > rstate.crow) out.print("\x1b[{d}B", .{rstate.rows - 1 - rstate.crow}) catch {};
@@ -613,34 +534,4 @@ pub fn readLine(
         history.append(gpa, dup) catch {};
     }
     return buf.items;
-}
-
-test "clipboard paste checks vision support before clipboard access" {
-    const MockGrabber = struct {
-        var calls: usize = 0;
-        var image: ?[]const u8 = "/tmp/test.png";
-
-        fn grab(_: Io) ?[]const u8 {
-            calls += 1;
-            return image;
-        }
-    };
-    const expectTag = struct {
-        fn expect(expected: std.meta.Tag(ClipboardPasteSource), actual: ClipboardPasteSource) !void {
-            try std.testing.expectEqual(expected, std.meta.activeTag(actual));
-        }
-    }.expect;
-
-    MockGrabber.calls = 0;
-    try expectTag(.no_vision, clipboardPasteSource(std.testing.io, false, true, MockGrabber.grab));
-    try expectTag(.no_vision, clipboardPasteSource(std.testing.io, false, false, MockGrabber.grab));
-    try expectTag(.unsupported_platform, clipboardPasteSource(std.testing.io, true, false, MockGrabber.grab));
-    try std.testing.expectEqual(@as(usize, 0), MockGrabber.calls);
-
-    try expectTag(.image, clipboardPasteSource(std.testing.io, true, true, MockGrabber.grab));
-    try std.testing.expectEqual(@as(usize, 1), MockGrabber.calls);
-
-    MockGrabber.image = null;
-    try expectTag(.no_image, clipboardPasteSource(std.testing.io, true, true, MockGrabber.grab));
-    try std.testing.expectEqual(@as(usize, 2), MockGrabber.calls);
 }

--- a/src/readline.zig
+++ b/src/readline.zig
@@ -51,6 +51,19 @@ const session = @import("session.zig");
 const Agent = agent_mod.Agent;
 const saveSession = session.saveSession;
 
+const ClipboardPasteSource = union(enum) {
+    image: []const u8,
+    no_image,
+    no_vision,
+    unsupported_platform,
+};
+
+fn clipboardPasteSource(io: Io, supports_vision: bool, is_macos: bool, grabber: anytype) ClipboardPasteSource {
+    if (!supports_vision) return .no_vision;
+    if (!is_macos) return .unsupported_platform;
+    return .{ .image = grabber(io) orelse return .no_image };
+}
+
 /// History + unsent-draft navigation for the line editor (#101). Mirrors the
 /// GUI's promptHistoryNavigation.ts: stepping UP out of the fresh slot snapshots
 /// the half-typed draft; stepping DOWN past the newest entry restores it instead
@@ -323,17 +336,22 @@ pub fn readLine(
             },
             0x16 => { // Ctrl-V: attach a clipboard image (macOS) at the cursor
                 var msg: ?[]const u8 = null;
-                if (grabClipboardImage(root.io)) |p| switch (stageImagePath(root, p)) {
-                    .ok => {
-                        const marker = "[Image] ";
-                        buf.insertSlice(gpa, cur, marker) catch {};
-                        cur += marker.len;
-                        addMark(gpa, &marks, "[Image]");
-                        redraw(out, buf.items, cur, marks.items, &rstate, prompt_col);
-                    },
+                switch (clipboardPasteSource(root.io, vision.visionCapable(root.provider), builtin.os.tag == .macos, grabClipboardImage)) {
                     .no_vision => msg = "this model can't see images — /model to a vision one (claude-*, gpt-5*)",
-                    .read_fail => msg = "couldn't read the clipboard image",
-                } else msg = if (builtin.os.tag == .macos) "no image on the clipboard — copy an image first (this is Ctrl-V; ⌘V can't be captured)" else "clipboard image paste is macOS-only — use /image <path>";
+                    .unsupported_platform => msg = "clipboard image paste is macOS-only — use /image <path>",
+                    .no_image => msg = "no image on the clipboard — copy an image first (this is Ctrl-V; ⌘V can't be captured)",
+                    .image => |p| switch (stageImagePath(root, p)) {
+                        .ok => {
+                            const marker = "[Image] ";
+                            buf.insertSlice(gpa, cur, marker) catch {};
+                            cur += marker.len;
+                            addMark(gpa, &marks, "[Image]");
+                            redraw(out, buf.items, cur, marks.items, &rstate, prompt_col);
+                        },
+                        .no_vision => msg = "this model can't see images — /model to a vision one (claude-*, gpt-5*)",
+                        .read_fail => msg = "couldn't read the clipboard image",
+                    },
+                }
                 if (msg) |m| { // feedback below the input, then redraw the prompt+buffer fresh
                     if (rstate.rows - 1 > rstate.crow) out.print("\x1b[{d}B", .{rstate.rows - 1 - rstate.crow}) catch {};
                     out.print("\r\n{s}· {s}{s}", .{ style.dim, m, style.reset }) catch {};
@@ -595,4 +613,34 @@ pub fn readLine(
         history.append(gpa, dup) catch {};
     }
     return buf.items;
+}
+
+test "clipboard paste checks vision support before clipboard access" {
+    const MockGrabber = struct {
+        var calls: usize = 0;
+        var image: ?[]const u8 = "/tmp/test.png";
+
+        fn grab(_: Io) ?[]const u8 {
+            calls += 1;
+            return image;
+        }
+    };
+    const expectTag = struct {
+        fn expect(expected: std.meta.Tag(ClipboardPasteSource), actual: ClipboardPasteSource) !void {
+            try std.testing.expectEqual(expected, std.meta.activeTag(actual));
+        }
+    }.expect;
+
+    MockGrabber.calls = 0;
+    try expectTag(.no_vision, clipboardPasteSource(std.testing.io, false, true, MockGrabber.grab));
+    try expectTag(.no_vision, clipboardPasteSource(std.testing.io, false, false, MockGrabber.grab));
+    try expectTag(.unsupported_platform, clipboardPasteSource(std.testing.io, true, false, MockGrabber.grab));
+    try std.testing.expectEqual(@as(usize, 0), MockGrabber.calls);
+
+    try expectTag(.image, clipboardPasteSource(std.testing.io, true, true, MockGrabber.grab));
+    try std.testing.expectEqual(@as(usize, 1), MockGrabber.calls);
+
+    MockGrabber.image = null;
+    try expectTag(.no_image, clipboardPasteSource(std.testing.io, true, true, MockGrabber.grab));
+    try std.testing.expectEqual(@as(usize, 2), MockGrabber.calls);
 }

--- a/src/readline_history.zig
+++ b/src/readline_history.zig
@@ -1,0 +1,72 @@
+//! Prompt history + unsent-draft navigation for the line editor (#101).
+//! Split out of readline.zig, which sat at 599 of its 600-line cap and so
+//! could not absorb any further change. Pure over std — no terminal, agent, or
+//! session state — which is what makes it directly unit-testable.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+/// History + unsent-draft navigation for the line editor (#101). Mirrors the
+/// GUI's promptHistoryNavigation.ts: stepping UP out of the fresh slot snapshots
+/// the half-typed draft; stepping DOWN past the newest entry restores it instead
+/// of clearing the line. `idx == history.len` is the fresh (editing) slot.
+pub const HistoryNav = struct {
+    idx: usize,
+    draft: ?[]const u8 = null, // owned snapshot of the unsent line; freed by the caller
+
+    pub fn init(history_len: usize) HistoryNav {
+        return .{ .idx = history_len };
+    }
+
+    /// UP / older. `current` is the live buffer. Returns the text the buffer
+    /// should show next, or null to leave it unchanged (already at the oldest).
+    /// Leaving the fresh slot snapshots `current` as the draft to restore later.
+    pub fn up(self: *HistoryNav, gpa: Allocator, history: []const []const u8, current: []const u8) ?[]const u8 {
+        if (self.idx == 0) return null;
+        if (self.idx == history.len) { // leaving the fresh slot: keep the draft
+            if (self.draft) |d| gpa.free(d);
+            self.draft = gpa.dupe(u8, current) catch null;
+        }
+        self.idx -= 1;
+        return history[self.idx];
+    }
+
+    /// DOWN / newer. Returns the text to show next, or null to leave it
+    /// unchanged (already at the fresh slot). Past the newest entry, restores the
+    /// snapshotted draft (or "" when there was none) instead of clearing it.
+    pub fn down(self: *HistoryNav, history: []const []const u8) ?[]const u8 {
+        if (self.idx >= history.len) return null;
+        self.idx += 1;
+        if (self.idx == history.len) return self.draft orelse "";
+        return history[self.idx];
+    }
+};
+
+test "HistoryNav: up snapshots the draft, down past newest restores it (#101)" {
+    const gpa = std.testing.allocator;
+    const history = [_][]const u8{ "first", "second" };
+    var nav: HistoryNav = .init(history.len);
+    defer if (nav.draft) |d| gpa.free(d);
+
+    // up from the fresh slot → newest entry, draft snapshotted
+    try std.testing.expectEqualStrings("second", nav.up(gpa, &history, "draft in progress").?);
+    // up again → older entry
+    try std.testing.expectEqualStrings("first", nav.up(gpa, &history, "second").?);
+    // up at the oldest → no change
+    try std.testing.expect(nav.up(gpa, &history, "first") == null);
+    // down → back to newest
+    try std.testing.expectEqualStrings("second", nav.down(&history).?);
+    // down past newest → the draft is restored, NOT cleared (the bug)
+    try std.testing.expectEqualStrings("draft in progress", nav.down(&history).?);
+    // down at the fresh slot → no change
+    try std.testing.expect(nav.down(&history) == null);
+}
+
+test "HistoryNav: no draft → fresh slot returns empty, no leak (#101)" {
+    const gpa = std.testing.allocator;
+    const history = [_][]const u8{"only"};
+    var nav: HistoryNav = .init(history.len);
+    defer if (nav.draft) |d| gpa.free(d);
+    try std.testing.expectEqualStrings("only", nav.up(gpa, &history, "").?);
+    try std.testing.expectEqualStrings("", nav.down(&history).?); // empty draft → empty line, as today
+}

--- a/src/scoring.zig
+++ b/src/scoring.zig
@@ -12,6 +12,9 @@ const Allocator = std.mem.Allocator;
 const pricing = @import("pricing.zig");
 const priceFor = pricing.priceFor;
 const util = @import("util.zig");
+// The closed slot vocabulary telemetrySlot allowlists against (#293). shapes.zig
+// is a std-only leaf, so this cannot cycle back through scoring.
+const shapes = @import("shapes.zig");
 
 /// Short stable fingerprint of a system prompt (first 8 bytes of SHA-256,
 /// hex): equal hashes along a trajectory edge mean the prompt didn't change.
@@ -186,6 +189,25 @@ pub fn telemetryProviderClass(value: []const u8) ?[]const u8 {
     for ([_][]const u8{ "frontier", "mid", "small" }) |name|
         if (std.ascii.eqlIgnoreCase(value, name)) return name;
     return null;
+}
+
+/// Project a workflow slot onto the wire — the third MAP-Elites coordinate
+/// (#290), after the niche and the provider class.
+///
+/// A slot originates from a free-form workflow phase title, so it gets the
+/// ALLOWLIST treatment (like telemetryProviderClass) rather than the
+/// hash-everything-else treatment (telemetryNiche/telemetryHash). That is
+/// only sound because the vocabulary in shapes.zig is CLOSED: a canonical
+/// slot is one of ten structural words carrying no user content, so it can
+/// ship as plaintext without widening the egress contract documented above.
+///
+/// Anything off-vocabulary returns "" (uncelled) rather than a fingerprint —
+/// hashing would mint a private per-title cell that no other run can ever
+/// join against, which is worse than not celling the round at all.
+pub fn telemetrySlot(value: []const u8) []const u8 {
+    for (shapes.canonical_slots) |slot|
+        if (std.ascii.eqlIgnoreCase(value, slot)) return slot;
+    return "";
 }
 
 /// Read the signing key from GRAFF_SCORE_KEY_FILE, or the conventional

--- a/src/scoring_slot_test.zig
+++ b/src/scoring_slot_test.zig
@@ -1,0 +1,86 @@
+//! Tests for the MAP-Elites slot axis (#290) — the third cell coordinate.
+//!
+//! Split into its own file because scoring.zig and subagent.zig are both at or
+//! near the 600-line cap. Pulled into the test root via src/main.zig's `test {}`
+//! hook: without that reference these tests compile to nothing and the suite
+//! still reports green (the exact trap that made #291's 9 new tests dead).
+
+const std = @import("std");
+const scoring = @import("scoring.zig");
+const shapes = @import("shapes.zig");
+
+test "telemetrySlot: canonical vocabulary passes through, case-insensitively" {
+    for (shapes.canonical_slots) |slot|
+        try std.testing.expectEqualStrings(slot, scoring.telemetrySlot(slot));
+    try std.testing.expectEqualStrings("verify", scoring.telemetrySlot("VERIFY"));
+    try std.testing.expectEqualStrings("synthesize", scoring.telemetrySlot("Synthesize"));
+}
+
+test "telemetrySlot: anything off-vocabulary is uncelled, never hashed, never echoed" {
+    // This is the privacy property the whole slot design rests on. telemetryNiche
+    // hashes free-form input to custom-<hex>; a slot must do NEITHER that nor echo
+    // the input, because a per-title hash mints a private cell nothing can join
+    // against, and echoing would put user task labels on the wire in cleartext.
+    const leaky = [_][]const u8{
+        "Migrate Acme billing schema",
+        "/Users/someone/secret-project",
+        "find", // NB: canonical only as a bare word; see the compound cases below
+        "code review",
+        "",
+        "custom-deadbeefdeadbeef",
+    };
+    for (leaky) |v| {
+        const got = scoring.telemetrySlot(v);
+        if (got.len == 0) continue; // uncelled: the safe outcome
+        // Whatever came back must be a member of the closed vocabulary — never a
+        // fingerprint, never a substring of the caller's text.
+        var member = false;
+        for (shapes.canonical_slots) |slot| if (std.mem.eql(u8, slot, got)) {
+            member = true;
+        };
+        try std.testing.expect(member);
+        try std.testing.expect(!std.mem.startsWith(u8, got, "custom-"));
+    }
+    // Free-form titles specifically must be dropped, not projected.
+    try std.testing.expectEqualStrings("", scoring.telemetrySlot("Migrate Acme billing schema"));
+    try std.testing.expectEqualStrings("", scoring.telemetrySlot("/Users/someone/secret-project"));
+}
+
+test "canonicalSlot + telemetrySlot compose: a real phase title reaches a cell or nothing" {
+    // The production path is telemetrySlot(canonicalSlot(title)).
+    const compose = struct {
+        fn f(title: []const u8) []const u8 {
+            return scoring.telemetrySlot(shapes.canonicalSlot(title));
+        }
+    }.f;
+    // Titles the shape catalog tells the model to use land in their cell.
+    try std.testing.expectEqualStrings("find", compose("find security bugs"));
+    try std.testing.expectEqualStrings("verify", compose("verify each finding"));
+    try std.testing.expectEqualStrings("synthesize", compose("Synthesize the results"));
+    try std.testing.expectEqualStrings("transform", compose("transform each file"));
+    // A customer name in a phase title reaches no cell and leaves no plaintext.
+    try std.testing.expectEqualStrings("", compose("Migrate Acme billing schema"));
+    // And the composed result is always vocabulary-or-empty, never caller text.
+    for ([_][]const u8{ "Migrate Acme billing", "ponder deeply", "", "x" }) |t| {
+        const got = compose(t);
+        if (got.len > 0) {
+            var member = false;
+            for (shapes.canonical_slots) |slot| if (std.mem.eql(u8, slot, got)) {
+                member = true;
+            };
+            try std.testing.expect(member);
+        }
+    }
+}
+
+test "slot never widens the niche: the signed niche stays exactly the agent name" {
+    // Regression guard for the design error that sank the first #290 attempt:
+    // the composite "agent/tier/slot" string was fed to signScore AND to the
+    // fleet niche, where telemetryNiche hashed it to custom-<hex> — so the score
+    // record and the fleet record named two different cells and stopped joining.
+    // The slot must therefore never be concatenated into a niche.
+    var buf: [23]u8 = undefined;
+    try std.testing.expectEqualStrings("reviewer", scoring.telemetryNiche(&buf, "reviewer"));
+    // If anyone reintroduces a composite, this is what it would do:
+    try std.testing.expect(std.mem.startsWith(u8, scoring.telemetryNiche(&buf, "reviewer/frontier/verify"), "custom-"));
+}

--- a/src/shapes.zig
+++ b/src/shapes.zig
@@ -34,7 +34,13 @@ pub const canonical_slots = [_][]const u8{
     // C — design/solve
     "variants",
     "build",
-    // D — migration/mechanical
+    // D — migration/mechanical.
+    // KNOWN GAP: pipeline stages call runSub directly and never reach the
+    // variant-scoring path, so a spec-compliant `transform` stage cannot fill
+    // its cell today — it is scoreable only via an off-catalog phase of the same
+    // name. Kept in the vocabulary because it is the right name and becomes
+    // reachable the moment pipeline stages are scored; see the pipeline-scoring
+    // issue. Migration execution is unaffected — only learning/promotion is.
     "transform",
     // E — feature
     "scope",
@@ -43,10 +49,20 @@ pub const canonical_slots = [_][]const u8{
 };
 
 /// The first alphanumeric token of `label`, lowercased into `buf`.
-/// Returns an empty slice when the label has no leading word.
+/// Returns an empty slice when the label has no leading ASCII word.
+///
+/// A byte >= 0x80 during the leading skip aborts the scan. Without that, the
+/// bytes of a non-ASCII leading word are each individually non-alphanumeric and
+/// get skipped as if they were punctuation, so a LATER word becomes the apparent
+/// first word: `canonicalSlot("安全 review")` returned `review`, filing that
+/// phase's fitness into a cell it does not belong to. Non-ASCII text is not a
+/// canonical slot, so refusing to look past it is both correct and conservative
+/// — the label is simply uncelled.
 fn firstWord(buf: []u8, label: []const u8) []const u8 {
     var start: usize = 0;
-    while (start < label.len and !std.ascii.isAlphanumeric(label[start])) start += 1;
+    while (start < label.len and !std.ascii.isAlphanumeric(label[start])) : (start += 1) {
+        if (label[start] >= 0x80) return buf[0..0];
+    }
     var n: usize = 0;
     var i = start;
     while (i < label.len and std.ascii.isAlphanumeric(label[i]) and n < buf.len) : (i += 1) {
@@ -107,7 +123,14 @@ pub const shape_catalog_note =
     \\Scale to the ask: "find bugs" is 3 finders + 1 verify; "thoroughly audit" is
     \\6 finders + 3-vote adversarial verify + synthesize. Use phases only when a
     \\phase genuinely needs ALL of the previous one; per-item work belongs in
-    \\pipeline. Give file-editing tasks isolation:"worktree" so they cannot collide.
+    \\pipeline.
+    \\
+    \\isolation:"worktree" ONLY for tasks that edit files IN PARALLEL within one
+    \\phase and whose edits nothing downstream has to read. Every task gets its
+    \\OWN worktree branched from HEAD, so a later stage cannot see an earlier
+    \\stage's edits. Never set it on a dependent chain (transform then verify,
+    \\implement then review) — those stages must share the working tree or the
+    \\reviewer inspects the original file and the edits are stranded.
 ;
 
 test "canonicalSlot: exact, first-word, and miss" {
@@ -121,6 +144,16 @@ test "canonicalSlot: exact, first-word, and miss" {
     try std.testing.expectEqualStrings("sweep", canonicalSlot("  - sweep the repo"));
     // The ordering hazard a substring rule would have: this is `review`, not `find`.
     try std.testing.expectEqualStrings("review", canonicalSlot("review the findings"));
+    // A leading NON-ASCII word must not be skipped past. Each of its bytes is
+    // individually non-alphanumeric, so the old scan treated them as punctuation
+    // and promoted a later word to "first", filing the phase into a cell it does
+    // not belong to. Uncelled is the correct answer.
+    try std.testing.expectEqualStrings("", canonicalSlot("安全 review"));
+    try std.testing.expectEqualStrings("", canonicalSlot("修复 implement billing"));
+    try std.testing.expectEqualStrings("", canonicalSlot("→ verify"));
+    // Non-ASCII AFTER a valid leading ASCII word is harmless.
+    try std.testing.expectEqualStrings("review", canonicalSlot("review 安全"));
+    try std.testing.expectEqualStrings("find", canonicalSlot("find — bugs"));
     // Off-vocabulary titles are uncelled rather than minting a new cell.
     try std.testing.expectEqualStrings("", canonicalSlot("code review"));
     try std.testing.expectEqualStrings("", canonicalSlot("ponder"));
@@ -149,4 +182,17 @@ test "shape catalog covers all five shapes and stays within a sane token budget"
     }
     // It rides on every ultracode turn; keep it from silently ballooning.
     try std.testing.expect(shape_catalog_note.len < 2048);
+}
+
+test "shape catalog never tells a dependent chain to isolate into worktrees" {
+    // Regression guard for the worst bug the catalog's own first review found.
+    // It used to say "give file-editing tasks isolation:worktree so they cannot
+    // collide". Every task gets its OWN worktree branched from HEAD, so on a
+    // dependent chain (transform -> verify, implement -> review) the later stage
+    // read the ORIGINAL file: a workflow could report a successful implement +
+    // review while the edits never reached the caller's tree at all.
+    try std.testing.expect(std.mem.indexOf(u8, shape_catalog_note, "IN PARALLEL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, shape_catalog_note, "Never set it on a dependent chain") != null);
+    // The old unconditional phrasing must not come back.
+    try std.testing.expect(std.mem.indexOf(u8, shape_catalog_note, "Give file-editing tasks isolation") == null);
 }

--- a/src/shapes.zig
+++ b/src/shapes.zig
@@ -1,0 +1,152 @@
+//! Ultracode orchestration shapes (#293): the fixed catalog of default
+//! multi-agent workflow shapes, the canonical slot vocabulary those shapes
+//! name their phases with, and the steering text appended to an ultracode
+//! turn.
+//!
+//! Lives outside pickers.zig (which owns the steering call site) for two
+//! reasons: pickers.zig is at the 600-line cap, and the slot vocabulary is
+//! not a picker concern — it is the third component of the MAP-Elites cell
+//! key (#290). Keeping this a std-only leaf module, prompts.zig-style, lets
+//! both the steering path and the fleet scoring path import it with no cycle.
+//!
+//! Why a fixed catalog at all: left to itself the model authors a different
+//! workflow shape every run, so two scores for the same persona are not
+//! comparable — the structure varied underneath them. A closed catalog with
+//! named slots makes "reviewer prompt, mid tier, verify slot" a cell that
+//! accrues real fitness across runs.
+
+const std = @import("std");
+
+/// Canonical phase/stage labels an ultracode workflow names its slots with.
+///
+/// This is the closed vocabulary behind the third component of the composite
+/// niche key (#290). A prompt variant's fitness is only comparable to another
+/// variant scored in the SAME slot, so the set has to be stable — free-text
+/// phase titles would mint a fresh cell per run and nothing would ever
+/// accumulate enough samples to promote.
+pub const canonical_slots = [_][]const u8{
+    // A — review/audit
+    "find",
+    "verify",
+    "synthesize",
+    // B — research/understand
+    "sweep",
+    // C — design/solve
+    "variants",
+    "build",
+    // D — migration/mechanical
+    "transform",
+    // E — feature
+    "scope",
+    "implement",
+    "review",
+};
+
+/// The first alphanumeric token of `label`, lowercased into `buf`.
+/// Returns an empty slice when the label has no leading word.
+fn firstWord(buf: []u8, label: []const u8) []const u8 {
+    var start: usize = 0;
+    while (start < label.len and !std.ascii.isAlphanumeric(label[start])) start += 1;
+    var n: usize = 0;
+    var i = start;
+    while (i < label.len and std.ascii.isAlphanumeric(label[i]) and n < buf.len) : (i += 1) {
+        buf[n] = std.ascii.toLower(label[i]);
+        n += 1;
+    }
+    return buf[0..n];
+}
+
+/// Normalize a free-text phase title / pipeline stage label to a canonical
+/// slot, or "" when it matches none.
+///
+/// Matching is on the label's FIRST WORD only, case-insensitively. That is
+/// deliberately narrow: a substring rule would make "review the findings"
+/// ambiguous between `review` and `find`, and which one won would depend on
+/// array order rather than on what the phase actually does. First-word
+/// matching keeps natural titles working ("find security bugs" -> `find`,
+/// "synthesize the results" -> `synthesize`) with no ordering hazard.
+///
+/// An unrecognized label maps to "" (uncelled) rather than minting a new cell
+/// — an off-vocabulary phase still runs, it just does not accrue fitness.
+pub fn canonicalSlot(label: []const u8) []const u8 {
+    var buf: [32]u8 = undefined;
+    const word = firstWord(&buf, label);
+    if (word.len == 0) return "";
+    for (canonical_slots) |slot| {
+        if (std.mem.eql(u8, slot, word)) return slot;
+    }
+    return "";
+}
+
+/// The shape catalog appended to every ultracode turn. Kept tight on purpose:
+/// this rides along on each turn of an opt-in mode, so it should buy structure
+/// per token rather than restate what the workflow tool's schema already says.
+pub const shape_catalog_note =
+    \\Pick ONE shape below and instantiate it with the workflow tool. Title each
+    \\phase with its slot word exactly — the fleet keys a variant's fitness on
+    \\that slot, and an off-vocabulary title makes the round unscoreable.
+    \\
+    \\A review/audit — there is a diff, or the ask is review/audit/find bugs:
+    \\  find       one reviewer per dimension (correctness, security, perf, tests), parallel
+    \\  verify     one skeptic per finding, told to REFUTE it; gate with when:"FINDING"
+    \\  synthesize one task; findings ranked most-severe first
+    \\B research/understand — the ask is a question about how something works:
+    \\  sweep      researchers each searching a DIFFERENT way (by symbol, by callers,
+    \\             by git history, by tests); tell them not to duplicate each other
+    \\  synthesize one map
+    \\C design/solve — open-ended "how should we…":
+    \\  variants   N implementers, same task, a DIFFERENT system_prompt each
+    \\             (MVP-first / risk-first / perf-first); 2+ variants are auto-judged
+    \\  build      synthesize from the winner, grafting the runners-up's best ideas
+    \\D migration/mechanical — the same edit across many files:
+    \\  use pipeline, NOT phases: {"pipeline":{"items":[…],"stages":[transform, verify]}}
+    \\  each item flows independently, so no item waits on any other
+    \\E feature — build something new:
+    \\  scope → implement → review
+    \\
+    \\Scale to the ask: "find bugs" is 3 finders + 1 verify; "thoroughly audit" is
+    \\6 finders + 3-vote adversarial verify + synthesize. Use phases only when a
+    \\phase genuinely needs ALL of the previous one; per-item work belongs in
+    \\pipeline. Give file-editing tasks isolation:"worktree" so they cannot collide.
+;
+
+test "canonicalSlot: exact, first-word, and miss" {
+    // Bare slot words map to themselves.
+    for (canonical_slots) |slot| try std.testing.expectEqualStrings(slot, canonicalSlot(slot));
+    // Natural titles match on their first word.
+    try std.testing.expectEqualStrings("find", canonicalSlot("find security bugs"));
+    try std.testing.expectEqualStrings("synthesize", canonicalSlot("Synthesize the results"));
+    try std.testing.expectEqualStrings("verify", canonicalSlot("VERIFY each finding"));
+    // Leading punctuation/whitespace is skipped.
+    try std.testing.expectEqualStrings("sweep", canonicalSlot("  - sweep the repo"));
+    // The ordering hazard a substring rule would have: this is `review`, not `find`.
+    try std.testing.expectEqualStrings("review", canonicalSlot("review the findings"));
+    // Off-vocabulary titles are uncelled rather than minting a new cell.
+    try std.testing.expectEqualStrings("", canonicalSlot("code review"));
+    try std.testing.expectEqualStrings("", canonicalSlot("ponder"));
+    try std.testing.expectEqualStrings("", canonicalSlot(""));
+    try std.testing.expectEqualStrings("", canonicalSlot("---"));
+}
+
+test "canonicalSlot: a word longer than the scratch buffer cannot match or overflow" {
+    const long = "a" ** 200;
+    try std.testing.expectEqualStrings("", canonicalSlot(long));
+    // A canonical slot followed by a very long tail still matches on word one.
+    try std.testing.expectEqualStrings("find", canonicalSlot("find " ++ long));
+}
+
+test "shape catalog names every canonical slot it depends on" {
+    // Guards the seam with #290: if a slot is added to the vocabulary but the
+    // catalog never tells the model to use it, that cell can never be filled.
+    for (canonical_slots) |slot| {
+        try std.testing.expect(std.mem.indexOf(u8, shape_catalog_note, slot) != null);
+    }
+}
+
+test "shape catalog covers all five shapes and stays within a sane token budget" {
+    for ([_][]const u8{ "A review/audit", "B research/understand", "C design/solve", "D migration/mechanical", "E feature" }) |shape| {
+        try std.testing.expect(std.mem.indexOf(u8, shape_catalog_note, shape) != null);
+    }
+    // It rides on every ultracode turn; keep it from silently ballooning.
+    try std.testing.expect(shape_catalog_note.len < 2048);
+}

--- a/src/startup.zig
+++ b/src/startup.zig
@@ -220,13 +220,13 @@ pub fn resolveKeys(io: Io, gpa: Allocator, arena: Allocator, environ_map: anytyp
     if (keys_cli.homeEnv(environ_map)) |home| {
         for (provider_mod.provider_specs, &keys.values, &keys.sources) |spec, *value, *source| {
             if (std.mem.eql(u8, spec.id, "kimi") and value.* == null) {
-                if (oauth.loadKimiOAuth(io, gpa, arena, home, false)) |key| {
+                if (oauth.loadKimiOAuth(io, gpa, arena, home, false, null)) |key| {
                     value.* = key;
                     source.* = .login;
                 }
             }
             if (std.mem.eql(u8, spec.id, "xai") and value.* == null) {
-                if (oauth.loadXaiOAuth(io, gpa, arena, home, false)) |key| {
+                if (oauth.loadXaiOAuth(io, gpa, arena, home, false, null)) |key| {
                     value.* = key;
                     source.* = .login;
                 }
@@ -537,7 +537,7 @@ pub fn runSubcommand(io: Io, gpa: Allocator, arena: Allocator, init: std.process
                     std.mem.eql(u8, flags.positionals.items[1], "--refresh") or
                     std.mem.eql(u8, flags.positionals.items[1], "update")),
         );
-        const kimi_token = init.environ_map.get("KIMI_API_KEY") orelse oauth.loadKimiOAuth(io, gpa, arena, home, false) orelse "";
+        const kimi_token = init.environ_map.get("KIMI_API_KEY") orelse oauth.loadKimiOAuth(io, gpa, arena, home, false, null) orelse "";
         _ = kimi_catalog.load(io, gpa, arena, home, kimi_token);
         try models_cache.command(io, gpa, arena, home, flags.positionals.items[1..]);
         return true;

--- a/src/startup.zig
+++ b/src/startup.zig
@@ -289,7 +289,19 @@ pub fn resolveKeys(io: Io, gpa: Allocator, arena: Allocator, environ_map: anytyp
             } else |_| std.process.fatal("no key/login for provider '{s}' (--model)", .{mname});
         };
         const nm = pricing.resolveModelName(keys, mname) orelse std.process.fatal("unknown --model '{s}' — run `graff models refresh` or see /models", .{mname});
-        default_provider = keys.providerFor(nm) catch std.process.fatal("no key/login for --model '{s}' — see /models", .{mname});
+        default_provider = keys.providerFor(nm) catch {
+            // #294: name the credential that actually needs repair. A Codex-only
+            // model with an expired ~/.codex/auth.json used to be rerouted to the
+            // gateway and surface as a CodeGraff error; now it fails here, so the
+            // message must point at the right login rather than "see /models".
+            var pbuf: [provider_mod.provider_specs.len][]const u8 = undefined;
+            const serving = provider_mod.catalogProvidersFor(&pbuf, nm);
+            if (serving.len > 0) std.process.fatal(
+                "'{s}' is served by {s}, which has no valid credential — run `graff login {s}` or `graff key set {s} <key>`",
+                .{ nm, serving[0], serving[0], serving[0] },
+            );
+            std.process.fatal("no key/login for --model '{s}' — see /models", .{mname});
+        };
     } else if (saved_model) |saved| {
         preferred_provider = saved.pid;
         // No --model flag: resume the model chosen last session only if that

--- a/src/subagent.zig
+++ b/src/subagent.zig
@@ -69,7 +69,8 @@ const subagent_run = @import("subagent_run.zig");
 pub const AgentUsage = subagent_run.AgentUsage;
 pub const SubRun = subagent_run.SubRun;
 pub const runSub = subagent_run.runSub;
-const childProvider = subagent_run.childProvider;
+const variantProviderClass = subagent_run.variantProviderClass;
+const shapes = @import("shapes.zig");
 const FailKind = subagent_run.FailKind;
 const classifyFailure = subagent_run.classifyFailure;
 
@@ -477,6 +478,17 @@ pub fn scoreVariants(
     }
     if (vn < 2) return;
 
+    // A tournament must vary exactly ONE axis: if the variants did not all run on
+    // the same capability tier, the ranking reflects the model as much as the
+    // prompt, and filing it under the prompt fingerprint writes model effects into
+    // the genome archive (#290). Bail before spawning a judge — unscoreable round.
+    for (1..vn) |k| {
+        if (!std.mem.eql(u8, variantProviderClass(ctx, vidx[0]), variantProviderClass(ctx, vidx[k]))) {
+            if (ctx.tracer) |tr| tr.note("fleet", "tournament skipped: variants span provider classes");
+            return;
+        }
+    }
+
     // All fallible work (prompt builds) before any future spawns, so an early
     // return can never abandon a running judge.
     const jprompts = arena.alloc([]const u8, vn) catch return;
@@ -487,8 +499,9 @@ pub fn scoreVariants(
     const jfuts = arena.alloc(Io.Future(ToolOutput), vn) catch return;
     for (jfuts, jprompts) |*jf, jp| jf.* = ctx.io.async(judgeTask, .{ ctx, jp });
 
-    const pclass = providerClass(childProvider(ctx.provider, ctx.subagent_provider, ctx.subagent_cross_provider).model);
     const run_id: []const u8 = &scoring.g_run_id;
+    // This phase's MAP-Elites slot (#290/#293); "" off-vocabulary. See telemetrySlot.
+    const slot = scoring.telemetrySlot(shapes.canonicalSlot(title));
     for (jfuts, 0..) |*jf, k| {
         const i = vidx[k];
         const jout = jf.await(ctx.io);
@@ -509,6 +522,7 @@ pub fn scoreVariants(
         // above; every score that leaves the client is [0,1], so divide at
         // the emission boundary — s01 is what gets signed and sent.
         const s01 = s / 100.0;
+        const pclass = variantProviderClass(ctx, i);
         const genome_fp = promptFingerprint(overrides[i].?);
         const esh_fp = promptFingerprint(raws[i]);
         const genome: []const u8 = &genome_fp;
@@ -521,7 +535,10 @@ pub fn scoreVariants(
         const sig = signScore(genome, "", s01, run_id, "", "", esh, niche, pclass);
         const sig_s: []const u8 = if (scoring.g_score_key != null) &sig else "";
         var provbuf: [512]u8 = undefined;
-        const prov = std.fmt.bufPrint(&provbuf, "{s}\t{s}\t{s}\t{s}\t{s}", .{ "", "", esh, pclass, niche }) catch "";
+        // Slot is APPENDED as a 6th component, so a collector indexing 0..4 is
+        // unaffected. Advisory like the rest of `prov` (signScore holds the
+        // authoritative copies); signing it would need a collector-first deploy.
+        const prov = std.fmt.bufPrint(&provbuf, "{s}\t{s}\t{s}\t{s}\t{s}\t{s}", .{ "", "", esh, pclass, niche, slot }) catch "";
         // Genome-send (issue #168 Gap 5), mirroring runEval: ride the variant's
         // text over on a propose (deduped by fingerprint server-side) so the
         // scored cell has a servable genome even when runSub never proposed it.

--- a/src/subagent_run.zig
+++ b/src/subagent_run.zig
@@ -101,6 +101,27 @@ pub fn childProvider(root: Provider, pinned: ?Provider, allow_cross_provider: bo
     return if (std.mem.eql(u8, child.id, root.id) or allow_cross_provider) child else root;
 }
 
+/// Capability tier ("frontier" | "mid" | "small") of the model that ran variant
+/// `i` of a workflow phase — the provider-class axis of the MAP-Elites cell.
+///
+/// Today every child in a phase resolves through the same session-level
+/// subagent provider, so this returns the same value for every `i`. It is
+/// written per-variant regardless, because this is exactly the seam that
+/// per-persona / per-spawn model pins (#292) extend: with the class hoisted to
+/// a phase-level constant, the first heterogeneous fan-out would keep reporting
+/// the ROOT's class for every variant and quietly file model effects under the
+/// prompt genome. Keeping the lookup per-variant means #292 changes this one
+/// function instead of having to notice a stale constant.
+///
+/// NOTE (#291): providerClass cannot currently distinguish gpt-5.6-sol from
+/// gpt-5.6-terra/-luna — all three classify as "frontier". Until that is
+/// resolved this axis cannot separate ladder rungs, and the matched-tournament
+/// guard in scoreVariants is correspondingly blind to a rung-only difference.
+pub fn variantProviderClass(ctx: tools.ToolCtx, i: usize) []const u8 {
+    _ = i; // per-variant model pins land in #292
+    return scoring.providerClass(childProvider(ctx.provider, ctx.subagent_provider, ctx.subagent_cross_provider).model);
+}
+
 pub const AgentUsage = struct {
     duration_ms: u64 = 0,
     tool_calls: u32 = 0,

--- a/src/vision.zig
+++ b/src/vision.zig
@@ -133,6 +133,43 @@ pub fn stageGuiImageAttachment(root: *Agent, msg: []const u8) void {
 /// macOS: dump the clipboard image (if any) to a temp PNG via osascript and
 /// return its path; null if the clipboard holds no image (or not macOS).
 /// (A terminal can't receive clipboard image bytes over stdin, so we ask the OS.)
+/// Why a Ctrl-V clipboard paste did or did not produce an image (#258).
+/// Ordered so the cheapest, most-likely-wrong condition is decided first.
+pub const ClipboardPasteSource = union(enum) {
+    image: []const u8,
+    no_image,
+    no_vision,
+    unsupported_platform,
+};
+
+/// Decide a Ctrl-V paste WITHOUT touching the clipboard unless it can help.
+///
+/// The vision check comes first deliberately: on a non-vision model the paste
+/// can never succeed, so shelling out to the clipboard would spend a subprocess
+/// (and on macOS, a pasteboard read of whatever the user last copied) purely to
+/// produce an error. `grabber` is injected so the ordering is testable without
+/// a real clipboard.
+pub fn clipboardPasteSource(io: Io, supports_vision: bool, is_macos: bool, grabber: anytype) ClipboardPasteSource {
+    if (!supports_vision) return .no_vision;
+    if (!is_macos) return .unsupported_platform;
+    return .{ .image = grabber(io) orelse return .no_image };
+}
+
+/// The user-facing line for every non-image paste outcome, so the caller's
+/// switch stays one prong instead of three parallel string literals.
+pub fn pasteMessage(source: ClipboardPasteSource) []const u8 {
+    return switch (source) {
+        .no_vision => no_vision_message,
+        .unsupported_platform => "clipboard image paste is macOS-only — use /image <path>",
+        .no_image => "no image on the clipboard — copy an image first (this is Ctrl-V; ⌘V can't be captured)",
+        .image => "",
+    };
+}
+
+/// Shared by the pre-clipboard guard and the post-stage failure path, which
+/// previously carried two copies of the same sentence.
+pub const no_vision_message = "this model can't see images — /model to a vision one (claude-*, gpt-5*)";
+
 pub fn grabClipboardImage(io: Io) ?[]const u8 {
     if (builtin.os.tag != .macos) return null;
     const path = "/tmp/.harness-clip.png";
@@ -206,4 +243,47 @@ test "visionModel: vision-capable model families only" {
     try std.testing.expect(!visionModel("mimo-v2.5"));
     try std.testing.expect(!visionModel("grok-build")); // grok-4 prefix only, not all grok
     try std.testing.expect(!visionModel("qwen2.5-coder-7b")); // text-only local model
+}
+
+test "clipboardPasteSource: vision is checked before the clipboard is touched (#258)" {
+    // The ordering IS the fix: on a non-vision model the paste can never work,
+    // so the clipboard must not be read at all. `calls` proves that.
+    const MockGrabber = struct {
+        var calls: usize = 0;
+        var image: ?[]const u8 = "/tmp/test.png";
+
+        fn grab(_: Io) ?[]const u8 {
+            calls += 1;
+            return image;
+        }
+    };
+    const expectTag = struct {
+        fn expect(expected: std.meta.Tag(ClipboardPasteSource), actual: ClipboardPasteSource) !void {
+            try std.testing.expectEqual(expected, std.meta.activeTag(actual));
+        }
+    }.expect;
+
+    MockGrabber.calls = 0;
+    try expectTag(.no_vision, clipboardPasteSource(std.testing.io, false, true, MockGrabber.grab));
+    try expectTag(.no_vision, clipboardPasteSource(std.testing.io, false, false, MockGrabber.grab));
+    try expectTag(.unsupported_platform, clipboardPasteSource(std.testing.io, true, false, MockGrabber.grab));
+    try std.testing.expectEqual(@as(usize, 0), MockGrabber.calls);
+
+    try expectTag(.image, clipboardPasteSource(std.testing.io, true, true, MockGrabber.grab));
+    try std.testing.expectEqual(@as(usize, 1), MockGrabber.calls);
+
+    MockGrabber.image = null;
+    try expectTag(.no_image, clipboardPasteSource(std.testing.io, true, true, MockGrabber.grab));
+    try std.testing.expectEqual(@as(usize, 2), MockGrabber.calls);
+}
+
+test "pasteMessage: every non-image outcome has a distinct, non-empty line" {
+    const cases = [_]ClipboardPasteSource{ .no_vision, .unsupported_platform, .no_image };
+    for (cases, 0..) |a, i| {
+        try std.testing.expect(pasteMessage(a).len > 0);
+        for (cases[i + 1 ..]) |b|
+            try std.testing.expect(!std.mem.eql(u8, pasteMessage(a), pasteMessage(b)));
+    }
+    // The staged-failure path reuses the same sentence rather than duplicating it.
+    try std.testing.expectEqualStrings(no_vision_message, pasteMessage(.no_vision));
 }


### PR DESCRIPTION
## What's in it

Three verified changes. Everything below was built off `origin/main` in isolated worktrees; nothing touched a shared tree.

### #293 — ultracode shape catalog (`src/shapes.zig`)

Ultracode previously told the model to "decompose into sequential phases of parallel subagents" and left the structure entirely to it. Every run invented a different shape, so two scores for the same persona were never comparable — the structure varied underneath them, which is a large part of why the fleet could not accrue fitness.

Adds a closed catalog of five shapes (review/audit, research/understand, design/solve, migration/mechanical, feature) plus the canonical slot vocabulary their phases are titled with. Both ultracode steering paths carry it.

**Verified against real Codex**, not a mock. `ultracode review src/shapes.zig for real bugs` produced exactly Shape A — `find` x3 (correctness / safety+perf / tests+edge, `agent:"reviewer"`) then `verify` gated on `when:"FINDING"` with a skeptic told to refute, then `synthesize`. It also hit the catalog's scale rule exactly: 3 finders + 1 verify for "find bugs".

That run then found **three real bugs in `shapes.zig` itself**, all fixed here:

- **HIGH** — the catalog told dependent stages to use `isolation:"worktree"`. Each spawn gets its own worktree from HEAD, so `verify`/`review` read the *original* file and edits were stranded; a workflow could report success while nothing reached the caller's tree. Guidance now scopes isolation to parallel same-phase editors and forbids it on dependent chains. Engine fix tracked in #295.
- **LOW** — `canonicalSlot("安全 review")` returned `review`; each byte of a leading non-ASCII word looked like punctuation, promoting a later word to "first" and mis-filing fitness.
- **LOW** — `transform` was advertised as scoreable but pipeline stages never reach the scoring path. Gap now documented at the declaration. Tracked in #296.

### #290 — MAP-Elites slot axis, as an allowlisted field

The first attempt joined the cell key into the niche string as `agent/tier/slot`. That cannot work: `writeOtlp` projects every fleet niche through `telemetryNiche`, whose allowlist is exactly the four builtin persona names — everything else becomes `custom-<16hex>`. A composite shipped hashed on fleet events and verbatim on the score record, so the two stopped naming the same cell. The niche is also an input to `signScore`, so changing its bytes changes the HMAC.

That projection is deliberate — free-form task labels must not leave as plaintext — so appending a slugified phase title would have put project names on the wire for every scored variant.

Instead the slot is a separate **allowlisted** field: `scoring.telemetrySlot()` allowlists against `shapes.canonical_slots`, mirroring `telemetryProviderClass`. Sound only because that vocabulary is closed. Off-vocabulary returns `""` (uncelled), never a hash. It rides as a 6th component appended to the provenance string, so a collector indexing 0..4 is unaffected. **The niche is unchanged**, so signatures and joins hold.

Also fixes two archive-integrity defects: provider class is resolved per-variant behind `subagent_run.variantProviderClass` (the seam #292 extends), and a phase whose variants span provider classes is skipped and traced rather than scored.

**Deliberately not included:** signing the slot (needs a collector-first deploy) and the tier axis entirely — see #291, `providerClass` returns `frontier` for sol/terra/luna alike, so it cannot separate the rungs it exists to compare.

### #294 — a catalogued model with no keyed provider must not fall to the gateway

Reported as "the CodeGraff balance check stops me using Codex". `Keys.providerFor` ended with a blanket fallback sending any unresolved model to the gateway. `gpt-5.6-sol` is catalogued only under `codex`, so an expired `~/.codex/auth.json` routed it to `gateway.codegraff.com`, which answers with model-not-available — or, on a low-credit account, a balance error. The user sees a billing problem while the actual cause is an expired login.

Reproduced end to end with an empty `CODEX_HOME`:

```
before:  {"provider":"codegraff","model":"gpt-5.6-sol"}
         error: Model 'gpt-5.6-sol' is not available on codegraff
after:   error: 'gpt-5.6-sol' is served by codex, which has no valid credential
                — run `graff login codex` or `graff key set codex <key>`
```

Only uncatalogued models keep the gateway fallback, which is all it was ever for. A model served by several providers still falls through to whichever is keyed.

## Verification

`rm -rf .zig-cache && zig build test` → **361/361**, `zig fmt --check src/` clean, `scripts/check-zig-lines.sh` passes.

Test counts were checked against baseline rather than trusted: `origin/main` is 351. Each change was confirmed live by baseline diff (351→352 for #294, 355→356 for the #293 fixes, +4 for #290), and the #293 tests were additionally proven by breaking an assertion and confirming the suite dropped to N-1/1. New test modules are wired into `main.zig`'s `test {}` hook — without that reference they compile to nothing and the suite still reports green.

## Not included

`feat/291-tier-ladder` is **not** in this branch. It failed verification (all 9 of its new tests were dead — never pulled into the test root) and it carries a blocked design decision: `providerClass` cannot distinguish the ladder rungs, so the tier axis it is supposed to feed cannot work yet.
