### PR TITLE
fix(tools): SystemFdQuotaExceeded gets honest advice, not 'run it in the foreground' (#253)

### DIFF
--- a/src/exec.zig
+++ b/src/exec.zig
@@ -240,9 +240,12 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
             const job = spawnJob(gpa, io, cmd) catch |err| return .{
                 // #122: backgrounding costs MORE fds (pipes + pump task), so the
                 // generic "run it in the foreground" advice is right for every
-                // error except the fd-quota one — special-case that.
+                // error except the fd-quota ones — special-case those. #253: for
+                // SYSTEM-wide exhaustion neither foregrounding nor ulimit helps.
                 .text = if (err == error.ProcessFdQuotaExceeded)
                     try gpa.dupe(u8, "could not start background job (ProcessFdQuotaExceeded) — graff hit its open-file limit. Wait for running jobs/tools to finish, then retry with less parallel fan-out; if it recurs, raise the limit (`ulimit -n 4096`) before starting graff.")
+                else if (err == error.SystemFdQuotaExceeded)
+                    try gpa.dupe(u8, "could not start background job (SystemFdQuotaExceeded) — the SYSTEM-wide open-file table is full, so neither foregrounding nor `ulimit` helps. Wait for other processes to release files (or close some applications), then retry.")
                 else
                     try std.fmt.allocPrint(gpa, "could not start background job ({t}) — run it in the foreground instead", .{err}),
                 .is_error = true,

--- a/src/main_test.zig
+++ b/src/main_test.zig
@@ -160,3 +160,19 @@ test "/bash slash command runs the bash tool and frees its gpa-allocated result"
 test {
     _ = @import("startup_tests.zig");
 }
+
+test "failure (#253): fd-quota errors carry actionable advice, system-wide says ulimit won't help" {
+    const tools = @import("tools.zig");
+    const gpa = std.testing.allocator;
+    const p = tools.failure(gpa, error.ProcessFdQuotaExceeded);
+    defer gpa.free(p.text);
+    try std.testing.expect(std.mem.indexOf(u8, p.text, "ulimit -n 4096") != null);
+    const s = tools.failure(gpa, error.SystemFdQuotaExceeded);
+    defer gpa.free(s.text);
+    try std.testing.expect(std.mem.indexOf(u8, s.text, "SYSTEM-wide") != null);
+    try std.testing.expect(std.mem.indexOf(u8, s.text, "`ulimit` will not help") != null);
+    // The generic path is untouched: unknown errors still print the bare name.
+    const g = tools.failure(gpa, error.AccessDenied);
+    defer gpa.free(g.text);
+    try std.testing.expectEqualStrings("error: AccessDenied", g.text);
+}

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -360,13 +360,13 @@ fn companionNativeFallback(bare: []const u8) []const u8 {
 }
 
 pub fn failure(gpa: Allocator, err: anyerror) ToolOutput {
-    // #122: the bare error name is useless advice for an open-file-limit hit —
-    // say what it means and what actually helps.
-    if (err == error.ProcessFdQuotaExceeded) {
-        const text = gpa.dupe(u8, "error: ProcessFdQuotaExceeded — graff hit its open-file limit, usually from many parallel tools/subagents/MCP servers in one turn. Retry the failed calls sequentially (less parallel fan-out); if it recurs, raise the limit (`ulimit -n 4096`) before starting graff.") catch return .{ .is_error = true };
-        return .{ .text = text, .is_error = true };
-    }
-    const text = std.fmt.allocPrint(gpa, "error: {t}", .{err}) catch return .{ .is_error = true };
+    // #122/#253: a bare error name is useless advice for an fd-limit hit — say
+    // what it means and what helps. ulimit cannot fix SYSTEM-wide exhaustion.
+    const text = (switch (err) {
+        error.ProcessFdQuotaExceeded => gpa.dupe(u8, "error: ProcessFdQuotaExceeded — graff hit its open-file limit, usually from many parallel tools/subagents/MCP servers in one turn. Retry the failed calls sequentially (less parallel fan-out); if it recurs, raise the limit (`ulimit -n 4096`) before starting graff."),
+        error.SystemFdQuotaExceeded => gpa.dupe(u8, "error: SystemFdQuotaExceeded — the SYSTEM-wide open-file table is full, so `ulimit` will not help. Wait for other processes to release files (or close some applications), then retry sequentially."),
+        else => std.fmt.allocPrint(gpa, "error: {t}", .{err}),
+    }) catch return .{ .is_error = true };
     return .{ .text = text, .is_error = true };
 }
 


### PR DESCRIPTION
The #122 special-case only covered ProcessFdQuotaExceeded; a SYSTEM-wide fd exhaustion fell to the generic branches, and the background-job path emitted actively wrong advice ("run it in the foreground instead" — foregrounding cannot help system-wide exhaustion, and neither can ulimit). Both surfaces (`tools.failure`, the `run_in_background` spawn-failure branch in exec.zig) now name the system-wide case and say what helps. This was the "worth fixing regardless" remainder named on #253.

`tools.zig` stays at exactly 600 lines (the failure() rewrite is net-zero); 673/673 tests (+1 new regression test asserting all three advice paths); fmt and line-cap checks green.