### PR TITLE
install kuri by default; ask both prompts for parallel tool calls

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,9 @@ set -euo pipefail
 #   # or, from a checkout:  ./install.sh
 #
 # Env overrides: HARNESS_REPO (source repo), HARNESS_DIR (install dir),
-# HARNESS_BUILD=source (skip the release download and compile).
+# HARNESS_BUILD=source (skip the release download and compile),
+# HARNESS_NO_GRAFF=1 (skip the codedb/zigrep companion suite),
+# HARNESS_NO_KURI=1 (skip kuri browser automation).
 
 REPO="${HARNESS_REPO:-https://github.com/justrach/codegraff}"
 INSTALL_DIR="${HARNESS_DIR:-$HOME/bin}"
@@ -191,6 +193,18 @@ main() {
     suite_pid=$!
   fi
 
+  # kuri (browser automation, web crawling, iOS/Android device control) backs
+  # the webfetch tool's markdown path and the kuri skill. Installed by default
+  # and backgrounded like the suite above, so it overlaps the graff download
+  # instead of adding to the wall clock. Opt out with HARNESS_NO_KURI=1.
+  KURI_INSTALL_URL="${KURI_INSTALL_URL:-https://raw.githubusercontent.com/justrach/kuri/main/install.sh}"
+  kuri_pid=""; kuri_log=""
+  if [ -z "${HARNESS_NO_KURI:-}" ] && ! command -v kuri >/dev/null 2>&1; then
+    kuri_log="$(mktemp)"
+    ( curl -fsSL --max-time 120 "$KURI_INSTALL_URL" | sh >/dev/null 2>&1 && echo ok || echo fail ) >"$kuri_log" 2>&1 &
+    kuri_pid=$!
+  fi
+
   if [ "${HARNESS_BUILD:-release}" != "source" ] && fetch_release "$platform"; then
     printf "  ${D}│${N} %-10s ${G}✓${N} (prebuilt release)\n" "download"
   else
@@ -222,22 +236,23 @@ main() {
     fi
   fi
 
-  # Optional skill (codex-style): kuri — browser automation, web crawling,
-  # iOS/Android device control. Opt in here with HARNESS_WITH_KURI=1, or any
-  # time later from inside the harness with `/skills add kuri`.
-  if [ -n "${HARNESS_WITH_KURI:-}" ]; then
-    if command -v kuri >/dev/null 2>&1; then
-      printf "  ${D}│${N} %-10s ${G}✓${N} (already present)\n" "kuri"
+  # Reap kuri, kicked off beside the suite. Same contract: never fatal, and the
+  # harness is fully functional without it (webfetch falls back to a plain GET).
+  if [ -z "${HARNESS_NO_KURI:-}" ]; then
+    printf "  ${D}│${N} %-10s " "kuri"
+    if [ -z "$kuri_pid" ]; then
+      printf "${G}✓${N} (already present)\n"
     else
-      printf "  ${D}│${N} %-10s " "kuri"
-      if curl -fsSL https://raw.githubusercontent.com/justrach/kuri/main/install.sh | sh >/dev/null 2>&1; then
+      wait "$kuri_pid" 2>/dev/null || true
+      if [ "$(cat "$kuri_log" 2>/dev/null)" = ok ]; then
         printf "${G}✓${N} (browser automation)\n"
       else
-        printf "${Y}skipped${N} ${D}(kuri install failed — try /skills add kuri later)${N}\n"
+        printf "${Y}skipped${N} ${D}(kuri install failed — /skills add kuri to retry)${N}\n"
       fi
+      rm -f "$kuri_log"
     fi
   else
-    printf "  ${D}optional: kuri browser automation — HARNESS_WITH_KURI=1, or /skills add kuri in the harness${N}\n"
+    printf "  ${D}kuri skipped (HARNESS_NO_KURI) — /skills add kuri any time${N}\n"
   fi
 
   case ":$PATH:" in

--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -10,7 +10,7 @@
     "src/main.zig",
     "src/repl.zig"
   ],
-  "test_count_baseline": 575,
+  "test_count_baseline": 576,
   "required_invariants": [
     {
       "id": "goal-epochs",

--- a/src/prompts.zig
+++ b/src/prompts.zig
@@ -66,6 +66,30 @@ pub const main_system_prompt =
     \\auto-checkpoints are the user's safety net; do not blow them away.
     \\
     \\Be direct and concise.
+++ parallel_tools_note;
+
+/// Appended to BOTH the root and subagent prompts. openai/codex carries this
+/// instruction verbatim in its base instructions ("Parallelize tool calls
+/// whenever possible - especially file reads"); graff had no equivalent on
+/// either prompt, so batching was left entirely to the model's own initiative.
+///
+/// The executor has always been ready for it: agent_tools.zig dispatches every
+/// external call in a batch as a future BEFORE awaiting any of them, with no
+/// cap and no root-vs-subagent branch. So this asks for nothing the harness
+/// does not already do - it only stops the capability going unused.
+///
+/// The last sentence is the load-bearing half. Batching two edits to one file,
+/// or a read whose path comes from the previous call's output, is wrong: graff
+/// (unlike codex, which takes a write lock for non-parallel-safe tools) runs
+/// the whole batch concurrently, so an unsafe batch really does race.
+pub const parallel_tools_note =
+    \\
+    \\
+    \\Parallelize tool calls whenever possible: when several reads or checks are
+    \\independent, issue them in ONE response instead of one per turn. Reads and
+    \\searches are the common case (read_file, codedb, grep-style bash) and they
+    \\run concurrently. Keep a call in its own turn when it depends on an earlier
+    \\call's result, or when two calls would write to the same file.
 ;
 
 pub const strict_note =
@@ -126,7 +150,7 @@ pub const sub_system_prompt =
     \\questions — make reasonable assumptions. Your final message is returned
     \\verbatim to the orchestrator as the result of the task: make it a
     \\concise, complete report with the concrete facts you found.
-;
+++ parallel_tools_note;
 
 pub const compact_instruction =
     \\Summarize this entire conversation for a context handoff. Capture: the
@@ -135,6 +159,28 @@ pub const compact_instruction =
     \\task checklist and each item's status, and any pending or unfinished
     \\work. Be thorough but compact. Reply with only the summary.
 ;
+
+// The harness has always run a returned tool batch concurrently, for subagents
+// exactly as for the root (agent_tools.zig dispatches every external call as a
+// future before awaiting any). Nothing ASKED for a batch, though, so the
+// capability rode entirely on the model's own initiative - openai/codex spells
+// it out in its base instructions and graff did not. Pin it on BOTH prompts:
+// the subagent one is the easier of the two to forget, since it is five lines
+// long and does not share a base with the root.
+test "both prompts ask for parallel tool calls, with the dependency caveat" {
+    for ([_][]const u8{ main_system_prompt, sub_system_prompt, main_system_prompt_strict }) |p| {
+        try std.testing.expect(std.mem.indexOf(u8, p, "Parallelize tool calls") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "ONE response") != null);
+        // Without the caveat this instruction is actively harmful: graff runs
+        // the whole batch concurrently, so two writes to one file would race.
+        try std.testing.expect(std.mem.indexOf(u8, p, "same file") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "depends on an earlier") != null);
+    }
+    // Composing must not have cost either prompt its own identity.
+    try std.testing.expect(std.mem.indexOf(u8, sub_system_prompt, "subagent spawned by an orchestrator") != null);
+    try std.testing.expect(std.mem.indexOf(u8, main_system_prompt, "Be direct and concise") != null);
+    try std.testing.expect(std.mem.indexOf(u8, main_system_prompt_strict, "STRICT MODE") != null);
+}
 
 test "root prompt permits explicit external targets without weakening confinement" {
     try std.testing.expect(std.mem.indexOf(u8, main_system_prompt, "explicitly names") != null);


### PR DESCRIPTION
Two independent changes, both small.

### kuri installs by default
kuri backs `webfetch`'s markdown path and the kuri skill, so an install without it silently degrades to a plain HTTP GET. It was gated behind `HARNESS_WITH_KURI=1`, which almost nobody sets.

Now default-on with `HARNESS_NO_KURI=1` to opt out, mirroring the suite's `HARNESS_NO_GRAFF`. It is also backgrounded beside the suite instead of run sequentially at the end, so it overlaps the graff download rather than adding to the wall clock. Same contract as before: never fatal, harness fully functional without it. `KURI_INSTALL_URL` overrides the source, matching `GRAFF_SUITE_URL`.

Verified with the network stubbed: by default both `codegraff.com` and kuri's `install.sh` are fetched; with `HARNESS_NO_KURI=1` only the suite is.

### Both prompts now ask for parallel tool calls
The harness has always executed a returned tool batch concurrently - `agent_tools.zig:177` dispatches every external call as a future before awaiting any, with no cap and no root-vs-subagent branch. Nothing ever ASKED for a batch, so the capability rode entirely on the model's own initiative.

openai/codex spells this out in its base instructions ("Parallelize tool calls whenever possible - especially file reads"); graff had no equivalent on either prompt. Added as one shared const appended to both, since they are separate literals with no common base and the subagent prompt is five lines long and easy to forget.

The dependency caveat is load-bearing, not padding: codex takes a write lock for tools that are not parallel-safe, graff runs the whole batch concurrently. Telling the model to batch without telling it when NOT to would make two writes to one file race.

Falsified: dropping the append from the subagent prompt alone turns the new test red.

576 tests, tier-1 green, CI green.