### PR TITLE
fix(edit_file): verify the edit actually landed before reporting success (#337)

### DIFF
--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -10,7 +10,7 @@
     "src/main.zig",
     "src/repl.zig"
   ],
-  "test_count_baseline": 646,
+  "test_count_baseline": 656,
   "required_invariants": [
     {
       "id": "goal-epochs",

--- a/scripts/test-edit-verify.py
+++ b/scripts/test-edit-verify.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Offline end-to-end proof of the #337 post-edit verification.
+
+One scripted codex/Responses mock drives a real `graff --json` turn that calls
+edit_file once. The only thing that changes between the three scenarios is what
+`zigpatch` is on PATH:
+
+liar     a stub that prints the real tool's success JSON and writes nothing.
+         edit_file must come back as a TOOL ERROR saying the edit did not
+         persist, the file must still be untouched, and the loud text must be
+         what the model sees on its next request. This is #337.
+honest   a stub that actually performs the replacement and reports success.
+         edit_file must succeed, say it verified, and the file must change.
+native   no zigpatch on PATH at all, so graff does the write itself. Same
+         success, same verification, same change on disk.
+
+Run: python3 scripts/test-edit-verify.py [--graff zig-out/bin/graff]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+from codex_ws_mock import CodexMock, RecordedRequest
+
+EDIT_CALL = "call_edit_once"
+TARGET = "target.txt"
+BEFORE = "alpha\nbeta\ngamma\n"
+AFTER = "alpha\nBETA\ngamma\n"
+FINAL_TEXT = "done"
+
+# A zigpatch that reports exactly what the real one reports on success and
+# touches nothing. Every byte of this lie is what the harness used to believe.
+LIAR_STUB = """#!/bin/sh
+printf '{"ok":true,"file":"%s","op":"replace_all","occurrences":1,"strategy":"exact"}\\n' "$1"
+exit 0
+"""
+
+# A zigpatch that keeps its word: `zigpatch FILE -p OLD --all --content NEW`.
+HONEST_STUB = """#!/bin/sh
+f=$1
+old=$3
+new=$6
+python3 - "$f" "$old" "$new" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, "r", encoding="utf-8") as fh:
+    data = fh.read()
+with open(path, "w", encoding="utf-8") as fh:
+    fh.write(data.replace(old, new))
+PY
+printf '{"ok":true,"file":"%s","op":"replace_all","occurrences":1,"strategy":"exact"}\\n' "$f"
+exit 0
+"""
+
+
+def message_item(text: str, item_id: str) -> dict:
+    return {
+        "type": "message",
+        "id": item_id,
+        "status": "completed",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": text, "annotations": []}],
+    }
+
+
+def call_item(name: str, call_id: str, arguments: dict) -> dict:
+    return {
+        "type": "function_call",
+        "id": f"fc_{call_id}",
+        "call_id": call_id,
+        "name": name,
+        "arguments": json.dumps(arguments, separators=(",", ":")),
+        "status": "completed",
+    }
+
+
+def response_events(item: dict, response_id: str) -> list[dict]:
+    return [
+        {"type": "response.output_item.done", "item": item},
+        {
+            "type": "response.completed",
+            "response": {
+                "id": response_id,
+                "usage": {
+                    "input_tokens": 900,
+                    "input_tokens_details": {"cached_tokens": 0},
+                    "output_tokens": 100,
+                    "total_tokens": 1000,
+                },
+            },
+        },
+    ]
+
+
+def script(request: RecordedRequest) -> list[dict]:
+    """One edit_file call, then a final message once its result comes back."""
+    seen = json.dumps(request.body.get("input"), separators=(",", ":"))
+    tag = f"resp_{request.ordinal}"
+    if EDIT_CALL not in seen:
+        return response_events(
+            call_item(
+                "edit_file",
+                EDIT_CALL,
+                {"path": TARGET, "old_string": "beta", "new_string": "BETA"},
+            ),
+            tag,
+        )
+    return response_events(message_item(FINAL_TEXT, f"msg_{tag}"), tag)
+
+
+def run_graff(graff: Path, port: int, stub: str | None) -> tuple[list[dict], str]:
+    """One `--json` turn against the mock; returns (events, target file bytes)."""
+    with tempfile.TemporaryDirectory(prefix="graff-edit-verify-") as tmp:
+        workspace = Path(tmp)
+        (workspace / TARGET).write_text(BEFORE, encoding="utf-8")
+        codex_home = workspace / "codex-home"
+        codex_home.mkdir()
+        (codex_home / "auth.json").write_text(
+            json.dumps(
+                {
+                    "tokens": {
+                        "access_token": "edit-verify-mock",
+                        "account_id": "acct-edit-verify",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        settings = workspace / ".harness" / "settings.json"
+        settings.parent.mkdir()
+        settings.write_text(
+            json.dumps({"skills": {"codedbpro": False, "muonry": False}}),
+            encoding="utf-8",
+        )
+
+        # A minimal PATH so the machine's real zigpatch cannot join the run; the
+        # scenario's stub (if any) is the only one there is.
+        path = "/usr/bin:/bin:/usr/sbin:/sbin"
+        if stub is not None:
+            bindir = workspace / "stub-bin"
+            bindir.mkdir()
+            target = bindir / "zigpatch"
+            target.write_text(stub, encoding="utf-8")
+            target.chmod(0o755)
+            path = f"{bindir}:{path}"
+
+        env = os.environ.copy()
+        for name in tuple(env):
+            if name.startswith("GRAFF_") or name.startswith("CODEX_"):
+                env.pop(name)
+        env.update(
+            {
+                "HOME": tmp,
+                "PATH": path,
+                "CODEX_HOME": str(codex_home),
+                "GRAFF_CODEX_URL": f"http://127.0.0.1:{port}/backend-api/codex/responses",
+                "GRAFF_CODEX_WS": "off",
+                "GRAFF_FLEET": "off",
+                "GRAFF_NO_SMOLIFY": "1",
+                "GRAFF_NO_TELEMETRY": "1",
+                "GRAFF_BEHAVIOR_TRACE": "0",
+            }
+        )
+        completed = subprocess.run(
+            [str(graff), "--model", "codex", "--json", "--yolo", "--no-telemetry"],
+            cwd=tmp,
+            env=env,
+            input=json.dumps({"type": "user", "text": "rename beta"}) + "\n",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=90,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise AssertionError(
+                f"graff exited {completed.returncode}\n"
+                f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+            )
+        events = [
+            json.loads(line)
+            for line in completed.stdout.splitlines()
+            if line.strip()
+        ]
+        return events, (workspace / TARGET).read_text(encoding="utf-8")
+
+
+def edit_result(events: list[dict]) -> dict:
+    results = [
+        e
+        for e in events
+        if e.get("type") == "tool_result" and e.get("name") == "edit_file"
+    ]
+    if len(results) != 1:
+        raise AssertionError(f"expected exactly one edit_file result: {results!r}")
+    return results[0]
+
+
+def assert_liar_is_loud(events: list[dict], on_disk: str, requests) -> None:
+    result = edit_result(events)
+    text = result.get("text", "")
+    if not result.get("is_error"):
+        raise AssertionError(f"a lying zigpatch still reported success: {result!r}")
+    for needle in ("did NOT persist", TARGET, "read_file"):
+        if needle not in text:
+            raise AssertionError(f"loud error is missing {needle!r}: {text!r}")
+    if "replaced" in text:
+        raise AssertionError(f"the success wording leaked into the error: {text!r}")
+    if on_disk != BEFORE:
+        raise AssertionError(f"the file changed after all: {on_disk!r}")
+    # The model has to SEE it: the failure is in the next request's input.
+    followups = [
+        r
+        for r in requests
+        if EDIT_CALL in json.dumps(r.body, separators=(",", ":"))
+    ]
+    if not followups:
+        raise AssertionError("the tool result never reached the model")
+    carried = json.dumps(followups[0].body, separators=(",", ":"))
+    if "did NOT persist" not in carried:
+        raise AssertionError(f"the model was not told: {carried[:800]}")
+
+
+def assert_edit_landed(events: list[dict], on_disk: str, expect_companion: bool) -> None:
+    result = edit_result(events)
+    text = result.get("text", "")
+    if result.get("is_error"):
+        raise AssertionError(f"a genuine edit was rejected: {result!r}")
+    if "replaced 1 occurrence(s)" not in text or "verified" not in text:
+        raise AssertionError(f"success message is wrong: {text!r}")
+    if expect_companion and "zigpatch" not in text:
+        raise AssertionError(f"expected the companion route: {text!r}")
+    if not expect_companion and "zigpatch" in text:
+        raise AssertionError(f"expected the native route: {text!r}")
+    if on_disk != AFTER:
+        raise AssertionError(f"the file did not get the edit: {on_disk!r}")
+
+
+def run(graff: Path) -> None:
+    scenarios = (
+        ("liar", LIAR_STUB, "a zigpatch that lies about success is caught and reported loudly"),
+        ("honest", HONEST_STUB, "a zigpatch that really writes still succeeds, and says it verified"),
+        ("native", None, "with no companion at all, graff's own write verifies the same way"),
+    )
+    for name, stub, label in scenarios:
+        mock = CodexMock(events_for_request=script)
+        port = mock.start()
+        try:
+            events, on_disk = run_graff(graff, port, stub)
+            requests = mock.recorded_requests()
+        finally:
+            mock.stop()
+        if name == "liar":
+            assert_liar_is_loud(events, on_disk, requests)
+        else:
+            assert_edit_landed(events, on_disk, expect_companion=stub is not None)
+        print(f"ok    {label}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--graff", type=Path, default=Path("zig-out/bin/graff"))
+    args = parser.parse_args()
+    graff = args.graff.resolve()
+    if not graff.is_file():
+        parser.error(f"graff binary not found: {graff}")
+    run(graff)
+    print("#337 edit_file verification E2E passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/edit_verify.zig
+++ b/src/edit_verify.zig
@@ -1,0 +1,582 @@
+//! edit_file's write path, and the post-edit verification that makes a write
+//! which did not land LOUD (#337).
+//!
+//! edit_file was reporting `replaced 1 occurrence(s) in <file>` — sometimes
+//! with a `(zigpatch)` suffix — over files it had left byte-identical. A loud
+//! failure costs one retry; a confident false success corrupts everything
+//! built on top of it. So the check lives ON the success path: every route
+//! that would emit that message re-reads the file from disk first, and no
+//! caller can skip it.
+//!
+//! Split out of exec.zig, which sits at the 600-line ceiling. `fsErrorText`
+//! and `preserveMode` came along because the edit path owns them; read_file
+//! and write_file only borrow them.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Io = std.Io;
+const Value = std.json.Value;
+const Allocator = std.mem.Allocator;
+
+const tools = @import("tools.zig");
+const ToolCtx = tools.ToolCtx;
+const ToolOutput = tools.ToolOutput;
+const strField = tools.strField;
+const missingArg = tools.missingArg;
+const outsideCwd = tools.outsideCwd;
+const approvals_mod = @import("approvals.zig");
+const confinedPath = approvals_mod.confinedPath;
+const noSymlinkEscape = approvals_mod.noSymlinkEscape;
+const runCapped = @import("jobs.zig").runCapped;
+
+/// Whole-file read ceiling for the splice source (unchanged from exec.zig).
+const edit_read_cap: usize = 1024 * 1024;
+/// The verification re-read is deliberately looser than the source cap: a
+/// `replace_all` can grow a file past it, and a re-read that failed on size
+/// alone would report a false "did not persist".
+const verify_read_cap: usize = 16 * 1024 * 1024;
+
+/// The companion binary the premium splice shells out to. `pub var` purely so
+/// a test can point it at a stub that CLAIMS success without writing — the
+/// exact shape of #337. Production leaves it at `zigpatch` on PATH.
+pub var companion_bin: []const u8 = "zigpatch";
+
+// --- same-file write serialization ---------------------------------------
+
+/// Striped write locks for the file-mutating tools. edit_file/write_file calls
+/// issued in ONE assistant message run CONCURRENTLY — agent_tools.zig fans
+/// them out with `io.async` and joins the futures afterwards — so two edits to
+/// the same file could interleave read → splice → write and silently drop one
+/// of them (#337 repro C: "both report success, only one persists"). Hashing
+/// the resolved path onto a stripe serializes exactly those: same file, one
+/// writer at a time. Different files usually land on different stripes and
+/// still run in parallel, and a hash collision costs a little serialization,
+/// never correctness. `Io.Mutex` rather than `std.Thread.Mutex` because the
+/// waiter parks through `io`, so it is correct on a fiber-backed Io too.
+var write_locks: [16]Io.Mutex = @splat(.init);
+
+/// Take the write lock covering `resolved`. The caller must `unlock(io)` it.
+pub fn lockPath(io: Io, resolved: []const u8) *Io.Mutex {
+    const idx: usize = @intCast(std.hash.Wyhash.hash(0, resolved) % write_locks.len);
+    const lock = &write_locks[idx];
+    lock.lockUncancelable(io);
+    return lock;
+}
+
+// --- the verifier ---------------------------------------------------------
+
+/// What a re-read of the file says about an edit that just reported success.
+pub const Verdict = enum {
+    /// The edit is on disk.
+    ok,
+    /// The file could not be re-read at all after the write.
+    unreadable,
+    /// Byte-identical to before the edit: nothing was written. The #337 shape.
+    unchanged,
+    /// Changed, but not into the bytes graff spliced.
+    mismatch,
+    /// new_string is nowhere in the file the companion left behind.
+    missing_new,
+    /// new_string is there, but fewer times than there were occurrences to
+    /// replace: the splice covered only some of them.
+    partial,
+    /// old_string survives more often than the replacement allows: the splice
+    /// was partial, or never happened.
+    stale_old,
+};
+
+/// Verify a splice graff computed AND wrote itself. We know the exact bytes
+/// that were supposed to land, so anything else on disk is a failure.
+pub fn verifyNative(before: []const u8, after: []const u8, expected: []const u8) Verdict {
+    if (std.mem.eql(u8, after, expected)) return .ok;
+    if (std.mem.eql(u8, after, before)) return .unchanged;
+    return .mismatch;
+}
+
+/// Verify a splice an EXTERNAL companion applied. An exact match against what
+/// graff would have written is the happy path, but not the only legal one — a
+/// companion is free to normalize (zigpatch reports a `strategy`, and only one
+/// of those is byte-exact), so the fallback is semantic:
+///
+///   * the file must not be byte-identical to what it was before,
+///   * new_string must appear at least once per occurrence that was supposed
+///     to be replaced (unless the edit was a deletion), and
+///   * old_string must be gone, except for the copies that legitimately live
+///     INSIDE new_string — the insert-around-existing-text case, where
+///     old ⊂ new leaves exactly one copy per occurrence replaced.
+///
+/// The occurrence *counts* matter, not just presence: when old ⊂ new, a splice
+/// that covered one of two sites leaves old_string exactly as often as a
+/// correct one would, and only the new_string tally tells them apart.
+pub fn verifyCompanion(before: []const u8, after: []const u8, expected: []const u8, old: []const u8, new: []const u8) Verdict {
+    if (std.mem.eql(u8, after, expected)) return .ok;
+    if (std.mem.eql(u8, after, before)) return .unchanged;
+    if (old.len == 0) return .mismatch; // caller rejects this earlier; never trust it here
+    const sites = std.mem.count(u8, before, old);
+    if (new.len > 0) {
+        const produced = std.mem.count(u8, after, new);
+        if (produced == 0) return .missing_new;
+        if (produced < sites) return .partial;
+    }
+    const inner = std.mem.count(u8, new, old); // 0 unless old is a substring of new
+    if (std.mem.count(u8, after, old) > sites * inner) return .stale_old;
+    return .ok;
+}
+
+/// The loud tool error a failed verdict becomes. Names the file, says plainly
+/// that the edit is NOT on disk, and points at the only safe recovery: read it
+/// again and re-issue against what is actually there. Never returns the
+/// success message. `via` names whatever claimed success.
+pub fn verdictText(gpa: Allocator, path: []const u8, verdict: Verdict, via: []const u8) Allocator.Error![]u8 {
+    const detail = switch (verdict) {
+        .ok => "the edit verified", // unreachable in practice; never phrased as a failure
+        .unreadable => "the file could not be read back at all",
+        .unchanged => "the file on disk is byte-for-byte what it was before",
+        .mismatch => "the file on disk is not the content that was spliced",
+        .missing_new => "new_string is not in the file",
+        .partial => "new_string reached only some of the places it should have",
+        .stale_old => "old_string is still in the file",
+    };
+    return std.fmt.allocPrint(
+        gpa,
+        "edit_file: the edit to {s} did NOT persist — {s} reported success but {s}. Treat the file as unchanged: nothing that depends on this edit has happened. read_file {s} again and re-issue the edit against the text that is actually there.",
+        .{ path, via, detail, path },
+    );
+}
+
+/// Re-read `resolved` and judge what landed. Runs on the success path of every
+/// route, right before the `replaced N occurrence(s)` message is built.
+fn verifyOnDisk(
+    gpa: Allocator,
+    io: Io,
+    resolved: []const u8,
+    before: []const u8,
+    expected: []const u8,
+    old: []const u8,
+    new: []const u8,
+    via_companion: bool,
+) Verdict {
+    const after = Io.Dir.cwd().readFileAlloc(io, resolved, gpa, .limited(verify_read_cap)) catch return .unreadable;
+    defer gpa.free(after);
+    return if (via_companion)
+        verifyCompanion(before, after, expected, old, new)
+    else
+        verifyNative(before, after, expected);
+}
+
+/// Has anything touched the file since `prev` was taken? Size or mtime is
+/// enough: an in-place truncate changes the size, an atomic tmp+rename changes
+/// the mtime. A missing baseline (the stat failed) can never claim drift.
+fn drifted(io: Io, resolved: []const u8, prev: ?Io.Dir.Stat) bool {
+    const base = prev orelse return false;
+    const now = Io.Dir.cwd().statFile(io, resolved, .{}) catch return false;
+    return now.size != base.size or now.mtime.nanoseconds != base.mtime.nanoseconds;
+}
+
+// --- the edit_file tool ---------------------------------------------------
+
+/// `edit_file`: argument validation, worktree resolution (#276 P0-1), then the
+/// verified splice.
+pub fn execEdit(ctx: ToolCtx, input: Value) !ToolOutput {
+    const gpa = ctx.gpa;
+    const path = strField(input, "path") orelse return missingArg(gpa, "path");
+    const old = strField(input, "old_string") orelse return missingArg(gpa, "old_string");
+    const new = strField(input, "new_string") orelse return missingArg(gpa, "new_string");
+    if (!confinedPath(path) or !noSymlinkEscape(ctx.io, path, ctx.agent_cwd)) return outsideCwd(gpa, path);
+    const all = tools.json_args.flag(input, "replace_all");
+    if (old.len == 0) return .{ .text = try gpa.dupe(u8, "old_string must not be empty"), .is_error = true };
+
+    // #276 P0-1: resolve under the agent's isolated worktree when set.
+    const resolved: []const u8 = if (ctx.agent_cwd) |base| try std.fmt.allocPrint(gpa, "{s}/{s}", .{ base, path }) else path;
+    defer if (ctx.agent_cwd != null) gpa.free(resolved);
+    return applyEdit(ctx, path, resolved, old, new, all);
+}
+
+/// Read, splice, write, VERIFY. `path` is what the model asked for (and what
+/// every message names); `resolved` is where the bytes actually live.
+pub fn applyEdit(ctx: ToolCtx, path: []const u8, resolved: []const u8, old: []const u8, new: []const u8, all: bool) !ToolOutput {
+    const gpa = ctx.gpa;
+    const io = ctx.io;
+
+    const lock = lockPath(io, resolved);
+    defer lock.unlock(io);
+
+    var attempt: u8 = 0;
+    while (true) : (attempt += 1) {
+        const data = Io.Dir.cwd().readFileAlloc(io, resolved, gpa, .limited(edit_read_cap)) catch |err| {
+            if (fsErrorText(gpa, .edit, path, err)) |t| return .{ .text = t, .is_error = true };
+            return err;
+        };
+        defer gpa.free(data);
+        // #179: capture the file's mode now so the atomic rewrite below can't
+        // drop a 0755 executable bit down to the default 0644. Doubles as the
+        // drift baseline.
+        const prev_stat = Io.Dir.cwd().statFile(io, resolved, .{}) catch null;
+
+        const count = std.mem.count(u8, data, old);
+        if (count == 0) return .{
+            .text = try std.fmt.allocPrint(gpa, "old_string not found in {s} — read_file it and match the existing text exactly", .{path}),
+            .is_error = true,
+        };
+        if (count > 1 and !all) return .{
+            .text = try std.fmt.allocPrint(gpa, "old_string matches {d} places in {s} — include more surrounding context to make it unique, or set replace_all", .{ count, path }),
+            .is_error = true,
+        };
+
+        const replaced = try gpa.alloc(u8, std.mem.replacementSize(u8, data, old, new));
+        defer gpa.free(replaced);
+        _ = std.mem.replace(u8, data, old, new, replaced);
+
+        // #337: the splice source is read live here — there is no cached copy
+        // of the file anywhere in this path — but an out-of-band writer (a
+        // `sed -i`, a formatter, an indexing daemon) landing between that read
+        // and this write would be clobbered by bytes computed off the older
+        // file. Re-stat and recompute once against what is there now; a second
+        // drift falls through to the write, where verification is the backstop.
+        if (attempt == 0 and drifted(io, resolved, prev_stat)) continue;
+
+        if (ctx.snapshots) |snaps| if (!ctx.from_sub) snaps.record(path, data); // pre-edit content for /rewind
+
+        // Premium splice: when the zigrep suite is installed, zigpatch does the
+        // write — an atomic tmp+rename byte-level --all splice (our count
+        // checks above already enforce the uniqueness semantics). Any failure,
+        // including the tool simply not being on PATH, falls back to the native
+        // in-place write below. zigpatch is a separate process (`.inherit`
+        // cwd, #276) so it's handed `resolved` — an absolute path when isolated
+        // — directly, rather than relying on its own cwd.
+        zp: {
+            const run = runCapped(gpa, io, &.{ companion_bin, resolved, "-p", old, "--all", "--content", new }, 4096, 4096, 0) catch break :zp;
+            defer {
+                gpa.free(run.stdout);
+                gpa.free(run.stderr);
+            }
+            const ok = switch (run.term) {
+                .exited => |code| code == 0,
+                else => false,
+            };
+            if (ok and std.mem.indexOf(u8, run.stdout, "\"ok\":true") != null) {
+                preserveMode(io, resolved, prev_stat); // #179: zigpatch renamed a fresh inode into place
+                // #337: zigpatch claiming success is not evidence that it
+                // wrote anything. Ask the filesystem.
+                const verdict = verifyOnDisk(gpa, io, resolved, data, replaced, old, new, true);
+                if (verdict != .ok) return .{ .text = try verdictText(gpa, path, verdict, "zigpatch"), .is_error = true };
+                return .{ .text = try std.fmt.allocPrint(gpa, "replaced {d} occurrence(s) in {s} (zigpatch, verified)", .{ count, path }) };
+            }
+        }
+        try Io.Dir.cwd().writeFile(io, .{ .sub_path = resolved, .data = replaced });
+        preserveMode(io, resolved, prev_stat); // #179: keep the pre-edit mode
+        const verdict = verifyOnDisk(gpa, io, resolved, data, replaced, old, new, false);
+        if (verdict != .ok) return .{ .text = try verdictText(gpa, path, verdict, "the write"), .is_error = true };
+        return .{ .text = try std.fmt.allocPrint(gpa, "replaced {d} occurrence(s) in {s} (verified)", .{ count, path }) };
+    }
+}
+
+// --- shared filesystem helpers (moved from exec.zig) ----------------------
+
+/// The three native file tools, used to shape a filesystem-error message with
+/// the tool's own name and the right recovery hint (#183).
+pub const FileOp = enum {
+    read,
+    edit,
+    write,
+    fn tool(self: FileOp) []const u8 {
+        return switch (self) {
+            .read => "read_file",
+            .edit => "edit_file",
+            .write => "write_file",
+        };
+    }
+};
+
+/// Maps an EXPECTED filesystem error from a native file tool to a clear message
+/// naming the tool, the supplied path, and the failure — so the model sees
+/// "read_file: foo.zig does not exist" instead of a bare "error: FileNotFound"
+/// (#183). Returns null for anything outside the usual path/permission set, so
+/// the caller re-throws it onto the generic harness-failure path. Confinement,
+/// symlink, and validation errors are already handled before the fs call and
+/// never reach here. Caller owns the returned slice.
+pub fn fsErrorText(gpa: Allocator, op: FileOp, path: []const u8, err: anyerror) ?[]u8 {
+    return (switch (err) {
+        // A missing target, or a non-directory used as a path component.
+        error.FileNotFound, error.NotDir => switch (op) {
+            .read => std.fmt.allocPrint(gpa, "read_file: {s} does not exist (paths are relative to the cwd) — check the name, or list the directory with bash `ls`", .{path}),
+            .edit => std.fmt.allocPrint(gpa, "edit_file: {s} does not exist — edit_file only rewrites an existing file; use write_file to create it", .{path}),
+            .write => std.fmt.allocPrint(gpa, "write_file: cannot create {s} — its parent directory does not exist; create it first with bash `mkdir -p`", .{path}),
+        },
+        error.IsDir => std.fmt.allocPrint(gpa, "{s}: {s} is a directory, not a file", .{ op.tool(), path }),
+        error.AccessDenied, error.PermissionDenied => std.fmt.allocPrint(gpa, "{s}: permission denied for {s}", .{ op.tool(), path }),
+        error.NoSpaceLeft => std.fmt.allocPrint(gpa, "write_file: no space left on device writing {s}", .{path}),
+        else => return null,
+    }) catch null;
+}
+
+/// Re-apply a file's saved permission bits after a rewrite. edit_file's atomic
+/// zigpatch splice — and write_file overwriting an existing file — land the new
+/// content on a fresh inode with the default 0644, silently dropping a 0755
+/// executable bit; restore it (#179). `prev` is null for a brand-new file (keep
+/// the default) or when the pre-write stat failed. Best-effort: a chmod failure
+/// never fails the write itself.
+pub fn preserveMode(io: Io, path: []const u8, prev: ?Io.Dir.Stat) void {
+    const st = prev orelse return;
+    Io.Dir.cwd().setFilePermissions(io, path, st.permissions, .{}) catch {};
+}
+
+// --- tests ----------------------------------------------------------------
+
+test "verify: an edit that actually landed passes on both routes" {
+    const before = "alpha\nbeta\ngamma\n";
+    const after = "alpha\nBETA\ngamma\n";
+    try std.testing.expectEqual(Verdict.ok, verifyNative(before, after, after));
+    try std.testing.expectEqual(Verdict.ok, verifyCompanion(before, after, after, "beta", "BETA"));
+}
+
+test "#337: a companion that reports success without writing is caught, not believed" {
+    const before = "alpha\nbeta\ngamma\n";
+    const expected = "alpha\nBETA\ngamma\n";
+    // The file came back byte-identical: the exact shape reported in #337.
+    try std.testing.expectEqual(Verdict.unchanged, verifyCompanion(before, before, expected, "beta", "BETA"));
+    try std.testing.expectEqual(Verdict.unchanged, verifyNative(before, before, expected));
+}
+
+test "verify: a partially applied replace_all is caught" {
+    const before = "x\nx\nx\n";
+    const expected = "y\ny\ny\n";
+    const partial = "y\nx\nx\n"; // one of three occurrences replaced
+    try std.testing.expectEqual(Verdict.partial, verifyCompanion(before, partial, expected, "x", "y"));
+    // The native route knows the exact bytes, so the same file reads as a mismatch.
+    try std.testing.expectEqual(Verdict.mismatch, verifyNative(before, partial, expected));
+
+    // A splice that ADDED new_string without removing old_string produces the
+    // right number of new occurrences and is still wrong.
+    const appended = "x\ny\n";
+    try std.testing.expectEqual(Verdict.stale_old, verifyCompanion("x\n", appended, "y\n", "x", "y"));
+}
+
+test "verify: old_string surviving INSIDE new_string is not a false alarm" {
+    // Insert-around-existing-text: old ⊂ new, so one copy of old legitimately
+    // remains per occurrence replaced. A naive "old must be gone" check would
+    // fail every wrap-this-call edit.
+    const before = "call(a);\n";
+    const new = "guard(); call(a);";
+    const after = "guard(); call(a);\n";
+    try std.testing.expectEqual(Verdict.ok, verifyCompanion(before, after, after, "call(a);", new));
+
+    // Two occurrences, both wrapped: two survivors are allowed, three are not.
+    const before2 = "hit\nhit\n";
+    const after2 = "[hit]\n[hit]\n";
+    try std.testing.expectEqual(Verdict.ok, verifyCompanion(before2, after2, after2, "hit", "[hit]"));
+    // …and a splice that covered only the first site still fails: old_string
+    // survives exactly as often as a CORRECT wrap would leave it, so only the
+    // new_string tally can tell the two apart.
+    const partial2 = "[hit]\nhit\n";
+    try std.testing.expectEqual(Verdict.partial, verifyCompanion(before2, partial2, after2, "hit", "[hit]"));
+}
+
+test "verify: insertion-only and deletion edits both verify" {
+    // Insertion: new_string carries old_string plus ~25 lines of fresh text
+    // (#337 repro D — success reported, none of the new identifiers present).
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(std.testing.allocator);
+    try body.appendSlice(std.testing.allocator, "anchor();\n");
+    for (0..25) |i| try body.print(std.testing.allocator, "    added_{d}();\n", .{i});
+    const before = "anchor();\n";
+    try std.testing.expectEqual(Verdict.ok, verifyCompanion(before, body.items, body.items, "anchor();\n", body.items));
+    // The insertion silently not happening is the failure we care about.
+    try std.testing.expectEqual(Verdict.unchanged, verifyCompanion(before, before, body.items, "anchor();\n", body.items));
+
+    // Deletion: new_string is empty, so presence-of-new cannot be the check;
+    // absence-of-old is.
+    const del_before = "keep\ndrop\nkeep\n";
+    const del_after = "keep\nkeep\n";
+    try std.testing.expectEqual(Verdict.ok, verifyCompanion(del_before, del_after, del_after, "drop\n", ""));
+    try std.testing.expectEqual(Verdict.stale_old, verifyCompanion(del_before, "keep\ndrop\nkeep\n\n", del_after, "drop\n", ""));
+}
+
+test "verify: a file that changed into something else entirely is not success" {
+    const before = "one\n";
+    const expected = "two\n";
+    const clobbered = "something a concurrent writer put there\n";
+    try std.testing.expectEqual(Verdict.mismatch, verifyNative(before, clobbered, expected));
+    try std.testing.expectEqual(Verdict.missing_new, verifyCompanion(before, clobbered, expected, "one", "two"));
+}
+
+test "verdictText names the file, refuses the success wording, and demands a re-read" {
+    const gpa = std.testing.allocator;
+    const msg = try verdictText(gpa, "src/thing.zig", .unchanged, "zigpatch");
+    defer gpa.free(msg);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "src/thing.zig") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "did NOT persist") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "read_file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "zigpatch") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "replaced") == null); // never the success message
+}
+
+/// Minimal ToolCtx for the file-tool tests: no client, no registry, no
+/// approvals — applyEdit touches none of them.
+fn testCtx(client: *std.http.Client) ToolCtx {
+    return .{
+        .gpa = std.testing.allocator,
+        .io = std.testing.io,
+        .client = client,
+        .provider = undefined,
+        .registry = null,
+        .from_sub = false,
+        .approvals = null,
+        .tracer = null,
+    };
+}
+
+test "edit_file: a genuine edit lands on disk and the result says it was verified" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "f.txt", .data = "alpha\nbeta\ngamma\n" });
+
+    const rel = try std.fmt.allocPrint(gpa, ".zig-cache/tmp/{s}/f.txt", .{&tmp.sub_path});
+    defer gpa.free(rel);
+    var client: std.http.Client = undefined;
+
+    const out = try applyEdit(testCtx(&client), rel, rel, "beta", "BETA", false);
+    defer gpa.free(out.text);
+    try std.testing.expect(!out.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, out.text, "replaced 1 occurrence(s)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.text, "verified") != null);
+
+    const on_disk = try tmp.dir.readFileAlloc(io, "f.txt", gpa, .limited(4096));
+    defer gpa.free(on_disk);
+    try std.testing.expectEqualStrings("alpha\nBETA\ngamma\n", on_disk);
+}
+
+test "#337: a companion that lies about success returns a LOUD error, never the success message" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const original = "alpha\nbeta\ngamma\n";
+    try tmp.dir.writeFile(io, .{ .sub_path = "f.txt", .data = original });
+    // A stub zigpatch that prints exactly what the real one prints on success
+    // and touches nothing. This is #337 in a bottle.
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "liar",
+        .data =
+        \\#!/bin/sh
+        \\printf '{"ok":true,"op":"replace_all","occurrences":1,"strategy":"exact"}\n'
+        \\exit 0
+        \\
+        ,
+        .flags = .{ .permissions = @enumFromInt(0o755) },
+    });
+
+    const dir = try std.fmt.allocPrint(gpa, ".zig-cache/tmp/{s}", .{&tmp.sub_path});
+    defer gpa.free(dir);
+    const rel = try std.fmt.allocPrint(gpa, "{s}/f.txt", .{dir});
+    defer gpa.free(rel);
+    var real_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const real_len = try tmp.dir.realPath(io, &real_buf);
+    const stub = try std.fmt.allocPrint(gpa, "{s}/liar", .{real_buf[0..real_len]});
+    defer gpa.free(stub);
+
+    const saved = companion_bin;
+    defer companion_bin = saved;
+    companion_bin = stub;
+
+    var client: std.http.Client = undefined;
+    const out = try applyEdit(testCtx(&client), rel, rel, "beta", "BETA", false);
+    defer gpa.free(out.text);
+    try std.testing.expect(out.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, out.text, "did NOT persist") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.text, "f.txt") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.text, "replaced") == null);
+
+    // And the harness did NOT quietly repair it behind the lie either: the
+    // report has to match the file.
+    const on_disk = try tmp.dir.readFileAlloc(io, "f.txt", gpa, .limited(4096));
+    defer gpa.free(on_disk);
+    try std.testing.expectEqualStrings(original, on_disk);
+}
+
+test "#337: two edits to one file in the same turn both survive" {
+    if (builtin.os.tag == .windows or builtin.single_threaded) return error.SkipZigTest;
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "f.txt", .data = "first\nsecond\n" });
+    // Widen the read→write window to something a race is reliably observable
+    // in: a companion that stalls and then declines pushes the native write
+    // 50ms past the read. That window is the real companion-spawn cost dilated,
+    // not a fake seam. With the per-path lock deleted this loop fails within a
+    // couple of iterations (verified while writing it) — the two calls splice
+    // the SAME pre-edit bytes and the later write erases the earlier one, which
+    // is #337 repro C, "both report success, only one persists".
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "slow",
+        .data =
+        \\#!/bin/sh
+        \\/bin/sleep 0.05
+        \\exit 1
+        \\
+        ,
+        .flags = .{ .permissions = @enumFromInt(0o755) },
+    });
+    var real_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const real_len = try tmp.dir.realPath(io, &real_buf);
+    const stub = try std.fmt.allocPrint(gpa, "{s}/slow", .{real_buf[0..real_len]});
+    defer gpa.free(stub);
+    const saved = companion_bin;
+    defer companion_bin = saved;
+    companion_bin = stub;
+
+    const rel = try std.fmt.allocPrint(gpa, ".zig-cache/tmp/{s}/f.txt", .{&tmp.sub_path});
+    defer gpa.free(rel);
+    var client: std.http.Client = undefined;
+    const ctx = testCtx(&client);
+
+    for (0..5) |_| {
+        try tmp.dir.writeFile(io, .{ .sub_path = "f.txt", .data = "first\nsecond\n" });
+        // The same fan-out agent_tools.zig uses for a multi-call assistant turn.
+        var a = io.async(applyEdit, .{ ctx, rel, rel, "first", "FIRST", false });
+        var b = io.async(applyEdit, .{ ctx, rel, rel, "second", "SECOND", false });
+        const out_a = try a.await(io);
+        defer gpa.free(out_a.text);
+        const out_b = try b.await(io);
+        defer gpa.free(out_b.text);
+        try std.testing.expect(!out_a.is_error);
+        try std.testing.expect(!out_b.is_error);
+
+        // A lost update would leave one of the two originals behind.
+        const on_disk = try tmp.dir.readFileAlloc(io, "f.txt", gpa, .limited(4096));
+        defer gpa.free(on_disk);
+        try std.testing.expectEqualStrings("FIRST\nSECOND\n", on_disk);
+    }
+}
+
+test "fsErrorText names the tool, path, and failure (#183)" {
+    const gpa = std.testing.allocator;
+
+    const nf = fsErrorText(gpa, .read, "src/foo.zig", error.FileNotFound).?;
+    defer gpa.free(nf);
+    try std.testing.expect(std.mem.indexOf(u8, nf, "read_file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, nf, "src/foo.zig") != null);
+
+    const ed = fsErrorText(gpa, .edit, "src/bar.zig", error.FileNotFound).?;
+    defer gpa.free(ed);
+    try std.testing.expect(std.mem.indexOf(u8, ed, "edit_file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ed, "write_file") != null); // points at creation
+
+    const wr = fsErrorText(gpa, .write, "nope/out.txt", error.FileNotFound).?;
+    defer gpa.free(wr);
+    try std.testing.expect(std.mem.indexOf(u8, wr, "write_file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, wr, "parent") != null); // distinguishes a missing parent dir
+
+    const perm = fsErrorText(gpa, .edit, "p", error.AccessDenied).?;
+    defer gpa.free(perm);
+    try std.testing.expect(std.mem.indexOf(u8, perm, "edit_file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, perm, "permission") != null);
+
+    // Errors outside the usual path/permission set fall through to the generic handler.
+    try std.testing.expect(fsErrorText(gpa, .read, "p", error.OutOfMemory) == null);
+}

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -58,6 +58,11 @@ const shellArgv = jobs.shellArgv;
 const skills = @import("skills.zig");
 const skill_docs = @import("skill_docs.zig");
 const read_file = @import("read_file.zig");
+// #337: edit_file's verified write path, plus the file-tool helpers that moved
+// out with it (this file is at the 600-line ceiling).
+const edit_verify = @import("edit_verify.zig");
+const fsErrorText = edit_verify.fsErrorText;
+const preserveMode = edit_verify.preserveMode;
 const hooks = @import("hooks.zig");
 const telemetry = @import("telemetry.zig");
 const learning_privacy = @import("learning_privacy.zig");
@@ -391,66 +396,10 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
         }
         return .{ .text = text };
     }
-    if (std.mem.eql(u8, call.name, "edit_file")) {
-        const path = strField(input, "path") orelse return missingArg(gpa, "path");
-        const old = strField(input, "old_string") orelse return missingArg(gpa, "old_string");
-        const new = strField(input, "new_string") orelse return missingArg(gpa, "new_string");
-        if (!confinedPath(path) or !noSymlinkEscape(io, path, ctx.agent_cwd)) return outsideCwd(gpa, path);
-        const all = tools.json_args.flag(input, "replace_all");
-        if (old.len == 0) return .{ .text = try gpa.dupe(u8, "old_string must not be empty"), .is_error = true };
-
-        // #276 P0-1: resolve under the agent's isolated worktree when set.
-        const resolved: []const u8 = if (ctx.agent_cwd) |base| try std.fmt.allocPrint(gpa, "{s}/{s}", .{ base, path }) else path;
-        defer if (ctx.agent_cwd != null) gpa.free(resolved);
-
-        const data = Io.Dir.cwd().readFileAlloc(io, resolved, gpa, .limited(1024 * 1024)) catch |err| {
-            if (fsErrorText(gpa, .edit, path, err)) |t| return .{ .text = t, .is_error = true };
-            return err;
-        };
-        defer gpa.free(data);
-        const count = std.mem.count(u8, data, old);
-        if (count == 0) return .{
-            .text = try std.fmt.allocPrint(gpa, "old_string not found in {s} — read_file it and match the existing text exactly", .{path}),
-            .is_error = true,
-        };
-        if (count > 1 and !all) return .{
-            .text = try std.fmt.allocPrint(gpa, "old_string matches {d} places in {s} — include more surrounding context to make it unique, or set replace_all", .{ count, path }),
-            .is_error = true,
-        };
-
-        const replaced = try gpa.alloc(u8, std.mem.replacementSize(u8, data, old, new));
-        defer gpa.free(replaced);
-        _ = std.mem.replace(u8, data, old, new, replaced);
-        if (ctx.snapshots) |snaps| if (!ctx.from_sub) snaps.record(path, data); // pre-edit content for /rewind
-        // #179: capture the file's mode now so the atomic rewrite below can't drop
-        // a 0755 executable bit down to the default 0644.
-        const prev_stat = Io.Dir.cwd().statFile(io, resolved, .{}) catch null;
-        // Premium splice: when the zigrep suite is installed, zigpatch does
-        // the write — an atomic tmp+rename byte-level --all splice (our count
-        // checks above already enforce the uniqueness semantics). Any
-        // failure, including the tool simply not being on PATH, falls back
-        // to the native in-place write below. zigpatch is a separate process
-        // (`.inherit` cwd, #276) so it's handed `resolved` — an absolute path
-        // when isolated — directly, rather than relying on its own cwd.
-        zp: {
-            const run = runCapped(gpa, io, &.{ "zigpatch", resolved, "-p", old, "--all", "--content", new }, 4096, 4096, 0) catch break :zp;
-            defer {
-                gpa.free(run.stdout);
-                gpa.free(run.stderr);
-            }
-            const ok = switch (run.term) {
-                .exited => |code| code == 0,
-                else => false,
-            };
-            if (ok and std.mem.indexOf(u8, run.stdout, "\"ok\":true") != null) {
-                preserveMode(io, resolved, prev_stat); // #179: zigpatch renamed a fresh inode into place
-                return .{ .text = try std.fmt.allocPrint(gpa, "replaced {d} occurrence(s) in {s} (zigpatch)", .{ count, path }) };
-            }
-        }
-        try Io.Dir.cwd().writeFile(io, .{ .sub_path = resolved, .data = replaced });
-        preserveMode(io, resolved, prev_stat); // #179: keep the pre-edit mode
-        return .{ .text = try std.fmt.allocPrint(gpa, "replaced {d} occurrence(s) in {s}", .{ count, path }) };
-    }
+    // #337: the read/splice/write/VERIFY path lives in edit_verify.zig, where
+    // the post-edit check sits ON the success path — a write that did not land
+    // can no longer be reported as `replaced N occurrence(s)`.
+    if (std.mem.eql(u8, call.name, "edit_file")) return edit_verify.execEdit(ctx, input);
     if (std.mem.eql(u8, call.name, "write_file")) {
         const path = strField(input, "path") orelse return missingArg(gpa, "path");
         const content = strField(input, "content") orelse return missingArg(gpa, "content");
@@ -460,6 +409,11 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
         // subagent, so the branch below never runs together with isolation.)
         const resolved: []const u8 = if (ctx.agent_cwd) |base| try std.fmt.allocPrint(gpa, "{s}/{s}", .{ base, path }) else path;
         defer if (ctx.agent_cwd != null) gpa.free(resolved);
+        // #337: a write_file racing an edit_file on the same path in the same
+        // assistant turn (agent_tools.zig runs them concurrently) would drop
+        // one of the two. Same stripe as edit_file, so they take turns.
+        const lock = edit_verify.lockPath(io, resolved);
+        defer lock.unlock(io);
         if (ctx.snapshots) |snaps| if (!ctx.from_sub) {
             // capture the prior content (or absence) before overwriting, for /rewind
             const before = Io.Dir.cwd().readFileAlloc(io, resolved, gpa, .limited(4 * 1024 * 1024)) catch null;
@@ -514,81 +468,6 @@ fn codedbCompactRead(gpa: Allocator, io: Io, path: []const u8, start: ?i64, end:
     };
     if (!ok or run.stdout.len == 0) return null;
     return ToolOutput{ .text = try std.fmt.allocPrint(gpa, "{s}\n[compact view — comments/blank lines stripped, line numbers shown; re-read WITHOUT compact before building an edit_file old_string]", .{run.stdout}) };
-}
-
-/// The three native file tools, used to shape a filesystem-error message with
-/// the tool's own name and the right recovery hint (#183).
-const FileOp = enum {
-    read,
-    edit,
-    write,
-    fn tool(self: FileOp) []const u8 {
-        return switch (self) {
-            .read => "read_file",
-            .edit => "edit_file",
-            .write => "write_file",
-        };
-    }
-};
-
-/// Maps an EXPECTED filesystem error from a native file tool to a clear message
-/// naming the tool, the supplied path, and the failure — so the model sees
-/// "read_file: foo.zig does not exist" instead of a bare "error: FileNotFound"
-/// (#183). Returns null for anything outside the usual path/permission set, so
-/// the caller re-throws it onto the generic harness-failure path. Confinement,
-/// symlink, and validation errors are already handled before the fs call and
-/// never reach here. Caller owns the returned slice.
-fn fsErrorText(gpa: Allocator, op: FileOp, path: []const u8, err: anyerror) ?[]u8 {
-    return (switch (err) {
-        // A missing target, or a non-directory used as a path component.
-        error.FileNotFound, error.NotDir => switch (op) {
-            .read => std.fmt.allocPrint(gpa, "read_file: {s} does not exist (paths are relative to the cwd) — check the name, or list the directory with bash `ls`", .{path}),
-            .edit => std.fmt.allocPrint(gpa, "edit_file: {s} does not exist — edit_file only rewrites an existing file; use write_file to create it", .{path}),
-            .write => std.fmt.allocPrint(gpa, "write_file: cannot create {s} — its parent directory does not exist; create it first with bash `mkdir -p`", .{path}),
-        },
-        error.IsDir => std.fmt.allocPrint(gpa, "{s}: {s} is a directory, not a file", .{ op.tool(), path }),
-        error.AccessDenied, error.PermissionDenied => std.fmt.allocPrint(gpa, "{s}: permission denied for {s}", .{ op.tool(), path }),
-        error.NoSpaceLeft => std.fmt.allocPrint(gpa, "write_file: no space left on device writing {s}", .{path}),
-        else => return null,
-    }) catch null;
-}
-
-/// Re-apply a file's saved permission bits after a rewrite. edit_file's atomic
-/// zigpatch splice — and write_file overwriting an existing file — land the new
-/// content on a fresh inode with the default 0644, silently dropping a 0755
-/// executable bit; restore it (#179). `prev` is null for a brand-new file (keep
-/// the default) or when the pre-write stat failed. Best-effort: a chmod failure
-/// never fails the write itself.
-fn preserveMode(io: Io, path: []const u8, prev: ?Io.Dir.Stat) void {
-    const st = prev orelse return;
-    Io.Dir.cwd().setFilePermissions(io, path, st.permissions, .{}) catch {};
-}
-
-test "fsErrorText names the tool, path, and failure (#183)" {
-    const gpa = std.testing.allocator;
-
-    const nf = fsErrorText(gpa, .read, "src/foo.zig", error.FileNotFound).?;
-    defer gpa.free(nf);
-    try std.testing.expect(std.mem.indexOf(u8, nf, "read_file") != null);
-    try std.testing.expect(std.mem.indexOf(u8, nf, "src/foo.zig") != null);
-
-    const ed = fsErrorText(gpa, .edit, "src/bar.zig", error.FileNotFound).?;
-    defer gpa.free(ed);
-    try std.testing.expect(std.mem.indexOf(u8, ed, "edit_file") != null);
-    try std.testing.expect(std.mem.indexOf(u8, ed, "write_file") != null); // points at creation
-
-    const wr = fsErrorText(gpa, .write, "nope/out.txt", error.FileNotFound).?;
-    defer gpa.free(wr);
-    try std.testing.expect(std.mem.indexOf(u8, wr, "write_file") != null);
-    try std.testing.expect(std.mem.indexOf(u8, wr, "parent") != null); // distinguishes a missing parent dir
-
-    const perm = fsErrorText(gpa, .edit, "p", error.AccessDenied).?;
-    defer gpa.free(perm);
-    try std.testing.expect(std.mem.indexOf(u8, perm, "edit_file") != null);
-    try std.testing.expect(std.mem.indexOf(u8, perm, "permission") != null);
-
-    // Errors outside the usual path/permission set fall through to the generic handler.
-    try std.testing.expect(fsErrorText(gpa, .read, "p", error.OutOfMemory) == null);
 }
 
 test "internal learning respects the parent privacy ceiling" {


### PR DESCRIPTION
Fixes #337.

`edit_file` was reporting `replaced 1 occurrence(s) in <file>` — sometimes with a `(zigpatch)` suffix — over files it had left byte-identical. The amplifier is the silence: a loud failure costs one retry, a confident false success corrupts everything built on top of it. This puts the check **on the success path** so no caller can skip it.

## Root cause, plainly

**Reproduced and fixed: batched same-file edits race (report pattern C).** Tool calls in one assistant message are NOT sequential. `src/agent_tools.zig:177` fans them out:

```zig
for (ext_idx.items, futures) |i, *fut| fut.* = self.io.async(execTool, .{ ctx, calls[i] });
for (futures, outputs) |*fut, *output| output.* = fut.await(self.io);
```

and `Io.Threaded.async` spawns real OS threads (up to `cpu_count - 1`) rather than running inline. Two `edit_file` calls against one file therefore interleaved read → splice → write, and the later write erased the earlier one. Both reported success; one persisted. That is exactly the shape reported in C, and the new concurrency test fails within a couple of iterations if the lock is removed (I verified that both ways before keeping it).

**Not reproduced: a single `zigpatch` call reporting `ok:true` without writing (patterns A, B, D).** I probed zigpatch 0.2.18 directly with multi-line patterns, CRLF files, empty `--content` (deletion), patterns and replacements beginning with `-`/`--`, a 25-line pattern, a 200 KB pattern, a symlinked target, an out-of-band `python3` rewrite immediately before the call, back-to-back edits and concurrent edits to the same file. It behaved correctly in every case. So I could not pin those three patterns on a specific defect — which is precisely why the fix is a filesystem-level check rather than a targeted patch: whatever made the write vanish, the harness now finds out before it speaks.

**No stale cache exists.** `edit_file` reads the file with `Io.Dir.cwd().readFileAlloc` immediately before splicing. There is no read-tracking state, no mtime-keyed cache, and no bytes carried over from an earlier tool call anywhere on this path, so there was nothing to invalidate. I added the guard the environment note asks for anyway (below), rather than inventing a cache to fix.

**One candidate left open.** For a worktree-isolated subagent (`ctx.agent_cwd`, #276 P0-1) the edit is applied to `<worktree>/<path>` while the result message names the bare relative `path`. An observer checking the main tree would see an unchanged file after an honest success. Verification cannot catch that (the write did land), and I did not change the behaviour here — flagging it in case some of the six reported occurrences were subagent edits.

## What changed

`src/edit_verify.zig` (new; `exec.zig` was at the 600-line ceiling, so the edit path moved out with `fsErrorText`/`preserveMode`).

1. **Post-edit verification.** Both routes that would emit `replaced N occurrence(s)` re-read the file from disk first.
   * Native write: byte-compare against the bytes graff spliced.
   * Companion (`zigpatch`) write: exact match is the happy path; otherwise the file must have changed, `new_string` must appear at least once per site that was supposed to be replaced, and `old_string` must be gone except for the copies that legitimately live *inside* `new_string` (the wrap-existing-text case, where `old ⊂ new` leaves one copy per replacement). The counts matter, not just presence: when `old ⊂ new`, a splice that covered one of two sites leaves `old_string` exactly as often as a correct one would, and only the `new_string` tally separates them.
   * A failed verdict returns a loud tool error naming the file, saying the edit did not persist, and sending the model back to `read_file` — never the success message.
2. **Same-file write serialization.** `edit_file` and `write_file` take a striped per-path lock (`Io.Mutex`, hashed on the resolved path) across the whole read-to-write window. Different files usually take different stripes and still run in parallel.
3. **Stale-source invalidation.** The file is re-stat'ed just before the write; if size or mtime moved (an out-of-band `sed -i`, a formatter, an indexing daemon), the read and splice are redone once against what is on disk now instead of clobbering it.

Success messages now read `replaced N occurrence(s) in <file> (verified)` / `(zigpatch, verified)`.

## Verification

`zig build test --summary all`: **646 → 656**, green. `bash scripts/eval-tier1.sh`: green (fmt, 600-line cap, reachability, build, suite, invariants, sdk); `test_count_baseline` ratcheted to 656.

Unit tests cover the verifier directly on applied-correctly, not-applied, partially-applied, appended-instead-of-substituted, `old ⊂ new`, insertion-only, and deletion; plus a real `applyEdit` against a stub `zigpatch` that prints the genuine success JSON and writes nothing (must return an error), a genuine edit (must succeed and say `verified`), and two concurrent edits to one file (both must survive).

E2E: `python3 scripts/test-edit-verify.py` drives a real `graff --json` run against a scripted codex/Responses mock, changing only what `zigpatch` is on PATH.

```
ok    a zigpatch that lies about success is caught and reported loudly
ok    a zigpatch that really writes still succeeds, and says it verified
ok    with no companion at all, graff's own write verifies the same way
#337 edit_file verification E2E passed
```

The `tool_result` events off that run:

```
=== scenario: liar
{"type": "tool_result","name": "edit_file","is_error": true,"text": "edit_file: the edit to target.txt did NOT persist — zigpatch reported success but the file on disk is byte-for-byte what it was before. Treat the file as unchanged: nothing that depends on this edit has happened. read_file target.txt again and re-issue the edit against the text that is actually there."}
target.txt on disk: 'alpha\nbeta\ngamma\n'

=== scenario: honest
{"type": "tool_result","name": "edit_file","is_error": false,"text": "replaced 1 occurrence(s) in target.txt (zigpatch, verified)"}
target.txt on disk: 'alpha\nBETA\ngamma\n'

=== scenario: native
{"type": "tool_result","name": "edit_file","is_error": false,"text": "replaced 1 occurrence(s) in target.txt (verified)"}
target.txt on disk: 'alpha\nBETA\ngamma\n'
```

The E2E asserts the loud text also reaches the model — it checks the next request's `input` carries `did NOT persist`, not just that the event was emitted.

## Deliberately left out

* No change to the MCP companion tools (`mcp__codedbpro__edit`/`patch`); they return the server's own result text and never produce graff's `replaced N occurrence(s)` message.
* No global serialization of non-mutating tools — reads still fan out in parallel.
* The re-stat drift guard retries once. A second drift falls through to the write, where verification is the backstop.
