### PR TITLE
feat(engine): #422 slice 1b — agent_ws and argstream emit typed events; spinner aliases and inline notices gone

### DIFF
--- a/src/agent_argstream.zig
+++ b/src/agent_argstream.zig
@@ -1,14 +1,15 @@
 //! Live streaming of `attempt_completion`/`ask_user` tool-argument prose:
 //! a byte-at-a-time JSON scanner (ArgLive) that finds the target string
-//! field inside the still-in-flight tool-call arguments and prints it as
-//! it arrives, so strict mode (where the whole answer is a tool call)
-//! doesn't look frozen until the call completes. Split out of the Agent
-//! struct (#123, 600-line goal).
+//! field inside the still-in-flight tool-call arguments and streams it out
+//! as typed events (#422) as it arrives, so strict mode (where the whole
+//! answer is a tool call) doesn't look frozen until the call completes.
+//! Split out of the Agent struct (#123, 600-line goal).
 
 const std = @import("std");
 const Io = std.Io;
 
 const main_mod = @import("main.zig");
+const engine_sink = @import("engine_sink.zig"); // #422: emissions go through the sink
 const agent_mod = @import("agent.zig");
 const tools_mod = @import("tools.zig");
 const Agent = agent_mod.Agent;
@@ -311,25 +312,22 @@ pub fn argLiveDelta(self: *Agent, obj: std.json.ObjectMap) void {
     }
 }
 
-/// Print live tool-argument text exactly like a text delta: clears the
-/// spinner, lands in the Esc-interrupt capture, and records which meta
-/// tool already showed its prose so handleMeta / sayToolUse don't repeat
-/// it after the call completes.
+/// Live tool-argument text (#422 slice 1b): the engine-side bookkeeping —
+/// the Esc-interrupt capture, and which meta tool already showed its prose
+/// so handleMeta / sayToolUse don't repeat it after the call completes —
+/// stays here; the bytes leave as a typed event. TuiSink renders them
+/// exactly like a text delta (spinner handoff included); the --json wire
+/// never carried these moments (argLiveDelta gates --json off), so JsonSink
+/// stays silent.
 pub fn emitArgText(self: *Agent, tool: ArgTool, text: []const u8) void {
-    const w = self.out orelse return;
+    if (self.out == null) return; // frontendless agents skip capture too, as ever
     if (text.len == 0) return;
-    self.spinnerStop(); // first visible byte: clear the thinking line
     self.streamed_text = true;
     if (self.streamed_args != tool) self.streamed_args_len = 0;
     self.streamed_args = tool;
     self.streamed_args_len += text.len;
     self.partial_text.appendSlice(self.arena, text) catch {};
-    if (main_mod.use_color) {
-        self.streamMarkdown(text);
-    } else {
-        w.writeAll(text) catch return;
-        w.flush() catch return;
-    }
+    engine_sink.forAgent(self).emit(self.io, .{ .tool_arg_delta = .{ .text = text } });
 }
 
 /// True iff this meta call's prose already streamed live *in full*: the
