### PR TITLE
feat(skills): teach skill-creator the full authoring loop

### DIFF
--- a/assets/skills/skill-creator.md
+++ b/assets/skills/skill-creator.md
@@ -1,14 +1,37 @@
 ---
 name: skill-creator
-description: Author, install, or edit a graff skill (a SKILL.md playbook) - use when the user wants to capture a repeatable workflow as a reusable skill, asks how skills work, or asks you to write or update a skill.
+description: Create, improve, or test a graff skill (a SKILL.md playbook). Use whenever the user wants to capture a repeatable workflow as a skill, says "turn this into a skill", wants to edit or tune an existing skill, wants to check that a skill actually works or triggers, or asks how skills are written - even if they never say the word "skill".
 ---
 
-# Writing a graff skill
+# Creating a graff skill
 
-A skill is a markdown playbook the harness finds on disk and loads on demand.
-Only its name and description sit in the system prompt; the body stays on disk
-until the `skill` tool loads it. That split is the whole point: the catalog
-line stays cheap, and the detail is there when a task actually needs it.
+A skill is a markdown playbook the harness discovers on disk and loads on
+demand. Only its name and description sit in the system prompt; the body stays
+on disk until the `skill` tool loads it. That split is the whole point: the
+catalog line stays cheap, and the detail arrives when a task needs it.
+
+Your job with this skill is to find where the user is in this loop and carry
+them forward:
+
+capture intent -> draft -> test on realistic prompts -> let the user judge ->
+improve -> repeat until they are happy.
+
+If the user just wants to vibe ("write it, skip the testing"), do that - the
+loop is the default, not a mandate.
+
+## Capture intent first
+
+The conversation often already contains the workflow the user wants captured
+("turn this into a skill"). Extract what you can before asking anything: the
+tools used, the order of steps, the corrections the user made along the way.
+The corrections are the most valuable lines in a skill - they are exactly what
+a fresh session would get wrong. Then fill the gaps:
+
+- What should the skill let a future session do?
+- When should it fire - which user phrases and situations?
+- What does a good result look like, concretely?
+
+Confirm your understanding in a sentence or two before writing.
 
 ## Where skills live
 
@@ -27,26 +50,75 @@ Two layouts, both valid:
 - `.harness/skills/<name>/SKILL.md` - use this when the skill ships helper files
 - `.harness/skills/<name>.md` - a single-file skill
 
-## Format
+## The description is the trigger
 
-```markdown
----
-name: run-migrations
-description: Apply or roll back database migrations in this repo - use when the user wants to migrate, add a migration, or a schema change needs deploying.
----
+The description is the only thing a future session sees before deciding to
+load the skill, so it carries the entire triggering burden. Two rules:
 
-# Run migrations
+- Say what the skill does AND when to reach for it, in one frontmatter line.
+- Models undertrigger skills: a description that only names the topic
+  ("migrations") will not fire. Make it a little pushy - name the tasks, the
+  phrasings, the situations, including ones where the user does not use the
+  obvious word. "Apply or roll back database migrations - use when the user
+  wants to migrate, mentions a schema change, or a deploy needs the database
+  updated, even if they never say migration."
 
-1. ...
-```
+## Write the body for a smart reader
 
