### PR TITLE
release: merge v0.0.240 back to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,23 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
-## v0.0.239 (unreleased)
+## v0.0.240 (unreleased)
+
+- The REPL/engine separation began (#422): agent output now flows through a
+  typed event vocabulary and a strict sink boundary (`engine_events.zig` /
+  `engine_sink.zig`), with streamed model output converted first — the TUI
+  renders and the `--json` wire serializes the same events, so the two can no
+  longer drift. Proven byte-identical to v0.0.239 by a golden before/after
+  eval harness (the same scripted mock session over both the protocol and a
+  real PTY) plus live one-shot, tool-call, and interactive smoke runs.
+  Groundwork for detached sessions and attach (#420).
+- Loop exit tears down the held codex WebSocket and its response-id anchor
+  (#424): the delta chain deliberately spans user turns, so only exit may
+  free them — and no exit path did. The socket now gets a proper close on
+  quit, and Debug builds finish with a clean allocator report instead of
+  four leak stacks.
+
+## v0.0.239 (2026-08-06)
 
 - A successful `/login` now reaches the live session (#402): the codex
   `.responses` error path runs the same bounded auth recovery as every other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ current is part of cutting a release.
 
 - The REPL/engine separation began (#422): agent output now flows through a
   typed event vocabulary and a strict sink boundary (`engine_events.zig` /
-  `engine_sink.zig`), with streamed model output converted first — the TUI
+  `engine_sink.zig`), with streamed model output, the codex WS transport
+  notices, and streamed tool-call arguments converted first — the TUI
   renders and the `--json` wire serializes the same events, so the two can no
   longer drift. Proven byte-identical to v0.0.239 by a golden before/after
   eval harness (the same scripted mock session over both the protocol and a

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -21,6 +21,10 @@ const harness_version = root.harness_version;
 pub const changelog_text =
     \\What's new
     \\──────────
+    \\0.0.240
+    \\  • Engine output now flows through a typed event stream behind a strict sink boundary — the start of the REPL/engine separation, with TUI and --json output proven byte-identical
+    \\  • Quitting no longer strands the held Codex socket: loop exit closes the WebSocket and its response anchor, and debug builds finish with a clean allocator report
+    \\
     \\0.0.239
     \\  • Codex WebSocket turns can't stall silently: visible output tightens the watchdog, a mute reused socket is retried in ~30s, and send/dial run under deadlines with Esc live
     \\  • A successful /login reaches the live session — codex auth recovery re-reads auth.json, spends the refresh token, and retries once instead of looping on a dead bearer
@@ -48,11 +52,6 @@ pub const changelog_text =
     \\  • Kimi Code now follows each live catalog model's native or Anthropic beta protocol, auth style, context, and thinking metadata
     \\  • Native Kimi tool schemas are normalized to Moonshot's stricter validator; OAuth requests carry the current Kimi Code identity headers
     \\  • `--model kimi` selects K3 today and automatically follows future pure Kimi generations
-    \\
-    \\0.0.206
-    \\  • The CLI now uses Codegraff's accessible vermilion-coral accent for prompts, tools, Markdown structure, and active selections
-    \\  • A quiet Ensō brush-circle is the stable thinking default; every existing animation remains selectable, including random
-    \\  • Ultracode motion is now a slower rust/coral/gold ember sweep instead of a full-spectrum rainbow
     \\
 ;
 


### PR DESCRIPTION
Standard post-release merge-back so the next cut from main carries the 0.0.240 release notes (CHANGELOG section + what's-new). Binaries shipped: notarized, published, `releases/latest` verified pointing at v0.0.240.