### PR TITLE
fix(vision): distinct clipboard stage errors, oversized-paste downscale, furl/PDF cascade

### DIFF
--- a/src/commands_model.zig
+++ b/src/commands_model.zig
@@ -545,10 +545,13 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             try out.flush();
             return true;
         }
-        switch (stageImagePath(root, path)) {
+        var mbuf: [320]u8 = undefined; // the message, or (first 16 bytes) just the size
+        const staged = stageImagePath(root, path);
+        switch (staged) {
             .no_vision => try out.print("⚠ {s} can't see images — switch to a vision model first, e.g. /model claude-opus-4-8 or /model gpt-5.5\n", .{root.provider.model}),
-            .read_fail => try out.print("can't read '{s}' (missing, or larger than 5MB)\n", .{path}),
-            .ok => try out.print("📎 attached {s} — sent with your next message\n", .{path}),
+            .ok => |o| try out.print("📎 attached {s} ({s}) — sent with your next message\n", .{ path, vision.fmtBytes(mbuf[0..16], o.bytes) }),
+            // Sized, distinct lines instead of "missing, or larger than 5MB" (#349).
+            .too_large, .not_found, .read_error => try out.print("{s}\n", .{vision.stageMessage(&mbuf, staged, path)}),
         }
         try out.flush();
         return true;
@@ -564,15 +567,20 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             try out.flush();
             return true;
         }