-- `name` is optional; it defaults to the file or directory name. Keep it
-  kebab-case, since that is what the user types after `/skills`.
-- `description` is the trigger, and the only thing another session sees before
-  deciding to load the skill. Say what it does AND when to reach for it, on one
-  line. A description that only names the topic ("migrations") will not fire.
-- The body is plain markdown. Bodies over 32 KB are truncated on load, with a
-  pointer to the file, so keep it focused.
+- Use the imperative, and explain why a step matters instead of stacking
+  ALL-CAPS MUSTs. A model that understands the reason generalizes past your
+  examples; one that only has the rule breaks the moment reality differs.
+  Rigid capitalized commands in a draft are a sign to reframe.
+- Keep it general. You are iterating against a handful of examples, but the
+  skill will run against prompts neither of you wrote. If a fix only works for
+  the test case in front of you, it is overfit - widen it or drop it.
+- Show one or two concrete input -> output examples where format matters.
+- If test runs keep writing the same helper script, stop and bundle it: put it
+  next to SKILL.md, reference it by relative path, and have the body say when
+  to run it. Write it once instead of letting every future session reinvent it.
+- Bodies over 32 KB are truncated on load, with a pointer to the file. Well
+  before that, move reference detail into helper files and keep SKILL.md the
+  index, not the encyclopedia.
+- A skill must never surprise the user who installed it: no hidden data
+  collection, nothing beyond what its description advertises.
+
+## Test it with fresh subagents
+
+A skill has to work in a session that lacks today's context, and you are the
+worst possible tester - you wrote it, so you cannot not know what it means.
+The `subagent` tool gives you what you need: a fresh context that has never
+seen this conversation.
+
+1. Write 2-3 realistic test prompts - concrete, detailed, the way users
+   actually type, not clean abstractions. Show them to the user before
+   running: "do these look right?"
+2. For each prompt, spawn a pair of subagents in the same turn so they finish
+   together:
+   - with-skill: "Load the skill '<name>' with the skill tool and follow it
+     for this task: <prompt>. Save what you produce under <dir>/with/."
+   - baseline: the same task, no mention of the skill, saving under
+     <dir>/without/. When improving an existing skill, the baseline is the old
+     version instead: copy it aside first and point the subagent at the copy.
+3. Read both transcripts, not just the outputs. If the with-skill run wasted
+   turns on something the body made it do, that part of the skill is costing
+   more than it pays.
+4. Show the user both results per prompt and collect their reactions. Their
+   complaints, not your judgment, drive the next revision.
+
+To test triggering separately: give a fresh subagent the catalog lines (name +
+description, exactly as the system prompt shows them) plus a dozen candidate
+prompts - some that should trigger, some near-misses that should not - and ask
+which skill, if any, it would load for each. Near-misses that share keywords
+with the skill are the valuable cases; obviously-unrelated prompts prove
+nothing. Tune the description until both directions hold.
+
+## Improve
+
+Generalize from the feedback rather than patching the example: ask what the
+user's complaint says about the class of task, put that understanding into the
+body, and delete anything that is not pulling its weight. Then rerun the same
+test prompts and compare against the previous round. Stop when the user is
+happy, the feedback comes back empty, or a round stops producing real change.
 
 ## Installing one
 
@@ -56,6 +128,13 @@ description: Apply or roll back database migrations in this repo - use when the 
 3. Its catalog line reaches the system prompt at the next start. Until then,
    load it by name.
 
+## Managing skills
+
+- `/skills` lists every skill with its source and file.
+- `/skills remove <name>` disables one (persisted as
+  `{"skills": {"<name>": false}}` in `.harness/settings.json`); `/skills add`
+  brings it back.
+
 ## What is worth a skill
 
 - A workflow repeated across sessions with steps that are easy to get wrong:
@@ -63,17 +142,3 @@ description: Apply or roll back database migrations in this repo - use when the 
 - Project conventions too long to sit in CLAUDE.md or AGENTS.md.
 - Not worth it: one-off instructions, or anything already obvious from reading
   the code. A skill nobody loads is context tax for every future session.
-
-## Helper files
-
-Anything next to SKILL.md travels with the skill. Reference it by relative path
-in the body and read it with `read_file` at the point it is needed - the loaded
-body tells you which directory the skill came from. Keep SKILL.md the index,
-not the encyclopedia.
-
-## Managing skills
-
-- `/skills` lists every skill with its source and file.
-- `/skills remove <name>` disables one. That persists as
-  `{"skills": {"<name>": false}}` in `.harness/settings.json`, and the skill
-  disappears from the catalog and from the `skill` tool entirely.


### PR DESCRIPTION
Upgrades the bundled `skill-creator` from a format reference to the full authoring process, distilled from how OpenAI's codex skill-creator and Claude Code's skill-creator both do it, adapted to graff's native tools:

- **Capture intent from the conversation first** - the user's corrections during a session are the most valuable lines a skill can carry.
- **The description is the trigger** - models undertrigger, so descriptions should be a little pushy: name the tasks, phrasings, and situations, including ones missing the obvious keyword.
- **Write for a smart reader** - explain why a step matters instead of stacking ALL-CAPS MUSTs; keep it general rather than overfit to the test prompts; bundle helper scripts that test runs keep independently rewriting.
- **Forward-test with fresh subagents** - paired with-skill vs baseline runs per test prompt (the author is the worst tester), reading transcripts not just outputs, plus a triggering check built from catalog lines and near-miss prompts.
- **Iterate on user feedback** until it comes back empty.

Verification: the description (336 chars) fits whole under the 500-char catalog budget, 627/627 tests pass (the comptime parse of the now-7 KB embedded file stays inside the branch quota), and the TUI lists the new catalog line.

Comparison notes from deepwiki on openai/codex: their skills system matches ours on every structural point (SKILL.md + name/description frontmatter, catalog-only-in-prompt with bodies on demand, repo > user > system shadowing, live rescan, per-skill disable, bundled skill-creator). Their $skill-name explicit-invocation syntax is the one feature we lack; noted as a possible follow-up.