### PR TITLE
fix(learn): document the aggregate default the binary actually ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,10 +259,11 @@ the directory, so concurrent processes never share a truncate/append cursor:
 - **Tool-use is mined too.** Each agent logs its tool calls (name + error flag,
   in order): the process signal behind "which tool combinations work",
   joinable to scores via `prompt_sha`.
-- **Consent-scoped fleet loop.** Learning stays local by default; users can
-  contribute prompt-free aggregate fitness or individually reviewed reusable
-  templates. `/trajectory` renders the current session's agent tree; see
-  [docs/hyperagents.md](docs/hyperagents.md) for the full design.
+- **Consent-scoped fleet loop.** Learning contributes prompt-free aggregate
+  fitness by default, announced once per machine; `/privacy local` opts out
+  entirely, and individually reviewed reusable templates need an exact
+  per-artifact approval on top. `/trajectory` renders the current session's
+  agent tree; see [docs/hyperagents.md](docs/hyperagents.md) for the full design.
 
 For controlled local hill-climbing, `graff learn` adds a separate
 parent → mutate → paired-evaluate → select loop with immutable evidence, manual
@@ -984,11 +985,13 @@ file paths, or tool arguments. The separately bounded behavioral payload follows
 the metadata/content rules above; only explicit content mode permits opaque
 adapter fields that may contain task content.
 
-**Fleet / evolution signals are local by default.** `/privacy` selects a
-session-scoped learning ceiling: `local` sends nothing automatically (the
-bundled `learn_candidate` tool can request one aggregate-only send); `aggregate` permits
-signed grades and prompt-free fleet metadata; `templates` additionally offers
-each private reusable persona/template for an exact preview approval; and
+**Fleet / evolution signals default to `aggregate`,** and the first session that
+could contribute says so once per machine. `/privacy` selects a session-scoped
+learning ceiling: `local` sends nothing automatically (the bundled
+`learn_candidate` tool can request one aggregate-only send); `aggregate` (the
+default) permits signed grades and prompt-free fleet metadata; `templates`
+additionally offers each private reusable persona/template for an exact preview
+approval; and
 `examples` reserves a future one-shot reviewed-example channel (raw example
 upload is not implemented). `GRAFF_LEARNING_PRIVACY` or
 `--learning-privacy` can select the same mode, while `GRAFF_FLEET=off` or

--- a/docs/hyperagents.md
+++ b/docs/hyperagents.md
@@ -342,9 +342,10 @@ serve elites. **No central inference → it runs at fleet scale for free.**
 - **Eval: private suite, public hash.** Only `eval_set_hash` is public; the
   suite is secret and rotated, so the honest majority can't study to the
   answer. Already bound into every score signature (Step 0).
-- **Contribution: local by default, independently scoped.** `/privacy
-  aggregate` admits prompt-free scores/metadata. `/privacy templates` raises
-  the ceiling, but each private persona still requires exact interactive
+- **Contribution: aggregate by default, independently scoped.** `/privacy
+  aggregate` is the shipped default, announced once per machine, and admits
+  prompt-free scores/metadata; `/privacy local` opts out. `/privacy templates`
+  raises the ceiling, but each private persona still requires exact interactive
   approval; `GRAFF_FLEET=off` remains a master kill switch.
 - **Grid: niche × provider-class.** The elite you *receive* is the one that won
   on *your* model tier — "let the provider be me" made literal.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -112,7 +112,7 @@ pub const usage_text =
     \\  --max-model-calls N total provider calls allowed across this run (default 256; includes children/title/judges)
     \\  --dedupe-tool-calls reject duplicate root tool name+input calls per turn
     \\  --no-telemetry   disable anonymous usage telemetry for this run
-    \\  --learning-privacy <mode>       learning egress ceiling: local|aggregate|templates|examples (default local)
+    \\  --learning-privacy <mode>       learning egress ceiling: local|aggregate|templates|examples (default aggregate)
     \\  -h, --help       this help
     \\  -V, --version    print version
     \\
@@ -127,8 +127,10 @@ pub const usage_text =
     \\OTEL_EXPORTER_OTLP_ENDPOINT (or GRAFF_OTEL_ENDPOINT) is set; opt out
     \\with --no-telemetry or GRAFF_NO_TELEMETRY=1. GRAFF_TELEMETRY_KEY sends
     \\an optional x-harness-key token to the configured collector.
-    \\learning privacy: prompt-policy learning stays local by default; /privacy
-    \\changes the session ceiling. Template text still needs exact approval.
+    \\learning privacy: local learning trials publish prompt-free aggregate grades
+    \\by default, announced once per machine; /privacy local (or
+    \\GRAFF_LEARNING_PRIVACY=local, GRAFF_FLEET=off, --no-telemetry) sends nothing.
+    \\/privacy changes the session ceiling; template text still needs exact approval.
     \\
 ;
 

--- a/src/learning_privacy.zig
+++ b/src/learning_privacy.zig
@@ -227,9 +227,9 @@ test "--help and --schema state the default ceiling the binary actually applies"
     const documented = "default " ++ @tagName(default_mode);
     try std.testing.expect(std.mem.indexOf(u8, usage_text, documented) != null);
     try std.testing.expect(std.mem.indexOf(u8, schema_flags_json, documented) != null);