-        const p = grabClipboardImage(root.io) orelse {
+        const grab = grabClipboardImage(root.io, root.gpa) orelse {
+            vision.tracePaste(root, "no_image", "none", 0, ""); // #350
             try out.writeAll("no image on the clipboard — copy an image first (text? just paste it normally)\n");
             try out.flush();
             return true;
         };
-        switch (stageImagePath(root, p)) {
-            .ok => try out.writeAll("📎 clipboard image attached — sent with your next message\n"),
+        defer grab.release(root.io, root.gpa); // temp export never outlives the command
+        var pbuf: [320]u8 = undefined;
+        const pasted = stageImagePath(root, grab.path);
+        vision.tracePasteResult(root, grab.flavor, pasted);
+        switch (pasted) {
+            .ok => |o| try out.print("📎 clipboard image attached ({s}, via {s}) — sent with your next message\n", .{ vision.fmtBytes(pbuf[0..16], o.bytes), grab.flavor.name() }),
             .no_vision => try out.print("⚠ {s} can't see images\n", .{root.provider.model}),
-            .read_fail => try out.writeAll("failed to read the clipboard image\n"),
+            .too_large, .not_found, .read_error => try out.print("{s}\n", .{vision.stageMessage(&pbuf, pasted, "the clipboard image")}),
         }
         try out.flush();
         return true;

--- a/src/readline.zig
+++ b/src/readline.zig
@@ -259,20 +259,31 @@ pub fn readLine(
                 redraw(out, buf.items, cur, marks.items, &rstate, prompt_col);
             },
             0x16 => { // Ctrl-V: attach a clipboard image (macOS) at the cursor
+                var mbuf: [224]u8 = undefined;
                 var msg: ?[]const u8 = null;
-                switch (vision.clipboardPasteSource(root.io, vision.visionCapable(root.provider), builtin.os.tag == .macos, grabClipboardImage)) {
-                    .image => |p| switch (stageImagePath(root, p)) {
-                        .ok => {
+                switch (vision.clipboardPasteSource(root.io, gpa, vision.visionCapable(root.provider), builtin.os.tag == .macos, grabClipboardImage)) {
+                    .image => |grab| {
+                        defer grab.release(root.io, gpa); // temp export never outlives the paste
+                        const staged = stageImagePath(root, grab.path);
+                        vision.tracePasteResult(root, grab.flavor, staged); // #350: every paste leaves a receipt
+                        if (staged.isOk()) {
                             const marker = "[Image] ";
                             buf.insertSlice(gpa, cur, marker) catch {};
                             cur += marker.len;
                             addMark(gpa, &marks, "[Image]");
                             redraw(out, buf.items, cur, marks.items, &rstate, prompt_col);
-                        },
-                        .no_vision => msg = vision.no_vision_message,
-                        .read_fail => msg = "couldn't read the clipboard image",
+                        } else {
+                            // No `.no_vision` arm here: clipboardPasteSource
+                            // already answers .no_vision above, so on a
+                            // text-only model the clipboard is never read and
+                            // that prong was unreachable (#349).
+                            msg = vision.stageMessage(&mbuf, staged, "the clipboard image");
+                        }
                     },
-                    else => |s| msg = vision.pasteMessage(s),
+                    else => |s| {
+                        vision.tracePaste(root, @tagName(s), "none", 0, "");
+                        msg = vision.pasteMessage(s);
+                    },
                 }
                 if (msg) |m| { // feedback below the input, then redraw the prompt+buffer fresh
                     if (rstate.rows - 1 > rstate.crow) out.print("\x1b[{d}B", .{rstate.rows - 1 - rstate.crow}) catch {};
@@ -441,11 +452,18 @@ pub fn readLine(
                                 // path however long it is.
                                 var staged = false;
                                 var dmsg: ?[]const u8 = null;
-                                if (isImagePath(dropped.?)) switch (stageImagePath(root, dropped.?)) {
-                                    .ok => staged = true,
-                                    .no_vision => dmsg = "this model can't see images — ✓ in /models' vision column shows ones that can; path inlined instead",
-                                    .read_fail => dmsg = "couldn't read that image (missing or >5MB) — path inlined instead",
-                                };
+                                var dbuf: [224]u8 = undefined;
+                                if (isImagePath(dropped.?)) {
+                                    const r = stageImagePath(root, dropped.?);
+                                    if (r.isOk()) {
+                                        staged = true;
+                                    } else if (r == .no_vision) {
+                                        dmsg = "this model can't see images — ✓ in /models' vision column shows ones that can; path inlined instead";
+                                    } else {
+                                        // Real numbers, not "missing or >5MB" (#349).
+                                        dmsg = vision.stageMessage(&dbuf, r, "that image");
+                                    }
+                                }
                                 if (staged) {
                                     const marker = "[Image] ";
                                     buf.insertSlice(gpa, cur, marker) catch {};

--- a/src/vision.zig
+++ b/src/vision.zig
@@ -151,9 +151,11 @@ pub fn stageImagePath(root: *Agent, path: []const u8) StageResult {
     const enc = std.base64.standard.Encoder;
     const b64 = arena.alloc(u8, enc.calcSize(data.len)) catch return .read_error;
     _ = enc.encode(b64, data);
-    // Media type from the file we actually encoded (a downscale step is always
-    // PNG), but labelled with the path the USER named — a temp file's random
-    // name means nothing to them.
+    // Media type from the file we actually encoded, but labelled with the path
+    // the USER named — a temp file's random name means nothing to them. A
+    // downscale step is PNG because `sipsResize` forces `-s format png` AND
+    // `fitToBudget` re-checks the magic bytes; without both, `sips -Z` would
+    // keep the source encoding and we'd send JPEG bytes as `image/png`.
     const media = imageMediaType(fit.path);
     root.pending_image = .{ .media_type = media, .b64 = b64, .label = arena.dupe(u8, path) catch path };
     return .{ .ok = .{ .bytes = fit.bytes, .media_type = media } };

--- a/src/vision.zig
+++ b/src/vision.zig
@@ -1,9 +1,11 @@
 //! Image/vision support: the staged-image type + per-provider vision-capability
 //! check, media-type-from-extension, the anthropic/openai/responses image
-//! message builder, and the /image·/paste·Ctrl-V·GUI-attachment stagers +
-//! macOS clipboard grab. Split out of main.zig (600-line goal). Back-imports
-//! main (as main_mod, since the stagers' param is named `root`) for Agent,
-//! Provider, and isImagePath. main aliases the public surface back.
+//! message builder, and the /image·/paste·Ctrl-V·GUI-attachment stagers.
+//! Split out of main.zig (600-line goal). Back-imports main (as main_mod,
+//! since the stagers' param is named `root`) for Agent, Provider, and
+//! isImagePath. main aliases the public surface back. The macOS pasteboard
+//! cascade itself (and the byte budget staged images live under) is one level
+//! down in vision_clipboard.zig and re-exported here.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -18,6 +20,16 @@ const Agent = agent_mod.Agent;
 const Provider = provider_mod.Provider;
 const input_util = @import("input_util.zig");
 const isImagePath = input_util.isImagePath;
+
+/// The macOS pasteboard cascade, temp paths, the sips gate/downscaler and the
+/// raw-byte budget (vision_clipboard.zig, 600-line goal). Re-exported below so
+/// readline/commands_model keep importing only `vision`.
+const clip = @import("vision_clipboard.zig");
+pub const Flavor = clip.Flavor;
+pub const Grab = clip.Grab;
+pub const grabClipboardImage = clip.grabClipboardImage;
+pub const max_staged_image_bytes = clip.max_staged_image_bytes;
+pub const fmtBytes = clip.fmtMb;
 
 pub const PendingImage = struct { media_type: []const u8, b64: []const u8, label: []const u8 };
 
@@ -95,19 +107,100 @@ pub fn imageMessage(arena: Allocator, kind: Provider.Kind, text: []const u8, img
     return .{ .object = msg };
 }
 
-pub const StageResult = enum { ok, no_vision, read_fail };
+/// Why an image did or did not reach the provider.
+///
+/// A tagged union, not an enum, because "too big" is only actionable if the
+/// user is told BY HOW MUCH. The old `.read_fail` collapsed oversize, missing,
+/// permission-denied and OOM into one sentence that guessed ("missing, or
+/// larger than 5MB"), so a 7.3 MB screenshot and a typo'd path produced the
+/// same unhelpful line (#349).
+pub const StageResult = union(enum) {
+    ok: struct { bytes: u64, media_type: []const u8 },
+    no_vision,
+    /// Over the wire budget even after `sips` downscaling. Both numbers are
+    /// carried so the message can print them.
+    too_large: struct { bytes: u64, limit: u64 },
+    /// Nothing at that path, or not a regular file.
+    not_found,
+    /// It was there and the right size, but the read or the encode failed.
+    read_error,
+
+    pub fn isOk(self: StageResult) bool {
+        return std.meta.activeTag(self) == .ok;
+    }
+};
 
 /// Read an image file, base64-encode it, and stage it on the agent for the next
 /// turn (shared by /image, /paste, and Ctrl-V). Refuses on non-vision models.
+///
+/// Stats before reading: the size has to be a number we can report, not
+/// something inferred after the fact from `error.StreamTooLong`. Over-budget
+/// files are downscaled rather than dropped.
 pub fn stageImagePath(root: *Agent, path: []const u8) StageResult {
     if (!visionCapable(root.provider)) return .no_vision;
+    const io = root.io;
+    const fit = switch (clip.planStage(io, root.gpa, path, clip.max_staged_image_bytes, clip.sipsResize)) {
+        .not_found => return .not_found,
+        .too_large => |bytes| return .{ .too_large = .{ .bytes = bytes, .limit = clip.max_staged_image_bytes } },
+        .fits => |f| f,
+    };
+    defer if (fit.temp) clip.discard(io, root.gpa, fit.path);
+
     const arena = root.arena;
-    const data = Io.Dir.cwd().readFileAlloc(root.io, path, arena, .limited(5 * 1024 * 1024)) catch return .read_fail;
+    const data = Io.Dir.cwd().readFileAlloc(io, fit.path, arena, .limited(@intCast(clip.max_staged_image_bytes))) catch return .read_error;
     const enc = std.base64.standard.Encoder;
-    const b64 = arena.alloc(u8, enc.calcSize(data.len)) catch return .read_fail;
+    const b64 = arena.alloc(u8, enc.calcSize(data.len)) catch return .read_error;
     _ = enc.encode(b64, data);
-    root.pending_image = .{ .media_type = imageMediaType(path), .b64 = b64, .label = arena.dupe(u8, path) catch path };
-    return .ok;
+    // Media type from the file we actually encoded (a downscale step is always
+    // PNG), but labelled with the path the USER named — a temp file's random
+    // name means nothing to them.
+    const media = imageMediaType(fit.path);
+    root.pending_image = .{ .media_type = media, .b64 = b64, .label = arena.dupe(u8, path) catch path };
+    return .{ .ok = .{ .bytes = fit.bytes, .media_type = media } };
+}
+
+/// One actionable line per staging failure. `what` names the thing that failed
+/// ("the clipboard image", "'shot.png'"); `buf` wants ~192 bytes.
+pub fn stageMessage(buf: []u8, r: StageResult, what: []const u8) []const u8 {
+    var got: [16]u8 = undefined;
+    var cap: [16]u8 = undefined;
+    return switch (r) {
+        .ok => "",
+        .no_vision => no_vision_message,
+        .too_large => |t| std.fmt.bufPrint(
+            buf,
+            "{s} is {s} — over the {s} limit; downscale it or use a smaller crop",
+            .{ what, clip.fmtMb(&got, t.bytes), clip.fmtMb(&cap, t.limit) },
+        ) catch "that image is too large to send",
+        .not_found => std.fmt.bufPrint(buf, "can't find {s}", .{what}) catch "can't find that image",
+        .read_error => std.fmt.bufPrint(buf, "couldn't read {s}", .{what}) catch "couldn't read that image",
+    };
+}
+
+/// One `clipboard_paste` receipt per Ctrl-V / `/paste`, whatever the outcome
+/// (#350). Before this a dropped paste left ZERO evidence behind: a failing
+/// and a succeeding run produced byte-identical `.graff/traces` JSONL. Carries
+/// the decision, the cascade flavor, the byte count and the mime — never the
+/// pixels.
+pub fn tracePaste(root: *Agent, result: []const u8, flavor: []const u8, bytes: u64, mime: []const u8) void {
+    const tracer = root.tracer orelse return;
+    tracer.write(.{
+        .t = tracer.elapsedMs(),
+        .ev = "clipboard_paste",
+        .result = result,
+        .flavor = flavor,
+        .bytes = bytes,
+        .mime = mime,
+    });
+}
+
+/// `tracePaste` for a paste that got as far as staging.
+pub fn tracePasteResult(root: *Agent, flavor: Flavor, r: StageResult) void {
+    switch (r) {
+        .ok => |o| tracePaste(root, "ok", flavor.name(), o.bytes, o.media_type),
+        .too_large => |t| tracePaste(root, "too_large", flavor.name(), t.bytes, ""),
+        else => tracePaste(root, @tagName(r), flavor.name(), 0, ""),
+    }
 }
 
 /// GUI image attachments arrive inline as `@[path]` markers in the prompt text
@@ -130,7 +223,7 @@ pub fn stageGuiImageAttachment(root: *Agent, msg: []const u8) void {
         const rest = msg[open + 2 ..];
         const close = std.mem.indexOfScalar(u8, rest, ']') orelse break;
         const path = rest[0..close];
-        if (isImagePath(path) and stageImagePath(root, path) == .ok) return;
+        if (isImagePath(path) and stageImagePath(root, path).isOk()) return;
         search = open + 2 + close + 1;
     }
 }
@@ -153,8 +246,11 @@ pub const McpImageBlock = struct {
     }
 };
 
-/// The same ceiling `stageImagePath` reads a file under.
-const max_mcp_image_bytes = 5 * 1024 * 1024;
+/// The same ceiling `stageImagePath` reads a file under — the base64 math is
+/// identical whether the pixels came from a tool or from disk, so an MCP
+/// screenshot over the budget is refused here (with a note the model reads)
+/// instead of turning into a provider 400 one call later.
+const max_mcp_image_bytes: usize = @intCast(clip.max_staged_image_bytes);
 
 /// Recognize an MCP image content block. Null for anything else — a text block,
 /// a non-`image/*` mime, base64 we cannot decode, or a payload over the ceiling
@@ -206,13 +302,12 @@ pub fn mcpImageHandoff(reg: anytype, supports_vision: bool, slot: *?PendingImage
     return true;
 }
 
-/// macOS: dump the clipboard image (if any) to a temp PNG via osascript and
-/// return its path; null if the clipboard holds no image (or not macOS).
-/// (A terminal can't receive clipboard image bytes over stdin, so we ask the OS.)
 /// Why a Ctrl-V clipboard paste did or did not produce an image (#258).
 /// Ordered so the cheapest, most-likely-wrong condition is decided first.
+/// (A terminal can't receive clipboard image bytes over stdin, so the actual
+/// pixels are fetched from the OS by `grabClipboardImage`'s flavor cascade.)
 pub const ClipboardPasteSource = union(enum) {
-    image: []const u8,
+    image: Grab,
     no_image,
     no_vision,
     unsupported_platform,
@@ -225,10 +320,10 @@ pub const ClipboardPasteSource = union(enum) {
 /// (and on macOS, a pasteboard read of whatever the user last copied) purely to
 /// produce an error. `grabber` is injected so the ordering is testable without
 /// a real clipboard.
-pub fn clipboardPasteSource(io: Io, supports_vision: bool, is_macos: bool, grabber: anytype) ClipboardPasteSource {
+pub fn clipboardPasteSource(io: Io, gpa: Allocator, supports_vision: bool, is_macos: bool, grabber: anytype) ClipboardPasteSource {
     if (!supports_vision) return .no_vision;
     if (!is_macos) return .unsupported_platform;
-    return .{ .image = grabber(io) orelse return .no_image };
+    return .{ .image = grabber(io, gpa) orelse return .no_image };
 }
 
 /// The user-facing line for every non-image paste outcome, so the caller's
@@ -246,39 +341,6 @@ pub fn pasteMessage(source: ClipboardPasteSource) []const u8 {
 /// previously carried two copies of the same sentence.
 pub const no_vision_message = "this model can't see images — /model to a vision one (claude-*, gpt-5*)";
 
-pub fn grabClipboardImage(io: Io) ?[]const u8 {
-    if (builtin.os.tag != .macos) return null;
-    const path = "/tmp/.harness-clip.png";
-    var child = std.process.spawn(io, .{
-        .argv = &.{
-            "osascript",
-            "-e",
-            "try",
-            "-e",
-            "set thePNG to (the clipboard as «class PNGf»)",
-            "-e",
-            "set fp to open for access POSIX file \"/tmp/.harness-clip.png\" with write permission",
-            "-e",
-            "set eof fp to 0",
-            "-e",
-            "write thePNG to fp",
-            "-e",
-            "close access fp",
-            "-e",
-            "on error",
-            "-e",
-            "error number 1",
-            "-e",
-            "end try",
-        },
-        .stdin = .ignore,
-        .stdout = .ignore,
-        .stderr = .ignore,
-    }) catch return null;
-    const term = child.wait(io) catch return null;
-    if (term == .exited and term.exited == 0) return path;
-    return null;
-}
 test "imageMediaType from extension" {
     try std.testing.expectEqualStrings("image/png", imageMediaType("shot.png"));
     try std.testing.expectEqualStrings("image/jpeg", imageMediaType("p.jpg"));
@@ -326,9 +388,9 @@ test "clipboardPasteSource: vision is checked before the clipboard is touched (#
     // so the clipboard must not be read at all. `calls` proves that.
     const MockGrabber = struct {
         var calls: usize = 0;
-        var image: ?[]const u8 = "/tmp/test.png";
+        var image: ?Grab = .{ .path = "/tmp/test.png", .flavor = .png, .owned = false };
 
-        fn grab(_: Io) ?[]const u8 {
+        fn grab(_: Io, _: Allocator) ?Grab {
             calls += 1;
             return image;
         }
@@ -340,16 +402,18 @@ test "clipboardPasteSource: vision is checked before the clipboard is touched (#
     }.expect;
 
     MockGrabber.calls = 0;
-    try expectTag(.no_vision, clipboardPasteSource(std.testing.io, false, true, MockGrabber.grab));
-    try expectTag(.no_vision, clipboardPasteSource(std.testing.io, false, false, MockGrabber.grab));
-    try expectTag(.unsupported_platform, clipboardPasteSource(std.testing.io, true, false, MockGrabber.grab));
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    try expectTag(.no_vision, clipboardPasteSource(io, gpa, false, true, MockGrabber.grab));
+    try expectTag(.no_vision, clipboardPasteSource(io, gpa, false, false, MockGrabber.grab));
+    try expectTag(.unsupported_platform, clipboardPasteSource(io, gpa, true, false, MockGrabber.grab));
     try std.testing.expectEqual(@as(usize, 0), MockGrabber.calls);
 
-    try expectTag(.image, clipboardPasteSource(std.testing.io, true, true, MockGrabber.grab));
+    try expectTag(.image, clipboardPasteSource(io, gpa, true, true, MockGrabber.grab));
     try std.testing.expectEqual(@as(usize, 1), MockGrabber.calls);
 
     MockGrabber.image = null;
-    try expectTag(.no_image, clipboardPasteSource(std.testing.io, true, true, MockGrabber.grab));
+    try expectTag(.no_image, clipboardPasteSource(io, gpa, true, true, MockGrabber.grab));
     try std.testing.expectEqual(@as(usize, 2), MockGrabber.calls);
 }
 
@@ -362,6 +426,27 @@ test "pasteMessage: every non-image outcome has a distinct, non-empty line" {
     }
     // The staged-failure path reuses the same sentence rather than duplicating it.
     try std.testing.expectEqualStrings(no_vision_message, pasteMessage(.no_vision));
+}
+
+test "stageMessage: an oversized paste names both real sizes, and each failure reads differently (#349)" {
+    var buf: [256]u8 = undefined;
+    const too_big = stageMessage(&buf, .{ .too_large = .{ .bytes = 7_682_253, .limit = max_staged_image_bytes } }, "the clipboard image");
+    // The whole point: the user is told how big it is and how big it may be,
+    // instead of the old "missing, or larger than 5MB" guess.
+    try std.testing.expectEqualStrings(
+        "the clipboard image is 7.3 MB — over the 3.5 MB limit; downscale it or use a smaller crop",
+        too_big,
+    );
+
+    var b2: [256]u8 = undefined;
+    const missing = stageMessage(&b2, .not_found, "'shot.png'");
+    try std.testing.expect(std.mem.indexOf(u8, missing, "shot.png") != null);
+    try std.testing.expect(!std.mem.eql(u8, missing, too_big));
+
+    var b3: [256]u8 = undefined;
+    const unreadable = stageMessage(&b3, .read_error, "'shot.png'");
+    try std.testing.expect(!std.mem.eql(u8, unreadable, missing));
+    try std.testing.expectEqualStrings(no_vision_message, stageMessage(&b3, .no_vision, "x"));
 }
 
 /// Parse one JSON literal into `a` — the MCP content blocks these tests feed in.

--- a/src/vision_clipboard.zig
+++ b/src/vision_clipboard.zig
@@ -1,0 +1,526 @@
+//! macOS clipboard → a file we can stage: the pasteboard flavor cascade behind
+//! Ctrl-V and `/paste`, the per-invocation temp path, the `sips`-based
+//! is-it-really-an-image gate / PNG normalizer / downscaler, and the raw-byte
+//! budget a staged image has to fit inside. Split out of vision.zig (600-line
+//! goal); vision.zig re-exports the parts its callers need.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+
+const trace = @import("trace.zig");
+
+/// Raw (pre-base64) ceiling for one staged image.
+///
+/// An image travels base64-encoded, which inflates it by 4/3 — `ceil(n/3)*4`
+/// bytes on the wire. Providers cap a SINGLE image at ~5 MB of *encoded*
+/// payload, so the raw file has to stay under `5_000_000 * 3/4 = 3_750_000`
+/// bytes. 3,700,000 encodes to 4,933,336 bytes and leaves the JSON envelope
+/// (media_type, quoting, the rest of the message) a little room.
+///
+/// The old ceiling was 5 MiB of raw bytes, which base64-expands to 6.99 MB:
+/// simultaneously too tight for reading (a 7.3 MB screenshot was refused) and
+/// too loose for the wire (a 4 MB one was accepted and then 400'd), #349.
+/// Raising it makes the wire failure worse, so the fix is `fitToBudget` —
+/// downscale, then refuse only if it still will not fit.
+pub const max_staged_image_bytes: u64 = 3_700_000;
+
+/// Successively smaller max-dimensions handed to `sips -Z`. Ordered
+/// largest-first so a paste keeps as much detail as the budget allows.
+pub const downscale_steps = [_][]const u8{ "2048", "1568", "1024" };
+
+/// Which pasteboard flavor produced the file. Recorded on the trace so a
+/// dropped paste can be told apart from a PDF-only or file-url-only clipboard
+/// after the fact (#350).
+pub const Flavor = enum {
+    /// `«class PNGf»` — macOS lazily synthesizes this from any raster flavor
+    /// (TIFF, JPEG, HEIC, live data-provider promises), so it covers almost
+    /// every real screenshot/copy-image clipboard.
+    png,
+    /// `«class furl»` — a file the user copied in Finder, Telegram, Slack…
+    /// The pasteboard carries only the URL, never pixels.
+    furl,
+    /// `«class PDF »` — Preview, Illustrator, Keynote and friends put up a
+    /// vector-only clipboard with no raster flavor at all.
+    pdf,
+
+    pub fn name(self: Flavor) []const u8 {
+        return @tagName(self);
+    }
+};
+
+/// A clipboard image that made it to disk.
+pub const Grab = struct {
+    path: []const u8,
+    flavor: Flavor,
+    /// The file at `path` is OURS and must be deleted on release. False when
+    /// the cascade landed on a file the *user* owns (a `furl` clipboard whose
+    /// target is already a stageable image) — deleting that would destroy the
+    /// thing they just copied.
+    owned: bool,
+
+    /// Drop the temp file (if any) and free the path. Safe to call exactly
+    /// once, success or failure, from a `defer` at the paste call site.
+    pub fn release(self: Grab, io: Io, gpa: Allocator) void {
+        if (self.owned) deleteQuietly(io, self.path);
+        gpa.free(self.path);
+    }
+};
+
+// ── temp paths ────────────────────────────────────────────────────────────
+
+/// A fresh scratch path for this paste.
+///
+/// The old code hardcoded `/tmp/.harness-clip.png` in TWO places — a Zig
+/// constant and, separately, a string inside the AppleScript source — which
+/// had to be kept in sync by hand. Being fixed and world-writable it was also
+/// a symlink-planting target and a live race: a second graff (or anything
+/// else) could delete the file between osascript writing it and the stager
+/// reading it, which reads out as a spurious "couldn't read the clipboard
+/// image" (#349). The path is built ONCE here and interpolated into the
+/// script's argv, so the two can no longer drift, and the 64 random bits make
+/// it unguessable.
+///
+/// Only `[A-Za-z0-9./-]` ever appears, so the result needs no shell or
+/// AppleScript quoting.
+pub fn tempPath(io: Io, gpa: Allocator, ext: []const u8) ?[]const u8 {
+    var raw: [8]u8 = undefined;
+    io.random(&raw);
+    const hex = std.fmt.bytesToHex(raw, .lower);
+    return std.fmt.allocPrint(gpa, "/tmp/graff-clip-{d}-{s}.{s}", .{ trace.currentPid(), hex[0..], ext }) catch null;
+}
+
+/// Delete a temp file and free its path — the cleanup half of `tempPath`.
+pub fn discard(io: Io, gpa: Allocator, path: []const u8) void {
+    deleteQuietly(io, path);
+    gpa.free(path);
+}
+
+fn deleteQuietly(io: Io, path: []const u8) void {
+    Io.Dir.cwd().deleteFile(io, path) catch {};
+}
+
+// ── filesystem probes ─────────────────────────────────────────────────────
+
+/// Size of `path` if it is a regular file, else null. Null therefore means
+/// "not there, or not a file" — never "too big", which is the distinction the
+/// old single `.read_fail` threw away.
+pub fn regularFileSize(io: Io, path: []const u8) ?u64 {
+    const st = Io.Dir.cwd().statFile(io, path, .{}) catch return null;
+    if (st.kind != .file) return null;
+    return st.size;
+}
+
+/// Extensions a provider accepts as-is (`imageMediaType` knows all of them).
+pub fn stageableExtension(path: []const u8) bool {
+    for ([_][]const u8{ ".png", ".jpg", ".jpeg", ".gif", ".webp" }) |ext|
+        if (std.ascii.endsWithIgnoreCase(path, ext)) return true;
+    return false;
+}
+
+/// `sips` as an is-this-an-image oracle: it exits 0 on an image it can read
+/// and 13 on anything else, without writing a file.
+pub fn sipsIsImage(io: Io, path: []const u8) bool {
+    if (builtin.os.tag != .macos) return false;
+    return runQuiet(io, &.{ "sips", "-g", "pixelWidth", path });
+}
+
+/// Can this `«class furl»` path actually be staged?
+///
+/// The coercion itself proves NOTHING. On a *plain-text* clipboard
+/// `the clipboard as «class furl»` still succeeds: copying the word "hello"
+/// yields the POSIX path `/hello` with exit status 0. So every furl path is
+/// validated here — it must exist, be a regular non-empty file, and either
+/// carry an image extension or survive the `sips` probe. `probe` is injected
+/// so the trap can be tested without a pasteboard or a subprocess.
+pub fn furlLooksStageable(io: Io, path: []const u8, probe: anytype) bool {
+    if (path.len == 0 or path[0] != '/') return false;
+    const size = regularFileSize(io, path) orelse return false;
+    if (size == 0) return false;
+    if (stageableExtension(path)) return true;
+    return probe(io, path);
+}
+
+// ── downscaling ───────────────────────────────────────────────────────────
+
+/// `sips -Z <max_dim> <in> --out <out>`: fit the image inside a square of
+/// `max_dim` points, preserving aspect ratio.
+pub fn sipsResize(io: Io, in: []const u8, max_dim: []const u8, out: []const u8) bool {
+    if (builtin.os.tag != .macos) return false;
+    return runQuiet(io, &.{ "sips", "-Z", max_dim, in, "--out", out });
+}
+
+/// Injected so `fitToBudget` is testable without macOS or a subprocess.
+pub const Resizer = *const fn (io: Io, in: []const u8, max_dim: []const u8, out: []const u8) bool;
+
+/// The file that will actually be read and encoded.
+pub const Fit = struct {
+    path: []const u8,
+    bytes: u64,
+    /// `path` is a downscale temp file: delete + free it after reading.
+    temp: bool,
+};
+
+/// Bring `path` under `budget`, re-encoding at successively smaller max
+/// dimensions rather than dropping the paste outright. Returns null only when
+/// even the smallest step is still too big (or the resizer is unavailable),
+/// which is what lets the caller report a real `too_large`.
+pub fn fitToBudget(io: Io, gpa: Allocator, path: []const u8, size: u64, budget: u64, resize: Resizer) ?Fit {
+    if (size <= budget) return .{ .path = path, .bytes = size, .temp = false };
+    for (downscale_steps) |dim| {
+        const out = tempPath(io, gpa, "png") orelse return null;
+        if (resize(io, path, dim, out)) {
+            if (regularFileSize(io, out)) |n| {
+                if (n > 0 and n <= budget) return .{ .path = out, .bytes = n, .temp = true };
+            }
+        }
+        discard(io, gpa, out);
+    }
+    return null;
+}
+
+/// What staging `path` will do, decided before a single byte is read. Split
+/// out of the Agent-facing stager so the size math is testable on its own.
+pub const Plan = union(enum) {
+    /// Missing, or not a regular file.
+    not_found,
+    /// Over budget and undownscalable; the payload is the file's REAL size,
+    /// statted rather than inferred from `error.StreamTooLong`.
+    too_large: u64,
+    fits: Fit,
+};
+
+pub fn planStage(io: Io, gpa: Allocator, path: []const u8, budget: u64, resize: Resizer) Plan {
+    const size = regularFileSize(io, path) orelse return .not_found;
+    const fit = fitToBudget(io, gpa, path, size, budget, resize) orelse return .{ .too_large = size };
+    return .{ .fits = fit };
+}
+
+// ── the flavor cascade ────────────────────────────────────────────────────
+
+/// macOS: export the clipboard image to a file and return its path, trying one
+/// pasteboard flavor per osascript invocation and stopping at the first that
+/// yields a real file. Null means the clipboard genuinely holds no image.
+///
+/// The old implementation asked for `«class PNGf»` and nothing else. That
+/// covers every raster clipboard (macOS synthesizes PNGf from TIFF/JPEG/HEIC
+/// and from live data-provider promises), but it silently loses the two cases
+/// users actually hit: a copied *file* (`furl`, what Telegram/Finder put up)
+/// and a vector-only `PDF ` clipboard (Preview, Illustrator, Keynote). #350.
+pub fn grabClipboardImage(io: Io, gpa: Allocator) ?Grab {
+    if (builtin.os.tag != .macos) return null;
+    if (grabPng(io, gpa)) |g| return g;
+    if (grabFurl(io, gpa)) |g| return g;
+    if (grabPdf(io, gpa)) |g| return g;
+    return null;
+}
+
+/// `open for access` line with our per-invocation path baked in.
+fn openLine(gpa: Allocator, path: []const u8) ?[]const u8 {
+    return std.fmt.allocPrint(gpa, "set fp to open for access POSIX file \"{s}\" with write permission", .{path}) catch null;
+}
+
+fn grabPng(io: Io, gpa: Allocator) ?Grab {
+    const path = tempPath(io, gpa, "png") orelse return null;
+    var keep = false;
+    defer if (!keep) discard(io, gpa, path);
+
+    const open = openLine(gpa, path) orelse return null;
+    defer gpa.free(open);
+    const argv = [_][]const u8{
+        "osascript",
+        "-e", "try",
+        "-e", "set theData to (the clipboard as «class PNGf»)",
+        "-e", open,
+        "-e", "set eof fp to 0",
+        "-e", "write theData to fp",
+        "-e", "close access fp",
+        "-e", "on error",
+        "-e", "error number 1",
+        "-e", "end try",
+    };
+    if (!runQuiet(io, &argv)) return null;
+    // Stat the export: osascript exiting 0 is not proof the bytes landed.
+    if ((regularFileSize(io, path) orelse 0) == 0) return null;
+    keep = true;
+    return .{ .path = path, .flavor = .png, .owned = true };
+}
+
+fn grabFurl(io: Io, gpa: Allocator) ?Grab {
+    const raw = runCapture(io, gpa, &.{ "osascript", "-e", "POSIX path of (the clipboard as «class furl»)" }) orelse return null;
+    defer gpa.free(raw);
+    const src = std.mem.trim(u8, raw, " \t\r\n");
+    if (!furlLooksStageable(io, src, sipsIsImage)) return null;
+    if (stageableExtension(src)) {
+        // The user's own file, in place. `owned = false`: never delete it.
+        const dup = gpa.dupe(u8, src) catch return null;
+        return .{ .path = dup, .flavor = .furl, .owned = false };
+    }
+    // A .heic/.tiff/.bmp/… that sips vouched for: normalize to PNG.
+    const out = tempPath(io, gpa, "png") orelse return null;
+    if (sipsToPng(io, src, out) and (regularFileSize(io, out) orelse 0) > 0)
+        return .{ .path = out, .flavor = .furl, .owned = true };
+    discard(io, gpa, out);
+    return null;
+}
+
+fn grabPdf(io: Io, gpa: Allocator) ?Grab {
+    const pdf = tempPath(io, gpa, "pdf") orelse return null;
+    defer discard(io, gpa, pdf); // the intermediate never outlives this call
+
+    const open = openLine(gpa, pdf) orelse return null;
+    defer gpa.free(open);
+    const argv = [_][]const u8{
+        "osascript",
+        "-e", "try",
+        "-e", "set theData to (the clipboard as «class PDF »)",
+        "-e", open,
+        "-e", "set eof fp to 0",
+        "-e", "write theData to fp",
+        "-e", "close access fp",
+        "-e", "on error",
+        "-e", "error number 1",
+        "-e", "end try",
+    };
+    if (!runQuiet(io, &argv)) return null;
+    if ((regularFileSize(io, pdf) orelse 0) == 0) return null;
+
+    const out = tempPath(io, gpa, "png") orelse return null;
+    if (sipsToPng(io, pdf, out) and (regularFileSize(io, out) orelse 0) > 0)
+        return .{ .path = out, .flavor = .pdf, .owned = true };
+    discard(io, gpa, out);
+    return null;
+}
+
+fn sipsToPng(io: Io, in: []const u8, out: []const u8) bool {
+    if (builtin.os.tag != .macos) return false;
+    return runQuiet(io, &.{ "sips", "-s", "format", "png", in, "--out", out });
+}
+
+// ── subprocess plumbing ───────────────────────────────────────────────────
+
+fn runQuiet(io: Io, argv: []const []const u8) bool {
+    var child = std.process.spawn(io, .{
+        .argv = argv,
+        .stdin = .ignore,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    }) catch return false;
+    const term = child.wait(io) catch return false;
+    return term == .exited and term.exited == 0;
+}
+
+/// stdout of a successful run, gpa-owned; null on spawn/read failure or a
+/// non-zero exit.
+fn runCapture(io: Io, gpa: Allocator, argv: []const []const u8) ?[]u8 {
+    var child = std.process.spawn(io, .{
+        .argv = argv,
+        .stdin = .ignore,
+        .stdout = .pipe,
+        .stderr = .ignore,
+    }) catch return null;
+    const f = child.stdout orelse {
+        _ = child.wait(io) catch {};
+        return null;
+    };
+    var rbuf: [4096]u8 = undefined;
+    var fr = f.readerStreaming(io, &rbuf);
+    const captured = fr.interface.allocRemaining(gpa, .limited(8 * 1024)) catch {
+        _ = child.wait(io) catch {};
+        return null;
+    };
+    const term = child.wait(io) catch {
+        gpa.free(captured);
+        return null;
+    };
+    if (term != .exited or term.exited != 0) {
+        gpa.free(captured);
+        return null;
+    }
+    return captured;
+}
+
+// ── formatting ────────────────────────────────────────────────────────────
+
+/// "7.3 MB" — MiB with one decimal, matching what a file manager shows, so the
+/// number in the error line is the number the user can see on their own disk.
+pub fn fmtMb(buf: *[16]u8, bytes: u64) []const u8 {
+    const mb = @as(f64, @floatFromInt(bytes)) / (1024.0 * 1024.0);
+    return std.fmt.bufPrint(buf, "{d:.1} MB", .{mb}) catch "?? MB";
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+// Anything that needs a live pasteboard (grabClipboardImage and the osascript
+// cascade) is deliberately NOT tested here: `zig build test` must not depend
+// on whatever the developer last copied.
+
+const testing = std.testing;
+
+test "tempPath: unique per call, and safe to drop into a shell/AppleScript literal" {
+    const io = testing.io;
+    const gpa = testing.allocator;
+    const a = tempPath(io, gpa, "png") orelse return error.NoTempPath;
+    defer gpa.free(a);
+    const b = tempPath(io, gpa, "png") orelse return error.NoTempPath;
+    defer gpa.free(b);
+    const c = tempPath(io, gpa, "pdf") orelse return error.NoTempPath;
+    defer gpa.free(c);
+
+    // The whole point of #349's race fix: two pastes never share a file.
+    try testing.expect(!std.mem.eql(u8, a, b));
+    try testing.expect(std.mem.endsWith(u8, a, ".png"));
+    try testing.expect(std.mem.endsWith(u8, c, ".pdf"));
+    try testing.expect(std.mem.startsWith(u8, a, "/tmp/graff-clip-"));
+    // No quoting anywhere: only these bytes may appear.
+    for (a) |ch| try testing.expect(std.ascii.isAlphanumeric(ch) or ch == '/' or ch == '.' or ch == '-');
+}
+
+test "stageableExtension: only formats a provider takes as-is" {
+    try testing.expect(stageableExtension("/tmp/a.png"));
+    try testing.expect(stageableExtension("/tmp/a.JPG"));
+    try testing.expect(stageableExtension("/tmp/a.jpeg"));
+    try testing.expect(stageableExtension("/tmp/a.gif"));
+    try testing.expect(stageableExtension("/tmp/a.webp"));
+    try testing.expect(!stageableExtension("/tmp/a.heic"));
+    try testing.expect(!stageableExtension("/tmp/a.pdf"));
+    try testing.expect(!stageableExtension("/hello"));
+}
+
+test "furlLooksStageable: the plain-text /hello coercion trap is rejected (#350)" {
+    const io = testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPath(io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "shot.png", .data = "\x89PNG\r\n\x1a\n not really a png, but the extension is enough" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "notes.txt", .data = "just text" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "empty.png", .data = "" });
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const png = try std.fmt.bufPrint(&path_buf, "{s}/shot.png", .{root});
+
+    const never = struct {
+        fn probe(_: Io, _: []const u8) bool {
+            return false;
+        }
+    }.probe;
+    const always = struct {
+        fn probe(_: Io, _: []const u8) bool {
+            return true;
+        }
+    }.probe;
+
+    // A real image file passes on its extension alone — no subprocess needed.
+    try testing.expect(furlLooksStageable(io, png, never));
+
+    // `the clipboard as «class furl»` SUCCEEDS on the plain text "hello" and
+    // hands back "/hello". It does not exist, so it must never be staged —
+    // not even when the probe would say yes.
+    try testing.expect(!furlLooksStageable(io, "/hello", always));
+    // Relative / empty coercion output is not a path at all.
+    try testing.expect(!furlLooksStageable(io, "hello", always));
+    try testing.expect(!furlLooksStageable(io, "", always));
+
+    // A real file that is not an image: the probe is the only gate, and it says no.
+    const txt = try std.fmt.bufPrint(&path_buf, "{s}/notes.txt", .{root});
+    try testing.expect(!furlLooksStageable(io, txt, never));
+
+    // A directory is not a file, and a zero-byte "image" is not an image.
+    try testing.expect(!furlLooksStageable(io, root, always));
+    const empty = try std.fmt.bufPrint(&path_buf, "{s}/empty.png", .{root});
+    try testing.expect(!furlLooksStageable(io, empty, always));
+}
+
+test "planStage: missing → not_found, oversize → too_large carrying the REAL size (#349)" {
+    const io = testing.io;
+    const gpa = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPath(io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    const body = "0123456789" ** 4; // 40 bytes
+    try tmp.dir.writeFile(io, .{ .sub_path = "big.png", .data = body });
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const big = try std.fmt.bufPrint(&path_buf, "{s}/big.png", .{root});
+
+    const cannot = struct {
+        fn resize(_: Io, _: []const u8, _: []const u8, _: []const u8) bool {
+            return false;
+        }
+    }.resize;
+
+    // Over budget and unshrinkable: the byte count reported is the statted
+    // size, never something inferred from error.StreamTooLong.
+    switch (planStage(io, gpa, big, 8, cannot)) {
+        .too_large => |n| try testing.expectEqual(@as(u64, body.len), n),
+        else => return error.ExpectedTooLarge,
+    }
+
+    // Under budget: read in place, nothing to clean up.
+    switch (planStage(io, gpa, big, max_staged_image_bytes, cannot)) {
+        .fits => |f| {
+            try testing.expect(!f.temp);
+            try testing.expectEqual(@as(u64, body.len), f.bytes);
+            try testing.expectEqualStrings(big, f.path);
+        },
+        else => return error.ExpectedFits,
+    }
+
+    // Missing is its own answer, distinct from both of the above.
+    const gone = try std.fmt.bufPrint(&path_buf, "{s}/nope.png", .{root});
+    try testing.expect(planStage(io, gpa, gone, max_staged_image_bytes, cannot) == .not_found);
+    // …as is "there, but not a regular file".
+    try testing.expect(planStage(io, gpa, root, max_staged_image_bytes, cannot) == .not_found);
+}
+
+test "fitToBudget: downscales instead of dropping, and cleans up the steps it rejects" {
+    const io = testing.io;
+    const gpa = testing.allocator;
+
+    // A stand-in for sips: the first (largest) step still overshoots, the
+    // second lands under budget — so a real paste keeps the most detail that
+    // fits rather than being refused outright.
+    const Fake = struct {
+        var attempts: usize = 0;
+        fn resize(rio: Io, _: []const u8, max_dim: []const u8, out: []const u8) bool {
+            attempts += 1;
+            const data = if (std.mem.eql(u8, max_dim, "2048")) "xxxxxxxxxxxxxxxx" else "xxxx";
+            Io.Dir.cwd().writeFile(rio, .{ .sub_path = out, .data = data }) catch return false;
+            return true;
+        }
+    };
+    Fake.attempts = 0;
+
+    const fit = fitToBudget(io, gpa, "/nonexistent-source.png", 1_000_000, 8, Fake.resize) orelse
+        return error.ExpectedDownscale;
+    defer discard(io, gpa, fit.path);
+    try testing.expect(fit.temp);
+    try testing.expectEqual(@as(u64, 4), fit.bytes);
+    try testing.expectEqual(@as(usize, 2), Fake.attempts);
+    // The rejected 2048 step left nothing behind.
+    try testing.expect(regularFileSize(io, fit.path) != null);
+
+    // Still too big at every step → null, which is what surfaces `too_large`.
+    Fake.attempts = 0;
+    try testing.expect(fitToBudget(io, gpa, "/nonexistent-source.png", 1_000_000, 2, Fake.resize) == null);
+    try testing.expectEqual(downscale_steps.len, Fake.attempts);
+}
+
+test "fmtMb: the size in the error line is the size the user sees" {
+    var buf: [16]u8 = undefined;
+    try testing.expectEqualStrings("7.3 MB", fmtMb(&buf, 7_682_253));
+    try testing.expectEqualStrings("3.5 MB", fmtMb(&buf, max_staged_image_bytes));
+    try testing.expectEqualStrings("1.4 MB", fmtMb(&buf, 1_470_878));
+}
+
+test "max_staged_image_bytes: base64 of a full-budget image stays under the 5 MB wire cap" {
+    const encoded = std.base64.standard.Encoder.calcSize(@intCast(max_staged_image_bytes));
+    try testing.expect(encoded < 5_000_000);
+    // …and the OLD 5 MiB ceiling did not, which is the #349 bug in one line.
+    try testing.expect(std.base64.standard.Encoder.calcSize(5 * 1024 * 1024) > 5_000_000);
+}

--- a/src/vision_clipboard.zig
+++ b/src/vision_clipboard.zig
@@ -144,15 +144,39 @@ pub fn furlLooksStageable(io: Io, path: []const u8, probe: anytype) bool {
 
 // ── downscaling ───────────────────────────────────────────────────────────
 
-/// `sips -Z <max_dim> <in> --out <out>`: fit the image inside a square of
-/// `max_dim` points, preserving aspect ratio.
+/// `sips -s format png -Z <max_dim> <in> --out <out>`: fit the image inside a
+/// square of `max_dim` points, preserving aspect ratio, and re-encode it as a
+/// real PNG.
+///
+/// `-s format png` is NOT optional. `sips -Z` alone keeps the SOURCE encoding
+/// whatever the output is called: `sips -Z 2048 photo.jpg --out step.png`
+/// exits 0 and writes JPEG bytes into a `.png`. Every downscale temp is named
+/// `.png` and the stager reads `media_type` off that extension, so without the
+/// explicit format a downscaled JPEG/GIF/WebP ships as `image/png` and the
+/// provider 400s on the mismatch — turning the #349 fix into a new failure for
+/// exactly the photos it was meant to rescue.
 pub fn sipsResize(io: Io, in: []const u8, max_dim: []const u8, out: []const u8) bool {
     if (builtin.os.tag != .macos) return false;
-    return runQuiet(io, &.{ "sips", "-Z", max_dim, in, "--out", out });
+    return runQuiet(io, &.{ "sips", "-s", "format", "png", "-Z", max_dim, in, "--out", out });
 }
 
 /// Injected so `fitToBudget` is testable without macOS or a subprocess.
 pub const Resizer = *const fn (io: Io, in: []const u8, max_dim: []const u8, out: []const u8) bool;
+
+/// The 8 bytes every PNG starts with.
+pub const png_magic = "\x89PNG\r\n\x1a\n";
+
+/// Does `path` actually hold a PNG? The downscale temp is named `.png` and the
+/// media type is read back off that extension, so the bytes have to agree —
+/// the belt to `sipsResize`'s `-s format png` braces, and it holds for any
+/// resizer, not just the one we ship.
+pub fn looksLikePng(io: Io, path: []const u8) bool {
+    const file = Io.Dir.cwd().openFile(io, path, .{}) catch return false;
+    defer file.close(io);
+    var head: [png_magic.len]u8 = undefined;
+    const got = file.readPositionalAll(io, &head, 0) catch return false;
+    return got == head.len and std.mem.eql(u8, &head, png_magic);
+}
 
 /// The file that will actually be read and encoded.
 pub const Fit = struct {
@@ -166,13 +190,19 @@ pub const Fit = struct {
 /// dimensions rather than dropping the paste outright. Returns null only when
 /// even the smallest step is still too big (or the resizer is unavailable),
 /// which is what lets the caller report a real `too_large`.
+///
+/// A step is only accepted if it really produced a PNG (see `looksLikePng`).
+/// The PNG re-encode is also far bigger than a JPEG source — a 4 MB phone
+/// photo lands at ~2.8 MB at 2048px, not ~0.5 MB — which is why the ladder
+/// goes all the way down to 1024.
 pub fn fitToBudget(io: Io, gpa: Allocator, path: []const u8, size: u64, budget: u64, resize: Resizer) ?Fit {
     if (size <= budget) return .{ .path = path, .bytes = size, .temp = false };
     for (downscale_steps) |dim| {
         const out = tempPath(io, gpa, "png") orelse return null;
         if (resize(io, path, dim, out)) {
             if (regularFileSize(io, out)) |n| {
-                if (n > 0 and n <= budget) return .{ .path = out, .bytes = n, .temp = true };
+                if (n > 0 and n <= budget and looksLikePng(io, out))
+                    return .{ .path = out, .bytes = n, .temp = true };
             }
         }
         discard(io, gpa, out);
@@ -484,12 +514,13 @@ test "fitToBudget: downscales instead of dropping, and cleans up the steps it re
 
     // A stand-in for sips: the first (largest) step still overshoots, the
     // second lands under budget — so a real paste keeps the most detail that
-    // fits rather than being refused outright.
+    // fits rather than being refused outright. Both steps emit real PNG bytes,
+    // which is the only thing `fitToBudget` will accept.
     const Fake = struct {
         var attempts: usize = 0;
         fn resize(rio: Io, _: []const u8, max_dim: []const u8, out: []const u8) bool {
             attempts += 1;
-            const data = if (std.mem.eql(u8, max_dim, "2048")) "xxxxxxxxxxxxxxxx" else "xxxx";
+            const data = if (std.mem.eql(u8, max_dim, "2048")) png_magic ++ "xxxxxxxx" else png_magic;
             Io.Dir.cwd().writeFile(rio, .{ .sub_path = out, .data = data }) catch return false;
             return true;
         }
@@ -500,7 +531,7 @@ test "fitToBudget: downscales instead of dropping, and cleans up the steps it re
         return error.ExpectedDownscale;
     defer discard(io, gpa, fit.path);
     try testing.expect(fit.temp);
-    try testing.expectEqual(@as(u64, 4), fit.bytes);
+    try testing.expectEqual(@as(u64, png_magic.len), fit.bytes);
     try testing.expectEqual(@as(usize, 2), Fake.attempts);
     // The rejected 2048 step left nothing behind.
     try testing.expect(regularFileSize(io, fit.path) != null);
@@ -509,6 +540,49 @@ test "fitToBudget: downscales instead of dropping, and cleans up the steps it re
     Fake.attempts = 0;
     try testing.expect(fitToBudget(io, gpa, "/nonexistent-source.png", 1_000_000, 2, Fake.resize) == null);
     try testing.expectEqual(downscale_steps.len, Fake.attempts);
+}
+
+test "fitToBudget: a step that is not really a PNG is rejected, never mislabelled" {
+    const io = testing.io;
+    const gpa = testing.allocator;
+
+    // `sips -Z` alone keeps the SOURCE encoding: pointed at a .jpg it exits 0
+    // and writes JPEG bytes into the `.png` temp, which the stager would then
+    // label `image/png` and the provider would 400 on. Well under every
+    // budget, so only the magic-byte check can reject it.
+    const Jpeg = struct {
+        var attempts: usize = 0;
+        fn resize(rio: Io, _: []const u8, _: []const u8, out: []const u8) bool {
+            attempts += 1;
+            Io.Dir.cwd().writeFile(rio, .{ .sub_path = out, .data = "\xff\xd8\xff\xe0 JFIF-ish" }) catch return false;
+            return true;
+        }
+    };
+    Jpeg.attempts = 0;
+
+    try testing.expect(fitToBudget(io, gpa, "/nonexistent-source.jpg", 1_000_000, 1_000, Jpeg.resize) == null);
+    // Every step was tried, and every one of them was cleaned up.
+    try testing.expectEqual(downscale_steps.len, Jpeg.attempts);
+}
+
+test "looksLikePng: magic bytes, not the file name" {
+    const io = testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPath(io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "real.png", .data = png_magic ++ "IHDR..." });
+    try tmp.dir.writeFile(io, .{ .sub_path = "liar.png", .data = "\xff\xd8\xff\xe0 actually a jpeg" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "tiny.png", .data = "\x89PNG" });
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expect(looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/real.png", .{root})));
+    try testing.expect(!looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/liar.png", .{root})));
+    // Shorter than the signature, and a path that is not there at all.
+    try testing.expect(!looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/tiny.png", .{root})));
+    try testing.expect(!looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/gone.png", .{root})));
 }
 
 test "fmtMb: the size in the error line is the size the user sees" {

--- a/src/vision_clipboard.zig
+++ b/src/vision_clipboard.zig
@@ -134,6 +134,13 @@ pub fn sipsIsImage(io: Io, path: []const u8) bool {
 /// validated here — it must exist, be a regular non-empty file, and either
 /// carry an image extension or survive the `sips` probe. `probe` is injected
 /// so the trap can be tested without a pasteboard or a subprocess.
+///
+/// The leading-`/` test is deliberately POSIX-shaped rather than
+/// `std.fs.path.isAbsolute`: the input is always AppleScript's
+/// `POSIX path of …`, so a path that does not start with `/` is coercion
+/// output rather than a file. No comptime OS gate is needed — the only caller
+/// is `grabFurl`, reached solely through `grabClipboardImage`, which already
+/// returns null off macOS.
 pub fn furlLooksStageable(io: Io, path: []const u8, probe: anytype) bool {
     if (path.len == 0 or path[0] != '/') return false;
     const size = regularFileSize(io, path) orelse return false;

--- a/src/vision_clipboard.zig
+++ b/src/vision_clipboard.zig
@@ -260,15 +260,24 @@ fn grabPng(io: Io, gpa: Allocator) ?Grab {
     defer gpa.free(open);
     const argv = [_][]const u8{
         "osascript",
-        "-e", "try",
-        "-e", "set theData to (the clipboard as «class PNGf»)",
-        "-e", open,
-        "-e", "set eof fp to 0",
-        "-e", "write theData to fp",
-        "-e", "close access fp",
-        "-e", "on error",
-        "-e", "error number 1",
-        "-e", "end try",
+        "-e",
+        "try",
+        "-e",
+        "set theData to (the clipboard as «class PNGf»)",
+        "-e",
+        open,
+        "-e",
+        "set eof fp to 0",
+        "-e",
+        "write theData to fp",
+        "-e",
+        "close access fp",
+        "-e",
+        "on error",
+        "-e",
+        "error number 1",
+        "-e",
+        "end try",
     };
     if (!runQuiet(io, &argv)) return null;
     // Stat the export: osascript exiting 0 is not proof the bytes landed.
@@ -303,15 +312,24 @@ fn grabPdf(io: Io, gpa: Allocator) ?Grab {
     defer gpa.free(open);
     const argv = [_][]const u8{
         "osascript",
-        "-e", "try",
-        "-e", "set theData to (the clipboard as «class PDF »)",
-        "-e", open,
-        "-e", "set eof fp to 0",
-        "-e", "write theData to fp",
-        "-e", "close access fp",
-        "-e", "on error",
-        "-e", "error number 1",
-        "-e", "end try",
+        "-e",
+        "try",
+        "-e",
+        "set theData to (the clipboard as «class PDF »)",
+        "-e",
+        open,
+        "-e",
+        "set eof fp to 0",
+        "-e",
+        "write theData to fp",
+        "-e",
+        "close access fp",
+        "-e",
+        "on error",
+        "-e",
+        "error number 1",
+        "-e",
+        "end try",
     };
     if (!runQuiet(io, &argv)) return null;
     if ((regularFileSize(io, pdf) orelse 0) == 0) return null;
@@ -381,220 +399,9 @@ pub fn fmtMb(buf: *[16]u8, bytes: u64) []const u8 {
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────
-// Anything that needs a live pasteboard (grabClipboardImage and the osascript
-// cascade) is deliberately NOT tested here: `zig build test` must not depend
-// on whatever the developer last copied.
+// Split into vision_clipboard_tests.zig to stay under the 600-line ceiling;
+// an unreferenced module's tests never run, hence the import below.
 
-const testing = std.testing;
-
-test "tempPath: unique per call, and safe to drop into a shell/AppleScript literal" {
-    const io = testing.io;
-    const gpa = testing.allocator;
-    const a = tempPath(io, gpa, "png") orelse return error.NoTempPath;
-    defer gpa.free(a);
-    const b = tempPath(io, gpa, "png") orelse return error.NoTempPath;
-    defer gpa.free(b);
-    const c = tempPath(io, gpa, "pdf") orelse return error.NoTempPath;
-    defer gpa.free(c);
-
-    // The whole point of #349's race fix: two pastes never share a file.
-    try testing.expect(!std.mem.eql(u8, a, b));
-    try testing.expect(std.mem.endsWith(u8, a, ".png"));
-    try testing.expect(std.mem.endsWith(u8, c, ".pdf"));
-    try testing.expect(std.mem.startsWith(u8, a, "/tmp/graff-clip-"));
-    // No quoting anywhere: only these bytes may appear.
-    for (a) |ch| try testing.expect(std.ascii.isAlphanumeric(ch) or ch == '/' or ch == '.' or ch == '-');
-}
-
-test "stageableExtension: only formats a provider takes as-is" {
-    try testing.expect(stageableExtension("/tmp/a.png"));
-    try testing.expect(stageableExtension("/tmp/a.JPG"));
-    try testing.expect(stageableExtension("/tmp/a.jpeg"));
-    try testing.expect(stageableExtension("/tmp/a.gif"));
-    try testing.expect(stageableExtension("/tmp/a.webp"));
-    try testing.expect(!stageableExtension("/tmp/a.heic"));
-    try testing.expect(!stageableExtension("/tmp/a.pdf"));
-    try testing.expect(!stageableExtension("/hello"));
-}
-
-test "furlLooksStageable: the plain-text /hello coercion trap is rejected (#350)" {
-    const io = testing.io;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root_len = try tmp.dir.realPath(io, &root_buf);
-    const root = root_buf[0..root_len];
-
-    try tmp.dir.writeFile(io, .{ .sub_path = "shot.png", .data = "\x89PNG\r\n\x1a\n not really a png, but the extension is enough" });
-    try tmp.dir.writeFile(io, .{ .sub_path = "notes.txt", .data = "just text" });
-    try tmp.dir.writeFile(io, .{ .sub_path = "empty.png", .data = "" });
-
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const png = try std.fmt.bufPrint(&path_buf, "{s}/shot.png", .{root});
-
-    const never = struct {
-        fn probe(_: Io, _: []const u8) bool {
-            return false;
-        }
-    }.probe;
-    const always = struct {
-        fn probe(_: Io, _: []const u8) bool {
-            return true;
-        }
-    }.probe;
-
-    // A real image file passes on its extension alone — no subprocess needed.
-    try testing.expect(furlLooksStageable(io, png, never));
-
-    // `the clipboard as «class furl»` SUCCEEDS on the plain text "hello" and
-    // hands back "/hello". It does not exist, so it must never be staged —
-    // not even when the probe would say yes.
-    try testing.expect(!furlLooksStageable(io, "/hello", always));
-    // Relative / empty coercion output is not a path at all.
-    try testing.expect(!furlLooksStageable(io, "hello", always));
-    try testing.expect(!furlLooksStageable(io, "", always));
-
-    // A real file that is not an image: the probe is the only gate, and it says no.
-    const txt = try std.fmt.bufPrint(&path_buf, "{s}/notes.txt", .{root});
-    try testing.expect(!furlLooksStageable(io, txt, never));
-
-    // A directory is not a file, and a zero-byte "image" is not an image.
-    try testing.expect(!furlLooksStageable(io, root, always));
-    const empty = try std.fmt.bufPrint(&path_buf, "{s}/empty.png", .{root});
-    try testing.expect(!furlLooksStageable(io, empty, always));
-}
-
-test "planStage: missing → not_found, oversize → too_large carrying the REAL size (#349)" {
-    const io = testing.io;
-    const gpa = testing.allocator;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root_len = try tmp.dir.realPath(io, &root_buf);
-    const root = root_buf[0..root_len];
-
-    const body = "0123456789" ** 4; // 40 bytes
-    try tmp.dir.writeFile(io, .{ .sub_path = "big.png", .data = body });
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const big = try std.fmt.bufPrint(&path_buf, "{s}/big.png", .{root});
-
-    const cannot = struct {
-        fn resize(_: Io, _: []const u8, _: []const u8, _: []const u8) bool {
-            return false;
-        }
-    }.resize;
-
-    // Over budget and unshrinkable: the byte count reported is the statted
-    // size, never something inferred from error.StreamTooLong.
-    switch (planStage(io, gpa, big, 8, cannot)) {
-        .too_large => |n| try testing.expectEqual(@as(u64, body.len), n),
-        else => return error.ExpectedTooLarge,
-    }
-
-    // Under budget: read in place, nothing to clean up.
-    switch (planStage(io, gpa, big, max_staged_image_bytes, cannot)) {
-        .fits => |f| {
-            try testing.expect(!f.temp);
-            try testing.expectEqual(@as(u64, body.len), f.bytes);
-            try testing.expectEqualStrings(big, f.path);
-        },
-        else => return error.ExpectedFits,
-    }
-
-    // Missing is its own answer, distinct from both of the above.
-    const gone = try std.fmt.bufPrint(&path_buf, "{s}/nope.png", .{root});
-    try testing.expect(planStage(io, gpa, gone, max_staged_image_bytes, cannot) == .not_found);
-    // …as is "there, but not a regular file".
-    try testing.expect(planStage(io, gpa, root, max_staged_image_bytes, cannot) == .not_found);
-}
-
-test "fitToBudget: downscales instead of dropping, and cleans up the steps it rejects" {
-    const io = testing.io;
-    const gpa = testing.allocator;
-
-    // A stand-in for sips: the first (largest) step still overshoots, the
-    // second lands under budget — so a real paste keeps the most detail that
-    // fits rather than being refused outright. Both steps emit real PNG bytes,
-    // which is the only thing `fitToBudget` will accept.
-    const Fake = struct {
-        var attempts: usize = 0;
-        fn resize(rio: Io, _: []const u8, max_dim: []const u8, out: []const u8) bool {
-            attempts += 1;
-            const data = if (std.mem.eql(u8, max_dim, "2048")) png_magic ++ "xxxxxxxx" else png_magic;
-            Io.Dir.cwd().writeFile(rio, .{ .sub_path = out, .data = data }) catch return false;
-            return true;
-        }
-    };
-    Fake.attempts = 0;
-
-    const fit = fitToBudget(io, gpa, "/nonexistent-source.png", 1_000_000, 8, Fake.resize) orelse
-        return error.ExpectedDownscale;
-    defer discard(io, gpa, fit.path);
-    try testing.expect(fit.temp);
-    try testing.expectEqual(@as(u64, png_magic.len), fit.bytes);
-    try testing.expectEqual(@as(usize, 2), Fake.attempts);
-    // The rejected 2048 step left nothing behind.
-    try testing.expect(regularFileSize(io, fit.path) != null);
-
-    // Still too big at every step → null, which is what surfaces `too_large`.
-    Fake.attempts = 0;
-    try testing.expect(fitToBudget(io, gpa, "/nonexistent-source.png", 1_000_000, 2, Fake.resize) == null);
-    try testing.expectEqual(downscale_steps.len, Fake.attempts);
-}
-
-test "fitToBudget: a step that is not really a PNG is rejected, never mislabelled" {
-    const io = testing.io;
-    const gpa = testing.allocator;
-
-    // `sips -Z` alone keeps the SOURCE encoding: pointed at a .jpg it exits 0
-    // and writes JPEG bytes into the `.png` temp, which the stager would then
-    // label `image/png` and the provider would 400 on. Well under every
-    // budget, so only the magic-byte check can reject it.
-    const Jpeg = struct {
-        var attempts: usize = 0;
-        fn resize(rio: Io, _: []const u8, _: []const u8, out: []const u8) bool {
-            attempts += 1;
-            Io.Dir.cwd().writeFile(rio, .{ .sub_path = out, .data = "\xff\xd8\xff\xe0 JFIF-ish" }) catch return false;
-            return true;
-        }
-    };
-    Jpeg.attempts = 0;
-
-    try testing.expect(fitToBudget(io, gpa, "/nonexistent-source.jpg", 1_000_000, 1_000, Jpeg.resize) == null);
-    // Every step was tried, and every one of them was cleaned up.
-    try testing.expectEqual(downscale_steps.len, Jpeg.attempts);
-}
-
-test "looksLikePng: magic bytes, not the file name" {
-    const io = testing.io;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root_len = try tmp.dir.realPath(io, &root_buf);
-    const root = root_buf[0..root_len];
-
-    try tmp.dir.writeFile(io, .{ .sub_path = "real.png", .data = png_magic ++ "IHDR..." });
-    try tmp.dir.writeFile(io, .{ .sub_path = "liar.png", .data = "\xff\xd8\xff\xe0 actually a jpeg" });
-    try tmp.dir.writeFile(io, .{ .sub_path = "tiny.png", .data = "\x89PNG" });
-
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    try testing.expect(looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/real.png", .{root})));
-    try testing.expect(!looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/liar.png", .{root})));
-    // Shorter than the signature, and a path that is not there at all.
-    try testing.expect(!looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/tiny.png", .{root})));
-    try testing.expect(!looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/gone.png", .{root})));
-}
-
-test "fmtMb: the size in the error line is the size the user sees" {
-    var buf: [16]u8 = undefined;
-    try testing.expectEqualStrings("7.3 MB", fmtMb(&buf, 7_682_253));
-    try testing.expectEqualStrings("3.5 MB", fmtMb(&buf, max_staged_image_bytes));
-    try testing.expectEqualStrings("1.4 MB", fmtMb(&buf, 1_470_878));
-}
-
-test "max_staged_image_bytes: base64 of a full-budget image stays under the 5 MB wire cap" {
-    const encoded = std.base64.standard.Encoder.calcSize(@intCast(max_staged_image_bytes));
-    try testing.expect(encoded < 5_000_000);
-    // …and the OLD 5 MiB ceiling did not, which is the #349 bug in one line.
-    try testing.expect(std.base64.standard.Encoder.calcSize(5 * 1024 * 1024) > 5_000_000);
+test {
+    _ = @import("vision_clipboard_tests.zig");
 }

--- a/src/vision_clipboard_tests.zig
+++ b/src/vision_clipboard_tests.zig
@@ -7,6 +7,7 @@
 //! on whatever the developer last copied.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const Io = std.Io;
 
 const clip = @import("vision_clipboard.zig");
@@ -56,6 +57,14 @@ test "stageableExtension: only formats a provider takes as-is" {
 }
 
 test "furlLooksStageable: the plain-text /hello coercion trap is rejected (#350)" {
+    // POSIX-only: every path here is judged by `furlLooksStageable`'s leading
+    // `/` check, which is a statement about AppleScript's `POSIX path of`
+    // output, not about paths in general. On Windows a tmpDir realPath is
+    // `C:\...` and "/hello" is not absolute at all, so both the positive and
+    // the negative cases would be decided by the wrong branch. The whole furl
+    // cascade is macOS-only (osascript), so there is nothing to assert there.
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
     const io = testing.io;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -147,6 +156,13 @@ test "planStage: missing → not_found, oversize → too_large carrying the REAL
 }
 
 test "fitToBudget: downscales instead of dropping, and cleans up the steps it rejects" {
+    // POSIX-only: `fitToBudget` writes each downscale step to `tempPath`, which
+    // hardcodes /tmp on purpose (see its doc comment — the path is interpolated
+    // into AppleScript and must need no quoting). There is no /tmp on Windows,
+    // so every step fails to write and the ladder reports "cannot shrink" for a
+    // reason that has nothing to do with the logic under test.
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
     const io = testing.io;
     const gpa = testing.allocator;
 
@@ -181,6 +197,12 @@ test "fitToBudget: downscales instead of dropping, and cleans up the steps it re
 }
 
 test "fitToBudget: a step that is not really a PNG is rejected, never mislabelled" {
+    // Same /tmp dependency as above. This one would *pass* on Windows, but only
+    // because every step fails to write — a green light for the wrong reason is
+    // worse than an honest skip, since it would keep passing if the magic-byte
+    // check were deleted outright.
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
     const io = testing.io;
     const gpa = testing.allocator;
 

--- a/src/vision_clipboard_tests.zig
+++ b/src/vision_clipboard_tests.zig
@@ -1,0 +1,238 @@
+//! #349/#350 clipboard-staging behaviour tests. Split out of
+//! vision_clipboard.zig (600-line ceiling); referenced from its test block so
+//! they actually run.
+//!
+//! Anything that needs a live pasteboard (grabClipboardImage and the osascript
+//! cascade) is deliberately NOT tested here: `zig build test` must not depend
+//! on whatever the developer last copied.
+
+const std = @import("std");
+const Io = std.Io;
+
+const clip = @import("vision_clipboard.zig");
+const max_staged_image_bytes = clip.max_staged_image_bytes;
+const downscale_steps = clip.downscale_steps;
+const png_magic = clip.png_magic;
+const tempPath = clip.tempPath;
+const discard = clip.discard;
+const regularFileSize = clip.regularFileSize;
+const stageableExtension = clip.stageableExtension;
+const furlLooksStageable = clip.furlLooksStageable;
+const looksLikePng = clip.looksLikePng;
+const fitToBudget = clip.fitToBudget;
+const planStage = clip.planStage;
+const fmtMb = clip.fmtMb;
+
+const testing = std.testing;
+
+test "tempPath: unique per call, and safe to drop into a shell/AppleScript literal" {
+    const io = testing.io;
+    const gpa = testing.allocator;
+    const a = tempPath(io, gpa, "png") orelse return error.NoTempPath;
+    defer gpa.free(a);
+    const b = tempPath(io, gpa, "png") orelse return error.NoTempPath;
+    defer gpa.free(b);
+    const c = tempPath(io, gpa, "pdf") orelse return error.NoTempPath;
+    defer gpa.free(c);
+
+    // The whole point of #349's race fix: two pastes never share a file.
+    try testing.expect(!std.mem.eql(u8, a, b));
+    try testing.expect(std.mem.endsWith(u8, a, ".png"));
+    try testing.expect(std.mem.endsWith(u8, c, ".pdf"));
+    try testing.expect(std.mem.startsWith(u8, a, "/tmp/graff-clip-"));
+    // No quoting anywhere: only these bytes may appear.
+    for (a) |ch| try testing.expect(std.ascii.isAlphanumeric(ch) or ch == '/' or ch == '.' or ch == '-');
+}
+
+test "stageableExtension: only formats a provider takes as-is" {
+    try testing.expect(stageableExtension("/tmp/a.png"));
+    try testing.expect(stageableExtension("/tmp/a.JPG"));
+    try testing.expect(stageableExtension("/tmp/a.jpeg"));
+    try testing.expect(stageableExtension("/tmp/a.gif"));
+    try testing.expect(stageableExtension("/tmp/a.webp"));
+    try testing.expect(!stageableExtension("/tmp/a.heic"));
+    try testing.expect(!stageableExtension("/tmp/a.pdf"));
+    try testing.expect(!stageableExtension("/hello"));
+}
+
+test "furlLooksStageable: the plain-text /hello coercion trap is rejected (#350)" {
+    const io = testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPath(io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "shot.png", .data = "\x89PNG\r\n\x1a\n not really a png, but the extension is enough" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "notes.txt", .data = "just text" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "empty.png", .data = "" });
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const png = try std.fmt.bufPrint(&path_buf, "{s}/shot.png", .{root});
+
+    const never = struct {
+        fn probe(_: Io, _: []const u8) bool {
+            return false;
+        }
+    }.probe;
+    const always = struct {
+        fn probe(_: Io, _: []const u8) bool {
+            return true;
+        }
+    }.probe;
+
+    // A real image file passes on its extension alone — no subprocess needed.
+    try testing.expect(furlLooksStageable(io, png, never));
+
+    // `the clipboard as «class furl»` SUCCEEDS on the plain text "hello" and
+    // hands back "/hello". It does not exist, so it must never be staged —
+    // not even when the probe would say yes.
+    try testing.expect(!furlLooksStageable(io, "/hello", always));
+    // Relative / empty coercion output is not a path at all.
+    try testing.expect(!furlLooksStageable(io, "hello", always));
+    try testing.expect(!furlLooksStageable(io, "", always));
+
+    // A real file that is not an image: the probe is the only gate, and it says no.
+    const txt = try std.fmt.bufPrint(&path_buf, "{s}/notes.txt", .{root});
+    try testing.expect(!furlLooksStageable(io, txt, never));
+
+    // A directory is not a file, and a zero-byte "image" is not an image.
+    try testing.expect(!furlLooksStageable(io, root, always));
+    const empty = try std.fmt.bufPrint(&path_buf, "{s}/empty.png", .{root});
+    try testing.expect(!furlLooksStageable(io, empty, always));
+}
+
+test "planStage: missing → not_found, oversize → too_large carrying the REAL size (#349)" {
+    const io = testing.io;
+    const gpa = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPath(io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    const body = "0123456789" ++ "0123456789" ++ "0123456789" ++ "0123456789"; // 40 bytes
+    try tmp.dir.writeFile(io, .{ .sub_path = "big.png", .data = body });
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const big = try std.fmt.bufPrint(&path_buf, "{s}/big.png", .{root});
+
+    const cannot = struct {
+        fn resize(_: Io, _: []const u8, _: []const u8, _: []const u8) bool {
+            return false;
+        }
+    }.resize;
+
+    // Over budget and unshrinkable: the byte count reported is the statted
+    // size, never something inferred from error.StreamTooLong.
+    switch (planStage(io, gpa, big, 8, cannot)) {
+        .too_large => |n| try testing.expectEqual(@as(u64, body.len), n),
+        else => return error.ExpectedTooLarge,
+    }
+
+    // Under budget: read in place, nothing to clean up.
+    switch (planStage(io, gpa, big, max_staged_image_bytes, cannot)) {
+        .fits => |f| {
+            try testing.expect(!f.temp);
+            try testing.expectEqual(@as(u64, body.len), f.bytes);
+            try testing.expectEqualStrings(big, f.path);
+        },
+        else => return error.ExpectedFits,
+    }
+
+    // Missing is its own answer, distinct from both of the above.
+    const gone = try std.fmt.bufPrint(&path_buf, "{s}/nope.png", .{root});
+    try testing.expect(planStage(io, gpa, gone, max_staged_image_bytes, cannot) == .not_found);
+    // …as is "there, but not a regular file".
+    try testing.expect(planStage(io, gpa, root, max_staged_image_bytes, cannot) == .not_found);
+}
+
+test "fitToBudget: downscales instead of dropping, and cleans up the steps it rejects" {
+    const io = testing.io;
+    const gpa = testing.allocator;
+
+    // A stand-in for sips: the first (largest) step still overshoots, the
+    // second lands under budget — so a real paste keeps the most detail that
+    // fits rather than being refused outright. Both steps emit real PNG bytes,
+    // which is the only thing `fitToBudget` will accept.
+    const Fake = struct {
+        var attempts: usize = 0;
+        fn resize(rio: Io, _: []const u8, max_dim: []const u8, out: []const u8) bool {
+            attempts += 1;
+            const data = if (std.mem.eql(u8, max_dim, "2048")) png_magic ++ "xxxxxxxx" else png_magic;
+            Io.Dir.cwd().writeFile(rio, .{ .sub_path = out, .data = data }) catch return false;
+            return true;
+        }
+    };
+    Fake.attempts = 0;
+
+    const fit = fitToBudget(io, gpa, "/nonexistent-source.png", 1_000_000, 8, Fake.resize) orelse
+        return error.ExpectedDownscale;
+    defer discard(io, gpa, fit.path);
+    try testing.expect(fit.temp);
+    try testing.expectEqual(@as(u64, png_magic.len), fit.bytes);
+    try testing.expectEqual(@as(usize, 2), Fake.attempts);
+    // The rejected 2048 step left nothing behind.
+    try testing.expect(regularFileSize(io, fit.path) != null);
+
+    // Still too big at every step → null, which is what surfaces `too_large`.
+    Fake.attempts = 0;
+    try testing.expect(fitToBudget(io, gpa, "/nonexistent-source.png", 1_000_000, 2, Fake.resize) == null);
+    try testing.expectEqual(downscale_steps.len, Fake.attempts);
+}
+
+test "fitToBudget: a step that is not really a PNG is rejected, never mislabelled" {
+    const io = testing.io;
+    const gpa = testing.allocator;
+
+    // `sips -Z` alone keeps the SOURCE encoding: pointed at a .jpg it exits 0
+    // and writes JPEG bytes into the `.png` temp, which the stager would then
+    // label `image/png` and the provider would 400 on. Well under every
+    // budget, so only the magic-byte check can reject it.
+    const Jpeg = struct {
+        var attempts: usize = 0;
+        fn resize(rio: Io, _: []const u8, _: []const u8, out: []const u8) bool {
+            attempts += 1;
+            Io.Dir.cwd().writeFile(rio, .{ .sub_path = out, .data = "\xff\xd8\xff\xe0 JFIF-ish" }) catch return false;
+            return true;
+        }
+    };
+    Jpeg.attempts = 0;
+
+    try testing.expect(fitToBudget(io, gpa, "/nonexistent-source.jpg", 1_000_000, 1_000, Jpeg.resize) == null);
+    // Every step was tried, and every one of them was cleaned up.
+    try testing.expectEqual(downscale_steps.len, Jpeg.attempts);
+}
+
+test "looksLikePng: magic bytes, not the file name" {
+    const io = testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPath(io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "real.png", .data = png_magic ++ "IHDR..." });
+    try tmp.dir.writeFile(io, .{ .sub_path = "liar.png", .data = "\xff\xd8\xff\xe0 actually a jpeg" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "tiny.png", .data = "\x89PNG" });
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expect(looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/real.png", .{root})));
+    try testing.expect(!looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/liar.png", .{root})));
+    // Shorter than the signature, and a path that is not there at all.
+    try testing.expect(!looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/tiny.png", .{root})));
+    try testing.expect(!looksLikePng(io, try std.fmt.bufPrint(&path_buf, "{s}/gone.png", .{root})));
+}
+
+test "fmtMb: the size in the error line is the size the user sees" {
+    var buf: [16]u8 = undefined;
+    try testing.expectEqualStrings("7.3 MB", fmtMb(&buf, 7_682_253));
+    try testing.expectEqualStrings("3.5 MB", fmtMb(&buf, max_staged_image_bytes));
+    try testing.expectEqualStrings("1.4 MB", fmtMb(&buf, 1_470_878));
+}
+
+test "max_staged_image_bytes: base64 of a full-budget image stays under the 5 MB wire cap" {
+    const encoded = std.base64.standard.Encoder.calcSize(@intCast(max_staged_image_bytes));
+    try testing.expect(encoded < 5_000_000);
+    // …and the OLD 5 MiB ceiling did not, which is the #349 bug in one line.
+    try testing.expect(std.base64.standard.Encoder.calcSize(5 * 1024 * 1024) > 5_000_000);
+}


### PR DESCRIPTION
Fixes #349. Fixes #350.

## What changed
- `StageResult` is now a tagged union (`ok{bytes,media_type}` / `no_vision` / `too_large{bytes,limit}` / `not_found` / `read_error`) instead of collapsing every failure into `.read_fail`; both paste call sites (Ctrl-V in `readline.zig`, `/paste`+`/image` in `commands_model.zig`) print actionable messages with real sizes (e.g. "clipboard image is 7.6 MB — over the 3.5 MB limit").
- Staging now stats before reading, and oversized images are **downscaled instead of dropped**: `sips -s format png -Z` steps through 2048 → 1568 → 1024 until the file fits the budget, with a PNG-magic check on every step so a non-PNG can never ship mislabeled.
- `grabClipboardImage` is now a flavor cascade: `«class PNGf»` → `«class furl»` (validated: absolute, regular, non-empty, image-gated via extension or `sips` probe — the plain-text `/hello` coercion trap is guarded) → `«class PDF »` via `sips` conversion. File-URL clipboards (the Telegram case) and PDF clipboards now attach.
- The shared `/tmp/.harness-clip.png` is replaced by a unique per-paste path (`/tmp/graff-clip-<pid>-<16hex>.<ext>`) built once and interpolated into the AppleScript argv, deleted after staging on every path.
- A `clipboard_paste` trace event (result, flavor, bytes, mime — never payload) is emitted for every paste outcome, so dropped attachments are finally visible in `.graff/traces`.
- Dead `.no_vision` prong removed from the Ctrl-V handler; cascade/budget/temp-path logic extracted to new `src/vision_clipboard.zig` with 10 headless regression tests (683/683 pass). All files stay ≤600 lines.

## Why
- **Problem/failure mode:** a >5 MiB moodboard paste printed a generic "couldn't read the clipboard image" and the prompt silently went out text-only (#349, reproduced live on 0.0.231); Telegram-style file-URL clipboards were rejected as "no image on the clipboard" (#350, reproduced via a 12-case synthetic clipboard matrix). Neither failure left any trace event.
- **Reason for this approach:** investigation showed macOS lazily synthesizes PNGf from *any* raster flavor, so a TIFF fallback (the issue's guess) would change nothing — only pixel-less clipboards (file-url/PDF) fail, hence the cascade. And simply raising the 5 MiB read cap would make things worse: 5 MiB raw base64-expands to 6.67 MiB, over the ~5 MB provider cap. Downscaling is the only fix that actually delivers the image.
- **Constraints/trade-offs:** the budget constant is 3,700,000 bytes — the largest round number whose base64 expansion clears both a 5 MB and a 5 MiB reading of the provider cap (a literal 3.75 MiB would base64 to 5,242,880 and fail a decimal cap). On non-macOS there is no `sips`, so oversized images fail with the honest `too_large` message rather than downscaling.
- **Rejected alternatives:** raising the cap (wire failure, above); NSPasteboard via an ObjC shim (heavier than three osascript flavors for the same coverage); keeping the fixed temp path (reproduced a real cross-session race and it's a symlink-planting target).

## Verification
Live PTY smoke against the rebuilt binary: 7.6 MB PNG now downscales at 2048 and attaches (previously dropped); 1.4 MB control unchanged; file-URL clipboard attaches via cascade (PNGf confirmed to fail on it first); PDF clipboard attaches; plain-text clipboard still correctly refused; oversized non-image reports its real size. Temp-file hygiene confirmed (`/tmp/graff-clip-*` empty after runs). Adversarially reviewed; the one blocking finding (sips -Z preserves source encoding → JPEG bytes in a .png) was fixed in the follow-up commit with byte-level `file`/magic verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbsV84fdmf39Bh2RF8LdPs