### PR TITLE
fix(cli): --max-model-calls help said default 256; real default is 0 = unlimited

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ flags:
   --timing                  show per-tool wall-clock on result lines (✓ (312ms) …)
   --cost                    show running session spend in the prompt ([model · 12k tok · $0.0042])
   --json                    structured stdio protocol (JSON in, JSONL events out, SDK transport)
-  --max-model-calls N  cap provider calls across root, children, retries, titles, compaction, and judges (default 256)
+  --max-model-calls N  cap provider calls across root, children, retries, titles, compaction, and judges (default 0 = unlimited)
   -h, --help       usage
   -V, --version    version
 ```

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -109,7 +109,7 @@ pub const usage_text =
     \\  --cost           show running session spend in the prompt
     \\  --json           structured stdio protocol (JSON in, JSONL events out)
     \\  --max-tool-calls N  reject root tool calls after N per turn (JSON-safe budget)
-    \\  --max-model-calls N total provider calls allowed across this run (default 256; includes children/title/judges)
+    \\  --max-model-calls N total provider calls allowed across this run (default 0 = unlimited; includes children/title/judges)
     \\  --dedupe-tool-calls reject duplicate root tool name+input calls per turn
     \\  --no-telemetry   disable anonymous usage telemetry for this run
     \\  --learning-privacy <mode>       learning egress ceiling: local|aggregate|templates|examples (default aggregate)


### PR DESCRIPTION
Related to #217.

## What changed
`--help` claimed `--max-model-calls` defaults to 256; `main.zig`/`run_budget.zig` default it to 0 = unlimited. The help text now tells the truth. Doc sweep included.

## Why
Users reading `--help` believed they had a finite run budget when they did not — directly relevant to the #217 budget work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbsV84fdmf39Bh2RF8LdPs