### PR TITLE
fix(shapes): avoid the `**` repeat operator, which Zig 0.17-dev rejects

### DIFF
--- a/src/shapes.zig
+++ b/src/shapes.zig
@@ -162,10 +162,16 @@ test "canonicalSlot: exact, first-word, and miss" {
 }
 
 test "canonicalSlot: a word longer than the scratch buffer cannot match or overflow" {
-    const long = "a" ** 200;
-    try std.testing.expectEqualStrings("", canonicalSlot(long));
+    // Built with @splat rather than the `"a" ** 200` repeat operator: Zig
+    // 0.17.0-dev (what CI pins) rejects that form with "binary operator '*' has
+    // whitespace on one side, but not the other", while 0.16 accepts it. @splat
+    // over an array is already used elsewhere in this tree and compiles on both.
+    const long: [200]u8 = @splat('a');
+    try std.testing.expectEqualStrings("", canonicalSlot(&long));
     // A canonical slot followed by a very long tail still matches on word one.
-    try std.testing.expectEqualStrings("find", canonicalSlot("find " ++ long));
+    var tailed: [205]u8 = @splat('a');
+    @memcpy(tailed[0..5], "find ");
+    try std.testing.expectEqualStrings("find", canonicalSlot(&tailed));
 }
 
 test "shape catalog names every canonical slot it depends on" {


### PR DESCRIPTION
The v0.0.217 release build failed on **every** target:

```
src/shapes.zig:165:22: error: binary operator '*' has whitespace on one side, but not the other
    const long = "a" ** 200;
```

Zig 0.16 accepts `"a" ** 200`; the **0.17.0-dev nightly CI pins does not**. Local `zig build test` was green against a different compiler than CI, so the breakage only surfaced after the tag was pushed. `release.yml` died at cross-compile, so no release was created and no artifacts were published.

Rebuilt with `@splat` — already used over arrays elsewhere in this tree, so it compiles on both — plus an explicit `@memcpy` for the prefixed case so no `++` on a comptime array is needed either. Test-only; the assertions are unchanged.

No macOS build of the pinned 0.17 nightly is published (`install-zig-ci.py` covers Linux/Windows x86_64 only), so the 0.17 side is verified by CI rather than locally — which is why this went to a branch instead of a force-updated tag. CI run `30126705422` is green.