-    inline for (@typeInfo(Mode).@"enum".fields) |field| {
-        if (comptime std.mem.eql(u8, field.name, @tagName(default_mode))) continue;
-        const stale = "default " ++ field.name;
+    inline for (comptime std.enums.values(Mode)) |mode| {
+        if (mode == default_mode) continue;
+        const stale = "default " ++ @tagName(mode);
         try std.testing.expect(std.mem.indexOf(u8, usage_text, stale) == null);
         try std.testing.expect(std.mem.indexOf(u8, schema_flags_json, stale) == null);
     }

--- a/src/learning_privacy.zig
+++ b/src/learning_privacy.zig
@@ -216,6 +216,25 @@ test "learning privacy defaults to aggregate, fails closed, and modes form a cei
     try std.testing.expect(!allowsExamples());
 }
 
+test "--help and --schema state the default ceiling the binary actually applies" {
+    // The generated SDKs are built from `graff --schema`, so a stale default
+    // there is a machine-readable promise of more privacy than init() applies.
+    // Every mode name is checked, not just the current one, so flipping
+    // default_mode without moving the text fails here rather than in a user's
+    // reading of the docs.
+    const usage_text = @import("cli.zig").usage_text;
+    const schema_flags_json = @import("schema.zig").schema_flags_json;
+    const documented = "default " ++ @tagName(default_mode);
+    try std.testing.expect(std.mem.indexOf(u8, usage_text, documented) != null);
+    try std.testing.expect(std.mem.indexOf(u8, schema_flags_json, documented) != null);
+    inline for (@typeInfo(Mode).@"enum".fields) |field| {
+        if (comptime std.mem.eql(u8, field.name, @tagName(default_mode))) continue;
+        const stale = "default " ++ field.name;
+        try std.testing.expect(std.mem.indexOf(u8, usage_text, stale) == null);
+        try std.testing.expect(std.mem.indexOf(u8, schema_flags_json, stale) == null);
+    }
+}
+
 test "secret canaries are blocked without flagging ordinary agent templates" {
     const canaries = [_][]const u8{
         "OPENAI_API_KEY=sk-proj-test-only-not-real",

--- a/src/schema.zig
+++ b/src/schema.zig
@@ -39,7 +39,10 @@ const schema_serve_json =
 ;
 /// Launch flags relevant to SDK clients, embedded verbatim in `--schema`
 /// output so generated clients can surface them as first-class options.
-const schema_flags_json =
+/// Pinned against learning_privacy.default_mode by a test there: the SDKs are
+/// generated from this text, so a stale default here is a promise the binary
+/// does not keep.
+pub const schema_flags_json =
     \\[
     \\  {"flag": "--model", "arg": "name", "description": "start on this model (same fuzzy resolution as /model)"},
     \\  {"flag": "--subagent-model", "arg": "name", "description": "pin direct subagents, workflow workers/retries, and judges to this model on the root provider; GRAFF_SUBAGENT_MODEL is the lower-precedence equivalent"},
@@ -53,7 +56,7 @@ const schema_flags_json =
     \\  {"flag": "--max-model-calls", "arg": "N", "description": "opt-in invocation-wide provider-call ceiling shared by root, review, subagents, retries, title, compaction, and judges; default unlimited"},
     \\  {"flag": "--dedupe-tool-calls", "arg": null, "description": "reject duplicate root tool name+normalized-input calls per turn"},
     \\  {"flag": "--no-telemetry", "arg": null, "description": "disable anonymous OTEL usage telemetry for this run"},
-    \\  {"flag": "--learning-privacy", "arg": "local|aggregate|templates|examples", "description": "set the prompt-learning egress ceiling; default local, and template text still requires exact interactive approval"}
+    \\  {"flag": "--learning-privacy", "arg": "local|aggregate|templates|examples", "description": "set the prompt-learning egress ceiling; default aggregate (signed prompt-free grades), local sends nothing, and template text still requires exact interactive approval"}
     \\]
 ;
 const ToolSpec = struct {


### PR DESCRIPTION
`--help`, the README (twice), and the `--schema` flag description all said the learning-privacy default is `local`, while `default_mode` is `.aggregate`. The schema copy is the worst of the three: it feeds the machine-readable surface the SDKs consume, and it under-stated what the binary sends.

The code is the side that's right: `default_mode` was born `.aggregate` in #302 ("Fleet contribution on by default"), which also added the one-time per-machine disclosure and a test pinning the default — #302 updated two docs and missed the rest. So this fixes every stale surface (`cli.zig` help, `schema.zig`, README ×2, `docs/hyperagents.md`) to say `aggregate`, and states the opt-out (`/privacy local`, `GRAFF_LEARNING_PRIVACY=local`, `GRAFF_FLEET=off`, `--no-telemetry`) next to it.

A new test pins `"default " ++ @tagName(default_mode)` into both `usage_text` and `schema_flags_json` and asserts no other mode's string appears — flipping either the code or the text alone fails it (falsified in both directions).

Deliberately untouched: the SDKs default `GRAFF_LEARNING_PRIVACY` to `local` (fail-closed, no artifact-review UI — rationale in `sdk/generate.py`). That CLI/SDK split is intentional but undocumented; separate follow-up.

Tests 576 → 577.