@@ -358,6 +356,16 @@ test "argStreamedFully: a non-object tool input is refused, not dereferenced" {
 }
 
 test "ArgLive streams the target argument field across fragment splits" {
+    // Pin the frontend the emitted events resolve to (#422 slice 1b): the
+    // bytes below are TuiSink's no-color rendering of .tool_arg_delta.
+    const saved_json = main_mod.json_mode;
+    const saved_color = main_mod.use_color;
+    main_mod.json_mode = false;
+    main_mod.use_color = false;
+    defer {
+        main_mod.json_mode = saved_json;
+        main_mod.use_color = saved_color;
+    }
     var aw: Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
     var a: Agent = .{

--- a/src/agent_stream_render.zig
+++ b/src/agent_stream_render.zig
@@ -3,9 +3,9 @@
 //! and the live dimmed "Thinking" reasoning block (streamThinking/
 //! closeThinkingBlock/toggleThinkingFold), moved verbatim out of
 //! agent_stream.zig so the transport loop owns no terminal drawing. Driven by
-//! TuiSink (engine_sink.zig); agent_ws.zig still reaches the spinner through
-//! its Agent member aliases. Frontend territory: term.zig/ansi.zig/anim.zig
-//! imports live here, never in engine files.
+//! TuiSink (engine_sink.zig) only, as of slice 1b — agent_ws.zig emits events
+//! now instead of reaching the spinner aliases. Frontend territory:
+//! term.zig/ansi.zig/anim.zig imports live here, never in engine files.
 //!
 //! Agent.g_spin_stop/Agent.g_spin_future are struct-level `pub var`s that stay
 //! declared directly inside the Agent struct (never alias a `var`) — reached

--- a/src/agent_ws.zig
+++ b/src/agent_ws.zig
@@ -27,6 +27,11 @@ const Agent = agent_mod.Agent;
 const ws = @import("ws.zig");
 const http_headers = @import("http_headers.zig");
 
+// #422 slice 1b: this file draws nothing. Wait/cut moments are typed events
+// through the sink; the spinner and the ⚠ notices are TuiSink's rendering.
+const engine_sink = @import("engine_sink.zig");
+const engine_events = @import("engine_events.zig");
+
 const term = @import("term.zig");
 const tty = term.tty;
 
@@ -93,33 +98,21 @@ pub fn postLive(self: *Agent, body: []const u8) ![]u8 {
     // reconnect budget in agent_request exhausts and the turn ends — exercises the
     // give-up path offline, no network/key needed.
     if (main_mod.g_force_stall_always) {
-        if (!main_mod.json_mode) if (self.out) |o| {
-            o.writeAll("\n⚠ stream stalled\n") catch {};
-            o.flush() catch {};
-        };
+        emitAbort(self, .stalled, false);
         return error.StreamStalled;
     }
     if (main_mod.g_force_drop_always) {
-        if (!main_mod.json_mode) if (self.out) |o| {
-            o.writeAll("\n⚠ connection dropped\n") catch {};
-            o.flush() catch {};
-        };
+        emitAbort(self, .dropped, false);
         return error.StreamDropped;
     }
     if (main_mod.g_force_stall_once) {
         main_mod.g_force_stall_once = false;
-        if (!main_mod.json_mode) if (self.out) |o| {
-            o.writeAll("\n⚠ stream stalled — ending turn\n") catch {};
-            o.flush() catch {};
-        };
+        emitAbort(self, .stalled, true);
         return error.StreamStalled;
     }
     if (main_mod.g_force_drop_once) {
         main_mod.g_force_drop_once = false;
-        if (!main_mod.json_mode) if (self.out) |o| {
-            o.writeAll("\n⚠ connection dropped — response ended early\n") catch {};
-            o.flush() catch {};
-        };
+        emitAbort(self, .dropped, true);
         return error.StreamDropped;
     }
     if (!wsEligible(self)) return self.postStream(body);
@@ -159,6 +152,14 @@ pub fn postLive(self: *Agent, body: []const u8) ![]u8 {
     };
     self.ws_transport_failures = 0;
     return response;
+}
+
+/// (#422 slice 1b) A transport cut becomes a typed event; the sink decides
+/// what shows. TuiSink: the old inline ⚠ lines, byte for byte. JsonSink:
+/// nothing — the wire never carried these moments and must not start to.
+fn emitAbort(self: *Agent, reason: engine_events.StreamAbort, turn_ending: bool) void {
+    const cut: engine_events.TransportAbort = .{ .reason = reason, .turn_ending = turn_ending };
+    engine_sink.forAgent(self).emit(self.io, .{ .transport_aborted = cut });
 }
 
 fn wssUrl(arena: std.mem.Allocator, https_url: []const u8) ![]u8 {
@@ -381,8 +382,11 @@ pub fn postResponsesWs(self: *Agent, body: []const u8) ![]u8 {
         tty.restore(o);
     };
 
-    self.spinnerStart();
-    defer self.spinnerStop();
+    // One wait spans the whole ws turn (frames reassemble, never stream live):
+    // the same bracket events postStream uses; the wire has no shape for them.
+    const sink = engine_sink.forAgent(self);
+    sink.emit(self.io, .stream_begin);
+    defer sink.emit(self.io, .stream_finished);
 
     if (self.tracer) |tr| tr.note("ws", "connecting");
     // (#codex-ws) Preemptive idle re-anchor: don't reuse a WS the server has
@@ -518,10 +522,7 @@ pub fn postResponsesWs(self: *Agent, body: []const u8) ![]u8 {
                 // blocking readMessage can hang forever on a half-open ws with no
                 // watchdog; end the turn as StreamStalled (never a hang, never a user
                 // Esc), exactly as the .deadline arm below does.
-                if (!main_mod.json_mode) if (self.out) |o| {
-                    o.writeAll("\n⚠ stream stalled — ending turn\n") catch {};
-                    o.flush() catch {};
-                };
+                emitAbort(self, .stalled, true);
                 if (self.tracer) |tr| tr.note("ws", "stall");
                 return error.StreamStalled;
             };
@@ -549,10 +550,8 @@ pub fn postResponsesWs(self: *Agent, body: []const u8) ![]u8 {
                     if (self.tracer) |tr| tr.note("ws", if (w == .esc) "esc" else "reuse dead — no first frame");
                     return watchdogError(w, error.HungRequest);
                 } else {
-                    if (w == .deadline and !main_mod.json_mode) if (self.out) |o| {
-                        o.writeAll("\n⚠ stream stalled — ending turn\n") catch {};
-                        o.flush() catch {};
-                    };
+                    // Only the deadline gets a notice; a user Esc stays silent.
+                    if (w == .deadline) emitAbort(self, .stalled, true);
                     if (self.tracer) |tr| tr.note("ws", if (w == .esc) "esc" else "stall");
                     return watchdogError(w, error.StreamStalled);
                 },

--- a/src/agent_ws_test.zig
+++ b/src/agent_ws_test.zig
@@ -1,12 +1,15 @@
 //! Regression tests for Codex WebSocket delta-session re-anchoring.
 
 const std = @import("std");
+const main_mod = @import("main.zig");
 const Agent = @import("agent.zig").Agent;
 const textMessage = @import("messages.zig").textMessage;
 const ws = @import("ws.zig");
 const agent_ws = @import("agent_ws.zig");
 const codex_chain = @import("codex_chain.zig");
 const agent_compact = @import("agent_compact.zig");
+const engine_sink = @import("engine_sink.zig");
+const engine_events = @import("engine_events.zig");
 
 test "closeCodexWs resets the delta session state + frees the response id (codex-ws)" {
     var agent: Agent = undefined;
@@ -94,6 +97,76 @@ test "WS fallback latches only after a retry" {
     try std.testing.expect(!agent_ws.wsShouldFallback(1));
     try std.testing.expect(agent_ws.wsShouldFallback(2));
     try std.testing.expect(agent_ws.wsShouldFallback(255));
+}
+
+fn sinkRecord(ctx: *anyopaque, ev: engine_sink.Stamped) void {
+    const rec: *std.ArrayList(engine_sink.Stamped) = @ptrCast(@alignCast(ctx));
+    rec.append(std.testing.allocator, ev) catch @panic("OOM");
+}
+
+// (#422 slice 1b) postLive draws nothing itself anymore: each forced stall/
+// drop seam emits exactly ONE transport_aborted event through the sink
+// (TuiSink renders the old inline ⚠ lines, JsonSink drops it — pinned in
+// engine_sink.zig) and returns the matching transport error. An injected
+// recording sink observes the contract directly — no TTY, no globals read.
+test "postLive force seams emit one transport_aborted through the sink (#422)" {
+    const saved_sa = main_mod.g_force_stall_always;
+    const saved_da = main_mod.g_force_drop_always;
+    const saved_so = main_mod.g_force_stall_once;
+    const saved_do = main_mod.g_force_drop_once;
+    defer {
+        main_mod.g_force_stall_always = saved_sa;
+        main_mod.g_force_drop_always = saved_da;
+        main_mod.g_force_stall_once = saved_so;
+        main_mod.g_force_drop_once = saved_do;
+    }
+    main_mod.g_force_stall_always = false;
+    main_mod.g_force_drop_always = false;
+    main_mod.g_force_stall_once = false;
+    main_mod.g_force_drop_once = false;
+
+    var rec: std.ArrayList(engine_sink.Stamped) = .empty;
+    defer rec.deinit(std.testing.allocator);
+    const vt: engine_sink.VTable = .{ .emit = sinkRecord, .durable = false };
+    var a: Agent = .{
+        .gpa = std.testing.allocator,
+        .arena = std.testing.allocator,
+        .io = undefined,
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = null,
+        .sink = .{ .ctx = &rec, .vt = &vt },
+    };
+
+    const Case = struct {
+        flag: *bool,
+        consumed: bool, // the once-seams reset themselves on use
+        err: anyerror,
+        reason: engine_events.StreamAbort,
+        turn_ending: bool,
+    };
+    const cases = [_]Case{
+        .{ .flag = &main_mod.g_force_stall_always, .consumed = false, .err = error.StreamStalled, .reason = .stalled, .turn_ending = false },
+        .{ .flag = &main_mod.g_force_drop_always, .consumed = false, .err = error.StreamDropped, .reason = .dropped, .turn_ending = false },
+        .{ .flag = &main_mod.g_force_stall_once, .consumed = true, .err = error.StreamStalled, .reason = .stalled, .turn_ending = true },
+        .{ .flag = &main_mod.g_force_drop_once, .consumed = true, .err = error.StreamDropped, .reason = .dropped, .turn_ending = true },
+    };
+    for (cases, 1..) |c, want_events| {
+        c.flag.* = true;
+        try std.testing.expectError(c.err, agent_ws.postLive(&a, "{}"));
+        if (c.consumed) try std.testing.expect(!c.flag.*) else c.flag.* = false;
+        try std.testing.expectEqual(want_events, rec.items.len); // exactly one event per cut
+        switch (rec.items[want_events - 1].event) {
+            .transport_aborted => |t| {
+                try std.testing.expectEqual(c.reason, t.reason);
+                try std.testing.expectEqual(c.turn_ending, t.turn_ending);
+            },
+            else => return error.TestUnexpectedEvent,
+        }
+    }
 }
 
 // (#codex-ws) End-to-end regression for the reanchor fix: buildBody's

--- a/src/engine_events.zig
+++ b/src/engine_events.zig
@@ -45,6 +45,20 @@ pub const Delta = struct {
     text: []const u8,
 };
 
+/// A live transport attempt was cut before the provider's terminal event —
+/// the transport-layer counterpart of StreamAbort, born in the connection/
+/// read guards (agent_ws.zig slice 1b) where nothing of the answer has
+/// rendered yet: sinks may surface a notice but have no held output to
+/// flush. `reason == .interrupted` is never emitted today (a deliberate Esc
+/// propagates as an error, silently); a sink renders nothing for it.
+pub const TransportAbort = struct {
+    reason: StreamAbort,
+    /// The guard is giving the turn up (its notice says so); false = an
+    /// attempt-level cut the reconnect ladder may still retry, surfaced
+    /// more tersely.
+    turn_ending: bool,
+};
+
 /// Everything the streaming path tells a frontend. Each doc comment states
 /// the emission site's contract, not how any one sink draws it.
 pub const EngineEvent = union(enum) {
@@ -60,6 +74,18 @@ pub const EngineEvent = union(enum) {
     /// TUI: streamed markdown (or raw bytes off-color). The first one also
     /// ends the reasoning presentation (block close, spinner stop).
     text_delta: Delta,
+    /// A chunk of user-facing prose streamed out of a whitelisted meta tool
+    /// call's still-in-flight arguments (attempt_completion's result,
+    /// ask_user's question — agent_argstream.zig, slice 1b). Never on the
+    /// wire: --json clients get the assembled tool_call instead, so a wire
+    /// sink stays silent. TUI: renders like answer text (spinner handoff
+    /// included) but does NOT end the reasoning presentation — argument
+    /// prose can stream while the model is still mid-call.
+    tool_arg_delta: Delta,
+    /// A live transport attempt was cut; the payload says how and whether
+    /// the turn ends with it (slice 1b). Distinct from stream_aborted: no
+    /// partial answer is in flight, so sinks notice without flushing.
+    transport_aborted: TransportAbort,
     /// The user asked to fold/unfold the live reasoning view (Ctrl-T, #92).
     /// Presentation-only; a headless frontend ignores it. TRANSITIONAL
     /// (Phase 1b): this is frontend INPUT round-tripping engine-ward through
@@ -147,6 +173,18 @@ test "stamp: reserving draws fresh monotonic ids; observing never advances" {
     try std.testing.expectEqual(b.sequence, o.sequence);
     try std.testing.expectEqual(b.sequence, protocol_seq.current());
     try std.testing.expectEqual(generation(), o.generation);
+}
+
+test "slice 1b: tool-arg prose and transport aborts are presentation pulses" {
+    // Neither ever appeared on the --json wire (argLiveDelta gates --json
+    // off; the transport notices were TTY-only), so neither may reserve a
+    // sequence id — promoting one is a schema_version event, not a default.
+    const pulses: [3]EngineEvent = .{
+        .{ .tool_arg_delta = .{ .text = "prose" } },
+        .{ .transport_aborted = .{ .reason = .stalled, .turn_ending = true } },
+        .{ .transport_aborted = .{ .reason = .dropped, .turn_ending = false } },
+    };
+    for (pulses) |ev| try std.testing.expect(!durable(ev));
 }
 
 test "generation only moves forward, one restart at a time" {

--- a/src/engine_sink.zig
+++ b/src/engine_sink.zig
@@ -122,7 +122,35 @@ fn tuiEmit(ctx: *anyopaque, ev: Stamped) void {
                 if (!a.sub) _ = tick_gate.setLineStart(d.text[d.text.len - 1] == '\n'); // #tui-tick
             }
         },
+        // Meta-tool argument prose renders like answer text — spinner handoff
+        // included — with two deliberate differences from .text_delta, both
+        // the old inline emitArgText behavior verbatim: the reasoning block
+        // stays as-is (the model is still mid-call), and the no-color branch
+        // never marks a tick-gate line start.
+        .tool_arg_delta => |d| {
+            render.spinnerStop(a); // first visible byte: clear the thinking line
+            if (main_mod.use_color) {
+                a.streamMarkdown(d.text);
+            } else if (a.out) |w| {
+                w.writeAll(d.text) catch return;
+                w.flush() catch return;
+            }
+        },
         .thinking_fold_toggle => render.toggleThinkingFold(a),
+        // Transport cuts carry no partial answer (nothing streamed on the ws
+        // path), so unlike .stream_aborted there is no tail to flush — only
+        // the notice, worded exactly as the old inline agent_ws lines were.
+        .transport_aborted => |t| notice(a, switch (t.reason) {
+            .interrupted => return, // deliberate stop: silent, as ever
+            .stalled => if (t.turn_ending)
+                "\n⚠ stream stalled — ending turn\n"
+            else
+                "\n⚠ stream stalled\n",
+            .dropped => if (t.turn_ending)
+                "\n⚠ connection dropped — response ended early\n"
+            else
+                "\n⚠ connection dropped\n",
+        }),
         .stream_aborted => |reason| {
             a.flushStreamTail(); // render any held partial markdown line
             switch (reason) {
@@ -162,12 +190,13 @@ fn jsonEmit(ctx: *anyopaque, ev: Stamped) void {
         .reasoning_delta => |d| jsonLine(w, ev.cursor, .{ .type = "reasoning", .text = d.text }),
         .text_delta => |d| jsonLine(w, ev.cursor, .{ .type = "text", .text = d.text }),
         // Stream end/abort still flushes the held render tail, as the old
-        // inline path did in EVERY mode: emitArgText streams tool-arg prose
-        // through streamMarkdown whenever use_color is on — --json on a TTY
-        // included — so md_buf/md_table can hold bytes even here. Yes, that
-        // interleaves non-JSONL text into the wire exactly as before;
-        // making --json drop the tail (or never dirty md state) is a
-        // deliberate future wire change, not slice-1 fallout.
+        // inline path did in EVERY mode. (Slice 1b correction to this note:
+        // tool-arg prose CANNOT dirty md state here — argLiveDelta has always
+        // gated --json off, and this sink drops .tool_arg_delta — so with
+        // .text_delta going to the wire the tail is clean and the flush adds
+        // no bytes today. It stays because removing a wire-visible behavior,
+        // however latent, is a deliberate schema-gated change, not refactor
+        // fallout.)
         .stream_aborted, .stream_complete => a.flushStreamTail(),
         else => {},
     }
@@ -258,6 +287,90 @@ test "JsonSink writes today's wire lines byte-for-byte" {
         "{\"seq\":1,\"type\":\"reasoning\",\"text\":\"why\"}\n{\"seq\":2,\"type\":\"text\",\"text\":\"hi\\n\"}\n",
         aw.writer.buffered(),
     );
+}
+
+test "TuiSink streams tool-arg prose raw and never ends the answer line (slice 1b)" {
+    const saved_color = main_mod.use_color; // pin the no-color branch
+    main_mod.use_color = false;
+    defer main_mod.use_color = saved_color;
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    var a: Agent = .{
+        .gpa = std.testing.allocator,
+        .arena = std.testing.allocator,
+        .io = undefined,
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = &aw.writer,
+    };
+    const s = tuiSink(&a);
+    s.emit(undefined, .{ .tool_arg_delta = .{ .text = "answer " } });
+    s.emit(undefined, .{ .tool_arg_delta = .{ .text = "prose" } });
+    // Exactly the bytes, flushed per delta, no separators added — the old
+    // inline emitArgText no-color branch.
+    try std.testing.expectEqualStrings("answer prose", aw.writer.buffered());
+}
+
+test "TuiSink transport-abort notices reproduce the old inline lines (slice 1b)" {
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    var a: Agent = .{
+        .gpa = std.testing.allocator,
+        .arena = std.testing.allocator,
+        .io = undefined,
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = &aw.writer,
+    };
+    const s = tuiSink(&a);
+    const cases = [_]struct { ev: engine_events.TransportAbort, want: []const u8 }{
+        .{ .ev = .{ .reason = .stalled, .turn_ending = false }, .want = "\n⚠ stream stalled\n" },
+        .{ .ev = .{ .reason = .stalled, .turn_ending = true }, .want = "\n⚠ stream stalled — ending turn\n" },
+        .{ .ev = .{ .reason = .dropped, .turn_ending = false }, .want = "\n⚠ connection dropped\n" },
+        .{ .ev = .{ .reason = .dropped, .turn_ending = true }, .want = "\n⚠ connection dropped — response ended early\n" },
+        // A deliberate interrupt was never announced at the transport layer.
+        .{ .ev = .{ .reason = .interrupted, .turn_ending = true }, .want = "" },
+    };
+    for (cases) |c| {
+        aw.clearRetainingCapacity();
+        s.emit(undefined, .{ .transport_aborted = c.ev });
+        try std.testing.expectEqualStrings(c.want, aw.writer.buffered());
+    }
+}
+
+test "JsonSink stays silent for moments the wire never carried (slice 1b)" {
+    const saved_json = main_mod.json_mode; // pin: see the dispatch-order test
+    main_mod.json_mode = false;
+    defer main_mod.json_mode = saved_json;
+    protocol_seq.resetForTest();
+    defer protocol_seq.resetForTest();
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    var a: Agent = .{
+        .gpa = std.testing.allocator,
+        .arena = std.testing.allocator,
+        .io = undefined,
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = &aw.writer,
+    };
+    const s = jsonSink(&a);
+    s.emit(undefined, .{ .tool_arg_delta = .{ .text = "prose" } });
+    s.emit(undefined, .{ .transport_aborted = .{ .reason = .stalled, .turn_ending = true } });
+    s.emit(undefined, .{ .transport_aborted = .{ .reason = .dropped, .turn_ending = false } });
+    // No wire line AND no sequence id burned: both stay pulses, so the
+    // wire's gap-free numbering is untouched by them (#330).
+    try std.testing.expectEqualStrings("", aw.writer.buffered());
+    try std.testing.expectEqual(@as(u64, 0), protocol_seq.current());
 }
 
 test "TuiSink renders a plain text delta exactly as the no-color TTY did" {


### PR DESCRIPTION
Slice 1b of #422, converting the two offenders slice 1 (#423) documented as debt.

## What's in it

- **`agent_ws.zig`**: all 8 render-alias sites gone — the spinner pair becomes `stream_begin`/`stream_finished` (the WS turn is exactly 'request in flight, nothing rendered', so no new vocabulary), and the four inline `⚠` stall/drop notices become a new `transport_aborted{reason, turn_ending}` event. A new event rather than reusing `stream_aborted`, deliberately: the WS sites never flushed the stream tail, so reuse would make byte-identity rest on 'md state happens to be clean' instead of being provable. The four historical wordings are reproduced exactly in TuiSink. `agent_ws.zig` retains `term.zig` only for Esc/stdin *input* seams — that's the epic's input-inversion phase, out of scope here.
- **`agent_argstream.zig`**: `emitArgText`'s inline json/tty branch inverted into the sinks via a new `tool_arg_delta` event — distinct from `text_delta` because its rendering contract differs in two load-bearing ways the old code encoded (no thinking-block close mid-call, no tick-gate line-start mark). The `--json` wire never carried arg prose (verified against the 4849a15 baseline), so JsonSink drops it and reserves no seq id.
- 5 new tests (event classification, both sink mappings, a recording-sink contract test for the WS force-seams); `engine_sink.zig` grows the two TuiSink arms.

## Evidence

Same golden harness as #423: **all 7 eval files PASS** (json + PTY transcripts byte-identical to the v0.0.239 goldens; test names +13/-0 across the two slices). Re-verified after rebasing onto current main (post-#425): **994/994 tests green**, `zig fmt --check` clean. `agent_ws.zig` now sits at 598/600 — the next edit there should budget a shave.

Part of #422.