### PR TITLE
feat(providers): add Kilo, Groq, Mistral

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,9 @@ from [models.dev](https://models.dev)'s `api.json` (snapshot 2026-06-10).
 | `openai`    | OpenAI chat, bearer         | `OPENAI_API_KEY`     |
 | `minimax`   | Anthropic Messages, bearer  | `MINIMAX_API_KEY`    |
 | `xiaomi` (MiMo) | OpenAI chat, bearer     | `XIAOMI_API_KEY`     |
+| `kilo`      | OpenAI chat, bearer         | `KILO_API_KEY`       |
+| `groq`      | OpenAI chat, bearer         | `GROQ_API_KEY`       |
+| `mistral`   | OpenAI chat, bearer         | `MISTRAL_API_KEY`    |
 | `kimi` | Live catalog-selected: native Kimi chat + bearer, or Anthropic beta Messages + x-api-key when declared | `graff login kimi` or `KIMI_API_KEY` |
 | `xai` (grok) / `zai` (GLM) | OpenAI chat, bearer | `XAI_API_KEY` / `ZAI_API_KEY` (via `graff key set`) |
 | `codex`     | Responses API, ChatGPT login | `${CODEX_HOME:-~/.codex}/auth.json` (no API key) |

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -61,6 +61,9 @@ pub const provider_specs = [_]ProviderSpec{
     .{ .id = "openai", .display_name = "OpenAI", .kind = .openai, .auth = .bearer, .url = "https://api.openai.com/v1/chat/completions", .env_key = "OPENAI_API_KEY", .default_model = "gpt-5.6" },
     .{ .id = "minimax", .display_name = "MiniMax", .kind = .anthropic, .auth = .bearer, .url = "https://api.minimax.io/anthropic/v1/messages", .env_key = "MINIMAX_API_KEY", .default_model = "MiniMax-M3" },
     .{ .id = "xiaomi", .display_name = "Xiaomi", .kind = .openai, .auth = .bearer, .url = "https://api.xiaomimimo.com/v1/chat/completions", .env_key = "XIAOMI_API_KEY", .default_model = "mimo-v2.5-pro" },
+    .{ .id = "kilo", .display_name = "Kilo Gateway", .kind = .openai, .auth = .bearer, .url = "https://api.kilo.ai/api/gateway/v1/chat/completions", .env_key = "KILO_API_KEY", .default_model = "kilo-auto/small" },
+    .{ .id = "groq", .display_name = "Groq", .kind = .openai, .auth = .bearer, .url = "https://api.groq.com/openai/v1/chat/completions", .env_key = "GROQ_API_KEY", .default_model = "openai/gpt-oss-120b" },
+    .{ .id = "mistral", .display_name = "Mistral", .kind = .openai, .auth = .bearer, .url = "https://api.mistral.ai/v1", .env_key = "MISTRAL_API_KEY", .default_model = "mistral-medium-latest" },
     // Kimi Code publishes the protocol per model. Missing/`kimi` is the native
     // chat-completions wire; a live `protocol: anthropic` row is switched in
     // Keys.build to the beta Messages endpoint + x-api-key, matching kimi-code.


### PR DESCRIPTION
Add a selection of OpenAI-compatible providers.

- Kilo Gateway - anonymous access, no sign-up required
- Groq - no training on user data, opt-in zero data retention
- Mistral - Europe's top AI provider; open weights, private hosting

Provide sensible model defaults for each provider.