### PR TITLE
feat(prompts): require what+why rationale in agent-authored PR descriptions

### DIFF
--- a/src/prompts.zig
+++ b/src/prompts.zig
@@ -60,6 +60,22 @@ pub const main_system_prompt =
     \\of the commit message, after a blank line:
     \\Co-Authored-By: Codegraff <blackfloofie@codegraff.com>
     \\
+    \\A pull request description you author must explain WHY the change was made,
+    \\not only what it does — a reviewer cannot reconstruct the reasoning from the
+    \\diff. Cover both halves:
+    \\## What changed
+    \\- concise summary of the implementation
+    \\## Why
+    \\- Problem/failure mode: the concrete bug, gap, or symptom that motivated it
+    \\- Reason for this approach: why this design over the obvious one
+    \\- Constraints or trade-offs: what the fix had to work around, and its costs
+    \\- Rejected alternatives (when relevant): what you considered and ruled out
+    \\Scale the rationale to the change: a subtle or non-obvious change earns the
+    \\full Why section, while a trivial one (typo, version bump, mechanical rename)
+    \\needs a single sentence — never pad a small change with boilerplate headings.
+    \\Apply the same what+why reasoning to the commit message body when the commit
+    \\is the only artifact the reviewer will see.
+    \\
     \\Never run git commands that discard work — `reset --hard`, `clean -f`,
     \\`checkout --`/`restore`, force-push, or `branch -D` — unless the user
     \\explicitly asks. Their existing commits and any -w worktree
@@ -180,6 +196,18 @@ test "both prompts ask for parallel tool calls, with the dependency caveat" {
     try std.testing.expect(std.mem.indexOf(u8, sub_system_prompt, "subagent spawned by an orchestrator") != null);
     try std.testing.expect(std.mem.indexOf(u8, main_system_prompt, "Be direct and concise") != null);
     try std.testing.expect(std.mem.indexOf(u8, main_system_prompt_strict, "STRICT MODE") != null);
+}
+
+// #351: agent-authored PRs described only the diff, which a reviewer can already
+// read. The rationale — the failure mode, why this design, what it trades off —
+// exists only in the agent's head at authoring time and is unrecoverable later,
+// so the prompt has to demand it. The proportionality clause is load-bearing in
+// the other direction: without it a one-line typo fix grows four empty headings.
+test "root prompt (#351) requires what+why rationale in PR descriptions, scaled to the change" {
+    for ([_][]const u8{ "## What changed", "## Why", "Problem/failure mode", "Reason for this approach", "Constraints or trade-offs", "Rejected alternatives" }) |section|
+        try std.testing.expect(std.mem.indexOf(u8, main_system_prompt, section) != null);
+    try std.testing.expect(std.mem.indexOf(u8, main_system_prompt, "Scale the rationale to the change") != null);
+    try std.testing.expect(std.mem.indexOf(u8, main_system_prompt, "never pad a small change with boilerplate") != null);
 }
 
 test "root prompt permits explicit external targets without weakening confinement" {


### PR DESCRIPTION
Fixes #351.

## What changed
- Added a paragraph to `main_system_prompt` in `src/prompts.zig` (directly after the commit-identity guidance) requiring agent-authored PR descriptions to include both `## What changed` and `## Why` (problem/failure mode, reason for this approach, constraints/trade-offs, rejected alternatives when relevant), with the proportionality clause from the issue — rationale scales with the change, no boilerplate headings on trivial diffs — plus a one-line carry-over to commit message bodies.
- Added a regression test pinning the section headings and the proportionality clause.

## Why
- **Problem/failure mode:** agent PRs documented *what* changed but not *why*, so later agents (or reviewers) could undo deliberate decisions or repeat already-rejected approaches (#351).
- **Reason for this approach:** `main_system_prompt` is the single base that all four shipped root variants (`sys_normal`/`sys_strict`/`sys_ultra`/`sys_ultra_strict`) derive from in `setSystemPrompts()`, so one edit reaches every root-agent mode. A repo-wide search confirmed this is the *only* shipped location of PR-authoring guidance — there is no PR template or tool description to update.
- **Constraints/trade-offs:** `sub_system_prompt` was deliberately left untouched (subagents rarely author PRs directly); previously bootstrapped learned root policies replace the prompt wholesale and won't pick this up until re-bootstrapped.
- **Rejected alternatives:** a `.github/PULL_REQUEST_TEMPLATE.md` (would nag human PRs too and doesn't reach the agent's `gh pr create` path); putting it in `docs/` only (agents don't reliably read docs before authoring PRs).

This PR's own description follows the new structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbsV84fdmf39Bh2RF8LdPs