### PR TITLE
docs: maintain CHANGELOG.md, curated release notes, README refresh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Notes preference: a hand-written docs/releases/<tag>.md wins, then
+          # the tag's CHANGELOG.md section, then GitHub's generated PR list.
           notes=(--generate-notes)
           notes_file="docs/releases/${GITHUB_REF_NAME}.md"
+          section="$(awk -v tag="${GITHUB_REF_NAME}" '
+            $1 == "##" && $2 == tag { hit = 1; next }
+            /^## / { hit = 0 }
+            hit { print }
+          ' CHANGELOG.md 2>/dev/null || true)"
           if [ -f "$notes_file" ]; then
             notes=(--notes-file "$notes_file")
+          elif [ -n "$section" ]; then
+            printf '%s\n' "$section" > changelog-notes.md
+            notes=(--notes-file changelog-notes.md)
           fi
           gh release create "$GITHUB_REF_NAME" graff-*.tar.gz SHA256SUMS install.sh \
             --title "$GITHUB_REF_NAME" --draft "${notes[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,132 @@
+# Changelog
+
+Notable changes per release, newest first. Some releases also have longer
+narrative notes under [docs/releases/](docs/releases/), `graff --version`
+prints a short what's-new, and the
+[releases page](https://github.com/justrach/codegraff/releases) has the full
+commit history for every tag.
+
+The release workflow uses a tag's section here as its release notes (a
+hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
+current is part of cutting a release.
+
+## v0.0.231 (2026-08-01)
+
+- `edit_file` now verifies every edit actually landed on disk before reporting
+  success: a silent no-op becomes a loud tool error instead of a false
+  "replaced 1 occurrence(s)" (#337, #338).
+- Batched edits to the same file are serialized per path, fixing a race where
+  parallel tool calls could erase each other's writes (#338).
+- Embedder mode part 1: a hard `--no-local-tools` / `GRAFF_NO_LOCAL_TOOLS=1`
+  gate disables local bash/file/codedb tools for the whole process, subagents
+  included, so coding tools can come from a sandbox MCP server instead (#330,
+  #335).
+- Embedder mode part 2: resumable `graff serve` streams with monotonic `seq`
+  ids, `?from=N` replay after a dropped connection, and durable sessions.
+  `--json` schema 0.10 (#330, #336).
+- Longer notes: [docs/releases/v0.0.231.md](docs/releases/v0.0.231.md).
+
+## v0.0.230 (2026-08-01)
+
+- The bundled `skill-creator` skill teaches the full authoring loop: capture
+  intent from the live conversation, write trigger-rich descriptions,
+  forward-test with fresh subagents against baseline runs, and iterate on user
+  feedback until it comes back empty (#334).
+
+## v0.0.229 (2026-07-31)
+
+- SKILL.md skills: drop a markdown playbook in `.harness/skills/<name>/` (or
+  `~/.harness/skills/` for every project) and graff loads it only when a task
+  calls for it. Only name + description enter the system prompt;
+  `.claude/skills/` is read for compatibility; `/skills` lists, hides, and
+  restores them. Ships with `skill-creator` and `mcp-config` built in (#333).
+  See [docs/skills.md](docs/skills.md).
+
+## v0.0.228 (2026-07-31)
+
+- Local learning defaults corrected to the documented privacy posture, with
+  the full write-up in [docs/learning-privacy.md](docs/learning-privacy.md)
+  (#332).
+- Test-dispatch fixes: modules whose tests were silently never running are now
+  wired into the test root (#331).
+
+## v0.0.227 (2026-07-31)
+
+- kuri, the headless-browser companion that backs `webfetch`'s markdown path
+  and the kuri skill, installs by default now; opt out with
+  `HARNESS_NO_KURI=1` (#329).
+- Both the root and subagent system prompts now ask for parallel tool calls,
+  with the dependency caveat that keeps same-file writes from racing (#329).
+
+## v0.0.226 (2026-07-31)
+
+- `/images` opens image URLs from the last response (for example a
+  `gh issue view` with attachments) in your browser (#103).
+- The prompt line is width-budgeted so long model and mode badges cannot break
+  interactive redraw (#209).
+- Kimi and xAI OAuth tokens refresh selectively at startup (#274).
+
+## v0.0.225 (2026-07-31)
+
+- Remote MCP supports stateless-core servers, with a legacy fallback.
+- The system-prompt variants are built through one funnel, removing drift
+  between the interactive, subagent, and review prompts (#326).
+
+## v0.0.224 (2026-07-30)
+
+- `/goal` hardening follow-ups: pinned call-site coverage and a real-PTY
+  regression for goal collapse.
+
+## v0.0.223 (2026-07-30)
+
+- Orchestration hardening: worktree commit-loss fix, JSON tag guards against
+  undefined-behavior derefs, subagent task pinning, and five ultracode audit
+  fixes (retry gating, all-failed abort, phase budgets, worktree rejection in
+  pipelines, shared context slots).
+- Anthropic models stream summarized thinking (#322), and review mode no
+  longer races the background learning writer (#324).
+
+## v0.0.222 (2026-07-30)
+
+- `/goal` and `/loop` are one autonomous run: the same engine with or without
+  a standing objective, including time budgets like `/goal 30m <text>`.
+
+## v0.0.221 (2026-07-30)
+
+- Goal epochs, and a standing `--goal` that survives compaction via an
+  objective snapshot (#318).
+- Retained reasoning is pinned across all wire formats.
+- MCP servers get a bounded teardown at session exit (#305).
+
+## v0.0.220 (2026-07-26)
+
+- `learn` auto-initialization fix (#304).
+
+## v0.0.219 (2026-07-26)
+
+- The local learning loop closed end to end: zero-config `graff learn init`,
+  session-triggered background trials, and the learned genome becomes the root
+  prompt (#302). See [docs/local-learning.md](docs/local-learning.md).
+
+## v0.0.218 (2026-07-26)
+
+- Workspace router configuration for providers; router cache entries
+  serialize independently.
+- GUI: provider surfaces reachable in QA mock mode, useful sidebar empty
+  states, and narrow-window fixes (#300).
+
+## v0.0.217 (2026-07-25)
+
+- Zig 0.17 nightly compatibility for CI (#298).
+- OAuth refresh is single-flight (#245), clipboard paste gets a vision guard
+  (#258), a provider-routing fix (#294), and the ultracode shape catalog with
+  a slot axis (#290, #293).
+
+## v0.0.216 (2026-07-24)
+
+- `/review` is bounded correctly without a hard call cap (#280, #281).
+- Subagent harness orchestration (#279).
+
+Older releases: narrative notes for v0.0.211, v0.0.212, and v0.0.215 live in
+[docs/releases/](docs/releases/), and `graff --version` prints highlights back
+to v0.0.192.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  Install it on your Mac or Linux machine, sign in with the AI subscription you
+  Install it on your Mac, Linux, or Windows machine, sign in with the AI subscription you
   <em>already have</em>, and hand it real tasks. graff writes and runs code,
   automates the boring stuff, digs through your files, researches the web, and
   runs its own experiments, on its own, until the job is done.<br/>
@@ -17,8 +17,8 @@
 </p>
 
 <p align="center">
-  <img alt="macOS · Linux" src="https://img.shields.io/badge/macOS%20·%20Linux-555">
-  <img alt="One binary, 2.7 MB" src="https://img.shields.io/badge/one%20binary-2.7%20MB-44cc11">
+  <img alt="macOS · Linux · Windows" src="https://img.shields.io/badge/macOS%20·%20Linux%20·%20Windows-555">
+  <img alt="One binary, 3.7 MB" src="https://img.shields.io/badge/one%20binary-3.7%20MB-44cc11">
   <img alt="Zero dependencies" src="https://img.shields.io/badge/dependencies-0-44cc11">
   <img alt="Built in Zig 0.17 dev" src="https://img.shields.io/badge/built%20in-Zig%200.17%20dev-f7a41d?logo=zig&logoColor=white">
 </p>
@@ -102,12 +102,12 @@ context when the conversation gets long.
 Prefer a window over a terminal? Download the latest signed, notarized build, drag it to Applications, and open it. The desktop app is **fully self-contained**: it bundles the `graff` agent, so there's nothing else to install to start coding, and it keeps itself up to date automatically. On first launch it drops two commands on your PATH: `codegraff <path>` (opens that folder in the app, `code`-style) and `graff` itself (the agent CLI, in your terminal), so the one install covers both the window and the command line. The terminal `graff` is symlinked into the app, so it auto-updates along with it. Not on Apple Silicon, or want a standalone CLI? Use the command-line install below.
 
 <p align="center">
-  <a href="https://github.com/justrach/codegraff/releases/latest/download/Codegraff.dmg"><img alt="Download Codegraff for macOS" src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white"></a>
+  <a href="https://github.com/justrach/codegraff/releases/download/v0.0.190/Codegraff.dmg"><img alt="Download Codegraff for macOS" src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white"></a>
   <br/>
   <sub><a href="https://github.com/justrach/codegraff/releases/latest">or browse all releases</a></sub>
 </p>
 
-### Command line: macOS · Linux
+### Command line: macOS · Linux · Windows
 
 Grab the latest prebuilt release binary: macOS builds are Developer ID signed
 and Apple notarized; on any other platform the installer builds from source with
@@ -124,6 +124,12 @@ From a checkout, just run `./install.sh`. The binary lands in `~/bin` by default
 | --------- | ------- |
 | `graff`   | the agent CLI + REPL: the one binary this script installs |
 | `codedb`  | optional code-intelligence companion (structural search/outline/callers). graff auto-detects it and points at the [one-line install](https://github.com/justrach/codedb) if it's missing; everything else works without it |
+| `kuri`    | optional [browser companion](https://github.com/justrach/kuri) backing `webfetch`'s markdown path, web crawling, and the kuri skill. Installed by default alongside graff; opt out with `HARNESS_NO_KURI=1`, never fatal if it fails |
+
+On Windows, grab `graff-x86_64-windows.tar.gz` (or `aarch64`) from the
+[latest release](https://github.com/justrach/codegraff/releases/latest), unpack
+it, and put `graff.exe` on your `PATH`; the shell installer itself is
+Unix-only and points Windows at WSL.
 
 ### Give it a key
 
@@ -473,6 +479,7 @@ other animation names remain available.
 /rewind [n]     list past prompts; /rewind <n> drops prompt n+after & reverts its file edits
 /image <path>   attach an image to your next message (vision models only)
 /paste          attach the clipboard image (macOS); also Ctrl-V (⌘V can't be captured)
+/images         open image URLs from the last response (e.g. issue attachments) in your browser
 /strict         toggle "every message is a tool" mode
 /yolo           toggle bash auto-approval (skip permission prompts)
 /trace          toggle this run's JSONL event trace and show its path
@@ -1219,26 +1226,28 @@ Honest list of what the harness still lacks, roughly in the order it hurts.
 
 **Later:**
 
-2. Windows support (install.sh punts to WSL today).
+2. ~~**Windows support.**~~ **Done, v0.0.167.** Every release ships prebuilt
+   `graff-{x86_64,aarch64}-windows.tar.gz`; install.sh itself is still
+   Unix-only (points Windows at WSL, or unpack the tarball by hand).
 3. Shell completions (zsh/bash) and a man page.
 4. A config file for defaults (`--timing`/`--cost`/model) so flags don't have to
    be retyped.
 5. Esc during *tool execution* (the interrupt currently lands at the next
    stream; a long-running bash call still runs to completion).
-6. Honor `Retry-After` on 429s (the backoff is plain exponential today).
+6. ~~Honor `Retry-After` on 429s.~~ **Done, v0.0.204.** Retry/stall/reconnect
+   handling now matches opencode and codex: `Retry-After` honored, in-stream
+   overload and quota-429s recovered, WS falls back to SSE.
 
-Recently shipped: **v0.1.0** · tagged GitHub release with prebuilt darwin/linux
-binaries · bash output truncates at its 128 KB cap instead of failing the tool
-call (`runCapped`: real exit code, `[truncated]` marker, memory stays flat while
-the child streams gigabytes) · measured performance budgets + the Rust-graff
-bake-off in [architecture.md](architecture.md) · 429/5xx retry with exponential
-backoff (1s·2ⁿ capped at 8s, Esc cancels the wait, `retry` notes in the trace) ·
-`--version` stamped from `git describe` at build time (`-Dversion=X.Y.Z`
-overrides) · Esc coverage from the moment the request is sent, so no more `^[`
-echo while a slow provider connects, and the interrupt lands before the first
-token · bare Esc at the prompt clears the line · one-shot `-p` print mode ·
-persistent approvals (`.harness/settings.json`) · plan mode (`/plan`) · `/clear`
-· bare-`/` command menu · interactive `/resume` picker · context-% statusline.
+Recently shipped (see [CHANGELOG.md](CHANGELOG.md) for the release-by-release
+view): SKILL.md skills with a bundled skill-creator · the local learning loop,
+zero-config and privacy-bounded (`graff learn init`) · `/goal` standing
+objectives with epochs and time budgets, `/loop` folded into the same
+autonomous run · embedder mode (hard `--no-local-tools` gate + resumable
+`serve` streams, schema 0.10) · verified `edit_file` with per-path write
+serialization · provider-robustness parity with opencode/codex (Retry-After,
+in-stream overload, WS→SSE) · kuri browser companion installed by default ·
+`/images` · summarized thinking for Anthropic models · prebuilt Windows
+binaries.
 
 </details>
 
@@ -1246,8 +1255,9 @@ persistent approvals (`.harness/settings.json`) · plan mode (`/plan`) · `/clea
 
 ## Coming soon
 
-Active directions. See the **Status & roadmap** details above for the full list,
-and the GitHub issues for what's in flight:
+Active directions. See [CHANGELOG.md](CHANGELOG.md) for what already landed,
+the **Status & roadmap** details above for the full list, and the GitHub
+issues for what's in flight:
 
 - **Sandboxes.** Run the agent's `bash`/file tools inside an isolated sandbox
   (ephemeral container / microVM) so untrusted or destructive steps can't touch
@@ -1257,10 +1267,11 @@ and the GitHub issues for what's in flight:
   first half of this today: `--no-local-tools` plus a sandbox MCP server. A
   first-class sandbox backend (create/exec/read/write/destroy with provider
   adapters) would remove the proxy you have to write yourself.
-- **Closing the evolution loop end-to-end:** a grounded judge, sync-back of
-  fleet trajectories, and automatic promotion of winning agent variants.
-- **Windows support, shell completions + man page, and a config file** for
-  default flags/model.
+- **Scaling the evolution loop.** The local half shipped in v0.0.219:
+  `graff learn init` runs privacy-bounded background trials and promotes the
+  winning genome into the root prompt. What remains is fleet scale: grounded
+  judging and trajectory sync-back across many installs.
+- **Shell completions + man page, and a config file** for default flags/model.
 
 ---
 

--- a/docs/releases/v0.0.231.md
+++ b/docs/releases/v0.0.231.md
@@ -1,0 +1,35 @@
+# Verified edits + embedder mode complete
+
+v0.0.231 makes `edit_file` prove its work and closes out embedder mode. The
+macOS binaries are Developer ID signed and Apple notarized.
+
+## edit_file can no longer claim success it didn't earn (#337)
+
+- Batched edits to the same file used to race: tool calls fan out on real OS
+  threads, and a later write could erase an earlier edit while both reported
+  success. Same-file writes are now serialized per path. The race is proven,
+  not assumed: removing the lock makes the new regression test fail.
+- The originally reported single-call silent no-op ("replaced 1 occurrence(s)"
+  with no change on disk) would not reproduce despite extensive direct probing,
+  so a verification layer now backstops it: after every edit the file is
+  re-read and the result checked. Any recurrence becomes a loud "did NOT
+  persist, re-read and re-issue" tool error the model can act on, and honest
+  edits report "(verified)".
+- `exec.zig` came down from 600 to 474 lines in the process. The suite now
+  runs 656 tests. (PR #338)
+
+## Embedder mode, both halves of #330
+
+- **A hard no-local-tools gate** (PR #335): `--no-local-tools` (or
+  `GRAFF_NO_LOCAL_TOOLS=1`) disables `bash`, the file tools, and `codedb` for
+  the whole process, subagents and workflow workers included. The gated tools
+  are never advertised to any provider, and dispatch refuses them if a model
+  hallucinates one anyway. `--yolo` does not lift it. Point graff at your
+  sandbox as an MCP server and the model gets those tools instead.
+- **Resumable serve streams** (PR #336): every `graff serve` event carries a
+  monotonic `seq`, a dropped consumer reconnects with `?from=N` and replays
+  exactly the gap, and sessions are durable across reconnects. The `--json`
+  schema is now 0.10, the SDK docs cover the reconnect and durable-session
+  surface, and CI runs a serve-resumability end-to-end test.
+
+**Full Changelog**: https://github.com/justrach/codegraff/compare/v0.0.230...v0.0.231

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -21,6 +21,14 @@ const harness_version = root.harness_version;
 pub const changelog_text =
     \\What's new
     \\──────────
+    \\0.0.231
+    \\  • edit_file verifies every edit actually landed on disk; a silent no-op is a loud tool error instead of a false success, and batched same-file edits can no longer race each other
+    \\  • Embedder mode is complete: the hard --no-local-tools gate (MCP-sourced coding tools) plus resumable serve streams with seq ids, ?from=N replay, and durable sessions (schema 0.10)
+    \\
+    \\0.0.229
+    \\  • SKILL.md skills: markdown playbooks in .harness/skills (or .claude/skills) load on demand, cost one catalog line each, and /skills manages them
+    \\  • The bundled skill-creator teaches the full authoring loop, from capturing intent mid-session to forward-testing with fresh subagents
+    \\
     \\0.0.215
     \\  • Local learning can race multiple prompt variants, rank correctness before tool economy, and expose only the winner to a hidden holdout
     \\  • Runs checkpoint safely, keep promotion manual by default, and can bundle an aggregate-only signed grade submission
@@ -42,16 +50,6 @@ pub const changelog_text =
     \\  • A send-failed request no longer re-pools its dead connection, so one network blip can't storm every later compaction, title, and subagent call
     \\  • The "ultracode" codeword is matched only on what you actually typed (not on appended goal/todo notes), and /clear now clears the standing goal and ultracode mode
     \\  • `graff login codex` lands on a branded, dark-mode-aware confirmation page instead of a bare line of text
-    \\
-    \\0.0.200
-    \\  • Codex WS delta bodies are never replayed over SSE — fixes "Unsupported parameter: previous_response_id" after a long idle
-    \\  • The held codex WS now re-anchors preemptively after 4 min idle (GRAFF_CODEX_WS_IDLE_SECS to tune) instead of eating a dead-socket round trip
-    \\  • A server-side previous_response_id rejection now self-heals with one full-input retry
-    \\
-    \\0.0.192
-    \\  • The REPL prompt now shows color-coded reasoning and active mode badges
-    \\  • PTY debugging can script commands, keys, assertions, and terminal dimensions
-    \\  • Interactive prompt redraws and ANSI colors now have a real-PTY CI regression
     \\
 ;
 


### PR DESCRIPTION
## What

- **CHANGELOG.md** at the repo root, seeded from v0.0.216 through v0.0.231, newest first. The intro documents the contract: keeping it current is part of cutting a release.
- **release.yml** now prefers, in order: a hand-written `docs/releases/<tag>.md`, then the tag's CHANGELOG.md section, then `--generate-notes`. So a normal release gets real notes from the changelog with zero extra steps.
- **docs/releases/v0.0.231.md**: narrative notes for the edit-verify + embedder release (also applied to the published release page).
- **README refresh** to match what actually shipped:
  - Windows joins the install path (badges, heading, tarball instructions); the roadmap item is struck through as done since v0.0.167.
  - `Retry-After` roadmap item struck through (provider-robustness parity, v0.0.204).
  - kuri added to the companion-tools table (installs by default since v0.0.227), `/images` added to the command list.
  - Desktop DMG badge pinned to v0.0.190, the last release that carries `Codegraff.dmg`; the `latest/download` link has 404'd since CLI-only releases took over `latest`.
  - "Recently shipped" and "Coming soon" rewritten to the current era, both pointing at CHANGELOG.md.
  - Binary-size badge updated to 3.7 MB (measured on the v0.0.231 release binary).
- **`graff --version` what's-new**: adds 0.0.231 and 0.0.229 entries, retires the two oldest (0.0.200, 0.0.192).

## Verification

- `zig build test` green locally, `zig fmt --check` clean.
- The awk section-extraction in release.yml matches the `## v0.0.X (date)` header shape used by CHANGELOG.md and falls through to `--generate-notes` when no section exists.