### PR TITLE
integration: the prime-adoption batch + engine slice 1c (merges #433 #434 #435 #436 #437 #438)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Embedder mode resumable serve streams (#330)
         run: python3 scripts/test-serve-resume.py zig-out/bin/graff
 
+      - name: Over-cap tool output spills to a session artifact (#409)
+        run: python3 scripts/test-spill-artifact.py zig-out/bin/graff
+
       - name: Live JSON stream contains no raw stdout lines
         run: python3 scripts/test-json-live.py zig-out/bin/graff
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
-## v0.0.240 (unreleased)
+## v0.0.241 (unreleased)
 
 - An oversized tool output is now spilled, not destroyed (#409). The
   per-result cap (#193/#201) used to delete the elided bytes, leaving the
@@ -23,6 +23,9 @@ current is part of cutting a release.
   disk), and reclaimed with the session: an artifact dir whose
   `<session>.session.json` is gone is swept at the next spill. Subagents,
   whose history is never persisted, keep the plain truncation.
+
+## v0.0.240 (2026-08-06)
+
 - The REPL/engine separation began (#422): agent output now flows through a
   typed event vocabulary and a strict sink boundary (`engine_events.zig` /
   `engine_sink.zig`), with streamed model output, the codex WS transport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,22 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
-## v0.0.240 (unreleased)
+## v0.0.241 (unreleased)
+
+- Cross-process locks stopped trusting a bare pid (#413): an owner record now
+  carries the holder's process START identity next to its pid (`/proc/<pid>/stat`
+  field 22 on Linux, `proc_pidinfo` on macOS, `GetProcessTimes` on Windows), so
+  liveness is "the pid is alive AND it is still the same process". A recycled
+  pid can no longer look like a live owner forever, and a crashed holder's lock
+  is reclaimed because its identity provably mismatches rather than because a
+  timeout guessed. A record written by an older graff carries no identity and
+  keeps the pid-only contract exactly as before, so an in-flight lock is never
+  bricked, and an identity that cannot be read fails safe: held, never stolen.
+  The #320 worktree lease gets the producer it was missing, and a session save
+  on a filesystem with no working locks (#289) now coordinates through an owner
+  record instead of racing unguarded.
+
+## v0.0.240 (2026-08-06)
 
 - The REPL/engine separation began (#422): agent output now flows through a
   typed event vocabulary and a strict sink boundary (`engine_events.zig` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,26 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
-## v0.0.240 (unreleased)
+## v0.0.241 (unreleased)
+
+- The system prompt is now assembled from capability-gated segments (#421):
+  an instruction ships only when its capability is actually present, read
+  from the same predicates dispatch uses to refuse a hallucinated call, so
+  the prompt can never disagree with the tool catalog. An embedder session
+  (`--no-local-tools`) drops 28.5% of the base prompt; the floor config
+  drops 43.2%. At full capability the compose returns the comptime constant
+  itself — zero allocation, byte-identical to what shipped before. Two
+  standing doctrine lines joined the always-on intro: never invent a tool or
+  wrapper API, and run the target project through its OWN environment — a
+  failure there is the relevant result.
+- A durable root session's prompt now names its own transcript (#410): the
+  path to `.graff/sessions/<name>.session.json`, described truthfully — one
+  JSON object, lags the live turn, rewritten in place by compaction (a
+  resume artifact, not an append-only archive) — so the model can consult
+  it without burning turns on wrong assumptions. Suppressed when local
+  tools are gone (an unreadable path is pure token waste).
+
+## v0.0.240 (2026-08-06)
 
 - The REPL/engine separation began (#422): agent output now flows through a
   typed event vocabulary and a strict sink boundary (`engine_events.zig` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,23 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
-## v0.0.240 (unreleased)
+## v0.0.241 (unreleased)
+
+- A no-progress `eval` is no longer paid for (#412). A goal/loop run
+  re-verifies on every continuation, so a model that has edited nothing since
+  the last RED re-ran the whole `--eval` command — plus a `--judge` model call,
+  plus 1500 bytes of output tail — to re-derive a verdict that could not have
+  changed. graff now fingerprints the verification before running it (the eval
+  command text, `git status --porcelain -z -uall`, `git diff --binary HEAD`,
+  and the contents of every untracked file, since the first two are blind to an
+  untracked edit); identical to the tree the last verification failed on means
+  the verifier is not run at all. The attempt still counts, so a stuck loop
+  converges on its iteration cap instead of spinning for free, and the model is
+  steered at the real blocker: the workspace has not changed, edit something
+  first. Fail-open throughout — no repo, no git, a timed-out or truncated
+  probe, an unreadable file all read as "changed" and the verifier runs.
+
+## v0.0.240 (2026-08-06)
 
 - The REPL/engine separation began (#422): agent output now flows through a
   typed event vocabulary and a strict sink boundary (`engine_events.zig` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ current is part of cutting a release.
 
 ## v0.0.240 (unreleased)
 
+- An oversized tool output is now spilled, not destroyed (#409). The
+  per-result cap (#193/#201) used to delete the elided bytes, leaving the
+  model to re-run the tool and guess a better slice; when the session is
+  durable the full output is now written to
+  `.graff/sessions/<session>/artifacts/tool-<n>.txt` first, and the marker in
+  the transcript cites the absolute path and the byte count, so the next turn
+  can read or grep exactly what it needs. Bounded by a 64 MiB per-session
+  budget (whole artifacts only, so a marker can never overstate what is on
+  disk), and reclaimed with the session: an artifact dir whose
+  `<session>.session.json` is gone is swept at the next spill. Subagents,
+  whose history is never persisted, keep the plain truncation.
 - The REPL/engine separation began (#422): agent output now flows through a
   typed event vocabulary and a strict sink boundary (`engine_events.zig` /
   `engine_sink.zig`), with streamed model output, the codex WS transport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,24 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
-## v0.0.240 (unreleased)
+## v0.0.241 (unreleased)
+
+- Context-overflow classification got a guard list and two behavioral
+  detectors (#414). Non-overflow patterns are now checked FIRST, so a
+  throttle whose wording collides with an overflow phrase — Bedrock's
+  `ThrottlingException: Too many tokens` is the canonical one — keeps riding
+  the Retry-After ladder instead of triggering a compaction that cannot help.
+  The overflow table itself grew from six substrings to the phrasings twelve
+  more providers actually send (Bedrock, Gemini, Copilot, xAI, Groq,
+  llama.cpp, Kimi, Mistral, Ollama, MiniMax, z.ai, Anthropic 413), and now
+  matches case-insensitively. Two shapes that never send an error at all are
+  caught from the reported usage instead: an HTTP 200 with an empty
+  completion whose input is at or over the window (z.ai's silent overflow),
+  and `finish_reason: length` with zero output while the input fills the
+  window (a provider truncating the input to fit, seen on MiMo) — the latter
+  is now named rather than shipped as an inexplicably short answer.
+
+## v0.0.240 (2026-08-06)
 
 - The REPL/engine separation began (#422): agent output now flows through a
   typed event vocabulary and a strict sink boundary (`engine_events.zig` /

--- a/README.md
+++ b/README.md
@@ -1067,7 +1067,13 @@ the data plane for task-aware recipe comparison; they do not silently switch
 models or effort levels.
 
 Long tool results are stored exactly under `.graff/tool-results/`; model history
-receives a short preview and an inspectable file pointer instead. Responses
+receives a short preview and an inspectable file pointer instead. A result that
+is still over the per-model result cap at send time is spilled the same way
+rather than truncated away: the full bytes go to
+`.graff/sessions/<session>/artifacts/`, and the note left in the transcript
+carries that absolute path and the byte count, so the next turn can read or grep
+the slice it needs. Artifacts are bounded per session and are reclaimed once the
+session file they belong to is gone. Responses
 requests are explicitly capped at 16k output tokens (4k for compaction and 64
 for titles), while compaction carries the latest clean ~8k-token user-turn
 suffix forward verbatim. A shared atomic run budget allows at most four model

--- a/examples/prepare_graff_tournament.py
+++ b/examples/prepare_graff_tournament.py
@@ -27,22 +27,34 @@ def write_json(path: Path, value: object) -> None:
 
 
 def extract_root_prompt(source: Path) -> str:
+    # justrach/codegraff#421 split the root prompt into capability-scoped
+    # segments, so "everything after `pub const main_system_prompt =`" no longer
+    # names one literal. The markers delimit the whole segment region instead.
+    # Lines WITHIN one segment join with a newline; segments concatenate with
+    # nothing, which is how prompts.zig composes them (several boundaries fall
+    # mid-sentence). Joining everything with "\n" would insert a blank line at
+    # each boundary and the seed genome would not be the shipped prompt.
     lines = source.read_text(encoding="utf-8").splitlines()
     collecting = False
-    result: list[str] = []
+    segments: list[list[str]] = []
     for line in lines:
-        if line.startswith("pub const main_system_prompt ="):
+        if line.startswith("// ── ROOT PROMPT BEGIN"):
             collecting = True
             continue
-        if collecting and line == ";":
+        if collecting and line.startswith("// ── ROOT PROMPT END"):
             break
-        if collecting:
-            marker = line.find("\\\\")
-            if marker >= 0:
-                result.append(line[marker + 2 :])
+        if not collecting:
+            continue
+        if line.startswith("pub const "):
+            segments.append([])
+            continue
+        marker = line.find("\\\\")
+        if marker >= 0 and segments:
+            segments[-1].append(line[marker + 2 :])
+    result = "".join("\n".join(seg) for seg in segments)
     if not result:
-        raise ValueError("could not extract main_system_prompt")
-    return "\n".join(result).strip() + "\n"
+        raise ValueError("could not extract the root prompt segments")
+    return result.strip() + "\n"
 
 
 def pin(path: Path) -> dict[str, str]:
@@ -78,7 +90,7 @@ def main() -> None:
             raise FileNotFoundError(path)
 
     parent = output / "parent.md"
-    parent.write_text(extract_root_prompt(repo / "src" / "prompts.zig"), encoding="utf-8")
+    parent.write_text(extract_root_prompt(repo / "src" / "prompt_text.zig"), encoding="utf-8")
     parent.chmod(0o600)
     primary = output / "primary.json"
     holdout = output / "fresh-holdout.json"

--- a/scripts/test-pty-overflow.py
+++ b/scripts/test-pty-overflow.py
@@ -14,6 +14,17 @@ precise:
   B. error.code = rate_limit_exceeded with a non-overflow message. graff must NOT
      mistake it for an overflow: the meter must not pin. Proves detection is precise.
 
+#414 adds three more, covering the classifier's guard list and its two behavioral
+detectors — the shapes where the provider never returns an error at all:
+
+  C. Bedrock's "ThrottlingException: Too many tokens, please wait before trying
+     again." — wording that collides with the generic "too many tokens" overflow
+     fallback, but is a 429. It must ride the retry ladder; the meter must not pin.
+  D. HTTP 200 with an EMPTY completion whose usage reports input at the window
+     (the z.ai silent overflow). graff must classify it as overflow anyway.
+  E. HTTP 200 with finish_reason=length and ZERO output at the window (MiMo
+     truncating our input to fit). graff must name it, not ship a silent short answer.
+
 Requires 127.0.0.1:1234 to be free (the lmstudio provider URL is fixed); skips if a
 real LM Studio (or anything) already holds it.
 """
@@ -37,12 +48,23 @@ GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
 METER_RE = re.compile(r"(\d+)k/(\d+)k ctx \((\d+)% · compact@(\d+)k\)")
 PINNED_RE = re.compile(r"(\d+)k/(\d+)k ctx \(100% · compact@\d+k\)")
 
+# lmstudio/lmstudio is a CATALOGUED model (pricing.zig context_overlay), so its
+# window is fixed at 200k and GRAFF_CONTEXT deliberately cannot shrink it (#203).
+# The #414 behavioral fixtures report usage against this number; scenario D
+# asserts the meter still reads it, so a catalog change fails loudly here.
+LMSTUDIO_WINDOW = 200_000
+
 
 class OpenAiErrorMock:
-    """Serves one fixed OpenAI-style error envelope for every /v1/chat/completions."""
+    """Serves one fixed OpenAI-style body for every /v1/chat/completions.
 
-    def __init__(self, error_obj: dict) -> None:
-        self.body = json.dumps({"error": error_obj}).encode()
+    `error_obj` is wrapped as {"error": ...}; pass a `raw` body instead to serve a
+    successful (HTTP 200) completion, which is how the #414 behavioral shapes are
+    reproduced — they never send an error to keyword-match.
+    """
+
+    def __init__(self, error_obj: dict | None = None, raw: dict | None = None) -> None:
+        self.body = json.dumps(raw if raw is not None else {"error": error_obj}).encode()
         self.hits = 0
         parent = self
 
@@ -75,9 +97,14 @@ class OpenAiErrorMock:
         self.httpd.server_close()
 
 
-def _run(error_obj: dict, tmp: str):
-    """Run one turn against a mock returning error_obj; return (rendered_text, hits)."""
-    mock = OpenAiErrorMock(error_obj)
+def _run(error_obj: dict, tmp: str, *, raw: dict | None = None, wait_for: str = "api error:"):
+    """Run one turn against a mock; return (rendered_text, hits).
+
+    `wait_for` is the literal that marks the turn as finished — an error turn ends
+    with "api error:", but a #414 behavioral-overflow turn ends with a normal
+    (empty) completion and is only visible through its own notice.
+    """
+    mock = OpenAiErrorMock(error_obj, raw=raw)
     mock.start()
     try:
         env = {
@@ -102,8 +129,7 @@ def _run(error_obj: dict, tmp: str):
             session.wait_for_literal("] ›")
             cursor = len(session.raw)
             session.send_line("hello")
-            # The turn ends with an api error either way; wait for it, then settle.
-            session.wait_for_literal("api error:", start=cursor)
+            session.wait_for_literal(wait_for, start=cursor)
             session.pump_for(1.5)
             rendered = terminal_text(bytes(session.raw[cursor:]))
 
@@ -180,6 +206,67 @@ def main() -> None:
                 f"({stray.group(0)!r}):\n{rendered}"
             )
         print("ok    non-overflow error did not pin the meter (detection is precise)")
+
+        # Scenario C (#414 guard): Bedrock's throttle wording collides head-on with
+        # the generic "too many tokens" overflow fallback. It is a 429: it must ride
+        # the retry ladder, never trigger a compaction.
+        rendered, _ = _run(
+            {
+                "message": "ThrottlingException: Too many tokens, please wait before trying again.",
+                "type": "throttling_error",
+            },
+            tmp,
+        )
+        if "Too many tokens" not in rendered:
+            raise AssertionError(f"C: throttle error was not surfaced:\n{rendered}")
+        stray = PINNED_RE.search(rendered)
+        if stray:
+            raise AssertionError(
+                "C: a Bedrock THROTTLE was classified as context overflow — the "
+                f"non-overflow guard list is not being consulted first ({stray.group(0)!r}):\n{rendered}"
+            )
+        print("ok    bedrock 'Too many tokens' throttle stayed on the retry path (#414 guard)")
+
+        # Scenario D (#414): z.ai's silent overflow. HTTP 200, an EMPTY completion,
+        # and usage that says the input already filled the window. Nothing in the
+        # body is an error, so only the behavioral detector can catch it.
+        rendered, hits = _run(
+            {},
+            tmp,
+            raw={
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": ""}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": LMSTUDIO_WINDOW, "completion_tokens": 0, "total_tokens": LMSTUDIO_WINDOW},
+            },
+            wait_for="silent_overflow",
+        )
+        if hits < 1:
+            raise AssertionError("D: graff never reached the backend")
+        if "silent_overflow" not in rendered:
+            raise AssertionError(
+                f"D: an HTTP 200 with no answer and over-window usage was accepted silently:\n{rendered}"
+            )
+        pinned = PINNED_RE.search(rendered)
+        if not pinned:
+            raise AssertionError(f"D: silent overflow did not pin the meter to the window:\n{rendered}")
+        if pinned.group(2) != str(LMSTUDIO_WINDOW // 1000):
+            raise AssertionError(f"D: lmstudio's catalogued window moved; update LMSTUDIO_WINDOW ({pinned.group(0)!r})")
+        print("ok    silent 200 (empty completion, usage at the window) classified as overflow (#414)")
+
+        # Scenario E (#414): MiMo truncates an oversized input to fit the window,
+        # then reports finish_reason=length with zero output. The reply is not a
+        # real answer and must be named as such, not shipped as a short one.
+        rendered, _ = _run(
+            {},
+            tmp,
+            raw={
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": ""}, "finish_reason": "length"}],
+                "usage": {"prompt_tokens": LMSTUDIO_WINDOW, "completion_tokens": 0, "total_tokens": LMSTUDIO_WINDOW},
+            },
+            wait_for="upstream_truncation",
+        )
+        if "upstream_truncation" not in rendered:
+            raise AssertionError(f"E: upstream truncation surfaced as a silent short answer:\n{rendered}")
+        print("ok    finish_reason=length with zero output at the wall reported as truncation (#414)")
 
 
 if __name__ == "__main__":

--- a/scripts/test-spill-artifact.py
+++ b/scripts/test-spill-artifact.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""End-to-end proof that an over-cap tool output is spilled, not destroyed (#409).
+
+The per-output cap (#193/#196) used to delete the elided bytes; the model's only
+recovery was to re-run the tool. #409 writes the FULL output to
+`.graff/sessions/<session>/artifacts/tool-<n>.txt` first and makes the marker
+cite that path, so the next turn can read or grep exactly the slice it needs.
+
+The loop is closed here with the repo's scripted-model recipe
+(scripts/eval/mock_model.py on the fixed lmstudio port), against a real graff:
+
+  1. a session file is seeded with an oversized tool output carrying a needle
+     PAST the cap, and graff is started with `--resume` on it;
+  2. turn 1's request is the harness's own wire history — it must carry the
+     marker (absolute path + byte count) and NOT the needle;
+  3. the artifact on disk must hold the original bytes, byte for byte;
+  4. the mock answers with a `bash` call against THE PATH THE MARKER CITED, and
+     turn 2's request must carry the needle back — the model recovered the
+     elided content without re-running the tool.
+
+No network beyond loopback, no provider credentials, no model.
+
+  python3 scripts/test-spill-artifact.py [zig-out/bin/graff]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts" / "eval"))
+from mock_model import ScriptedModel  # noqa: E402
+
+SESSION = "spill-e2e"
+NEEDLE = "GRAFF-SPILL-NEEDLE-409"
+# The cap is window-proportional (Provider.perOutputCap = context/2 bytes), and
+# GRAFF_CONTEXT declares the window for an unknown/local model. 40k tokens ->
+# a 20_000-byte cap, with auto-compaction (80% = 32k tokens) far out of reach of
+# the ~7.5k tokens this history weighs.
+CONTEXT_TOKENS = 40_000
+OUTPUT_BYTES = 30_000
+# "…the FULL <n> bytes are at <path>; read or grep…" — src/tool_spill.zig
+MARKER_RE = re.compile(r"the FULL (\d+) bytes are at (\S+?); read or grep")
+
+
+class SpillModel(ScriptedModel):
+    """Turn 1: read back the artifact the marker cited. Turn 2: stop."""
+
+    def __init__(self) -> None:
+        super().__init__([])
+        self.cited: tuple[int, str] | None = None
+
+    def next_reply(self, body: dict) -> dict:
+        super().next_reply(body)  # records the request; the empty script never answers
+        if len(self.requests) == 1:
+            found = MARKER_RE.search(json.dumps(body))
+            if not found:
+                return {"text": "no marker in the history"}
+            self.cited = (int(found.group(1)), found.group(2))
+            return {"tool": "bash", "arguments": {
+                "command": f"tail -c 120 {shlex.quote(found.group(2))}",
+            }}
+        return {"text": "recovered the tail from the artifact"}
+
+
+def seed_session(workspace: pathlib.Path, output: str) -> None:
+    """A saved conversation whose last tool output is over the per-output cap."""
+    sessions = workspace / ".graff" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    messages = [
+        {"role": "user", "content": "dump the build log"},
+        {"role": "assistant", "content": "", "tool_calls": [{
+            "id": "call_seed", "type": "function",
+            "function": {"name": "bash", "arguments": json.dumps({"command": "cat build.log"})},
+        }]},
+        {"role": "tool", "tool_call_id": "call_seed", "content": output},
+    ]
+    (sessions / f"{SESSION}.session.json").write_text(json.dumps({
+        "provider": "lmstudio", "model": "spill-mock-model", "strict": False,
+        "ultracode_mode": False, "goal": None, "todos": [],
+        "title": "spill artifact e2e", "updated_ms": 0, "messages": messages,
+    }), encoding="utf-8")
+    harness = workspace / ".harness"
+    harness.mkdir(parents=True, exist_ok=True)
+    # The AI titler would otherwise fire an extra quiet turn on the first prompt.
+    (harness / "settings.json").write_text('{"ai_title": false}', encoding="utf-8")
+
+
+def run(graff: str, workspace: pathlib.Path, model: SpillModel) -> tuple[str, str, int | None]:
+    env = {k: v for k, v in os.environ.items() if not k.endswith("_API_KEY")}
+    env.update({
+        "HOME": str(workspace),
+        "LMSTUDIO_API_KEY": "local",
+        "GRAFF_CONTEXT": str(CONTEXT_TOKENS),
+        "GRAFF_NO_TELEMETRY": "1",
+        "GRAFF_FLEET": "off",
+        "GRAFF_NO_SMOLIFY": "1",
+        "GRAFF_LEARN_AUTO": "0",
+        "GRAFF_BEHAVIOR_UPLOAD": "0",
+        "GRAFF_NO_BROWSER": "1",
+        "NO_COLOR": "1",
+    })
+    argv = [graff, "--json", "--yolo", "--no-telemetry",
+            "--model", "lmstudio", "--resume", SESSION]
+    try:
+        done = subprocess.run(
+            argv, cwd=workspace, env=env, text=True, capture_output=True,
+            input=json.dumps({"type": "user", "text": "what did the build log end with?"}) + "\n",
+            timeout=90,
+        )
+        return done.stdout, done.stderr, done.returncode
+    except subprocess.TimeoutExpired as exc:
+        out = exc.stdout if isinstance(exc.stdout, str) else (exc.stdout or b"").decode("utf-8", "ignore")
+        err = exc.stderr if isinstance(exc.stderr, str) else (exc.stderr or b"").decode("utf-8", "ignore")
+        return out, err, None
+
+
+def main() -> None:
+    graff = os.path.abspath(sys.argv[1] if len(sys.argv) > 1 else str(REPO / "zig-out" / "bin" / "graff"))
+    if not os.access(graff, os.X_OK):
+        sys.exit(f"test-spill-artifact: not an executable: {graff}")
+
+    # A padded output whose needle sits well past the cap, so nothing but the
+    # artifact can still produce it.
+    output = ("build step ok\n" * 3000)[:OUTPUT_BYTES - len(NEEDLE) - 1] + NEEDLE + "\n"
+    assert len(output) == OUTPUT_BYTES, len(output)
+
+    failures: list[str] = []
+    spilled: str | None = None
+    model = SpillModel()
+    model.start(1234)
+    try:
+        with tempfile.TemporaryDirectory(prefix="graff-spill-") as tmp:
+            workspace = pathlib.Path(tmp)
+            seed_session(workspace, output)
+            stdout, stderr, code = run(graff, workspace, model)
+            # Read the artifact while the workspace still exists.
+            if model.cited is not None:
+                try:
+                    spilled = pathlib.Path(model.cited[1]).read_text(encoding="utf-8")
+                except OSError as exc:
+                    failures.append(f"the cited artifact is not readable: {exc}")
+    finally:
+        model.stop()
+        time.sleep(0.05)  # the port is fixed; let the socket clear
+
+    if code != 0:
+        failures.append(f"graff exited {code}\n{stderr[-2000:]}")
+    if not model.requests:
+        failures.append("the harness never called the model")
+        report(failures, stdout, stderr)
+
+    first = json.dumps(model.requests[0])
+    # (b) the capped message carries an actionable marker, and only the marker.
+    if model.cited is None:
+        failures.append("request[0] carried no #409 marker (path + byte count)")
+    else:
+        cited_bytes, cited_path = model.cited
+        if cited_bytes != OUTPUT_BYTES:
+            failures.append(f"the marker claimed {cited_bytes} bytes, wanted {OUTPUT_BYTES}")
+        if not cited_path.startswith("/"):
+            failures.append(f"the marker cited a relative path: {cited_path}")
+        expected_tail = f"/.graff/sessions/{SESSION}/artifacts/tool-0.txt"
+        if not cited_path.endswith(expected_tail):
+            failures.append(f"the artifact is not under this session: {cited_path}")
+        # (a) the artifact holds the ORIGINAL bytes.
+        if spilled is not None and spilled != output:
+            failures.append(f"the artifact holds {len(spilled)} bytes, wanted the original {OUTPUT_BYTES}")
+    if NEEDLE in first:
+        failures.append("request[0] still carried the elided bytes; the cap did not apply")
+    if len(model.requests) < 2:
+        failures.append("the harness never sent a second request, so the read-back never happened")
+    # (c) the follow-up read of the cited path brought the elided content back.
+    elif NEEDLE not in json.dumps(model.requests[1]):
+        failures.append("request[1] did not carry the artifact tail back; the loop does not close")
+
+    report(failures, stdout, stderr)
+
+
+def report(failures: list[str], stdout: str, stderr: str) -> None:
+    if failures:
+        print("test-spill-artifact: FAIL")
+        for failure in failures:
+            print(f"  - {failure}")
+        print(f"--- graff stdout (tail) ---\n{stdout[-2000:]}")
+        print(f"--- graff stderr (tail) ---\n{stderr[-2000:]}")
+        sys.exit(1)
+    print("test-spill-artifact: ok — over-cap output spilled, cited, and read back (#409)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -165,6 +165,7 @@ pub const Agent = struct {
     eval_verified: bool = false, // latest workspace state has a target-meeting verifier result
     eval_repair_pending: bool = false, // a contradiction blocks completion until a fresh green eval
     eval_repair_grants: u8 = 0, // RED continuations consumed (agent_steps.grantRepairTurn); reset by any green eval, capped by eval_control.max_repair_grants
+    eval_fp: ?[32]u8 = null, // #412: worktree fingerprint at the last RED eval (verify_fingerprint.Digest); an identical tree skips the re-verify instead of paying for it
     strict: bool = false,
     completed: ?[]const u8 = null,
     last_context_tokens: u64 = 0,

--- a/src/agent_compact.zig
+++ b/src/agent_compact.zig
@@ -17,6 +17,12 @@ const goal_flow = @import("goal_flow.zig");
 const messages_mod = @import("messages.zig");
 const textMessage = messages_mod.textMessage;
 
+// #409: the per-output cap's truncation primitives, plus the artifact spill that
+// now runs inside them. Moved out of this file, which sits at the 600-line cap.
+const tool_spill = @import("tool_spill.zig");
+const isToolOutputMsg = tool_spill.isToolOutputMsg;
+const truncateToolOutput = tool_spill.truncateToolOutput;
+
 const title_mod = @import("title.zig");
 const assistantText = title_mod.assistantText;
 
@@ -366,56 +372,6 @@ pub fn emergencyCutIndex(items: []const Value) ?usize {
     return null;
 }
 
-/// True if `m` is a tool-output message whose payload can be truncated to
-/// reclaim context: responses `function_call_output`, openai `role:"tool"`, or an
-/// anthropic user message carrying `tool_result` blocks (#163).
-fn isToolOutputMsg(m: Value) bool {
-    if (m != .object) return false;
-    if (m.object.get("type")) |t| if (t == .string and std.mem.eql(u8, t.string, "function_call_output")) return true;
-    if (m.object.get("role")) |r| if (r == .string) {
-        if (std.mem.eql(u8, r.string, "tool")) return true;
-        if (std.mem.eql(u8, r.string, "user")) if (m.object.get("content")) |c| if (c == .array)
-            for (c.array.items) |blk| {
-                if (blk == .object) if (blk.object.get("type")) |bt|
-                    if (bt == .string and std.mem.eql(u8, bt.string, "tool_result")) return true;
-            };
-    };
-    return false;
-}
-
-fn truncateStrField(arena: Allocator, o: *std.json.ObjectMap, key: []const u8, cap: usize, note: []const u8) usize {
-    const v = o.get(key) orelse return 0;
-    if (v != .string or v.string.len <= cap) return 0;
-    const orig = v.string.len;
-    // Keep the prefix short enough that prefix + '\n' + note <= cap, so the marker
-    // never grows an output that was only barely over the cap.
-    const stub = std.fmt.allocPrint(arena, "{s}\n{s}", .{ utf8Prefix(v.string, cap -| (note.len + 1)), note }) catch return 0;
-    o.put(arena, key, .{ .string = stub }) catch return 0;
-    return orig -| stub.len;
-}
-
-/// Truncate an over-large tool-output payload in `m` in place to ~`cap` bytes,
-/// preserving the message and its call/output pairing. Returns bytes reclaimed.
-fn truncateToolOutput(arena: Allocator, m: *Value, cap: usize, note: []const u8) usize {
-    if (m.* != .object) return 0;
-    if (m.object.get("type")) |t| if (t == .string and std.mem.eql(u8, t.string, "function_call_output"))
-        return truncateStrField(arena, &m.object, "output", cap, note);
-    if (m.object.get("role")) |r| if (r == .string) {
-        if (std.mem.eql(u8, r.string, "tool")) return truncateStrField(arena, &m.object, "content", cap, note);
-        if (std.mem.eql(u8, r.string, "user")) if (m.object.get("content")) |c| if (c == .array) {
-            var saved: usize = 0;
-            for (m.object.get("content").?.array.items) |*blk| {
-                if (blk.* != .object) continue;
-                const bt = blk.object.get("type") orelse continue;
-                if (bt == .string and std.mem.eql(u8, bt.string, "tool_result"))
-                    saved += truncateStrField(arena, &blk.object, "content", cap, note);
-            }
-            return saved;
-        };
-    };
-    return 0;
-}
-
 /// Re-pair the meter after removing locally measurable context. The server-only
 /// delta remains intact, while the current local component reflects the trim.
 fn accountForReclaimedTokens(self: *Agent, reclaimed_tokens: u64) void {
@@ -447,7 +403,7 @@ pub fn trimOldestToolOutputsAlloc(self: *Agent, arena: Allocator) usize {
         if (!isToolOutputMsg(m.*)) continue;
         seen += 1;
         if (seen > total - keep_recent) break; // keep the most recent verbatim
-        reclaimed += truncateToolOutput(arena, m, stub_cap, "[old tool output truncated to recover context (#163)]");
+        reclaimed += truncateToolOutput(arena, m, stub_cap, .{ .fallback = "[old tool output truncated to recover context (#163)]" });
     }
     accountForReclaimedContext(self, reclaimed);
     return reclaimed;
@@ -467,12 +423,22 @@ pub fn trimOldestToolOutputs(self: *Agent) usize {
 /// the most-recent outputs verbatim. Cap is window-proportional (Provider.perOutputCap)
 /// so large-context models keep full results untouched. Preserves every call/output
 /// pairing (shrinks strings, never drops a message). Returns bytes reclaimed.
+///
+/// #409: the elided bytes are no longer destroyed. When this agent has a durable
+/// session, each oversized output is written to that session's artifact dir
+/// first and the marker cites the absolute path and the full byte count, so the
+/// model can read or grep the slice it needs instead of re-running the tool. A
+/// subagent (no persisted history) keeps the plain truncation below.
 pub fn capOversizedToolOutputs(self: *Agent, cap: usize) usize {
     if (cap == 0) return 0;
+    const note: tool_spill.Note = .{
+        .fallback = "[tool output truncated: over this model's per-result cap — read/fetch a smaller range (#193)]",
+        .session = tool_spill.sessionFor(self.sub, self.session_name),
+    };
     var reclaimed: usize = 0;
     for (self.messages.items) |*m| {
         if (isToolOutputMsg(m.*))
-            reclaimed += truncateToolOutput(self.messageMutationAlloc(), m, cap, "[tool output truncated: over this model's per-result cap — read/fetch a smaller range (#193)]");
+            reclaimed += truncateToolOutput(self.messageMutationAlloc(), m, cap, note);
     }
     // These outputs are appended after the prior response's usage was recorded,
     // so reclaimed bytes were never part of that authoritative server reading.

--- a/src/agent_compact_test.zig
+++ b/src/agent_compact_test.zig
@@ -333,6 +333,7 @@ test "capOversizedToolOutputs (#193): bounds an oversized output in every wire f
     agent.last_context_tokens = 200_000;
     agent.provider = .{ .id = "codex", .kind = .responses, .auth = .bearer, .url = "", .api_key = "", .model = "gpt-5", .context = 270_000 };
     agent.sub = false;
+    agent.session_name = ""; // #409: no durable session here, so the cap truncates without spilling
     agent.strict = false;
     agent.sys_normal = "";
     agent.sys_strict = "";
@@ -358,8 +359,7 @@ test "capOversizedToolOutputs (#193): bounds an oversized output in every wire f
     // within-cap output and the non-tool message are untouched
     try std.testing.expectEqualStrings("ok", agent.messages.items[3].object.get("output").?.string);
     try std.testing.expectEqualStrings("hello", agent.messages.items[4].object.get("content").?.string);
-    // cap == 0 disables the cap entirely (unknown window)
-    try std.testing.expectEqual(@as(usize, 0), capOversizedToolOutputs(&agent, 0));
+    try std.testing.expectEqual(@as(usize, 0), capOversizedToolOutputs(&agent, 0)); // cap == 0 disables the cap entirely (unknown window)
 }
 
 test "cleanUserTurn: plain user text yes; assistant/tool_result no" {

--- a/src/agent_eval.zig
+++ b/src/agent_eval.zig
@@ -28,6 +28,7 @@ const playbook_reflect = @import("playbook_reflect.zig"); // #383 Reflector: one
 const orch_rows = @import("orchestration_rows.zig"); // the orchestration outcome rides the same score funnel
 const shapes = @import("shapes.zig");
 const failure_evidence = @import("failure_evidence.zig"); // a RED verdict is parked as escalation evidence
+const verify_fingerprint = @import("verify_fingerprint.zig"); // #412 no-progress guard: an unmoved worktree is not re-verified
 
 test {
     _ = @import("agent_eval_tests.zig");
@@ -42,6 +43,21 @@ pub fn runEval(self: *Agent, note: []const u8) !ExecResult {
         .text = "no eval command configured - relaunch graff with --eval <scoring cmd> and --until <N>, or ask the user to set one",
         .is_error = true,
     };
+
+    // #412 no-progress guard. The tree the verifier is about to run against is
+    // fingerprinted BEFORE the command runs (the command itself may write), and
+    // when the last verdict was RED over a byte-identical tree the verifier is
+    // not run at all: nothing it could report can have changed, so the whole
+    // scoring command, its judge model call and its output tail are saved and
+    // the model is steered at the real blocker instead. The attempt still
+    // counts - a model that keeps calling eval without editing has to converge
+    // on the iteration cap, not spin for free. Unknown (no repo, git error,
+    // truncated probe) never matches, so the guard fails open.
+    const tree_fp = verify_fingerprint.capture(self.gpa, self.io, cmd);
+    if (verify_fingerprint.skipReverify(self.eval_repair_pending, self.eval_fp, tree_fp)) {
+        self.eval_iter += 1;
+        return .{ .text = try verify_fingerprint.noProgressText(self.arena, self.eval_iter), .is_error = true };
+    }
 
     // Behavioral commitment (issue #256): the eval-driven loop is the first
     // production caller of turn_committed/model_mispredicted. The commitment
@@ -64,6 +80,11 @@ pub fn runEval(self: *Agent, note: []const u8) !ExecResult {
         if (behavior) |bt| bt.recordMisprediction(eval_turn, commitment_id, .{ .pass = true }, .{ .pass = false, .exit = @as(i32, -1) }, "eval command could not run");
         self.eval_verified = false;
         self.eval_repair_pending = true;
+        // #412: a command that never ran is not a verdict about the workspace,
+        // and "edit source files" is not the fix for it - disarm the guard so
+        // the next call really does try the command again (and so a fingerprint
+        // left by an earlier RED cannot suppress it).
+        self.eval_fp = null;
         eval_memory.record(self, note, null, -1, false);
         return .{ .text = try std.fmt.allocPrint(self.arena, "eval command could not run: {t}", .{e}), .is_error = true };
     };
@@ -104,6 +125,10 @@ pub fn runEval(self: *Agent, note: []const u8) !ExecResult {
     const met = if (combined) |s| s >= target_f else false;
     self.eval_repair_pending = exit_code != 0 or !met;
     self.eval_verified = !self.eval_repair_pending;
+    // #412: a RED remembers the tree it failed on, so the next eval over that
+    // same tree is skipped; a green forgets it, because the next RED must be
+    // measured against its own tree and never against a stale one.
+    self.eval_fp = if (self.eval_repair_pending) tree_fp else null;
     // A RED verdict is harness ground truth about a FAILED attempt: park a
     // capped excerpt so the next escalation decision carries the evidence
     // (the R0d revision advisory, or an R3 fleet's briefs).

--- a/src/agent_eval_tests.zig
+++ b/src/agent_eval_tests.zig
@@ -14,6 +14,8 @@ const trace = @import("trace.zig");
 const Tracer = trace.Tracer;
 const btrace = @import("behavior_trace.zig");
 const BehaviorTrace = btrace.BehaviorTrace;
+const process_runner = @import("process_runner.zig");
+const verify_fingerprint = @import("verify_fingerprint.zig");
 
 test "runEval: commits before the command runs, mispredicts on a missed target, and leaves a met target commitment-only (#256)" {
     // The chdir below is POSIX-only, matching session_start.zig's own
@@ -129,4 +131,113 @@ test "runEval: commits before the command runs, mispredicts on a missed target, 
     // The met-target commitment has no paired misprediction: absence is the
     // success signal (docs/behavioral-trajectories.md).
     try std.testing.expect(lines.next() == null);
+}
+
+/// Run a command in the process cwd, failing the test if it did not succeed.
+/// The #412 test needs a REAL git repo: reading git is the whole feature, and
+/// a mocked probe would prove nothing about the porcelain/diff/untracked split.
+fn fixtureCmd(gpa: std.mem.Allocator, io: Io, argv: []const []const u8) !void {
+    const r = process_runner.runCapped(gpa, io, argv, 1 << 16, 1 << 16, 60_000) catch
+        return error.SkipZigTest; // no git on this machine: skip rather than fail on the environment
+    defer gpa.free(r.stdout);
+    defer gpa.free(r.stderr);
+    if (!process_runner.ranOk(r)) return error.FixtureCommandFailed;
+}
+
+/// How many times the --eval command was actually SPAWNED. The counter lives
+/// under .graff/, which the fixture repo gitignores, so counting can never
+/// itself move the fingerprint the guard is reading.
+fn verifierCalls(gpa: std.mem.Allocator, io: Io) usize {
+    const body = Io.Dir.cwd().readFileAlloc(io, ".graff/verifier-calls", gpa, .limited(4096)) catch return 0;
+    defer gpa.free(body);
+    return body.len;
+}
+
+test "#412: an unchanged worktree is not re-verified, and any change re-arms the verifier" {
+    // POSIX-only for the same reason as the test above: the fchdir isolation.
+    if (builtin.os.tag == .windows) return;
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var orig_dir = try Io.Dir.cwd().openDir(io, ".", .{});
+    defer orig_dir.close(io);
+    defer _ = std.posix.system.fchdir(orig_dir.handle);
+    if (std.posix.system.fchdir(tmp.dir.handle) != 0) return error.ChdirFailed;
+
+    // A real single-commit repo. `.graff/` is ignored so the harness's own eval
+    // log, its notes and the call counter can never read as work the model did
+    // - without that the tree would move on every eval and never skip.
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = ".gitignore", .data = ".graff/\n" });
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = "work.txt", .data = "one\n" });
+    try fixtureCmd(gpa, io, &.{ "git", "init", "-q" });
+    try fixtureCmd(gpa, io, &.{ "git", "add", "-A" });
+    try fixtureCmd(gpa, io, &.{ "git", "-c", "user.email=t@example.com", "-c", "user.name=t", "-c", "commit.gpgsign=false", "commit", "-q", "--no-verify", "-m", "fixture" });
+
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    var agent: Agent = .{
+        .gpa = gpa,
+        .arena = arena_state.allocator(),
+        .io = io,
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = null,
+        .tracer = null,
+        // Always RED, and it leaves one byte behind per real invocation.
+        .eval_cmd = "mkdir -p .graff && printf x >> .graff/verifier-calls; exit 1",
+        .eval_target = 90,
+    };
+
+    // Attempt 1: nothing to compare against, so the verifier runs. Its RED
+    // verdict arms the guard over the tree it failed on.
+    const first = try agent.runEval("");
+    try std.testing.expect(!first.is_error); // a RED is a verdict, not a tool error
+    try std.testing.expectEqual(@as(usize, 1), verifierCalls(gpa, io));
+    try std.testing.expect(agent.eval_repair_pending);
+    try std.testing.expect(agent.eval_fp != null);
+
+    // Attempt 2, workspace untouched. This is the whole feature: before it, a
+    // /goal continuation re-ran the entire scoring command (plus a --judge
+    // model call) to re-derive a verdict that could not have changed.
+    const second = try agent.runEval("");
+    try std.testing.expectEqual(@as(usize, 1), verifierCalls(gpa, io)); // NOT spawned
+    try std.testing.expectEqual(@as(u32, 2), agent.eval_iter); // but the attempt still counts
+    try std.testing.expect(second.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, second.text, verify_fingerprint.no_progress_steer) != null);
+    try std.testing.expect(std.mem.indexOf(u8, second.text, "eval output (tail)") == null); // no verdict was manufactured
+    // A skipped run verifies nothing, so completion stays blocked.
+    try std.testing.expect(agent.eval_repair_pending and !agent.eval_verified);
+
+    // A TRACKED edit is progress: the verifier runs again...
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = "work.txt", .data = "two\n" });
+    _ = try agent.runEval("");
+    try std.testing.expectEqual(@as(usize, 2), verifierCalls(gpa, io));
+    // ...and its RED arms the skip over the NEW tree, not the old one.
+    _ = try agent.runEval("");
+    try std.testing.expectEqual(@as(usize, 2), verifierCalls(gpa, io));
+
+    // An UNTRACKED file is progress too, and its CONTENTS are what prove it:
+    // `git status --porcelain` says `?? scratch.txt` either way and
+    // `git diff HEAD` stays empty, so a fingerprint built from those two alone
+    // would skip both of these attempts over real work.
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = "scratch.txt", .data = "a" });
+    _ = try agent.runEval("");
+    try std.testing.expectEqual(@as(usize, 3), verifierCalls(gpa, io));
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = "scratch.txt", .data = "b" });
+    _ = try agent.runEval("");
+    try std.testing.expectEqual(@as(usize, 4), verifierCalls(gpa, io));
+
+    // Six attempts, four verifier runs: the two no-progress ones were free.
+    try std.testing.expectEqual(@as(u32, 6), agent.eval_iter);
+
+    // A green eval disarms the guard entirely - the next RED must be measured
+    // against its own tree, never against one this run already left behind.
+    agent.eval_cmd = "printf 'score: 100\\n'";
+    _ = try agent.runEval("");
+    try std.testing.expect(agent.eval_verified and agent.eval_fp == null);
 }

--- a/src/agent_output.zig
+++ b/src/agent_output.zig
@@ -53,6 +53,32 @@ fn endsLine(comptime fmt: []const u8) bool {
     return fmt.len > 0 and fmt[fmt.len - 1] == '\n';
 }
 
+/// say() for text that is already rendered (#422: a sink holds the bytes, not
+/// a comptime format). Same routing, same worker-line framing, same tick-gate
+/// rule — only the line-ending test moves from the format to the last byte.
+/// Errors are swallowed: an event sink's emit path has nowhere to return them.
+pub fn sayText(self: *Agent, text: []const u8) void {
+    if (main_mod.json_mode and !self.sub) return;
+    if (self.out) |w| {
+        w.print("{s}", .{text}) catch return;
+        w.flush() catch return;
+        if (!self.sub and !main_mod.json_mode and text.len > 0 and text[text.len - 1] == '\n') _ = tick_gate.setLineStart(true);
+        return;
+    }
+    // A pool-thread child has no writer: same fixed slot, same label prefix,
+    // and the same repair when an over-long line lost its newline to the cut.
+    var buf: [tick_gate.slot_bytes]u8 = undefined;
+    var sink = Io.Writer.fixed(&buf);
+    const fit = if (sink.print("  [{s}] {s}", .{ self.label, text })) |_| true else |_| false;
+    var line = sink.buffered();
+    if (!fit or line.len == 0 or line[line.len - 1] != '\n') {
+        const at: usize = @min(line.len, buf.len - 1);
+        buf[at] = '\n';
+        line = buf[0 .. at + 1];
+    }
+    tick_gate.workerLine(line);
+}
+
 /// Remember the formatted message for the --json `error` event, then print
 /// like say() + a #398 duration hint; last_api_error keeps provider words.
 pub fn sayApiError(self: *Agent, comptime fmt: []const u8, args: anytype) !void {

--- a/src/agent_overflow.zig
+++ b/src/agent_overflow.zig
@@ -1,0 +1,512 @@
+//! Context-overflow classification and the recovery it drives (#193 arc, #414).
+//!
+//! Three questions, asked in this order:
+//!   1. is this failure something OTHER than an over-window input — throttling,
+//!      a billing cap? A guard hit wins outright, so the retry/Retry-After
+//!      ladder is never shadowed by a compaction that cannot help.
+//!   2. does the failure's structured code or wording name an over-window input?
+//!   3. did the provider ACCEPT the oversized input and admit it only in its own
+//!      usage numbers — HTTP 200 with nothing generated — rather than in an error?
+//!
+//! (1) and (2) are `isContextOverflow`; (3) is `classifyCompletion`. The recovery
+//! all three feed (pin the meter to the window, emergency-trim, retry the turn
+//! once) is `applyOverflowRecovery`, shared by every wire format.
+
+const std = @import("std");
+const Value = std.json.Value;
+
+const Agent = @import("agent.zig").Agent;
+const Provider = @import("provider.zig").Provider;
+const telemetry = @import("telemetry.zig");
+const util = @import("util.zig");
+const usageInt = @import("agent_context.zig").usageInt;
+
+/// Non-overflow guards, tested BEFORE every overflow pattern and against both
+/// the message and the structured code.
+///
+/// The motivating case is Bedrock, which formats throttling as
+/// "ThrottlingException: Too many tokens, please wait before trying again." —
+/// a 429 whose wording collides head-on with the generic "too many tokens"
+/// overflow fallback below. Classifying that as overflow throws away real
+/// conversation to fix a problem compaction cannot fix, AND shadows the
+/// Retry-After backoff that would have worked.
+///
+/// Deliberately scoped to throttling / quota — the family whose remedy is
+/// "wait", not "send less". Broader guards (a bare "overloaded", a generic
+/// "server_error") were considered and rejected: a guard that swallows a REAL
+/// overflow wedges the session forever, which is the #193 symptom and strictly
+/// worse than one wasted compaction.
+const non_overflow_needles = [_][]const u8{
+    "throttlingexception", // bedrock: "ThrottlingException: Too many tokens, ..."
+    "throttling error", // bedrock, formatBedrockError's human-readable prefix
+    "throttled",
+    "rate limit", // "rate limit exceeded", "Rate limit reached", "rate limited (429)"
+    "rate_limit", // structured codes: rate_limit_exceeded / rate_limit_error
+    "ratelimit",
+    "too many requests", // generic HTTP 429 phrasing
+    "tokens per minute", // anthropic org cap: "rate limit of 40000 input tokens per minute"
+    "requests per minute",
+    "please wait before trying again", // bedrock's throttle tail, verbatim
+    "quota", // insufficient_quota / "exceeded your current quota" — isQuotaExceeded owns it
+    "service unavailable",
+};
+
+/// Structured error codes that mean "input over the window" on their own (#203),
+/// matched exactly so a local or non-English provider recovers even when its
+/// message text is unfamiliar.
+const overflow_codes = [_][]const u8{
+    "context_length_exceeded", // openai
+    "context_window_exceeded", // openai / responses
+    "model_context_window_exceeded", // z.ai
+    "request_too_large", // anthropic 413 (byte size, not token count)
+};
+
+/// Provider phrasings for "input over the window", matched case-insensitively —
+/// the same rejection arrives Title-Cased from some gateways and lower-cased
+/// from others, and a case-sensitive miss wedges the session.
+const overflow_needles = [_][]const u8{
+    // #193/#203, unchanged: the shapes graff already recovered from.
+    "context window", // codex/responses: "exceeds the context window"
+    "context length", // openai: "maximum context length is N tokens"; lmstudio
+    "context_length_exceeded", // openai error code echoed into the message
+    "context limit", // anthropic: "input length and max_tokens exceed context limit"
+    "prompt is too long", // anthropic: "prompt is too long: N tokens > M maximum"
+    "maximum context", // defensive: "maximum context ... exceeded"
+    // #414: providers graff ships that phrase it differently. Each one is a
+    // rejection the old table let die as a plain api error.
+    "context_window_exceeded",
+    "request_too_large", // anthropic 413
+    "input is too long for requested model", // bedrock
+    "input token count", // google: "The input token count (N) exceeds the maximum ..."
+    "prompt token count", // github copilot: "prompt token count of N exceeds the limit of M"
+    "maximum prompt length", // xai: "This model's maximum prompt length is N ..."
+    "reduce the length of the messages", // groq
+    "exceeds the available context size", // llama.cpp server
+    "exceeded model token limit", // kimi for coding
+    "too large for model with", // mistral: "... too large for model with N maximum context length"
+    "prompt too long", // ollama: "prompt too long; exceeded max context length"
+    // Generic fallbacks. These are the reason the guard list above exists: they
+    // are broad enough to catch an unknown provider and broad enough to collide
+    // with throttling, so they are only ever reached after the guards decline.
+    "too many tokens",
+    "token limit exceeded",
+};
+
+/// True if `msg`/`code` is a NON-overflow condition — throttling or a billing
+/// cap — whose remedy is waiting, not compacting.
+pub fn isNonOverflow(msg: []const u8, code: ?[]const u8) bool {
+    for (non_overflow_needles) |n| {
+        if (util.indexOfIgnoreCase(msg, n) != null) return true;
+        if (code) |c| if (util.indexOfIgnoreCase(c, n) != null) return true;
+    }
+    return false;
+}
+
+/// True if `msg` is a provider's "input is over the context window" rejection,
+/// across wire formats: codex/responses ("exceeds the context window"), openai
+/// ("maximum context length", "context_length_exceeded"), anthropic ("prompt is
+/// too long", "exceed context limit"), plus the #414 table above. Drives the
+/// in-turn emergency-trim + retry recovery symmetrically for every provider
+/// (#193) — before it, only the codex path recovered and anthropic/openai died
+/// on an over-window turn.
+pub fn isContextOverflow(msg: []const u8, code: ?[]const u8) bool {
+    // #414: guards first, unconditionally. A throttle whose wording overlaps an
+    // overflow pattern must ride the existing 429/Retry-After ladder instead.
+    if (isNonOverflow(msg, code)) return false;
+    if (code) |c| {
+        for (overflow_codes) |k| if (std.ascii.eqlIgnoreCase(c, k)) return true;
+    }
+    for (overflow_needles) |n| if (util.indexOfIgnoreCase(msg, n) != null) return true;
+    return false;
+}
+
+/// How the provider says it stopped, normalized across wire formats.
+pub const StopKind = enum {
+    normal, // end_turn / stop_sequence / stop
+    length, // finish_reason "length" / stop_reason "max_tokens"
+    other, // anything else, including "not reported"
+};
+
+/// One completed HTTP 200 response, reduced to the four numbers that decide
+/// whether the provider silently overflowed.
+pub const Completion = struct {
+    /// Everything that occupied the window: prompt + cache reads + cache writes.
+    input_tokens: u64 = 0,
+    output_tokens: u64 = 0,
+    stop: StopKind = .other,
+    /// Any assistant text or any tool call — i.e. the turn produced something.
+    has_content: bool = false,
+};
+
+pub const Verdict = enum {
+    ok,
+    /// z.ai: HTTP 200, nothing generated, usage says the input already filled
+    /// (or overran) the window. The provider accepted an over-window request
+    /// and answered with silence instead of an error.
+    silent_overflow,
+    /// Xiaomi MiMo: the server truncated an oversized input to exactly fit the
+    /// window, leaving no room to generate, then reported finish_reason=length
+    /// with zero output. The conversation the model saw is NOT the one we sent.
+    upstream_truncation,
+};
+
+/// Percent of the window the reported input must fill before a `length` stop
+/// counts as upstream truncation. 99 (not 100) because a provider's own
+/// tokenizer rounds a few tokens differently than its advertised window, and a
+/// server that truncates-to-fit lands one or two tokens short of the wall.
+pub const truncation_fill_pct: u64 = 99;
+
+/// Classify a successful (HTTP 200) response from its own reported usage.
+///
+/// Conservative by construction — three independent conditions must hold before
+/// `upstream_truncation` fires, so an ORDINARY max-tokens completion (the model
+/// genuinely wrote until it hit its output cap) can never trip it:
+///   * `output_tokens == 0` — a normal length-stop spends its whole output
+///     budget, so any generated token at all disqualifies it;
+///   * `has_content == false` — and it leaves that text behind;
+///   * the reported input fills >= 99% of the window — a normal length-stop
+///     happens at any input size, including a two-line prompt.
+/// `silent_overflow` needs an empty completion too: if the input is over our
+/// window figure and the model STILL answered, the window figure is wrong (a
+/// stale catalog row), and trimming real history over a bad constant is the
+/// more expensive mistake.
+pub fn classifyCompletion(c: Completion, window: u64) Verdict {
+    if (window == 0) return .ok; // unknown window — never guess
+    if (c.input_tokens == 0) return .ok; // no usage reported — nothing to judge
+    if (c.has_content) return .ok;
+    // Checked before the plain over-window rule so the more specific diagnosis
+    // wins when a truncating provider lands exactly ON the window.
+    if (c.stop == .length and c.output_tokens == 0 and
+        c.input_tokens >= window / 100 * truncation_fill_pct) return .upstream_truncation;
+    if (c.input_tokens >= window) return .silent_overflow;
+    return .ok;
+}
+
+fn stopFromString(kind: Provider.Kind, s: []const u8) StopKind {
+    if (std.mem.eql(u8, s, "length") or std.mem.eql(u8, s, "max_tokens")) return .length;
+    return switch (kind) {
+        .anthropic => if (std.mem.eql(u8, s, "end_turn") or std.mem.eql(u8, s, "stop_sequence")) .normal else .other,
+        else => if (std.mem.eql(u8, s, "stop")) .normal else .other,
+    };
+}
+
+fn str(obj: std.json.ObjectMap, name: []const u8) ?[]const u8 {
+    const v = obj.get(name) orelse return null;
+    return if (v == .string) v.string else null;
+}
+
+fn arr(obj: std.json.ObjectMap, name: []const u8) ?std.json.Array {
+    const v = obj.get(name) orelse return null;
+    return if (v == .array) v.array else null;
+}
+
+fn usageOf(root: std.json.ObjectMap) ?std.json.ObjectMap {
+    const v = root.get("usage") orelse return null;
+    return if (v == .object) v.object else null;
+}
+
+fn nonNegative(n: i64) u64 {
+    return if (n > 0) @intCast(n) else 0;
+}
+
+/// Reduce a parsed 200 response to the numbers `classifyCompletion` needs.
+/// Everything is optional: a provider that reports no usage yields
+/// `input_tokens == 0`, which classifies as `.ok`.
+pub fn readCompletion(kind: Provider.Kind, root: std.json.ObjectMap) Completion {
+    var c: Completion = .{};
+    return switch (kind) {
+        .anthropic => {
+            if (usageOf(root)) |u| {
+                c.input_tokens = nonNegative(usageInt(u, "input_tokens") +|
+                    usageInt(u, "cache_read_input_tokens") +| usageInt(u, "cache_creation_input_tokens"));
+                c.output_tokens = nonNegative(usageInt(u, "output_tokens"));
+            }
+            if (str(root, "stop_reason")) |s| c.stop = stopFromString(kind, s);
+            if (arr(root, "content")) |blocks| for (blocks.items) |b| {
+                if (b != .object) continue;
+                const bt = str(b.object, "type") orelse continue;
+                if (std.mem.eql(u8, bt, "tool_use")) c.has_content = true;
+                if (std.mem.eql(u8, bt, "text")) {
+                    if (str(b.object, "text")) |t| if (t.len > 0) {
+                        c.has_content = true;
+                    };
+                }
+            };
+            return c;
+        },
+        .openai => {
+            if (usageOf(root)) |u| {
+                // prompt_tokens already includes cached prompt tokens.
+                c.input_tokens = nonNegative(usageInt(u, "prompt_tokens"));
+                c.output_tokens = nonNegative(usageInt(u, "completion_tokens"));
+            }
+            const choices = arr(root, "choices") orelse return c;
+            if (choices.items.len == 0 or choices.items[0] != .object) return c;
+            const choice = choices.items[0].object;
+            if (str(choice, "finish_reason")) |s| c.stop = stopFromString(kind, s);
+            const message = choice.get("message") orelse return c;
+            if (message != .object) return c;
+            if (str(message.object, "content")) |t| if (t.len > 0) {
+                c.has_content = true;
+            };
+            if (arr(message.object, "tool_calls")) |tc| if (tc.items.len > 0) {
+                c.has_content = true;
+            };
+            return c;
+        },
+        .responses => {
+            if (usageOf(root)) |u| {
+                // Responses usage.input_tokens already includes cached input.
+                c.input_tokens = nonNegative(usageInt(u, "input_tokens"));
+                c.output_tokens = nonNegative(usageInt(u, "output_tokens"));
+            }
+            // parseResponses collapses every terminal to output items + an
+            // `incomplete` flag, so there is no finish_reason to read: leave
+            // `stop` at .other and let only the silent-overflow rule apply.
+            if (arr(root, "output")) |items| for (items.items) |item| {
+                if (item != .object) continue;
+                const it = str(item.object, "type") orelse continue;
+                if (std.mem.eql(u8, it, "function_call") or std.mem.eql(u8, it, "custom_tool_call")) c.has_content = true;
+                if (!std.mem.eql(u8, it, "message")) continue;
+                const blocks = arr(item.object, "content") orelse continue;
+                for (blocks.items) |b| {
+                    if (b != .object) continue;
+                    if (str(b.object, "text")) |t| if (t.len > 0) {
+                        c.has_content = true;
+                    };
+                }
+            };
+            return c;
+        },
+    };
+}
+
+/// Pin the meter to the window, emergency-trim, and retry the turn once.
+///
+/// Pins FIRST so the between-turns compaction engages even when we cannot
+/// recover here — a rejected request returns no usage to correct the lagging
+/// meter (#174). Guarded by `retried` (one `context_retried` per request) so a
+/// second overflow falls through instead of looping. Returns true if the caller
+/// should `continue` its rebuild loop.
+fn applyOverflowRecovery(self: *Agent, retried: *bool) bool {
+    self.last_request_context_overflow = true;
+    // Rejection proves at least the advertised window, not an exact total.
+    // Preserve stronger server/local evidence already above that floor.
+    const estimate = self.contextEstimate();
+    self.last_context_tokens = @max(estimate.effective, self.provider.context);
+    self.context_local_tokens = estimate.local;
+    // compact() marks its synthetic summary request explicitly. Generic
+    // in-request recovery is destructive there: the synthetic compact
+    // instruction is the newest clean user turn, so emergencyTrim can discard
+    // the entire real conversation and retry with only "summarize it". Let the
+    // outer compactOrRecover policy handle a failed summary after compact()'s
+    // errdefer removes that synthetic instruction.
+    if (self.compaction_request) return false;
+    if (retried.* or self.emergencyTrim() == 0) return false;
+    retried.* = true;
+    if (self.tracer) |tr| tr.note("context", "input over the window — emergency-trimmed and retrying the turn");
+    return true;
+}
+
+/// #193 follow-up: shared in-turn context-overflow recovery for the codex
+/// failure branch and the three anthropic/openai error branches (streamed error
+/// event, non-streamed `{"type":"error"}` envelope, and the generic
+/// apiErrorMessage path). These wire formats send the full input each rebuild,
+/// so — unlike the codex branch — no closeCodexWs re-anchor is needed.
+pub fn recoverContextOverflow(self: *Agent, msg: []const u8, code: ?[]const u8, retried: *bool) bool {
+    if (!isContextOverflow(msg, code)) return false;
+    return applyOverflowRecovery(self, retried);
+}
+
+/// #414: the provider returned HTTP 200 and no answer, and only its own usage
+/// numbers say why. Runs on every successful response, after recordUsage* has
+/// already banked the sample. Compaction requests are excluded: an empty
+/// summary is compact()'s own escalation (#379), and recovering here would
+/// trim against the synthetic instruction.
+///
+/// Both verdicts surface DISTINCTLY — a line, a trace note, a telemetry event —
+/// rather than reaching the user as an inexplicably short answer, and both then
+/// take the ordinary overflow recovery. When recovery is unavailable (already
+/// retried this request, or nothing left to trim) the reason is recorded as
+/// `last_api_error` so a subagent's parent and the --json error event carry it.
+pub fn recoverBehavioralOverflow(self: *Agent, root: std.json.ObjectMap, retried: *bool) bool {
+    if (self.compaction_request) return false;
+    const c = readCompletion(self.provider.kind, root);
+    const window = self.provider.context;
+    const verdict = classifyCompletion(c, window);
+    if (verdict == .ok) return false;
+    const kind: []const u8 = if (verdict == .silent_overflow) "silent_overflow" else "upstream_truncation";
+    const what: []const u8 = if (verdict == .silent_overflow)
+        "returned no answer while reporting"
+    else
+        "truncated the input to fit the window and had no room left to answer:";
+    self.say("[{s}: {s} {s} {d} input tokens against a {d}-token window — compacting and retrying (#414)]\n", .{
+        kind, self.provider.id, what, c.input_tokens, window,
+    }) catch {};
+    if (self.tracer) |tr| tr.note("context", kind);
+    if (telemetry.g_telem) |t| t.errorEvent(kind, self.provider.id);
+    const recovered = applyOverflowRecovery(self, retried);
+    if (!recovered) self.last_api_error = std.fmt.allocPrint(
+        self.arena,
+        "{s}: {s} accepted {d} input tokens against a {d}-token window and produced no output — the reply is not a real answer",
+        .{ kind, self.provider.id, c.input_tokens, window },
+    ) catch null;
+    return recovered;
+}
+
+const ClassifyRow = struct {
+    msg: []const u8,
+    code: ?[]const u8 = null,
+    want: bool,
+    why: []const u8,
+};
+
+test "isContextOverflow (#193/#203/#414): guards beat patterns; every provider phrasing still classifies" {
+    const rows = [_]ClassifyRow{
+        // ---- #414 guards: real throttle/quota strings that must ride the retry ladder
+        .{ .msg = "ThrottlingException: Too many tokens, please wait before trying again.", .want = false, .why = "bedrock throttle collides with the generic 'too many tokens' fallback" },
+        .{ .msg = "Throttling error: Too many tokens, please wait before trying again.", .want = false, .why = "bedrock formatBedrockError prefix" },
+        .{ .msg = "Rate limit reached for gpt-4o: Limit 30000 tokens per minute", .code = "rate_limit_exceeded", .want = false, .why = "openai TPM cap" },
+        .{ .msg = "This request would exceed your organization's rate limit of 40000 input tokens per minute.", .want = false, .why = "anthropic org TPM cap" },
+        .{ .msg = "429 too many requests", .want = false, .why = "generic 429" },
+        .{ .msg = "rate limited (429): quota/billing cap — You exceeded your current quota", .want = false, .why = "graff's own quota-cap marker must not compact" },
+        .{ .msg = "Service unavailable: the model is starting up", .want = false, .why = "5xx, not a window" },
+        .{ .msg = "de invoerlengte is te groot", .code = "rate_limit_error", .want = false, .why = "guard applies to the structured code too" },
+        // A guard must NOT swallow a real overflow that merely mentions a limit.
+        .{ .msg = "prompt is too long: 219373 tokens > 200000 maximum", .code = "rate_limit_exceeded", .want = false, .why = "documented precedence: guards win outright, even over an explicit overflow phrase" },
+        // ---- regression rows: everything #193/#203 already classified, unchanged
+        .{ .msg = "Your input exceeds the context window of 272000 tokens", .want = true, .why = "codex/responses" },
+        .{ .msg = "This model's maximum context length is 128000 tokens. However, you requested 130000", .want = true, .why = "openai" },
+        .{ .msg = "context_length_exceeded", .want = true, .why = "openai code echoed into the message" },
+        .{ .msg = "prompt is too long: 219373 tokens > 200000 maximum", .want = true, .why = "anthropic" },
+        .{ .msg = "input length and max_tokens exceed context limit", .want = true, .why = "anthropic" },
+        .{ .msg = "de invoerlengte overschrijdt het venster", .code = "context_length_exceeded", .want = true, .why = "#203 structured code, unfamiliar text" },
+        .{ .msg = "", .code = "context_window_exceeded", .want = true, .why = "#203 structured code, empty text" },
+        .{ .msg = "maximum context reached", .want = true, .why = "defensive needle" },
+        .{ .msg = "The API Key appears to be invalid or may have expired.", .want = false, .why = "auth" },
+        .{ .msg = "tool_choice is not supported", .want = false, .why = "capability" },
+        .{ .msg = "rate limit exceeded", .want = false, .why = "throttle" },
+        .{ .msg = "model not found", .want = false, .why = "routing" },
+        .{ .msg = "some unrelated failure", .code = "rate_limit_exceeded", .want = false, .why = "unrelated code" },
+        // ---- #414 provider phrasings the old six-needle table let die as api errors
+        .{ .msg = "Input is too long for requested model.", .want = true, .why = "bedrock" },
+        .{ .msg = "The input token count (1196265) exceeds the maximum number of tokens allowed (1048575)", .want = true, .why = "google gemini" },
+        .{ .msg = "prompt token count of 141000 exceeds the limit of 128000", .want = true, .why = "github copilot" },
+        .{ .msg = "This model's maximum prompt length is 131072 but the request contains 537812 tokens", .want = true, .why = "xai/grok" },
+        .{ .msg = "Please reduce the length of the messages or completion.", .want = true, .why = "groq" },
+        .{ .msg = "the request exceeds the available context size, try increasing it", .want = true, .why = "llama.cpp" },
+        .{ .msg = "Your request exceeded model token limit: 262144 (requested: 300000)", .want = true, .why = "kimi for coding" },
+        .{ .msg = "Prompt contains 40000 tokens, too large for model with 32768 maximum context length", .want = true, .why = "mistral" },
+        .{ .msg = "prompt too long; exceeded max context length by 4096 tokens", .want = true, .why = "ollama" },
+        .{ .msg = "tokens to keep from the initial prompt is greater than the context length", .want = true, .why = "lm studio" },
+        .{ .msg = "invalid params, context window exceeds limit", .want = true, .why = "minimax" },
+        .{ .msg = "413 request_too_large: Request exceeds the maximum size", .want = true, .why = "anthropic 413 byte-size overflow" },
+        .{ .msg = "", .code = "model_context_window_exceeded", .want = true, .why = "z.ai non-standard code" },
+        .{ .msg = "Token limit exceeded for this request", .want = true, .why = "generic fallback" },
+        // Case-insensitivity: the same rejection Title-Cased by a gateway.
+        .{ .msg = "PROMPT IS TOO LONG: 219373 TOKENS > 200000 MAXIMUM", .want = true, .why = "case-insensitive match" },
+        .{ .msg = "Context Length Exceeded", .want = true, .why = "case-insensitive match" },
+    };
+    for (rows) |r| {
+        const got = isContextOverflow(r.msg, r.code);
+        if (got != r.want) {
+            std.debug.print("row failed ({s}): msg={s} code={?s} want={} got={}\n", .{ r.why, r.msg, r.code, r.want, got });
+            return error.TestUnexpectedResult;
+        }
+    }
+}
+
+const CompletionRow = struct {
+    kind: Provider.Kind,
+    body: []const u8,
+    window: u64,
+    want: Verdict,
+    why: []const u8,
+};
+
+test "classifyCompletion (#414): the silent-200 and truncate-then-length shapes, and what must NOT trip" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    const rows = [_]CompletionRow{
+        // ---- silent overflow (z.ai): HTTP 200, empty completion, usage at/over the window
+        .{ .kind = .openai, .window = 128_000, .want = .silent_overflow, .why = "z.ai silent 200", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"stop"}],
+        \\ "usage":{"prompt_tokens":131072,"completion_tokens":0,"total_tokens":131072}}
+        },
+        .{ .kind = .openai, .window = 128_000, .want = .silent_overflow, .why = "exactly AT the window still counts", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":null},"finish_reason":"stop"}],
+        \\ "usage":{"prompt_tokens":128000,"completion_tokens":0}}
+        },
+        .{ .kind = .anthropic, .window = 200_000, .want = .silent_overflow, .why = "cache reads count toward the window", .body =
+        \\{"stop_reason":"end_turn","content":[],
+        \\ "usage":{"input_tokens":1000,"cache_read_input_tokens":199000,"output_tokens":0}}
+        },
+        .{ .kind = .responses, .window = 272_000, .want = .silent_overflow, .why = "reasoning-only output is not an answer", .body =
+        \\{"output":[{"type":"reasoning","summary":[]}],
+        \\ "usage":{"input_tokens":280000,"output_tokens":0}}
+        },
+        // ---- upstream truncation (MiMo): finish_reason=length, zero output, input fills the window
+        .{ .kind = .openai, .window = 32_768, .want = .upstream_truncation, .why = "MiMo truncate-then-length", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"length"}],
+        \\ "usage":{"prompt_tokens":32768,"completion_tokens":0,"total_tokens":32768}}
+        },
+        .{ .kind = .openai, .window = 32_768, .want = .upstream_truncation, .why = "99% fill: a truncating server lands a hair short", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"length"}],
+        \\ "usage":{"prompt_tokens":32500,"completion_tokens":0}}
+        },
+        .{ .kind = .anthropic, .window = 200_000, .want = .upstream_truncation, .why = "anthropic spells the same stop max_tokens", .body =
+        \\{"stop_reason":"max_tokens","content":[],
+        \\ "usage":{"input_tokens":200000,"output_tokens":0}}
+        },
+        // ---- must NOT trip: an ORDINARY max-tokens completion
+        .{ .kind = .openai, .window = 32_768, .want = .ok, .why = "normal max-tokens: real output, small input", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":"here is a very long answer that ran out of room"},"finish_reason":"length"}],
+        \\ "usage":{"prompt_tokens":900,"completion_tokens":16000}}
+        },
+        .{ .kind = .openai, .window = 32_768, .want = .ok, .why = "normal max-tokens on a nearly-full window still generated", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":"partial answer"},"finish_reason":"length"}],
+        \\ "usage":{"prompt_tokens":32700,"completion_tokens":68}}
+        },
+        .{ .kind = .openai, .window = 32_768, .want = .ok, .why = "length stop, zero output, but the input is nowhere near the wall", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"length"}],
+        \\ "usage":{"prompt_tokens":900,"completion_tokens":0}}
+        },
+        // ---- must NOT trip: ordinary success, and the two "no evidence" cases
+        .{ .kind = .openai, .window = 128_000, .want = .ok, .why = "an over-window figure the model ANSWERED means our window is wrong, not the history", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],
+        \\ "usage":{"prompt_tokens":131072,"completion_tokens":12}}
+        },
+        .{ .kind = .openai, .window = 128_000, .want = .ok, .why = "a tool call is content", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"c1","function":{"name":"bash","arguments":"{}"}}]},"finish_reason":"tool_calls"}],
+        \\ "usage":{"prompt_tokens":131072,"completion_tokens":9}}
+        },
+        .{ .kind = .openai, .window = 128_000, .want = .ok, .why = "empty answer but the input is well under the window (a terse model, not overflow)", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"stop"}],
+        \\ "usage":{"prompt_tokens":40,"completion_tokens":0}}
+        },
+        .{ .kind = .openai, .window = 0, .want = .ok, .why = "unknown window never guesses", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"stop"}],
+        \\ "usage":{"prompt_tokens":131072,"completion_tokens":0}}
+        },
+        .{ .kind = .openai, .window = 128_000, .want = .ok, .why = "no usage reported: nothing to judge", .body =
+        \\{"choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"stop"}]}
+        },
+        .{ .kind = .responses, .window = 272_000, .want = .ok, .why = "a real responses answer", .body =
+        \\{"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}],
+        \\ "usage":{"input_tokens":280000,"output_tokens":4}}
+        },
+        .{ .kind = .anthropic, .window = 200_000, .want = .ok, .why = "anthropic text block is content", .body =
+        \\{"stop_reason":"end_turn","content":[{"type":"text","text":"hi"}],
+        \\ "usage":{"input_tokens":210000,"output_tokens":2}}
+        },
+    };
+    for (rows) |r| {
+        const parsed = try std.json.parseFromSliceLeaky(Value, a, r.body, .{ .allocate = .alloc_always });
+        const got = classifyCompletion(readCompletion(r.kind, parsed.object), r.window);
+        if (got != r.want) {
+            std.debug.print("row failed ({s}): want={s} got={s}\n", .{ r.why, @tagName(r.want), @tagName(got) });
+            return error.TestUnexpectedResult;
+        }
+    }
+}

--- a/src/agent_overflow_tests.zig
+++ b/src/agent_overflow_tests.zig
@@ -1,0 +1,153 @@
+//! Recovery-side tests for agent_overflow.zig — the half that drives a live
+//! Agent (pin the meter, emergency-trim, retry once). The pure classification
+//! tables are tested next to the tables themselves, in agent_overflow.zig.
+
+const std = @import("std");
+const Value = std.json.Value;
+
+const Agent = @import("agent.zig").Agent;
+const overflow = @import("agent_overflow.zig");
+const recoverContextOverflow = overflow.recoverContextOverflow;
+const recoverBehavioralOverflow = overflow.recoverBehavioralOverflow;
+
+test { // main.zig's test root lists this file; carry agent_overflow.zig's own tests in with it
+    _ = overflow;
+}
+
+/// A history emergencyTrim can actually reclaim: one clean user turn followed
+/// by fat tool outputs (the #163 shape trimOldestToolOutputs recovers from).
+fn trimmableAgent(a: std.mem.Allocator, kind: @import("provider.zig").Provider.Kind, window: u64) !Agent {
+    var msgs = std.json.Array.init(a);
+    var um: std.json.ObjectMap = .empty;
+    try um.put(a, "role", .{ .string = "user" });
+    try um.put(a, "content", .{ .string = "do a thing" });
+    try msgs.append(.{ .object = um });
+    const big = try a.alloc(u8, 5000);
+    @memset(big, 'x');
+    var i: usize = 0;
+    while (i < 10) : (i += 1) {
+        var o: std.json.ObjectMap = .empty;
+        try o.put(a, "type", .{ .string = "function_call_output" });
+        try o.put(a, "call_id", .{ .string = "c" });
+        try o.put(a, "output", .{ .string = big });
+        try msgs.append(.{ .object = o });
+    }
+    var agent: Agent = undefined;
+    agent.arena = a;
+    agent.messages = msgs;
+    agent.tracer = null;
+    agent.provider = .{ .id = @tagName(kind), .kind = kind, .auth = .x_api_key, .url = "", .api_key = "", .model = "claude", .context = window };
+    agent.last_context_tokens = 0;
+    agent.sub = false;
+    agent.strict = false;
+    agent.sys_normal = "";
+    agent.sys_strict = "";
+    agent.tools_anthropic = "";
+    agent.tools_openai = "";
+    agent.context_local_tokens = agent.fullRequestEstimateTokens();
+    agent.stream_quiet = true;
+    agent.compaction_request = false;
+    agent.last_request_context_overflow = false;
+    agent.last_api_error = null;
+    agent.out = null;
+    agent.label = "test";
+    return agent;
+}
+
+test "recoverContextOverflow (#414): a Bedrock throttle rides the retry ladder instead of compacting" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var agent = try trimmableAgent(a, .anthropic, 100000);
+    const before = agent.messages.items.len;
+
+    // The whole point of the guard list: this string matches the generic
+    // "too many tokens" overflow fallback, but it is a 429. Recovering here
+    // would discard real history AND shadow the Retry-After backoff.
+    var retried = false;
+    try std.testing.expect(!recoverContextOverflow(&agent, "ThrottlingException: Too many tokens, please wait before trying again.", null, &retried));
+    try std.testing.expect(!retried);
+    try std.testing.expect(!agent.last_request_context_overflow); // meter untouched: no compaction is scheduled
+    try std.testing.expectEqual(@as(u64, 0), agent.last_context_tokens);
+    try std.testing.expectEqual(before, agent.messages.items.len);
+}
+
+fn parse(a: std.mem.Allocator, body: []const u8) !std.json.ObjectMap {
+    const v = try std.json.parseFromSliceLeaky(Value, a, body, .{ .allocate = .alloc_always });
+    return v.object;
+}
+
+test "recoverBehavioralOverflow (#414): the silent 200 compacts and retries; a normal reply does not" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var agent = try trimmableAgent(a, .openai, 128_000);
+
+    // An ordinary answer is never touched, even at a high token count.
+    const ok_body =
+        \\{"choices":[{"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],
+        \\ "usage":{"prompt_tokens":120000,"completion_tokens":8}}
+    ;
+    var retried = false;
+    try std.testing.expect(!recoverBehavioralOverflow(&agent, try parse(a, ok_body), &retried));
+    try std.testing.expect(!retried);
+    try std.testing.expect(!agent.last_request_context_overflow);
+    try std.testing.expect(agent.last_api_error == null);
+
+    // z.ai's shape: HTTP 200, no answer, usage over the window.
+    const silent =
+        \\{"choices":[{"message":{"role":"assistant","content":""},"finish_reason":"stop"}],
+        \\ "usage":{"prompt_tokens":131072,"completion_tokens":0}}
+    ;
+    const before = agent.fullRequestEstimateTokens();
+    try std.testing.expect(recoverBehavioralOverflow(&agent, try parse(a, silent), &retried));
+    try std.testing.expect(retried);
+    try std.testing.expect(agent.last_request_context_overflow);
+    try std.testing.expect(agent.fullRequestEstimateTokens() < before); // history was actually trimmed
+    try std.testing.expect(agent.last_api_error == null); // recovered -> nothing to report
+
+    // Same request, second occurrence: the retry guard stops a loop, but the
+    // meter stays pinned at the window so the between-turns compaction still
+    // engages, and the now-unrecoverable condition is named instead of
+    // surfacing as an inexplicably short answer.
+    try std.testing.expect(!recoverBehavioralOverflow(&agent, try parse(a, silent), &retried));
+    try std.testing.expectEqual(agent.provider.context, agent.last_context_tokens);
+    try std.testing.expect(agent.last_api_error != null);
+    try std.testing.expect(std.mem.indexOf(u8, agent.last_api_error.?, "silent_overflow") != null);
+
+    // A compaction summary request owns its own empty-summary escalation (#379).
+    agent.compaction_request = true;
+    agent.last_api_error = null;
+    var fresh = false;
+    try std.testing.expect(!recoverBehavioralOverflow(&agent, try parse(a, silent), &fresh));
+    try std.testing.expect(agent.last_api_error == null);
+}
+
+test "recoverBehavioralOverflow (#414): truncate-then-length is reported as truncation, not a short answer" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var agent = try trimmableAgent(a, .openai, 32_768);
+
+    // A genuine max-tokens completion must never be reclassified: it generated.
+    const normal_length =
+        \\{"choices":[{"message":{"role":"assistant","content":"a long answer that ran out of room"},"finish_reason":"length"}],
+        \\ "usage":{"prompt_tokens":32700,"completion_tokens":68}}
+    ;
+    var retried = false;
+    try std.testing.expect(!recoverBehavioralOverflow(&agent, try parse(a, normal_length), &retried));
+    try std.testing.expect(!agent.last_request_context_overflow);
+
+    // MiMo: the server truncated our input to fit, so it had no room to answer.
+    const truncated =
+        \\{"choices":[{"message":{"role":"assistant","content":""},"finish_reason":"length"}],
+        \\ "usage":{"prompt_tokens":32768,"completion_tokens":0}}
+    ;
+    try std.testing.expect(recoverBehavioralOverflow(&agent, try parse(a, truncated), &retried));
+    try std.testing.expect(agent.last_request_context_overflow);
+
+    // Unrecoverable repeat: the distinct diagnosis reaches last_api_error, which
+    // is what a subagent's parent and the --json error event read.
+    try std.testing.expect(!recoverBehavioralOverflow(&agent, try parse(a, truncated), &retried));
+    try std.testing.expect(std.mem.indexOf(u8, agent.last_api_error.?, "upstream_truncation") != null);
+}

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -24,6 +24,7 @@ const tools_mod = @import("tools.zig");
 const apiErrorMessage = tools_mod.apiErrorMessage;
 const mentionsReasoningEffort = tools_mod.mentionsReasoningEffort;
 const telemetry = @import("telemetry.zig");
+const tool_spill = @import("tool_spill.zig"); // #409: did the cap preserve the bytes, or destroy them?
 const run_budget_mod = @import("run_budget.zig");
 const wire_messages = @import("messages.zig");
 
@@ -141,13 +142,24 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
     // window past what the in-turn recovery below can reclaim (it keeps the most
     // recent outputs verbatim). Window-proportional, so large-context models keep
     // full tool results untouched.
+    const spills_before = tool_spill.spillCount();
     const capped = self.capOversizedToolOutputs(self.provider.perOutputCap());
     if (capped > 0) {
         // #202: don't truncate silently. The model already sees an inline marker;
-        // surface it to the trace and (interactively) to the user too.
-        if (self.tracer) |tr| tr.note("context", "capped an oversized tool output before send");
-        if (!main_mod.json_mode and !self.sub)
-            self.say("[tool output over this model's per-result cap — truncated {d} bytes before send (#193)]\n", .{capped}) catch {};
+        // surface it to the trace and (interactively) to the user too. #409: say
+        // which of the two happened — the elided bytes are only GONE when there
+        // was no durable session to spill them to.
+        const spilled = tool_spill.spillCount() > spills_before;
+        if (self.tracer) |tr| tr.note("context", if (spilled)
+            "capped an oversized tool output before send (full bytes kept as a session artifact)"
+        else
+            "capped an oversized tool output before send");
+        if (!main_mod.json_mode and !self.sub) {
+            if (spilled)
+                self.say("[tool output over this model's per-result cap — {d} bytes elided before send; the full output is in this session's artifacts and the model has the path (#409)]\n", .{capped}) catch {}
+            else
+                self.say("[tool output over this model's per-result cap — truncated {d} bytes before send (#193)]\n", .{capped}) catch {};
+        }
     }
     var context_retried = false; // #193: at most one in-turn overflow recovery per request
     // #56: bounded stream-stall / drop reconnect budget (codex's stream_max_retries

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -28,9 +28,15 @@ const run_budget_mod = @import("run_budget.zig");
 const wire_messages = @import("messages.zig");
 
 const policy = @import("agent_request_policy.zig");
+const overflow = @import("agent_overflow.zig");
 const errorCode = policy.errorCode;
 const isQuotaExceeded = policy.isQuotaExceeded;
-const recoverContextOverflow = policy.recoverContextOverflow;
+const recoverContextOverflow = overflow.recoverContextOverflow;
+// #414: an HTTP 200 that overflowed silently — the provider accepted an
+// over-window input and answered with nothing (z.ai), or truncated our input
+// to fit and had no room left to generate (MiMo). Neither shape produces an
+// error to keyword-match, so it is classified from the reported usage instead.
+const recoverBehavioralOverflow = overflow.recoverBehavioralOverflow;
 const retryAfterAuthRefresh = policy.retryAfterAuthRefresh;
 const retryTransientServerError = policy.retryTransientServerError;
 
@@ -334,6 +340,13 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
                 .ok => |obj| {
                     if (!self.compaction_request) self.compact_transport_failures = 0;
                     self.recordUsageResponses(obj, body.len);
+                    // #414: an empty output whose usage already fills the window
+                    // is an overflow the provider never reported. Re-anchor like
+                    // the error branch above: the recovery trims full history.
+                    if (recoverBehavioralOverflow(self, obj, &context_retried)) {
+                        self.closeCodexWs();
+                        continue :rebuild;
+                    }
                     if (self.tracer) |tr| tr.api(self.label, self.sub, self.provider.model, ms, body.len, resp_body.len, self.last_context_tokens, self.last_cache_read, false);
                     if (main_mod.json_mode and !self.sub) self.emit(.{ .type = "model_call_finished", .provider = self.provider.id, .model = self.provider.model, .ok = true, .ms = ms });
                     return obj;
@@ -403,6 +416,7 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
                     return error.ApiError;
                 };
                 self.recordUsage(root, body.len);
+                if (recoverBehavioralOverflow(self, root, &context_retried)) continue; // #414: silent overflow / upstream truncation → trim + retry
                 if (!self.compaction_request) self.compact_transport_failures = 0;
                 if (self.tracer) |tr| tr.api(self.label, self.sub, self.provider.model, ms, body.len, resp_body.len, self.last_context_tokens, self.last_cache_read, false);
                 if (main_mod.json_mode and !self.sub) self.emit(.{ .type = "model_call_finished", .provider = self.provider.id, .model = self.provider.model, .ok = true, .ms = ms });
@@ -466,6 +480,7 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
         }
 
         self.recordUsage(root, body.len);
+        if (recoverBehavioralOverflow(self, root, &context_retried)) continue; // #414: same, on the non-streamed body
         if (!self.compaction_request) self.compact_transport_failures = 0;
         if (self.tracer) |tr| tr.api(self.label, self.sub, self.provider.model, ms, body.len, resp_body.len, self.last_context_tokens, self.last_cache_read, false);
         if (main_mod.json_mode and !self.sub) self.emit(.{ .type = "model_call_finished", .provider = self.provider.id, .model = self.provider.model, .ok = true, .ms = ms });

--- a/src/agent_request_policy.zig
+++ b/src/agent_request_policy.zig
@@ -315,31 +315,15 @@ test "retryAfterAuthRefresh (#402): a different ChatGPT account is never adopted
     try std.testing.expectEqualStrings("other-tok", sibling.provider.api_key);
 }
 
-/// True if `msg` is a provider's "input is over the context window" rejection,
-/// across wire formats: codex/responses ("exceeds the context window"), openai
-/// ("maximum context length", "context_length_exceeded"), anthropic ("prompt is
-/// too long", "exceed context limit"). Drives the in-turn emergency-trim + retry
-/// recovery symmetrically for every provider (#193) — before it, only the codex
-/// path recovered and anthropic/openai died on an over-window turn.
-fn isContextOverflow(msg: []const u8, code: ?[]const u8) bool {
-    // #203: match the structured error code first (openai/codex parity — a local or
-    // non-English provider whose message text differs still recovers), then fall back
-    // to the human-readable phrasing.
-    if (code) |c| {
-        const codes = [_][]const u8{ "context_length_exceeded", "context_window_exceeded" };
-        for (codes) |k| if (std.mem.eql(u8, c, k)) return true;
-    }
-    const needles = [_][]const u8{
-        "context window", // codex/responses: "exceeds the context window"
-        "context length", // openai: "maximum context length is N tokens"
-        "context_length_exceeded", // openai error code echoed into the message
-        "context limit", // anthropic: "input length and max_tokens exceed context limit"
-        "prompt is too long", // anthropic: "prompt is too long: N tokens > M maximum"
-        "maximum context", // defensive: "maximum context ... exceeded"
-    };
-    for (needles) |n| if (std.mem.indexOf(u8, msg, n) != null) return true;
-    return false;
-}
+/// #414: overflow classification (which failures mean "the input is over the
+/// window", which only look like it, and the HTTP-200 shapes that never say so)
+/// moved to agent_overflow.zig — this file was at the 600-line cap and the new
+/// guard list plus behavioral detectors did not fit. Re-exported so existing
+/// call sites resolve, and the two tests below stay HERE deliberately: they are
+/// the contract the request loop depends on, and moving their names would read
+/// as deleted coverage in the behavioral eval harness.
+pub const isContextOverflow = @import("agent_overflow.zig").isContextOverflow;
+pub const recoverContextOverflow = @import("agent_overflow.zig").recoverContextOverflow;
 
 /// The structured error code from a parsed error envelope, if any: openai / lmstudio /
 /// deepseek put it at root.error.code; some providers use a top-level root.code (#203).
@@ -370,39 +354,6 @@ pub fn errorCode(root: std.json.ObjectMap) ?[]const u8 {
         }
     }
     return null;
-}
-
-/// #193 follow-up: shared in-turn context-overflow recovery for the three
-/// anthropic/openai error branches (streamed error event, non-streamed
-/// `{"type":"error"}` envelope, and the generic apiErrorMessage path). Before
-/// this, only the codex/.responses branch recovered — anthropic/openai died on an
-/// over-window turn. Returns true if the caller should `continue` the rebuild loop
-/// (emergency-trimmed, retry the same request once); false to fall through to the
-/// normal error. Pins the meter to the window FIRST so the between-turns
-/// compaction engages even when we can't recover here (the rejected request
-/// returns no usage to correct the lagging meter). Guarded by `retried` (one
-/// `context_retried` shared across every branch of a request) so a second overflow
-/// falls through and never loops. These wire formats send the full input each
-/// rebuild, so — unlike the codex branch — no closeCodexWs re-anchor is needed.
-pub fn recoverContextOverflow(self: *Agent, msg: []const u8, code: ?[]const u8, retried: *bool) bool {
-    if (!isContextOverflow(msg, code)) return false;
-    self.last_request_context_overflow = true;
-    // Rejection proves at least the advertised window, not an exact total.
-    // Preserve stronger server/local evidence already above that floor.
-    const estimate = self.contextEstimate();
-    self.last_context_tokens = @max(estimate.effective, self.provider.context);
-    self.context_local_tokens = estimate.local;
-    // compact() marks its synthetic summary request explicitly. Generic
-    // in-request recovery is destructive there: the synthetic compact
-    // instruction is the newest clean user turn, so emergencyTrim can discard
-    // the entire real conversation and retry with only "summarize it". Let the
-    // outer compactOrRecover policy handle a failed summary after compact()'s
-    // errdefer removes that synthetic instruction.
-    if (self.compaction_request) return false;
-    if (retried.* or self.emergencyTrim() == 0) return false;
-    retried.* = true;
-    if (self.tracer) |tr| tr.note("context", "input over the window — emergency-trimmed and retrying the turn");
-    return true;
 }
 
 const max_server_retries: usize = 3; // #opencode-parity: bounded retries for a transient in-stream server overload
@@ -477,25 +428,6 @@ test "isQuotaExceeded (#opencode-parity): billing cap detected, transient thrott
     try std.testing.expect(!isQuotaExceeded("429 too many requests"));
 }
 
-test "isContextOverflow (#193/#203): matches structured code + every provider's phrasing, not unrelated errors" {
-    // codex/responses, openai, anthropic wire-format rejections all recover in-turn
-    try std.testing.expect(isContextOverflow("Your input exceeds the context window of 272000 tokens", null));
-    try std.testing.expect(isContextOverflow("This model's maximum context length is 128000 tokens. However, you requested 130000", null));
-    try std.testing.expect(isContextOverflow("context_length_exceeded", null));
-    try std.testing.expect(isContextOverflow("prompt is too long: 219373 tokens > 200000 maximum", null));
-    try std.testing.expect(isContextOverflow("input length and max_tokens exceed context limit", null));
-    // #203: a structured error code recovers even when the message text is unfamiliar
-    // (a local / non-English provider whose phrasing we don't match on)
-    try std.testing.expect(isContextOverflow("de invoerlengte overschrijdt het venster", "context_length_exceeded"));
-    try std.testing.expect(isContextOverflow("", "context_window_exceeded"));
-    // unrelated API errors must NOT trigger a trim + retry, by message or by code
-    try std.testing.expect(!isContextOverflow("The API Key appears to be invalid or may have expired.", null));
-    try std.testing.expect(!isContextOverflow("tool_choice is not supported", null));
-    try std.testing.expect(!isContextOverflow("rate limit exceeded", null));
-    try std.testing.expect(!isContextOverflow("model not found", null));
-    try std.testing.expect(!isContextOverflow("some unrelated failure", "rate_limit_exceeded"));
-}
-
 test "errorCode (#203): pulls root.error.code (openai/lmstudio), falls back to root.code, else null" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -523,6 +455,28 @@ test "errorCode (#203): pulls root.error.code (openai/lmstudio), falls back to r
     var root4: std.json.ObjectMap = .empty;
     try root4.put(a, "response", .{ .object = responses_payload });
     try std.testing.expectEqualStrings("context_length_exceeded", errorCode(root4).?);
+}
+
+test "isContextOverflow (#193/#203): matches structured code + every provider's phrasing, not unrelated errors" {
+    // codex/responses, openai, anthropic wire-format rejections all recover in-turn
+    try std.testing.expect(isContextOverflow("Your input exceeds the context window of 272000 tokens", null));
+    try std.testing.expect(isContextOverflow("This model's maximum context length is 128000 tokens. However, you requested 130000", null));
+    try std.testing.expect(isContextOverflow("context_length_exceeded", null));
+    try std.testing.expect(isContextOverflow("prompt is too long: 219373 tokens > 200000 maximum", null));
+    try std.testing.expect(isContextOverflow("input length and max_tokens exceed context limit", null));
+    // #203: a structured error code recovers even when the message text is unfamiliar
+    // (a local / non-English provider whose phrasing we don't match on)
+    try std.testing.expect(isContextOverflow("de invoerlengte overschrijdt het venster", "context_length_exceeded"));
+    try std.testing.expect(isContextOverflow("", "context_window_exceeded"));
+    // unrelated API errors must NOT trigger a trim + retry, by message or by code
+    try std.testing.expect(!isContextOverflow("The API Key appears to be invalid or may have expired.", null));
+    try std.testing.expect(!isContextOverflow("tool_choice is not supported", null));
+    try std.testing.expect(!isContextOverflow("rate limit exceeded", null));
+    try std.testing.expect(!isContextOverflow("model not found", null));
+    try std.testing.expect(!isContextOverflow("some unrelated failure", "rate_limit_exceeded"));
+    // #414: the guard list is consulted FIRST — a throttle whose wording collides
+    // with the generic "too many tokens" fallback stays on the retry ladder.
+    try std.testing.expect(!isContextOverflow("ThrottlingException: Too many tokens, please wait before trying again.", null));
 }
 
 test "recoverContextOverflow (#193): overflow trims + retries once; guard and non-overflow fall through" {

--- a/src/agent_tool_render.zig
+++ b/src/agent_tool_render.zig
@@ -12,6 +12,11 @@
 //! - write errors are swallowed rather than propagated, because a sink's emit
 //!   path returns void. A caller that used to abort its batch on a broken
 //!   stdout now continues into the next failing write instead.
+//!
+//! WHO may announce a moment stays engine policy: the `!self.sub` gates on the
+//! batch tallies and the meta notices remain at their emit sites, so nothing
+//! here back-reads Agent policy to decide whether to draw. The only Agent
+//! reads below are drawing handles — the writer and the allocator.
 
 const std = @import("std");
 const Io = std.Io;
@@ -21,7 +26,7 @@ const agent_mod = @import("agent.zig");
 const Agent = agent_mod.Agent;
 const agent_output = @import("agent_output.zig");
 const sayText = agent_output.sayText;
-const util = @import("util.zig"); // tests only: repeatBytes for the arg-cap case
+const util = @import("util.zig"); // tests only: repeatBytes for the two cap cases
 
 const ansi = @import("ansi.zig");
 const style = &ansi.style;
@@ -92,14 +97,12 @@ pub fn toolResultLine(a: *Agent, r: ToolOutcome) void {
 const notice_buf_bytes: usize = 192;
 
 pub fn parallelBatchStarted(a: *Agent, count: usize) void {
-    if (a.sub) return; // a child's fan-out is the root's line to draw, not its own
     var buf: [notice_buf_bytes]u8 = undefined;
     const line = std.fmt.bufPrint(&buf, "  {s}↯ running {d} tools in parallel{s}\n", .{ style.dim, count, style.reset }) catch return;
     sayText(a, line);
 }
 
 pub fn parallelBatchFinished(a: *Agent, o: BatchOutcome) void {
-    if (a.sub) return;
     var buf: [notice_buf_bytes]u8 = undefined;
     const line = std.fmt.bufPrint(&buf, "  {s}↯ parallel tools finished: {d} completed, {d} failed, {d} cancelled{s}\n", .{ style.dim, o.done, o.failed, o.cancelled, style.reset }) catch return;
     sayText(a, line);
@@ -108,7 +111,6 @@ pub fn parallelBatchFinished(a: *Agent, o: BatchOutcome) void {
 /// #318: the checklist isn't settled, so the completion parks. The escapes are
 /// the literal bytes the old call site spelled out (⏸, 🎯 below).
 pub fn completionDeferred(a: *Agent) void {
-    if (a.sub) return;
     sayText(a, "\xe2\x8f\xb8 completion deferred \xe2\x80\x94 the standing goal's checklist isn't settled\n");
 }
 
@@ -118,7 +120,6 @@ pub fn goalCompleted(a: *Agent) void {
 
 /// A meta tool's own user-facing text, one line, exactly as it came.
 pub fn toolTextLine(a: *Agent, text: []const u8) void {
-    if (a.sub) return;
     var line: Io.Writer.Allocating = .init(a.gpa);
     defer line.deinit();
     line.writer.print("{s}\n", .{text}) catch return;
@@ -169,7 +170,9 @@ test "the ⚙ line reproduces the old inline announcement, cap and ellipsis incl
     const line = aw.writer.buffered();
     try std.testing.expect(std.mem.startsWith(u8, line, "⚙ codedb {\"q\":\"xxx"));
     try std.testing.expect(std.mem.endsWith(u8, line, "…\n"));
-    try std.testing.expectEqual(arg_preview_bytes, line.len - "⚙ codedb ".len - "…\n".len);
+    // The literal, not arg_preview_bytes: this asserts the conversion kept the
+    // pre-#422 inline cap, and asserting the constant against itself would not.
+    try std.testing.expectEqual(@as(usize, 160), line.len - "⚙ codedb ".len - "…\n".len);
 }
 
 test "the result line marks success, failure and cancellation and previews one line" {
@@ -198,6 +201,15 @@ test "the result line marks success, failure and cancellation and previews one l
     aw.clearRetainingCapacity();
     toolResultLine(&a, .{ .name = "todo_write", .text = "todos", .is_error = false, .meta = true });
     try std.testing.expectEqualStrings("", aw.writer.buffered());
+
+    // Over the cap: exactly 100 bytes of the first line, then the ellipsis —
+    // the literal the pre-#422 inline path spelled out, not result_preview_bytes.
+    aw.clearRetainingCapacity();
+    const long = util.repeatBytes("z", 250);
+    toolResultLine(&a, .{ .name = "bash", .text = &long, .is_error = false });
+    const rline = aw.writer.buffered();
+    try std.testing.expect(std.mem.endsWith(u8, rline, "…\n"));
+    try std.testing.expectEqual(@as(usize, 100), rline.len - "  ✓ ".len - "…\n".len);
 
     // --timing adds the measured duration between the mark and the preview.
     aw.clearRetainingCapacity();
@@ -236,12 +248,8 @@ test "batch tallies and meta notices render the old wording verbatim" {
     toolTextLine(&a, "completion recorded");
     try std.testing.expectEqualStrings("completion recorded\n", aw.writer.buffered());
 
-    // A subagent announces none of the root's batch/goal lines.
-    aw.clearRetainingCapacity();
-    a.sub = true;
-    parallelBatchStarted(&a, 3);
-    parallelBatchFinished(&a, .{ .done = 1, .failed = 0, .cancelled = 0 });
-    completionDeferred(&a);
-    toolTextLine(&a, "x");
-    try std.testing.expectEqualStrings("", aw.writer.buffered());
+    // Who may announce these is engine policy, not a drawing decision: the
+    // `!self.sub` gates live at the emit sites (agent_tools.runTools /
+    // handleMeta), so a subagent never produces the moment at all and this
+    // file needs no read into the Agent to suppress it.
 }

--- a/src/agent_tool_render.zig
+++ b/src/agent_tool_render.zig
@@ -1,0 +1,247 @@
+//! TuiSink's half of the tool-execution cluster (#422 slice 1c): the terminal
+//! rendering for the tool events engine_events.zig defines — the ⚙ call line,
+//! the compact ✓/✗/⊘ result line, the parallel-batch tallies, and the
+//! meta-tool notices. Frontend territory, like agent_stream_render.zig: this
+//! is the ONLY file in the tool cluster that reaches the terminal palette, and
+//! engine_sink.zig is its only caller.
+//!
+//! Every function here is the old inline agent_tools.zig code path, gate for
+//! gate and byte for byte, with two deliberate mechanical differences:
+//! - text is rendered whole and handed to agent_output.sayText, which is
+//!   say()'s runtime-string sibling (same routing, same worker-line framing);
+//! - write errors are swallowed rather than propagated, because a sink's emit
+//!   path returns void. A caller that used to abort its batch on a broken
+//!   stdout now continues into the next failing write instead.
+
+const std = @import("std");
+const Io = std.Io;
+
+const main_mod = @import("main.zig");
+const agent_mod = @import("agent.zig");
+const Agent = agent_mod.Agent;
+const agent_output = @import("agent_output.zig");
+const sayText = agent_output.sayText;
+const util = @import("util.zig"); // tests only: repeatBytes for the arg-cap case
+
+const ansi = @import("ansi.zig");
+const style = &ansi.style;
+
+const engine_events = @import("engine_events.zig");
+const ToolInvocation = engine_events.ToolInvocation;
+const ToolOutcome = engine_events.ToolOutcome;
+const BatchOutcome = engine_events.BatchOutcome;
+
+/// How much of a call's JSON arguments the ⚙ line shows. A byte cap, not a
+/// character one: the cut may split a UTF-8 sequence, exactly as before.
+const arg_preview_bytes: usize = 160;
+/// How much of a result's first line the ✓ line shows.
+const result_preview_bytes: usize = 100;
+
+/// The ⚙ announcement line. Suppressed when the call's prose already streamed
+/// live out of its arguments — the line would just repeat what was read.
+pub fn toolUseLine(a: *Agent, t: ToolInvocation) void {
+    if (t.arg_streamed) return;
+    var args: Io.Writer.Allocating = .init(a.gpa);
+    defer args.deinit();
+    var s: std.json.Stringify = .{ .writer = &args.writer };
+    s.write(t.input) catch return;
+    const full = args.writer.buffered();
+    const shown = if (full.len > arg_preview_bytes) full[0..arg_preview_bytes] else full;
+    var line: Io.Writer.Allocating = .init(a.gpa);
+    defer line.deinit();
+    line.writer.print("{s}⚙{s} {s}{s} {s}{s}{s}{s}\n", .{
+        style.dim,   style.reset, style.accent, t.name,
+        style.dim,   shown,
+        if (full.len > arg_preview_bytes) "…" else "",
+        style.reset,
+    }) catch return;
+    sayText(a, line.writer.buffered());
+}
+
+/// Compact result feedback for one finished tool call: a green ✓ / red ✗ /
+/// yellow ⊘ and a one-line preview of what it returned. Root only (subagents
+/// have no writer); meta tools render their own UX, so skip them. This one
+/// writes straight to the writer — it never ended a tick-gate row.
+pub fn toolResultLine(a: *Agent, r: ToolOutcome) void {
+    const w = a.out orelse return;
+    if (r.meta) return;
+    const all = std.mem.trim(u8, r.text, " \t\r\n");
+    var preview = all;
+    if (std.mem.indexOfScalar(u8, preview, '\n')) |nl| preview = preview[0..nl];
+    preview = std.mem.trim(u8, preview, " \t\r");
+    const shown = if (preview.len > result_preview_bytes) preview[0..result_preview_bytes] else preview;
+    const truncated = shown.len < all.len; // more content (extra lines or >100 chars)
+    const mark = if (r.cancelled) "⊘" else if (r.is_error) "✗" else "✓";
+    const mc = if (r.cancelled) style.yellow else if (r.is_error) style.red else style.green;
+    var tbuf: [24]u8 = undefined;
+    const timing = if (main_mod.show_timing and r.ms > 0)
+        (std.fmt.bufPrint(&tbuf, " ({d}ms)", .{r.ms}) catch "")
+    else
+        "";
+    w.print("  {s}{s}{s}{s}{s}{s} {s}{s}{s}{s}\n", .{
+        mc,          mark,  style.reset, style.dim, timing, style.reset,
+        style.dim,   shown,
+        if (truncated) "…" else "",
+        style.reset,
+    }) catch return;
+    w.flush() catch return;
+}
+
+// The batch tallies fit a fixed slot with room to spare: the widest line is
+// three usize decimals plus ~50 bytes of wording and two short style runs.
+const notice_buf_bytes: usize = 192;
+
+pub fn parallelBatchStarted(a: *Agent, count: usize) void {
+    if (a.sub) return; // a child's fan-out is the root's line to draw, not its own
+    var buf: [notice_buf_bytes]u8 = undefined;
+    const line = std.fmt.bufPrint(&buf, "  {s}↯ running {d} tools in parallel{s}\n", .{ style.dim, count, style.reset }) catch return;
+    sayText(a, line);
+}
+
+pub fn parallelBatchFinished(a: *Agent, o: BatchOutcome) void {
+    if (a.sub) return;
+    var buf: [notice_buf_bytes]u8 = undefined;
+    const line = std.fmt.bufPrint(&buf, "  {s}↯ parallel tools finished: {d} completed, {d} failed, {d} cancelled{s}\n", .{ style.dim, o.done, o.failed, o.cancelled, style.reset }) catch return;
+    sayText(a, line);
+}
+
+/// #318: the checklist isn't settled, so the completion parks. The escapes are
+/// the literal bytes the old call site spelled out (⏸, 🎯 below).
+pub fn completionDeferred(a: *Agent) void {
+    if (a.sub) return;
+    sayText(a, "\xe2\x8f\xb8 completion deferred \xe2\x80\x94 the standing goal's checklist isn't settled\n");
+}
+
+pub fn goalCompleted(a: *Agent) void {
+    sayText(a, "\xf0\x9f\x8e\xaf standing goal complete\n");
+}
+
+/// A meta tool's own user-facing text, one line, exactly as it came.
+pub fn toolTextLine(a: *Agent, text: []const u8) void {
+    if (a.sub) return;
+    var line: Io.Writer.Allocating = .init(a.gpa);
+    defer line.deinit();
+    line.writer.print("{s}\n", .{text}) catch return;
+    sayText(a, line.writer.buffered());
+}
+
+fn testAgent(w: *Io.Writer) Agent {
+    return .{
+        .gpa = std.testing.allocator,
+        .arena = std.testing.allocator,
+        .io = undefined,
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = w,
+    };
+}
+
+test "the ⚙ line reproduces the old inline announcement, cap and ellipsis included" {
+    const saved = ansi.style;
+    ansi.style = .{}; // no color: assert the text, not the palette
+    defer ansi.style = saved;
+    const saved_json = main_mod.json_mode; // sayText's root gate reads it
+    main_mod.json_mode = false;
+    defer main_mod.json_mode = saved_json;
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    var a = testAgent(&aw.writer);
+
+    const input = try std.json.parseFromSliceLeaky(std.json.Value, arena_state.allocator(), "{\"path\":\"fixture.txt\"}", .{});
+    toolUseLine(&a, .{ .name = "read_file", .input = input });
+    try std.testing.expectEqualStrings("⚙ read_file {\"path\":\"fixture.txt\"}\n", aw.writer.buffered());
+
+    // Prose that already streamed live is not announced a second time.
+    aw.clearRetainingCapacity();
+    toolUseLine(&a, .{ .name = "attempt_completion", .input = input, .arg_streamed = true });
+    try std.testing.expectEqualStrings("", aw.writer.buffered());
+
+    // Over the cap: exactly arg_preview_bytes of JSON, then the ellipsis.
+    aw.clearRetainingCapacity();
+    const long = try std.fmt.allocPrint(arena_state.allocator(), "{{\"q\":\"{s}\"}}", .{&util.repeatBytes("x", 400)});
+    const long_input = try std.json.parseFromSliceLeaky(std.json.Value, arena_state.allocator(), long, .{});
+    toolUseLine(&a, .{ .name = "codedb", .input = long_input });
+    const line = aw.writer.buffered();
+    try std.testing.expect(std.mem.startsWith(u8, line, "⚙ codedb {\"q\":\"xxx"));
+    try std.testing.expect(std.mem.endsWith(u8, line, "…\n"));
+    try std.testing.expectEqual(arg_preview_bytes, line.len - "⚙ codedb ".len - "…\n".len);
+}
+
+test "the result line marks success, failure and cancellation and previews one line" {
+    const saved = ansi.style;
+    ansi.style = .{};
+    defer ansi.style = saved;
+    const saved_timing = main_mod.show_timing;
+    main_mod.show_timing = false;
+    defer main_mod.show_timing = saved_timing;
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    var a = testAgent(&aw.writer);
+
+    toolResultLine(&a, .{ .name = "read_file", .text = "line one\nline two\n", .is_error = false });
+    try std.testing.expectEqualStrings("  ✓ line one…\n", aw.writer.buffered());
+
+    aw.clearRetainingCapacity();
+    toolResultLine(&a, .{ .name = "bash", .text = "boom", .is_error = true });
+    try std.testing.expectEqualStrings("  ✗ boom\n", aw.writer.buffered());
+
+    aw.clearRetainingCapacity();
+    toolResultLine(&a, .{ .name = "bash", .text = "stopped", .is_error = true, .cancelled = true });
+    try std.testing.expectEqualStrings("  ⊘ stopped\n", aw.writer.buffered());
+
+    // Meta tools draw their own UX; the ✓ line stays out of their way.
+    aw.clearRetainingCapacity();
+    toolResultLine(&a, .{ .name = "todo_write", .text = "todos", .is_error = false, .meta = true });
+    try std.testing.expectEqualStrings("", aw.writer.buffered());
+
+    // --timing adds the measured duration between the mark and the preview.
+    aw.clearRetainingCapacity();
+    main_mod.show_timing = true;
+    toolResultLine(&a, .{ .name = "bash", .text = "ok", .is_error = false, .ms = 42 });
+    try std.testing.expectEqualStrings("  ✓ (42ms) ok\n", aw.writer.buffered());
+}
+
+test "batch tallies and meta notices render the old wording verbatim" {
+    const saved = ansi.style;
+    ansi.style = .{};
+    defer ansi.style = saved;
+    const saved_json = main_mod.json_mode; // sayText's root gate reads it
+    main_mod.json_mode = false;
+    defer main_mod.json_mode = saved_json;
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    var a = testAgent(&aw.writer);
+
+    parallelBatchStarted(&a, 3);
+    try std.testing.expectEqualStrings("  ↯ running 3 tools in parallel\n", aw.writer.buffered());
+
+    aw.clearRetainingCapacity();
+    parallelBatchFinished(&a, .{ .done = 2, .failed = 1, .cancelled = 0 });
+    try std.testing.expectEqualStrings("  ↯ parallel tools finished: 2 completed, 1 failed, 0 cancelled\n", aw.writer.buffered());
+
+    aw.clearRetainingCapacity();
+    completionDeferred(&a);
+    try std.testing.expectEqualStrings("⏸ completion deferred — the standing goal's checklist isn't settled\n", aw.writer.buffered());
+
+    aw.clearRetainingCapacity();
+    goalCompleted(&a);
+    try std.testing.expectEqualStrings("🎯 standing goal complete\n", aw.writer.buffered());
+
+    aw.clearRetainingCapacity();
+    toolTextLine(&a, "completion recorded");
+    try std.testing.expectEqualStrings("completion recorded\n", aw.writer.buffered());
+
+    // A subagent announces none of the root's batch/goal lines.
+    aw.clearRetainingCapacity();
+    a.sub = true;
+    parallelBatchStarted(&a, 3);
+    parallelBatchFinished(&a, .{ .done = 1, .failed = 0, .cancelled = 0 });
+    completionDeferred(&a);
+    toolTextLine(&a, "x");
+    try std.testing.expectEqualStrings("", aw.writer.buffered());
+}

--- a/src/agent_tools.zig
+++ b/src/agent_tools.zig
@@ -21,8 +21,12 @@ const AnswerRequest = tools_mod.AnswerRequest;
 const answerParseError = tools_mod.answerParseError;
 const parseAnswerRequest = tools_mod.parseAnswerRequest;
 
-const ansi = @import("ansi.zig");
-const style = &ansi.style;
+// #422 slice 1c: every emission here leaves as a typed event; the terminal
+// palette lives in agent_tool_render.zig, behind the sink. `term.zig` stays
+// because raw/nonblocking stdin for the Esc watcher below is frontend INPUT,
+// which belongs to the input-inversion issue (#430), not to this one.
+const engine_events = @import("engine_events.zig");
+const engine_sink = @import("engine_sink.zig");
 
 const terminal = @import("term.zig");
 const tty = terminal.tty;
@@ -128,8 +132,8 @@ pub fn runTools(self: *Agent, calls: []const ToolCall) ![]ExecResult {
     }
 
     if (ext_idx.items.len > 0) {
-        if (ext_idx.items.len > 1 and !self.sub) {
-            try self.say("  {s}↯ running {d} tools in parallel{s}\n", .{ style.dim, ext_idx.items.len, style.reset });
+        if (ext_idx.items.len > 1) {
+            engine_sink.forAgent(self).emit(self.io, .{ .parallel_batch_started = .{ .count = ext_idx.items.len } });
         }
         const ctx: ToolCtx = .{
             .gpa = self.gpa,
@@ -189,15 +193,13 @@ pub fn runTools(self: *Agent, calls: []const ToolCall) ![]ExecResult {
         brief_diversity.noteSiblingBatch(self.arena, self.tracer, calls, ext_idx.items, results); // #382
         // #266: a cancelled parallel batch used to just look "running" and then
         // failed — one terminal line says what completed, failed, and cancelled.
-        if (ext_idx.items.len > 1 and !self.sub) {
-            var done: usize = 0;
-            var failed: usize = 0;
-            var cancelled: usize = 0;
+        if (ext_idx.items.len > 1) {
+            var tally: engine_events.BatchOutcome = .{ .done = 0, .failed = 0, .cancelled = 0 };
             for (ext_idx.items) |i| {
                 const r = results[i];
-                if (r.cancelled) cancelled += 1 else if (r.is_error) failed += 1 else done += 1;
+                if (r.cancelled) tally.cancelled += 1 else if (r.is_error) tally.failed += 1 else tally.done += 1;
             }
-            try self.say("  {s}↯ parallel tools finished: {d} completed, {d} failed, {d} cancelled{s}\n", .{ style.dim, done, failed, cancelled, style.reset });
+            engine_sink.forAgent(self).emit(self.io, .{ .parallel_batch_finished = tally });
         }
     }
     // Show a compact ✓/✗ + preview for each non-meta call (no-op for subs).
@@ -257,9 +259,16 @@ pub fn toolDedupeKey(self: *Agent, call: ToolCall) ![]const u8 {
     return key;
 }
 
+/// A refusal that happened before the tool ran. The terminal has never drawn
+/// one (the user learns of it through the model's next answer), so only a
+/// wire sink gives this moment a shape.
 pub fn emitToolRejected(self: *Agent, call: ToolCall, reason: []const u8, message: []const u8) void {
-    if (!main_mod.json_mode) return;
-    self.emit(.{ .type = "tool_rejected", .name = call.name, .reason = reason, .input = call.input, .message = message });
+    engine_sink.forAgent(self).emit(self.io, .{ .tool_rejected = .{
+        .name = call.name,
+        .input = call.input,
+        .reason = reason,
+        .message = message,
+    } });
 }
 
 /// #225: clock_sleep meta tool — root-only, feature-flagged (main.zig
@@ -306,7 +315,7 @@ pub fn handleMeta(self: *Agent, call: ToolCall) !ExecResult {
         }
         if (try goal_state.completionGate(self.arena, self)) |refusal| {
             goal_state.noteCompletionRefused(self); // arm the double-check (across turns) and mark the turn as worked (#318)
-            if (!self.sub) try self.say("\xe2\x8f\xb8 completion deferred \xe2\x80\x94 the standing goal's checklist isn't settled\n", .{});
+            engine_sink.forAgent(self).emit(self.io, .completion_deferred);
             return .{ .text = refusal, .is_error = true };
         }
         const result = if (tools_mod.json_args.object(call.input)) |o| (tools_mod.json_args.str(o, "result") orelse "") else "";
@@ -315,12 +324,12 @@ pub fn handleMeta(self: *Agent, call: ToolCall) !ExecResult {
         // A --goal standing objective is exempt: the completion is recorded above, the steering stays, and only /goal clear|pause|<new> retires it.
         if (goal_state.retireOnCompletion(self, util.unixMs(self.io))) {
             if (self.tracer) |t| t.note("goal", "completed via attempt_completion");
-            try self.say("\xf0\x9f\x8e\xaf standing goal complete\n", .{});
+            engine_sink.forAgent(self).emit(self.io, .goal_completed);
         } else if (goal_state.goalActive(self)) {
             if (self.tracer) |t| t.note("goal", "completion; standing goal retained");
         }
         // Skip the re-print only when the result streamed live in full.
-        if (!self.sub and !self.argStreamedFully(call)) try self.say("{s}\n", .{result});
+        if (!self.argStreamedFully(call)) engine_sink.forAgent(self).emit(self.io, .{ .completion_text = .{ .text = result } });
         return .{ .text = "completion recorded", .is_error = false };
     }
     if (std.mem.eql(u8, call.name, "eval")) {
@@ -331,7 +340,7 @@ pub fn handleMeta(self: *Agent, call: ToolCall) !ExecResult {
         // Epoch-scoped replace, keeping omitted completed items; a write with
         // no usable items is rejected untouched (#318). goal_todo owns the rule.
         const r = try goal_todo.applyTodoWrite(self, if (tools_mod.json_args.object(call.input)) |o| o.get("todos") else null);
-        if (!self.sub and !r.rejected) try self.say("{s}\n", .{r.text});
+        if (!r.rejected) engine_sink.forAgent(self).emit(self.io, .{ .todo_list_updated = .{ .text = r.text } });
         return .{ .text = r.text, .is_error = r.rejected };
     }
     if (std.mem.eql(u8, call.name, "clock_sleep")) {
@@ -424,61 +433,42 @@ pub fn emitAskUser(self: *Agent, call_id: []const u8, question: []const u8, inpu
     try w.flush();
 }
 
+/// The call's announcement moment, as one pair of events: the bracket a
+/// --json supervisor times against, and the ⚙ line the terminal draws for the
+/// first of the two. Which of them a frontend surfaces (the wire skips
+/// ask_user, the terminal skips prose that already streamed) is the sink's
+/// call — engine_events.durable() decides the wire half so no sequence id is
+/// ever reserved for a line the wire drops.
 pub fn sayToolUse(self: *Agent, call: ToolCall) !void {
-    if (main_mod.json_mode) {
-        if (std.mem.eql(u8, call.name, "ask_user")) return;
-        self.emit(.{ .type = "tool_call", .name = call.name, .input = call.input });
-        self.emit(.{ .type = "tool_call_started", .name = call.name, .input = call.input });
-        return;
-    }
-    // The ⚙ line would just repeat prose that already streamed live.
-    if (self.argStreamedFully(call)) return;
-    var aw: Io.Writer.Allocating = .init(self.gpa);
-    defer aw.deinit();
-    var s: std.json.Stringify = .{ .writer = &aw.writer };
-    try s.write(call.input);
-    const full = aw.writer.buffered();
-    const shown = if (full.len > 160) full[0..160] else full;
-    try self.say("{s}⚙{s} {s}{s} {s}{s}{s}{s}\n", .{
-        style.dim,   style.reset, style.accent, call.name,
-        style.dim,   shown,
-        if (full.len > 160) "…" else "",
-        style.reset,
-    });
+    const ev: engine_events.ToolInvocation = .{
+        .name = call.name,
+        .input = call.input,
+        .ask_user = std.mem.eql(u8, call.name, "ask_user"),
+        .arg_streamed = self.argStreamedFully(call),
+    };
+    const sink = engine_sink.forAgent(self);
+    sink.emit(self.io, .{ .tool_call_announced = ev });
+    sink.emit(self.io, .{ .tool_call_started = ev });
 }
 
-/// Compact result feedback for one finished tool call: a green ✓ / red ✗
-/// and a one-line preview of what it returned. Root only (subagents have
-/// no writer); meta tools render their own UX, so skip them.
+/// The same bracket, closing: the result a frontend shows and the finish
+/// event carrying its outcome and duration. Meta tools render their own UX,
+/// so both sinks drop them (ask_user excepted on the wire, where the typed
+/// reply IS the result).
 pub fn sayToolResult(self: *Agent, name: []const u8, r: ExecResult) void {
-    const w = self.out orelse return;
-    if (main_mod.json_mode) {
-        if (isMetaName(name) and !std.mem.eql(u8, name, "ask_user")) return;
-        self.emit(.{ .type = "tool_result", .name = name, .is_error = r.is_error, .text = r.text });
-        self.emit(.{ .type = "tool_call_finished", .name = name, .is_error = r.is_error, .ms = r.ms });
-        return;
-    }
-    if (isMetaName(name)) return;
-    const all = std.mem.trim(u8, r.text, " \t\r\n");
-    var preview = all;
-    if (std.mem.indexOfScalar(u8, preview, '\n')) |nl| preview = preview[0..nl];
-    preview = std.mem.trim(u8, preview, " \t\r");
-    const shown = if (preview.len > 100) preview[0..100] else preview;
-    const truncated = shown.len < all.len; // more content (extra lines or >100 chars)
-    const mark = if (r.cancelled) "⊘" else if (r.is_error) "✗" else "✓";
-    const mc = if (r.cancelled) style.yellow else if (r.is_error) style.red else style.green;
-    var tbuf: [24]u8 = undefined;
-    const timing = if (main_mod.show_timing and r.ms > 0)
-        (std.fmt.bufPrint(&tbuf, " ({d}ms)", .{r.ms}) catch "")
-    else
-        "";
-    w.print("  {s}{s}{s}{s}{s}{s} {s}{s}{s}{s}\n", .{
-        mc,          mark,  style.reset, style.dim, timing, style.reset,
-        style.dim,   shown,
-        if (truncated) "…" else "",
-        style.reset,
-    }) catch return;
-    w.flush() catch return;
+    if (self.out == null) return; // no frontend attached: nothing to tell, as ever
+    const ev: engine_events.ToolOutcome = .{
+        .name = name,
+        .text = r.text,
+        .is_error = r.is_error,
+        .cancelled = r.cancelled,
+        .ms = r.ms,
+        .meta = isMetaName(name),
+        .ask_user = std.mem.eql(u8, name, "ask_user"),
+    };
+    const sink = engine_sink.forAgent(self);
+    sink.emit(self.io, .{ .tool_result = ev });
+    sink.emit(self.io, .{ .tool_call_finished = ev });
 }
 
 test "parseClockSleepMs: valid ms passes through, missing/negative/non-integer reject, over-cap clamps (#225)" {

--- a/src/agent_tools.zig
+++ b/src/agent_tools.zig
@@ -132,7 +132,11 @@ pub fn runTools(self: *Agent, calls: []const ToolCall) ![]ExecResult {
     }
 
     if (ext_idx.items.len > 0) {
-        if (ext_idx.items.len > 1) {
+        // A child's fan-out is the root's to announce, so the moment is not
+        // produced at all for a subagent: engine policy about who owns the
+        // terminal, kept at the emit site rather than re-derived by a sink
+        // that would need to back-read the Agent to know (#422 slice-1 rule).
+        if (ext_idx.items.len > 1 and !self.sub) {
             engine_sink.forAgent(self).emit(self.io, .{ .parallel_batch_started = .{ .count = ext_idx.items.len } });
         }
         const ctx: ToolCtx = .{
@@ -193,7 +197,7 @@ pub fn runTools(self: *Agent, calls: []const ToolCall) ![]ExecResult {
         brief_diversity.noteSiblingBatch(self.arena, self.tracer, calls, ext_idx.items, results); // #382
         // #266: a cancelled parallel batch used to just look "running" and then
         // failed — one terminal line says what completed, failed, and cancelled.
-        if (ext_idx.items.len > 1) {
+        if (ext_idx.items.len > 1 and !self.sub) { // root's line to draw, as above
             var tally: engine_events.BatchOutcome = .{ .done = 0, .failed = 0, .cancelled = 0 };
             for (ext_idx.items) |i| {
                 const r = results[i];
@@ -315,7 +319,7 @@ pub fn handleMeta(self: *Agent, call: ToolCall) !ExecResult {
         }
         if (try goal_state.completionGate(self.arena, self)) |refusal| {
             goal_state.noteCompletionRefused(self); // arm the double-check (across turns) and mark the turn as worked (#318)
-            engine_sink.forAgent(self).emit(self.io, .completion_deferred);
+            if (!self.sub) engine_sink.forAgent(self).emit(self.io, .completion_deferred); // root-only notice, as ever
             return .{ .text = refusal, .is_error = true };
         }
         const result = if (tools_mod.json_args.object(call.input)) |o| (tools_mod.json_args.str(o, "result") orelse "") else "";
@@ -329,7 +333,7 @@ pub fn handleMeta(self: *Agent, call: ToolCall) !ExecResult {
             if (self.tracer) |t| t.note("goal", "completion; standing goal retained");
         }
         // Skip the re-print only when the result streamed live in full.
-        if (!self.argStreamedFully(call)) engine_sink.forAgent(self).emit(self.io, .{ .completion_text = .{ .text = result } });
+        if (!self.sub and !self.argStreamedFully(call)) engine_sink.forAgent(self).emit(self.io, .{ .completion_text = .{ .text = result } });
         return .{ .text = "completion recorded", .is_error = false };
     }
     if (std.mem.eql(u8, call.name, "eval")) {
@@ -340,7 +344,7 @@ pub fn handleMeta(self: *Agent, call: ToolCall) !ExecResult {
         // Epoch-scoped replace, keeping omitted completed items; a write with
         // no usable items is rejected untouched (#318). goal_todo owns the rule.
         const r = try goal_todo.applyTodoWrite(self, if (tools_mod.json_args.object(call.input)) |o| o.get("todos") else null);
-        if (!r.rejected) engine_sink.forAgent(self).emit(self.io, .{ .todo_list_updated = .{ .text = r.text } });
+        if (!self.sub and !r.rejected) engine_sink.forAgent(self).emit(self.io, .{ .todo_list_updated = .{ .text = r.text } });
         return .{ .text = r.text, .is_error = r.rejected };
     }
     if (std.mem.eql(u8, call.name, "clock_sleep")) {
@@ -437,8 +441,9 @@ pub fn emitAskUser(self: *Agent, call_id: []const u8, question: []const u8, inpu
 /// --json supervisor times against, and the ⚙ line the terminal draws for the
 /// first of the two. Which of them a frontend surfaces (the wire skips
 /// ask_user, the terminal skips prose that already streamed) is the sink's
-/// call — engine_events.durable() decides the wire half so no sequence id is
-/// ever reserved for a line the wire drops.
+/// call — engine_events.durable() decides the wire half, and jsonSink is
+/// non-durable for an agent with no writer, so no sequence id is ever
+/// reserved for a line the wire drops (#330).
 pub fn sayToolUse(self: *Agent, call: ToolCall) !void {
     const ev: engine_events.ToolInvocation = .{
         .name = call.name,

--- a/src/engine_events.zig
+++ b/src/engine_events.zig
@@ -59,6 +59,50 @@ pub const TransportAbort = struct {
     turn_ending: bool,
 };
 
+/// One tool call as the engine hands it to a frontend (#422 slice 1c).
+/// `ask_user` is called out on its own because a --json client learns of
+/// that moment through its own `ask_user` event, never as a tool-call pair.
+/// `arg_streamed` says the call's prose already streamed out of its
+/// still-in-flight arguments (agent_argstream.zig), so an announcement line
+/// would repeat what the reader just watched arrive.
+pub const ToolInvocation = struct {
+    name: []const u8,
+    input: std.json.Value,
+    ask_user: bool = false,
+    arg_streamed: bool = false,
+};
+
+/// One finished tool call. `text` is the model-facing result the engine
+/// already capped and previewed; `ms` is its measured wall clock. `meta`
+/// marks a meta tool (schema.isMetaName) — those own their UX and, except
+/// for ask_user, never carried a result on the wire.
+pub const ToolOutcome = struct {
+    name: []const u8,
+    text: []const u8,
+    is_error: bool,
+    cancelled: bool = false,
+    ms: i64 = 0,
+    meta: bool = false,
+    ask_user: bool = false,
+};
+
+/// A tool call the harness refused before it ran: the verifier boundary, a
+/// stale eval, the --max-tool-calls budget, the dedupe rule, or review mode.
+pub const ToolRejection = struct {
+    name: []const u8,
+    input: std.json.Value,
+    reason: []const u8,
+    message: []const u8,
+};
+
+/// How a parallel tool batch ended (#266): the tallies, not a rendered line.
+pub const BatchOutcome = struct { done: usize, failed: usize, cancelled: usize };
+
+/// Text whose layout belongs to the meta tool that produced it (a completion
+/// answer, a rendered todo list) — carried whole because the structure lives
+/// in that tool's own module, not in this vocabulary.
+pub const ToolText = struct { text: []const u8 };
+
 /// Everything the streaming path tells a frontend. Each doc comment states
 /// the emission site's contract, not how any one sink draws it.
 pub const EngineEvent = union(enum) {
@@ -106,14 +150,63 @@ pub const EngineEvent = union(enum) {
     /// tear down live-stream presentation (spinner, an open reasoning-only
     /// Thinking block).
     stream_finished,
+
+    // ── The tool-execution cluster (slice 1c) ────────────────────────────
+    /// A tool call cleared the gates and is about to run. Wire: the existing
+    /// `tool_call` event. TUI: the ⚙ announcement line.
+    tool_call_announced: ToolInvocation,
+    /// The same call, now dispatched — the bracket a supervisor times against.
+    /// Wire: the existing `tool_call_started` event. TUI: nothing (the ⚙ line
+    /// already said it).
+    tool_call_started: ToolInvocation,
+    /// A tool call returned. Wire: the existing `tool_result` event. TUI: the
+    /// compact ✓/✗/⊘ line with a one-line preview.
+    tool_result: ToolOutcome,
+    /// The same call's closing bracket, carrying the outcome and duration
+    /// rather than the text. Wire: `tool_call_finished`. TUI: nothing.
+    tool_call_finished: ToolOutcome,
+    /// A tool call the harness refused before running it. Wire: the existing
+    /// `tool_rejected` event; the TUI has never drawn one (the refusal reaches
+    /// the user as the model's next answer).
+    tool_rejected: ToolRejection,
+    /// A batch of external tool calls is fanning out across the pool.
+    /// Presentation-only: the wire brackets each call individually.
+    parallel_batch_started: struct { count: usize },
+    /// That batch is joined; the payload is the tally (#266 — a cancelled
+    /// batch used to just look "running" and then fail).
+    parallel_batch_finished: BatchOutcome,
+    /// attempt_completion was refused because the standing goal's checklist
+    /// is not settled (#318). Presentation-only; the model gets the refusal
+    /// as its tool result.
+    completion_deferred,
+    /// A standing --goal was retired by an accepted attempt_completion.
+    goal_completed,
+    /// The answer attempt_completion carried, surfaced because it did NOT
+    /// stream live out of the call's arguments.
+    completion_text: ToolText,
+    /// todo_write applied; the payload is the list as goal_todo rendered it.
+    todo_list_updated: ToolText,
 };
 
 /// Durable events are the protocol stream: what the --json wire emits today
 /// and what a future event log persists. Only they reserve sequence ids —
 /// presentation pulses must not open gaps in the wire's numbering.
+///
+/// This reads the PAYLOAD, not just the tag, and it has to: whether a tool
+/// moment reaches the wire depends on which tool it is. A durable sink writes
+/// exactly the events this returns true for (engine_sink.jsonEmit asserts it),
+/// so a reserved id can never burn with no line behind it (#330).
 pub fn durable(ev: EngineEvent) bool {
     return switch (ev) {
         .reasoning_delta, .text_delta => true,
+        // Every tool's call bracket is on the wire except ask_user's: a
+        // --json client is handed that moment as its own `ask_user` event,
+        // and answers it on stdin.
+        .tool_call_announced, .tool_call_started => |t| !t.ask_user,
+        // Meta tools render their own UX and never carried a wire result —
+        // except ask_user, whose typed reply IS the result.
+        .tool_result, .tool_call_finished => |r| !r.meta or r.ask_user,
+        .tool_rejected => true,
         else => false,
     };
 }
@@ -183,6 +276,48 @@ test "slice 1b: tool-arg prose and transport aborts are presentation pulses" {
         .{ .tool_arg_delta = .{ .text = "prose" } },
         .{ .transport_aborted = .{ .reason = .stalled, .turn_ending = true } },
         .{ .transport_aborted = .{ .reason = .dropped, .turn_ending = false } },
+    };
+    for (pulses) |ev| try std.testing.expect(!durable(ev));
+}
+
+test "slice 1c: the tool bracket is durable per TOOL, not per tag" {
+    const call: ToolInvocation = .{ .name = "bash", .input = .null };
+    const ask: ToolInvocation = .{ .name = "ask_user", .input = .null, .ask_user = true };
+    // An ordinary tool's bracket is the wire's tool_call/tool_call_started…
+    try std.testing.expect(durable(.{ .tool_call_announced = call }));
+    try std.testing.expect(durable(.{ .tool_call_started = call }));
+    // …while ask_user's reaches a --json client as the `ask_user` event, so
+    // neither half may reserve an id the wire will not spend (#330).
+    try std.testing.expect(!durable(.{ .tool_call_announced = ask }));
+    try std.testing.expect(!durable(.{ .tool_call_started = ask }));
+    // arg_streamed is a TUI-only suppression: the wire still carries the call.
+    const streamed: ToolInvocation = .{ .name = "bash", .input = .null, .arg_streamed = true };
+    try std.testing.expect(durable(.{ .tool_call_announced = streamed }));
+
+    const ext: ToolOutcome = .{ .name = "bash", .text = "ok", .is_error = false };
+    const meta: ToolOutcome = .{ .name = "todo_write", .text = "ok", .is_error = false, .meta = true };
+    const answer: ToolOutcome = .{ .name = "ask_user", .text = "yes", .is_error = false, .meta = true, .ask_user = true };
+    try std.testing.expect(durable(.{ .tool_result = ext }));
+    try std.testing.expect(durable(.{ .tool_call_finished = ext }));
+    try std.testing.expect(!durable(.{ .tool_result = meta }));
+    try std.testing.expect(!durable(.{ .tool_call_finished = meta }));
+    try std.testing.expect(durable(.{ .tool_result = answer }));
+    try std.testing.expect(durable(.{ .tool_call_finished = answer }));
+
+    // A refusal has always been a wire-only moment.
+    try std.testing.expect(durable(.{ .tool_rejected = .{ .name = "bash", .input = .null, .reason = "budget", .message = "no" } }));
+}
+
+test "slice 1c: the tool-cluster notices are presentation pulses" {
+    // None of these ever appeared on the --json wire, so promoting one is a
+    // schema_version event rather than refactor fallout.
+    const pulses: [6]EngineEvent = .{
+        .{ .parallel_batch_started = .{ .count = 3 } },
+        .{ .parallel_batch_finished = .{ .done = 2, .failed = 1, .cancelled = 0 } },
+        .completion_deferred,
+        .goal_completed,
+        .{ .completion_text = .{ .text = "done" } },
+        .{ .todo_list_updated = .{ .text = "todos" } },
     };
     for (pulses) |ev| try std.testing.expect(!durable(ev));
 }

--- a/src/engine_sink.zig
+++ b/src/engine_sink.zig
@@ -36,6 +36,7 @@ const engine_events = @import("engine_events.zig");
 const EngineEvent = engine_events.EngineEvent;
 const protocol_seq = @import("protocol_seq.zig");
 const render = @import("agent_stream_render.zig");
+const tool_render = @import("agent_tool_render.zig"); // slice 1c: the tool cluster's terminal half
 const tick_gate = @import("tick_gate.zig"); // #tui-tick: child ticks wait for a foreground line boundary
 
 /// An event plus its position, as delivered to a sink.
@@ -171,6 +172,18 @@ fn tuiEmit(ctx: *anyopaque, ev: Stamped) void {
             render.closeThinkingBlock(a); // a reasoning-only turn still closes its block
             render.spinnerStop(a);
         },
+        // The tool cluster (slice 1c). Its drawing lives in agent_tool_render,
+        // the one file down here that still reaches the palette; the moments
+        // the terminal never drew (the dispatch/close brackets, refusals) are
+        // silent rather than absent from the vocabulary.
+        .tool_call_announced => |t| tool_render.toolUseLine(a, t),
+        .tool_result => |r| tool_render.toolResultLine(a, r),
+        .tool_call_started, .tool_call_finished, .tool_rejected => {},
+        .parallel_batch_started => |b| tool_render.parallelBatchStarted(a, b.count),
+        .parallel_batch_finished => |b| tool_render.parallelBatchFinished(a, b),
+        .completion_deferred => tool_render.completionDeferred(a),
+        .goal_completed => tool_render.goalCompleted(a),
+        .completion_text, .todo_list_updated => |t| tool_render.toolTextLine(a, t.text),
     }
 }
 
@@ -186,19 +199,35 @@ fn notice(a: *Agent, text: []const u8) void {
 fn jsonEmit(ctx: *anyopaque, ev: Stamped) void {
     const a: *Agent = @ptrCast(@alignCast(ctx));
     const w = a.out orelse return;
+    // The invariant that keeps #330's numbering gap-free: this sink writes a
+    // line for EXACTLY the events engine_events.durable() claims, so a
+    // reserved id can never end up with nothing behind it. Payload-dependent
+    // durability (ask_user's bracket, a meta tool's result) is decided there,
+    // once, rather than re-derived per branch below.
+    //
+    // Stream end/abort still flushes the held render tail, as the old inline
+    // path did in EVERY mode. (Slice 1b correction to this note: tool-arg
+    // prose CANNOT dirty md state here — argLiveDelta has always gated --json
+    // off, and this sink drops .tool_arg_delta — so with .text_delta going to
+    // the wire the tail is clean and the flush adds no bytes today. It stays
+    // because removing a wire-visible behavior, however latent, is a
+    // deliberate schema-gated change, not refactor fallout.)
+    if (!engine_events.durable(ev.event)) return switch (ev.event) {
+        .stream_aborted, .stream_complete => a.flushStreamTail(),
+        else => {},
+    };
     switch (ev.event) {
         .reasoning_delta => |d| jsonLine(w, ev.cursor, .{ .type = "reasoning", .text = d.text }),
         .text_delta => |d| jsonLine(w, ev.cursor, .{ .type = "text", .text = d.text }),
-        // Stream end/abort still flushes the held render tail, as the old
-        // inline path did in EVERY mode. (Slice 1b correction to this note:
-        // tool-arg prose CANNOT dirty md state here — argLiveDelta has always
-        // gated --json off, and this sink drops .tool_arg_delta — so with
-        // .text_delta going to the wire the tail is clean and the flush adds
-        // no bytes today. It stays because removing a wire-visible behavior,
-        // however latent, is a deliberate schema-gated change, not refactor
-        // fallout.)
-        .stream_aborted, .stream_complete => a.flushStreamTail(),
-        else => {},
+        .tool_call_announced => |t| jsonLine(w, ev.cursor, .{ .type = "tool_call", .name = t.name, .input = t.input }),
+        .tool_call_started => |t| jsonLine(w, ev.cursor, .{ .type = "tool_call_started", .name = t.name, .input = t.input }),
+        .tool_result => |r| jsonLine(w, ev.cursor, .{ .type = "tool_result", .name = r.name, .is_error = r.is_error, .text = r.text }),
+        .tool_call_finished => |r| jsonLine(w, ev.cursor, .{ .type = "tool_call_finished", .name = r.name, .is_error = r.is_error, .ms = r.ms }),
+        .tool_rejected => |r| jsonLine(w, ev.cursor, .{ .type = "tool_rejected", .name = r.name, .reason = r.reason, .input = r.input, .message = r.message }),
+        // Unreachable: durable() gated every other tag out above. Kept as a
+        // hard stop so a NEW durable variant cannot silently reach the wire
+        // without a shape — that would burn its id on nothing (#330).
+        else => @panic("engine_sink: durable event with no wire shape"),
     }
 }
 
@@ -252,6 +281,23 @@ test "a presentation sink never reserves sequence ids" {
     try std.testing.expectEqual(@as(u64, 0), protocol_seq.current());
 }
 
+/// The Agent shape every sink test renders through: allocator-backed, rooted
+/// (not a subagent), writing into the caller's buffer. `io` stays undefined —
+/// dispatch only touches it under the --json lock, which these tests pin off.
+fn testAgent(w: *Io.Writer) Agent {
+    return .{
+        .gpa = std.testing.allocator,
+        .arena = std.testing.allocator,
+        .io = undefined,
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = w,
+    };
+}
+
 fn recordEmit(ctx: *anyopaque, ev: Stamped) void {
     const rec: *std.ArrayList(Stamped) = @ptrCast(@alignCast(ctx));
     rec.append(std.testing.allocator, ev) catch @panic("OOM");
@@ -265,17 +311,7 @@ test "JsonSink writes today's wire lines byte-for-byte" {
     defer protocol_seq.resetForTest();
     var aw: Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
-    var a: Agent = .{
-        .gpa = std.testing.allocator,
-        .arena = std.testing.allocator,
-        .io = undefined,
-        .client = undefined,
-        .provider = undefined,
-        .messages = undefined,
-        .sub = false,
-        .label = "test",
-        .out = &aw.writer,
-    };
+    var a = testAgent(&aw.writer);
     const s = jsonSink(&a);
     s.emit(undefined, .{ .reasoning_delta = .{ .text = "why" } });
     s.emit(undefined, .{ .text_delta = .{ .text = "hi\n" } });
@@ -295,17 +331,7 @@ test "TuiSink streams tool-arg prose raw and never ends the answer line (slice 1
     defer main_mod.use_color = saved_color;
     var aw: Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
-    var a: Agent = .{
-        .gpa = std.testing.allocator,
-        .arena = std.testing.allocator,
-        .io = undefined,
-        .client = undefined,
-        .provider = undefined,
-        .messages = undefined,
-        .sub = false,
-        .label = "test",
-        .out = &aw.writer,
-    };
+    var a = testAgent(&aw.writer);
     const s = tuiSink(&a);
     s.emit(undefined, .{ .tool_arg_delta = .{ .text = "answer " } });
     s.emit(undefined, .{ .tool_arg_delta = .{ .text = "prose" } });
@@ -317,17 +343,7 @@ test "TuiSink streams tool-arg prose raw and never ends the answer line (slice 1
 test "TuiSink transport-abort notices reproduce the old inline lines (slice 1b)" {
     var aw: Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
-    var a: Agent = .{
-        .gpa = std.testing.allocator,
-        .arena = std.testing.allocator,
-        .io = undefined,
-        .client = undefined,
-        .provider = undefined,
-        .messages = undefined,
-        .sub = false,
-        .label = "test",
-        .out = &aw.writer,
-    };
+    var a = testAgent(&aw.writer);
     const s = tuiSink(&a);
     const cases = [_]struct { ev: engine_events.TransportAbort, want: []const u8 }{
         .{ .ev = .{ .reason = .stalled, .turn_ending = false }, .want = "\n⚠ stream stalled\n" },
@@ -352,17 +368,7 @@ test "JsonSink stays silent for moments the wire never carried (slice 1b)" {
     defer protocol_seq.resetForTest();
     var aw: Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
-    var a: Agent = .{
-        .gpa = std.testing.allocator,
-        .arena = std.testing.allocator,
-        .io = undefined,
-        .client = undefined,
-        .provider = undefined,
-        .messages = undefined,
-        .sub = false,
-        .label = "test",
-        .out = &aw.writer,
-    };
+    var a = testAgent(&aw.writer);
     const s = jsonSink(&a);
     s.emit(undefined, .{ .tool_arg_delta = .{ .text = "prose" } });
     s.emit(undefined, .{ .transport_aborted = .{ .reason = .stalled, .turn_ending = true } });
@@ -373,20 +379,101 @@ test "JsonSink stays silent for moments the wire never carried (slice 1b)" {
     try std.testing.expectEqual(@as(u64, 0), protocol_seq.current());
 }
 
+test "JsonSink writes the tool bracket byte-for-byte, in wire order (slice 1c)" {
+    const saved_json = main_mod.json_mode; // pin: see the dispatch-order test
+    main_mod.json_mode = false;
+    defer main_mod.json_mode = saved_json;
+    protocol_seq.resetForTest();
+    defer protocol_seq.resetForTest();
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    var a = testAgent(&aw.writer);
+    const s = jsonSink(&a);
+
+    const input = try std.json.parseFromSliceLeaky(std.json.Value, arena_state.allocator(), "{\"path\":\"fixture.txt\"}", .{});
+    const call: engine_events.ToolInvocation = .{ .name = "read_file", .input = input };
+    const done: engine_events.ToolOutcome = .{ .name = "read_file", .text = "hi", .is_error = false, .ms = 7 };
+    s.emit(undefined, .{ .tool_call_announced = call });
+    s.emit(undefined, .{ .tool_call_started = call });
+    s.emit(undefined, .{ .tool_result = done });
+    s.emit(undefined, .{ .tool_call_finished = done });
+    s.emit(undefined, .{ .tool_rejected = .{ .name = "bash", .input = input, .reason = "budget", .message = "no" } });
+    try std.testing.expectEqualStrings(
+        "{\"seq\":1,\"type\":\"tool_call\",\"name\":\"read_file\",\"input\":{\"path\":\"fixture.txt\"}}\n" ++
+            "{\"seq\":2,\"type\":\"tool_call_started\",\"name\":\"read_file\",\"input\":{\"path\":\"fixture.txt\"}}\n" ++
+            "{\"seq\":3,\"type\":\"tool_result\",\"name\":\"read_file\",\"is_error\":false,\"text\":\"hi\"}\n" ++
+            "{\"seq\":4,\"type\":\"tool_call_finished\",\"name\":\"read_file\",\"is_error\":false,\"ms\":7}\n" ++
+            "{\"seq\":5,\"type\":\"tool_rejected\",\"name\":\"bash\",\"reason\":\"budget\",\"input\":{\"path\":\"fixture.txt\"},\"message\":\"no\"}\n",
+        aw.writer.buffered(),
+    );
+}
+
+test "JsonSink drops ask_user's bracket and a meta result without burning ids (slice 1c)" {
+    const saved_json = main_mod.json_mode; // pin: see the dispatch-order test
+    main_mod.json_mode = false;
+    defer main_mod.json_mode = saved_json;
+    protocol_seq.resetForTest();
+    defer protocol_seq.resetForTest();
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    var a = testAgent(&aw.writer);
+    const s = jsonSink(&a);
+
+    const ask: engine_events.ToolInvocation = .{ .name = "ask_user", .input = .null, .ask_user = true };
+    s.emit(undefined, .{ .tool_call_announced = ask }); // the wire's `ask_user` event carries this moment
+    s.emit(undefined, .{ .tool_call_started = ask });
+    s.emit(undefined, .{ .tool_result = .{ .name = "todo_write", .text = "todos", .is_error = false, .meta = true } });
+    s.emit(undefined, .{ .parallel_batch_started = .{ .count = 2 } }); // TUI-only notices
+    s.emit(undefined, .completion_deferred);
+    s.emit(undefined, .{ .completion_text = .{ .text = "done" } });
+    // No line AND no id spent: the wire's numbering stays gap-free (#330).
+    try std.testing.expectEqualStrings("", aw.writer.buffered());
+    try std.testing.expectEqual(@as(u64, 0), protocol_seq.current());
+
+    // ask_user's own RESULT is on the wire, though — the typed reply is it.
+    s.emit(undefined, .{ .tool_result = .{ .name = "ask_user", .text = "yes", .is_error = false, .meta = true, .ask_user = true } });
+    try std.testing.expectEqualStrings(
+        "{\"seq\":1,\"type\":\"tool_result\",\"name\":\"ask_user\",\"is_error\":false,\"text\":\"yes\"}\n",
+        aw.writer.buffered(),
+    );
+}
+
+test "TuiSink draws the ⚙ and ✓ lines and nothing for the brackets (slice 1c)" {
+    const saved_color = main_mod.use_color;
+    main_mod.use_color = false;
+    defer main_mod.use_color = saved_color;
+    const saved_json = main_mod.json_mode; // sayText's root gate reads it
+    main_mod.json_mode = false;
+    defer main_mod.json_mode = saved_json;
+    const ansi = @import("ansi.zig");
+    const saved_style = ansi.style;
+    ansi.style = .{}; // assert the text, not the palette
+    defer ansi.style = saved_style;
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    var a = testAgent(&aw.writer);
+    const s = tuiSink(&a);
+
+    const input = try std.json.parseFromSliceLeaky(std.json.Value, arena_state.allocator(), "{\"path\":\"fixture.txt\"}", .{});
+    const call: engine_events.ToolInvocation = .{ .name = "read_file", .input = input };
+    const done: engine_events.ToolOutcome = .{ .name = "read_file", .text = "line one\nline two\n", .is_error = false };
+    s.emit(undefined, .{ .tool_call_announced = call });
+    s.emit(undefined, .{ .tool_call_started = call }); // silent: the ⚙ line already said it
+    s.emit(undefined, .{ .tool_result = done });
+    s.emit(undefined, .{ .tool_call_finished = done }); // silent
+    s.emit(undefined, .{ .tool_rejected = .{ .name = "bash", .input = input, .reason = "budget", .message = "no" } }); // silent
+    // Exactly the two lines the eval golden's tool turn shows.
+    try std.testing.expectEqualStrings("⚙ read_file {\"path\":\"fixture.txt\"}\n  ✓ line one…\n", aw.writer.buffered());
+}
+
 test "TuiSink renders a plain text delta exactly as the no-color TTY did" {
     var aw: Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
-    var a: Agent = .{
-        .gpa = std.testing.allocator,
-        .arena = std.testing.allocator,
-        .io = undefined,
-        .client = undefined,
-        .provider = undefined,
-        .messages = undefined,
-        .sub = false,
-        .label = "test",
-        .out = &aw.writer,
-    };
+    var a = testAgent(&aw.writer);
     const s = tuiSink(&a);
     s.emit(undefined, .{ .text_delta = .{ .text = "plain\n" } });
     try std.testing.expectEqualStrings("plain\n", aw.writer.buffered());

--- a/src/engine_sink.zig
+++ b/src/engine_sink.zig
@@ -14,7 +14,12 @@
 //! - JsonSink: the existing --json wire lines for these events,
 //!   byte-identical to the old inline emits. The ONE translation point from
 //!   internal type to wire shape: any change here is externally visible and
-//!   gated behind a schema_version bump.
+//!   gated behind a schema_version bump. Not yet the ONLY producer of those
+//!   shapes, though: subagent_run.zig's guiEmit writes `tool_call`/
+//!   `tool_result` rows with an extra `id` (schema_protocol.zig) straight to
+//!   stdout, bypassing this sink. Routing them through it needs an optional
+//!   `id` on ToolInvocation/ToolOutcome — decide that when #429 takes the
+//!   subagent cluster, while these structs are still cheap to change.
 //!
 //! Events are stamped with a {generation, sequence} Cursor at the dispatch
 //! boundary. In --json mode (the only durable sink today), durable events
@@ -61,11 +66,11 @@ pub const EngineSink = struct {
     /// The emission boundary: stamp, then hand off. `io` backs the stdout
     /// lock, taken only when a durable sink reserves AND json_mode is on —
     /// a global, so `io` may be passed undefined only where json_mode is
-    /// known false (TUI dispatch; the tests here pin it). Durable emitters
-    /// must not emit durable events a sink will drop (jsonEmit returns on
-    /// out == null): the reserved id would burn with no wire line, opening
-    /// a seq gap (#330). Today printDelta guarantees that by returning
-    /// early when out == null, before any durable emission.
+    /// known false (TUI dispatch; the tests here pin it). A durable sink must
+    /// never be handed an event it will drop: the reserved id would burn with
+    /// no wire line, opening a seq gap (#330). jsonSink enforces that at
+    /// construction — an agent with no writer gets a non-durable vtable — so
+    /// emitters need no `out == null` guard of their own.
     pub fn emit(self: EngineSink, io: Io, ev: EngineEvent) void {
         const reserve = self.vt.durable and engine_events.durable(ev);
         if (reserve and main_mod.json_mode) {
@@ -91,12 +96,21 @@ pub fn tuiSink(a: *Agent) EngineSink {
     return .{ .ctx = a, .vt = &tui_vtable };
 }
 
+/// The --json wire, for an agent that HAS one. A frontendless agent — a
+/// pool-thread subagent (subagent_run.zig builds every child with
+/// `.out = null`) or the ACP root (acp.zig nulls it while json_mode is on) —
+/// gets the same emitter but a NON-durable vtable: jsonEmit drops every line
+/// for it, and a durable sink would have reserved a sequence id for each of
+/// those dropped lines, opening exactly the gap #330 promises cannot exist.
+/// Structural, so no emitter has to re-derive the rule per call site.
 pub fn jsonSink(a: *Agent) EngineSink {
-    return .{ .ctx = a, .vt = &json_vtable };
+    return .{ .ctx = a, .vt = if (a.out == null) &json_dropped_vtable else &json_vtable };
 }
 
 const tui_vtable: VTable = .{ .emit = tuiEmit, .durable = false };
 const json_vtable: VTable = .{ .emit = jsonEmit, .durable = true };
+/// Same writer, nothing to write to: see jsonSink.
+const json_dropped_vtable: VTable = .{ .emit = jsonEmit, .durable = false };
 
 /// Today's interactive rendering, relocated behind the event contract. Every
 /// branch is the old inline agent_stream.zig code path, gate for gate.
@@ -438,6 +452,37 @@ test "JsonSink drops ask_user's bracket and a meta result without burning ids (s
         "{\"seq\":1,\"type\":\"tool_result\",\"name\":\"ask_user\",\"is_error\":false,\"text\":\"yes\"}\n",
         aw.writer.buffered(),
     );
+}
+
+test "a frontendless agent's wire sink burns no ids for the lines it cannot write (#330)" {
+    const saved_json = main_mod.json_mode; // pin: see the dispatch-order test
+    main_mod.json_mode = false;
+    defer main_mod.json_mode = saved_json;
+    protocol_seq.resetForTest();
+    defer protocol_seq.resetForTest();
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    var a = testAgent(&aw.writer);
+    a.out = null; // a pool-thread subagent, or the ACP root: nowhere to write
+    const s = jsonSink(&a);
+    try std.testing.expect(!s.vt.durable); // the guarantee is structural, not per-call-site
+
+    const input = try std.json.parseFromSliceLeaky(std.json.Value, arena_state.allocator(), "{\"path\":\"f\"}", .{});
+    const call: engine_events.ToolInvocation = .{ .name = "read_file", .input = input };
+    const done: engine_events.ToolOutcome = .{ .name = "read_file", .text = "hi", .is_error = false };
+    s.emit(undefined, .{ .tool_call_announced = call });
+    s.emit(undefined, .{ .tool_call_started = call });
+    s.emit(undefined, .{ .tool_result = done });
+    s.emit(undefined, .{ .tool_call_finished = done });
+    s.emit(undefined, .{ .tool_rejected = .{ .name = "bash", .input = input, .reason = "budget", .message = "no" } });
+    s.emit(undefined, .{ .text_delta = .{ .text = "hi" } });
+    // Every one of those would have been a wire line for a rooted agent. With
+    // no writer there is no line, so there must be no id either: a supervisor
+    // reads a gap as lost data.
+    try std.testing.expectEqualStrings("", aw.writer.buffered());
+    try std.testing.expectEqual(@as(u64, 0), protocol_seq.current());
 }
 
 test "TuiSink draws the ⚙ and ✓ lines and nothing for the brackets (slice 1c)" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -585,10 +585,10 @@ test { // pull in tests from imported modules (mcp.zig)
     _ = mcp;
     _ = @import("mcp_rpc.zig");
     _ = @import("main_test.zig");
-    // A module whose tests must run needs an explicit reference here: a
-    // plain @import elsewhere (or a type-only alias) is NOT enough — it
-    // compiles to nothing; scripts/eval-tier1.sh --only reach catches one.
+    // A module whose tests must run needs an explicit reference here: a plain @import
+    // elsewhere (or a type-only alias) is NOT enough — it compiles to nothing; scripts/eval-tier1.sh --only reach catches one.
     _ = @import("test_hooks.zig"); // unreached modules; their tests were silently skipped
+    _ = @import("agent_overflow_tests.zig"); // #414: and, through it, agent_overflow.zig's table tests
     _ = @import("learn_delete.zig"); // #303: its tests were dead until listed here
     _ = @import("readline_history.zig");
     _ = @import("goal_pacing_autonomous_test.zig");

--- a/src/playbook_tests.zig
+++ b/src/playbook_tests.zig
@@ -298,6 +298,7 @@ fn stubRoot(gpa: std.mem.Allocator, arena: std.mem.Allocator, out: *Io.Writer) A
         .sub = false,
         .label = "test",
         .out = out,
+        .session_name = "", // #410: a scratch stub has no durable session, so setRootSystemPrompts stays a pure string funnel here
     };
 }
 

--- a/src/proc_identity.zig
+++ b/src/proc_identity.zig
@@ -1,0 +1,460 @@
+//! Process START identity: the half of a lock owner record that a recycled pid
+//! cannot forge (#413).
+//!
+//! A bare pid is not an owner. Pids are a small recycled namespace, so after a
+//! crash the OS hands the dead holder's number to something unrelated, and a
+//! lock keyed on the pid alone then reads as "still held" forever — or, if the
+//! lock is time-based instead, gets stolen from a holder that is very much
+//! alive. Recording the process's START time alongside the pid removes both:
+//! the pair is unique for as long as the machine is up, so liveness becomes
+//! "the pid is alive AND it is still the same process", and a provable
+//! mismatch is what makes a stale lock reclaimable.
+//!
+//! Where the number comes from, one source per platform:
+//!
+//!   * Linux   `/proc/<pid>/stat` field 22 (`starttime`, clock ticks since
+//!             boot). Field 2 is `(comm)` and comm may contain BOTH spaces and
+//!             ')' — `(my )weird( proc)` is a legal name — so the fields are
+//!             counted from the LAST ')' in the line, never by splitting it.
+//!   * macOS   `proc_pidinfo(PROC_PIDTBSDINFO)` -> `pbi_start_tvsec/tvusec`,
+//!             the same instant `ps -o lstart= -p <pid>` prints. libproc is a
+//!             plain libSystem call, so it beats the `ps` subprocess: no fork
+//!             in a lock path, no locale-dependent date parsing, and
+//!             microsecond instead of one-second resolution (two graffs
+//!             started in the same second must not share an identity).
+//!   * Windows `GetProcessTimes` -> `ftCreationTime` (100 ns ticks).
+//!   * anything else: no identity is available, so `probe` answers with
+//!     pid-only liveness and `selfStartId` returns 0. Records stamped there
+//!     carry `start_id = 0` and are read under the legacy rule below, which is
+//!     exactly the pre-#413 behaviour. Nothing degrades further than that.
+//!
+//! Two rules make the upgrade safe, and both live in `ownerState`:
+//!
+//!   * A record with `start_id == 0` — written by a graff older than #413, or
+//!     on a platform with no identity source — keeps the old pid-only
+//!     contract. An in-flight lock from an older binary is never bricked, and
+//!     never stolen just because the new binary cannot verify it.
+//!   * A probe that FAILS (permissions, no /proc, an unexpected errno) is
+//!     `.unknown`, and unknown means held. Wrongly reclaiming a live lock
+//!     corrupts; wrongly honouring a dead one only waits.
+//!
+//! `claimOwnerFile`/`releaseOwnerFile` package the whole protocol for locks
+//! that cannot lean on `flock` — session_lock.zig's degraded path today, the
+//! credential store and any daemon lease next — so a future lock inherits the
+//! identity rules instead of reinventing a timeout.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Io = std.Io;
+
+/// Opaque per-process value that changes every time the OS starts a process.
+/// The units differ per platform, so it is only ever compared against another
+/// reading of the SAME pid on the SAME boot — never across machines, never
+/// interpreted as a wall clock. 0 means "no identity recorded".
+pub const StartId = u64;
+
+/// What the OS says about one pid right now.
+pub const Probe = union(enum) {
+    /// The pid is alive and this is the start identity of what holds it.
+    id: StartId,
+    /// Nothing holds the pid: the recorded owner is provably gone.
+    gone,
+    /// The pid could not be resolved to an identity — it may be alive and
+    /// simply opaque to us (another user's process), or the identity source
+    /// may be missing. Callers must treat this as live.
+    unknown,
+};
+
+pub const OwnerState = enum {
+    /// Someone still owns this record. Wait, do not take the lock.
+    held,
+    /// The recorded owner is gone or the pid now belongs to a different
+    /// process. The lock is stale and may be taken.
+    reclaimable,
+};
+
+/// The identity half of an owner record: what every graff lock writes down so
+/// the next process can decide whether the holder is real.
+pub const Record = struct {
+    pid: i32 = 0,
+    start_id: StartId = 0,
+};
+
+/// The whole #413 decision, pure so it can be tested without a process to kill.
+pub fn ownerState(rec_start_id: StartId, live: Probe) OwnerState {
+    return switch (live) {
+        .gone => .reclaimable,
+        // Fail SAFE: an unreadable identity is never evidence of death.
+        .unknown => .held,
+        // rec_start_id == 0 is a legacy (or identity-less platform) record:
+        // pid alive == held, exactly as before #413.
+        .id => |v| if (rec_start_id == 0 or v == rec_start_id) .held else .reclaimable,
+    };
+}
+
+pub fn selfPid() i32 {
+    // Mirrors trace.currentPid deliberately: this module is a leaf with no
+    // graff imports so that any lock can use it without pulling in telemetry.
+    return if (builtin.os.tag == .windows)
+        @intCast(std.os.windows.GetCurrentProcessId())
+    else
+        @intCast(std.posix.system.getpid());
+}
+
+/// This process's start identity, or 0 where the platform has no source.
+pub fn selfStartId(io: Io) StartId {
+    return switch (probe(io, selfPid())) {
+        .id => |v| v,
+        else => 0,
+    };
+}
+
+/// The owner record to write when taking a lock.
+pub fn selfRecord(io: Io) Record {
+    return .{ .pid = selfPid(), .start_id = selfStartId(io) };
+}
+
+/// `ownerState` for a record read off disk, probing the OS for the answer.
+pub fn stateOf(io: Io, rec: Record) OwnerState {
+    return ownerState(rec.start_id, probe(io, rec.pid));
+}
+
+pub fn probe(io: Io, pid: i32) Probe {
+    if (pid <= 0) return .gone;
+    return switch (builtin.os.tag) {
+        .linux => probeLinux(io, pid),
+        .macos, .ios, .tvos, .watchos, .visionos, .driverkit, .maccatalyst => probeDarwin(io, pid),
+        .windows => probeWindows(io, pid),
+        else => probePidOnly(io, pid),
+    };
+}
+
+/// Liveness with no identity: alive answers `.unknown` (held, never stolen),
+/// only a definitively free pid answers `.gone`. This is the pre-#413 contract
+/// and the floor every platform degrades to.
+fn probePidOnly(io: Io, pid: i32) Probe {
+    _ = io;
+    if (builtin.os.tag == .windows) return .unknown;
+    std.posix.kill(@intCast(pid), @enumFromInt(0)) catch |err| switch (err) {
+        error.ProcessNotFound => return .gone,
+        // PermissionDenied means alive and owned by someone else.
+        else => return .unknown,
+    };
+    return .unknown;
+}
+
+fn probeLinux(io: Io, pid: i32) Probe {
+    var path_buf: [64]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "/proc/{d}/stat", .{pid}) catch return .unknown;
+    // procfs reports size 0, so this reads to EOF rather than to a stat size.
+    var buf: [4096]u8 = undefined;
+    const text = Io.Dir.cwd().readFile(io, path, &buf) catch |err| switch (err) {
+        error.FileNotFound => return .gone,
+        else => return .unknown,
+    };
+    return if (parseLinuxStat(text)) |v| .{ .id = v } else .unknown;
+}
+
+/// Field 22 of a `/proc/<pid>/stat` line. Field 2 is `(comm)`, which may hold
+/// spaces and ')' alike, so the only safe anchor is the LAST ')': everything
+/// after it is space separated and positional, starting at field 3.
+pub fn parseLinuxStat(text: []const u8) ?StartId {
+    const close = std.mem.lastIndexOfScalar(u8, text, ')') orelse return null;
+    var it = std.mem.tokenizeAny(u8, text[close + 1 ..], " \t\r\n");
+    var n: usize = 0;
+    while (it.next()) |tok| {
+        n += 1; // token 1 is field 3 (state), so field 22 is token 20.
+        if (n == 20) return std.fmt.parseInt(StartId, tok, 10) catch null;
+    }
+    return null;
+}
+
+const darwin = struct {
+    const PROC_PIDTBSDINFO: c_int = 3;
+
+    /// `struct proc_bsdinfo` from <sys/proc_info.h>. Only the tail is read,
+    /// but the whole layout has to be spelled out for the offsets to land; the
+    /// comptime assert below is what keeps that honest.
+    const ProcBsdInfo = extern struct {
+        flags: u32,
+        status: u32,
+        xstatus: u32,
+        pid: u32,
+        ppid: u32,
+        uid: u32,
+        gid: u32,
+        ruid: u32,
+        rgid: u32,
+        svuid: u32,
+        svgid: u32,
+        rfu_1: u32,
+        comm: [16]u8,
+        name: [32]u8,
+        nfiles: u32,
+        pgid: u32,
+        pjobc: u32,
+        e_tdev: u32,
+        e_tpgid: u32,
+        nice: i32,
+        start_tvsec: u64,
+        start_tvusec: u64,
+    };
+
+    extern "c" fn proc_pidinfo(pid: c_int, flavor: c_int, arg: u64, buffer: ?*anyopaque, buffersize: c_int) c_int;
+};
+
+fn probeDarwin(io: Io, pid: i32) Probe {
+    comptime std.debug.assert(@sizeOf(darwin.ProcBsdInfo) == 136);
+    comptime std.debug.assert(@offsetOf(darwin.ProcBsdInfo, "start_tvsec") == 120);
+    var info: darwin.ProcBsdInfo = undefined;
+    const size: c_int = @sizeOf(darwin.ProcBsdInfo);
+    const n = darwin.proc_pidinfo(@intCast(pid), darwin.PROC_PIDTBSDINFO, 0, &info, size);
+    // A short answer means ESRCH (dead) or EPERM (alive, another user's).
+    // kill(pid, 0) tells those apart without reading errno by hand.
+    if (n != size) return probePidOnly(io, pid);
+    const usec = info.start_tvsec *% std.time.us_per_s +% info.start_tvusec;
+    return if (usec == 0) .unknown else .{ .id = usec };
+}
+
+const win = struct {
+    const w = std.os.windows;
+    const PROCESS_QUERY_LIMITED_INFORMATION: w.DWORD = 0x1000;
+
+    extern "kernel32" fn OpenProcess(dwDesiredAccess: w.DWORD, bInheritHandle: w.BOOL, dwProcessId: w.DWORD) callconv(.winapi) ?w.HANDLE;
+    extern "kernel32" fn GetProcessTimes(
+        hProcess: w.HANDLE,
+        lpCreationTime: *w.FILETIME,
+        lpExitTime: *w.FILETIME,
+        lpKernelTime: *w.FILETIME,
+        lpUserTime: *w.FILETIME,
+    ) callconv(.winapi) w.BOOL;
+};
+
+fn probeWindows(io: Io, pid: i32) Probe {
+    _ = io;
+    const w = std.os.windows;
+    // QUERY_LIMITED_INFORMATION is the least privilege that still answers
+    // GetProcessTimes, and it works across integrity levels.
+    const handle = win.OpenProcess(win.PROCESS_QUERY_LIMITED_INFORMATION, .FALSE, @intCast(pid)) orelse {
+        // INVALID_PARAMETER is Windows for "no process has that id"; a denial
+        // means it exists and is simply out of reach.
+        return switch (w.GetLastError()) {
+            .INVALID_PARAMETER => .gone,
+            else => .unknown,
+        };
+    };
+    defer w.CloseHandle(handle);
+    var created: w.FILETIME = undefined;
+    var exited: w.FILETIME = undefined;
+    var kernel: w.FILETIME = undefined;
+    var user: w.FILETIME = undefined;
+    if (!win.GetProcessTimes(handle, &created, &exited, &kernel, &user).toBool()) return .unknown;
+    const ticks = (@as(u64, created.dwHighDateTime) << 32) | @as(u64, created.dwLowDateTime);
+    return if (ticks == 0) .unknown else .{ .id = ticks };
+}
+
+/// One line, ASCII, no allocator: a lock file must be writable from a path
+/// that is already failing. `formatRecord` needs at least `record_max` bytes.
+pub const record_max = 80;
+
+pub fn formatRecord(buf: *[record_max]u8, rec: Record) []const u8 {
+    return std.fmt.bufPrint(buf, "graff-owner 1 pid={d} start={d}\n", .{ rec.pid, rec.start_id }) catch unreachable;
+}
+
+/// Tolerant on purpose. `start=` missing (a pre-#413 writer) yields
+/// `start_id = 0`, which `ownerState` honours under the legacy rule, and a
+/// bare number is read as the classic one-line pidfile. Anything else is null:
+/// an unparsable record is no record, never a spurious owner.
+pub fn parseRecord(text: []const u8) ?Record {
+    const line = std.mem.trim(u8, text[0 .. std.mem.indexOfScalar(u8, text, '\n') orelse text.len], " \t\r");
+    if (line.len == 0) return null;
+    if (!std.mem.startsWith(u8, line, "graff-owner")) {
+        // The classic one-line pidfile: a number and nothing else.
+        const pid = std.fmt.parseInt(i32, line, 10) catch return null;
+        return if (pid > 0) .{ .pid = pid } else null;
+    }
+    var rec: Record = .{};
+    var have_pid = false;
+    var it = std.mem.tokenizeAny(u8, line, " \t");
+    while (it.next()) |tok| {
+        if (std.mem.startsWith(u8, tok, "pid=")) {
+            rec.pid = std.fmt.parseInt(i32, tok[4..], 10) catch return null;
+            have_pid = true;
+        } else if (std.mem.startsWith(u8, tok, "start=")) {
+            rec.start_id = std.fmt.parseInt(StartId, tok[6..], 10) catch return null;
+        }
+    }
+    if (!have_pid or rec.pid <= 0) return null;
+    return rec;
+}
+
+/// A record is worth waiting for only when it names someone ELSE and is still
+/// held. Our own record is never contention.
+pub fn heldByOther(rec: Record, my_pid: i32, state: OwnerState) bool {
+    return rec.pid != my_pid and state == .held;
+}
+
+pub fn readOwnerFile(io: Io, dir: Io.Dir, path: []const u8) ?Record {
+    var buf: [record_max]u8 = undefined;
+    const text = dir.readFile(io, path, &buf) catch return null;
+    return parseRecord(text);
+}
+
+/// Take an owner file, or report that a live owner still has it. This is the
+/// whole cross-process lock protocol for a lock that cannot use `flock` —
+/// a filesystem with no working locks, or a lock that must outlive an open
+/// file descriptor — and it is what makes the identity worth recording: a
+/// crashed owner's record is RECLAIMED because its identity provably no longer
+/// matches, with no timeout to tune and no live owner ever robbed.
+///
+/// Failing to read or write the file itself is deliberately not an error. An
+/// owner file is a best-effort stand-in for a lock, and it must never become
+/// the reason the operation it guards cannot happen at all.
+pub fn claimOwnerFile(io: Io, dir: Io.Dir, path: []const u8) error{LockHeld}!void {
+    if (readOwnerFile(io, dir, path)) |rec| {
+        if (heldByOther(rec, selfPid(), stateOf(io, rec))) return error.LockHeld;
+    }
+    var stamp: [record_max]u8 = undefined;
+    dir.writeFile(io, .{ .sub_path = path, .data = formatRecord(&stamp, selfRecord(io)) }) catch {};
+}
+
+pub fn releaseOwnerFile(io: Io, dir: Io.Dir, path: []const u8) void {
+    dir.deleteFile(io, path) catch {};
+}
+
+test "ownerState: the same pid holds only while it is the same process (#413)" {
+    // Live and unchanged: the lock is genuinely held.
+    try std.testing.expectEqual(OwnerState.held, ownerState(4242, .{ .id = 4242 }));
+    // Same pid, different process: a recycled pid may never keep the lock.
+    try std.testing.expectEqual(OwnerState.reclaimable, ownerState(4242, .{ .id = 4243 }));
+    // Nothing holds the pid at all.
+    try std.testing.expectEqual(OwnerState.reclaimable, ownerState(4242, .gone));
+}
+
+test "ownerState: a record with no start identity keeps the pre-#413 contract" {
+    // An older graff's in-flight lock: pid alive means held, and it is never
+    // stolen merely because the new binary cannot verify it.
+    try std.testing.expectEqual(OwnerState.held, ownerState(0, .{ .id = 999 }));
+    try std.testing.expectEqual(OwnerState.held, ownerState(0, .unknown));
+    // Only a provably free pid retires it — the old rule, unchanged.
+    try std.testing.expectEqual(OwnerState.reclaimable, ownerState(0, .gone));
+}
+
+test "ownerState: a failed identity read fails safe and never steals a lock" {
+    try std.testing.expectEqual(OwnerState.held, ownerState(4242, .unknown));
+    try std.testing.expectEqual(OwnerState.held, ownerState(0, .unknown));
+}
+
+test "parseLinuxStat: field 22 survives a comm holding spaces and ')'" {
+    // comm is `graff (test) x`: a naive whitespace split answers 1 here, and
+    // any anchor but the LAST ')' lands inside the name.
+    const weird = "4242 (graff (test) x) S 4241 4242 4242 0 -1 4194304 512 0 0 0 7 3 0 0 20 0 1 0 987654321 12345678 900 18446744073709551615";
+    try std.testing.expectEqual(@as(?StartId, 987654321), parseLinuxStat(weird));
+
+    // The ordinary shape, captured from a real /proc/<pid>/stat.
+    const plain = "1 (systemd) S 0 1 1 0 -1 4194560 24512 366 89 0 61 213 0 0 20 0 1 0 12 170201088 3221 18446744073709551615 1 1 0 0 0 0 671173123 4096 1260 0 0 0 17 2 0 0 0 0 0\n";
+    try std.testing.expectEqual(@as(?StartId, 12), parseLinuxStat(plain));
+
+    // Truncated or nonsense input is no identity rather than a wrong one.
+    try std.testing.expectEqual(@as(?StartId, null), parseLinuxStat("4242 (graff) S 1 2 3"));
+    try std.testing.expectEqual(@as(?StartId, null), parseLinuxStat("no parens here"));
+}
+
+test "parseRecord: round trips, tolerates a legacy pidfile, rejects garbage" {
+    var buf: [record_max]u8 = undefined;
+    const line = formatRecord(&buf, .{ .pid = 4242, .start_id = 1785994345056160 });
+    const back = parseRecord(line) orelse return error.ExpectedRecord;
+    try std.testing.expectEqual(@as(i32, 4242), back.pid);
+    try std.testing.expectEqual(@as(StartId, 1785994345056160), back.start_id);
+
+    // A record from a graff older than #413: pid, no identity.
+    const legacy = parseRecord("graff-owner 1 pid=77\n") orelse return error.ExpectedRecord;
+    try std.testing.expectEqual(@as(i32, 77), legacy.pid);
+    try std.testing.expectEqual(@as(StartId, 0), legacy.start_id);
+    // The classic one-line pidfile, same treatment.
+    const bare = parseRecord("77\n") orelse return error.ExpectedRecord;
+    try std.testing.expectEqual(@as(i32, 77), bare.pid);
+    try std.testing.expectEqual(@as(StartId, 0), bare.start_id);
+
+    try std.testing.expect(parseRecord("") == null);
+    try std.testing.expect(parseRecord("graff-owner 1\n") == null);
+    try std.testing.expect(parseRecord("graff-owner 1 pid=0 start=5") == null);
+    try std.testing.expect(parseRecord("graff-owner 1 pid=nonsense") == null);
+    try std.testing.expect(parseRecord("half a written line") == null);
+}
+
+test "heldByOther: only a live record belonging to someone else is a holder" {
+    const me = selfPid();
+    try std.testing.expect(heldByOther(.{ .pid = me + 1, .start_id = 7 }, me, .held));
+    // Our own record is not contention, whatever it says.
+    try std.testing.expect(!heldByOther(.{ .pid = me, .start_id = 7 }, me, .held));
+    // A crashed owner, or one whose pid now belongs to something else.
+    try std.testing.expect(!heldByOther(.{ .pid = me + 1, .start_id = 7 }, me, .reclaimable));
+}
+
+test "claimOwnerFile: a crashed owner is reclaimed, a live one is waited for" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest; // no pid 1
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const lock = "engine.owner";
+    var buf: [record_max]u8 = undefined;
+
+    // Nobody has it: taking it stamps our own record.
+    try claimOwnerFile(io, tmp.dir, lock);
+    const mine = readOwnerFile(io, tmp.dir, lock) orelse return error.ExpectedRecord;
+    try std.testing.expectEqual(selfPid(), mine.pid);
+    // Re-entrant: our own record never locks us out of our own lock.
+    try claimOwnerFile(io, tmp.dir, lock);
+
+    // pid 1 (init/launchd) is alive on every unix and is never us. A record
+    // with NO start identity is what a graff older than #413 wrote, and it
+    // must still be honoured or the upgrade would brick an in-flight lock.
+    try tmp.dir.writeFile(io, .{ .sub_path = lock, .data = "graff-owner 1 pid=1\n" });
+    try std.testing.expectError(error.LockHeld, claimOwnerFile(io, tmp.dir, lock));
+
+    switch (probe(io, 1)) {
+        .id => |live| {
+            // Same pid, provably a different process: the record is reclaimed.
+            try tmp.dir.writeFile(io, .{ .sub_path = lock, .data = formatRecord(&buf, .{ .pid = 1, .start_id = live +% 1 }) });
+            try claimOwnerFile(io, tmp.dir, lock);
+            // Same pid AND the same identity: never stolen from.
+            try tmp.dir.writeFile(io, .{ .sub_path = lock, .data = formatRecord(&buf, .{ .pid = 1, .start_id = live }) });
+            try std.testing.expectError(error.LockHeld, claimOwnerFile(io, tmp.dir, lock));
+        },
+        // pid 1 is opaque to an unprivileged user on macOS; unreadable is
+        // held, which the legacy assertion above already proved here.
+        .unknown => {},
+        .gone => return error.InitProcessReportedGone,
+    }
+
+    // An unreadable or truncated record is no record: it must not lock the
+    // world out, and it must not survive the next claim either.
+    try tmp.dir.writeFile(io, .{ .sub_path = lock, .data = "half a written l" });
+    try claimOwnerFile(io, tmp.dir, lock);
+    releaseOwnerFile(io, tmp.dir, lock);
+    try std.testing.expect(readOwnerFile(io, tmp.dir, lock) == null);
+}
+
+test "probe: this process is alive and stably identified; a free pid is gone" {
+    const io = std.testing.io;
+    const me = selfPid();
+    try std.testing.expect(me > 0);
+    switch (probe(io, me)) {
+        // Every supported platform must identify the process it is running in.
+        .id => |v| {
+            try std.testing.expect(v != 0);
+            // Stable: a second reading of the same live pid must agree, or
+            // every lock would look reclaimable the moment it was checked.
+            try std.testing.expectEqual(OwnerState.held, stateOf(io, selfRecord(io)));
+            // And a neighbouring identity must not.
+            try std.testing.expectEqual(OwnerState.reclaimable, stateOf(io, .{ .pid = me, .start_id = v + 1 }));
+        },
+        // A platform with no identity source degrades to pid-only liveness.
+        .unknown => try std.testing.expectEqual(OwnerState.held, stateOf(io, .{ .pid = me })),
+        .gone => return error.LiveProcessReportedGone,
+    }
+    // pid 0 and negatives are not processes, so nothing can be held by them.
+    try std.testing.expectEqual(Probe.gone, probe(io, 0));
+    try std.testing.expectEqual(Probe.gone, probe(io, -1));
+}

--- a/src/prompt_snapshot_tests.zig
+++ b/src/prompt_snapshot_tests.zig
@@ -1,0 +1,339 @@
+//! #421 + #410: prompt-snapshot tests. The root system prompt is now assembled
+//! from capability-scoped segments (prompts.zig), which makes two things
+//! testable that never were:
+//!
+//!   1. an absent capability contributes ZERO instruction text — not "less"
+//!      text, none, asserted by exact length AND by the dropped segment's own
+//!      bytes being unfindable in the result;
+//!   2. the full-capability prompt is pinned to an inline golden below, so the
+//!      next person who changes the wording has to change this file too. Prompt
+//!      drift becomes a conscious choice instead of a diff nobody reviewed.
+//!
+//! The golden is the WHOLE prompt on purpose. A hash would catch drift just as
+//! well and teach a reviewer nothing; this way the diff of a prompt change is
+//! readable in review, right next to the assertion that it was intended.
+
+const std = @import("std");
+const prompts = @import("prompts.zig");
+const skills = @import("skills.zig");
+const skill_docs = @import("skill_docs.zig");
+const imagegen = @import("imagegen.zig");
+const tool_gates = @import("tool_gates.zig");
+const no_local_tools = @import("no_local_tools.zig");
+const repl_glue = @import("repl_glue.zig");
+const session_index = @import("session_index.zig");
+const agent_mod = @import("agent.zig");
+
+/// The FULL-capability root prompt, verbatim. Regenerate by reading
+/// `prompts.main_system_prompt`; never "fix" this to make a test pass without
+/// looking at what changed.
+const golden_full_prompt =
+    \\You are a coding agent running in a minimal terminal harness on the
+    \\user's machine. Use the provided tools to inspect and modify the current
+    \\working directory and to run commands.
+    \\Use the tools exactly as this session's catalog defines them: never invent
+    \\a tool, a parameter, or a wrapper API around one, and never assume a
+    \\capability that is not listed for you — when the thing you want is absent,
+    \\say so and finish the task with what is here.
+    \\read_file before editing; prefer
+    \\edit_file for changes to existing files and write_file only for new
+    \\files or full rewrites. To navigate code — finding symbols, callers,
+    \\definitions, or where logic lives — prefer the codedb tool (it's indexed
+    \\and structural) over bash grep/find/ls. Before an exact edit, read one current uncompressed target span, apply the smallest edit that preserves terminal-newline state, do not verify after success, and reread/retry only on stale source, ambiguity, or failure. Some bash commands need user approval — if one
+    \\is declined, try another approach or ask. Native file tools deliberately
+    \\stay inside the current working directory. If the user explicitly names
+    \\a repository or path outside it, the root agent may inspect and modify
+    \\that target with permission-gated bash: quote every path, inspect its git
+    \\status first, preserve existing changes, and explain that those edits are
+    \\not covered by /rewind. Do not claim a relaunch is required. Never extend
+    \\this exception to an inferred path or to a subagent.
+    \\For independent,
+    \\self-contained chunks of work — exploring several directories, running
+    \\unrelated checks, summarizing multiple files — fan out: call the
+    \\subagent tool several times in a single response and the subagents run
+    \\in parallel. For larger fan-out work that needs a synthesis step, use
+    \\the workflow tool: sequential phases of parallel subagents, with
+    \\{{prev}} carrying each phase's results into the next.
+    \\Use todo_write to
+    \\track multi-step work. Work directly for small sequential steps.
+    \\
+    \\The harness writes this run's JSONL event trace beneath
+    \\.graff/traces in the working directory (`/trace` shows its exact path):
+    \\one object per line with
+    \\"ev" of "api" (model round trips: ms latency, request/response bytes,
+    \\context_tokens) or "tool" (tool executions: name, ms, result bytes,
+    \\errors), and "t" = ms since session start. When asked to debug, profile,
+    \\or explain the harness's own behavior — including your own — use `/trace`
+    \\to locate that run's file, then read and analyze it.
+    \\
+    \\If you hit a bug or limitation in the harness itself (this graff/codegraff
+    \\agent — its tools, prompts, streaming, sessions, or behavior — as opposed
+    \\to the project you happen to be working in), report it by opening a GitHub
+    \\issue at justrach/codegraff (`gh issue create --repo justrach/codegraff
+    \\...`), never in the current working repository's issue tracker.
+    \\
+    \\When making git commits on behalf of the user, commit as the USER's own git
+    \\identity — do NOT override GIT_AUTHOR_*/GIT_COMMITTER_*; their configured
+    \\name + email (matching their GitHub account) must be the commit Author, just
+    \\as when they commit by hand. Credit the assist with a trailer at the very end
+    \\of the commit message, after a blank line:
+    \\Co-Authored-By: Codegraff <blackfloofie@codegraff.com>
+    \\
+    \\A pull request description you author must explain WHY the change was made,
+    \\not only what it does — a reviewer cannot reconstruct the reasoning from the
+    \\diff. Cover both halves:
+    \\## What changed
+    \\- concise summary of the implementation
+    \\## Why
+    \\- Problem/failure mode: the concrete bug, gap, or symptom that motivated it
+    \\- Reason for this approach: why this design over the obvious one
+    \\- Constraints or trade-offs: what the fix had to work around, and its costs
+    \\- Rejected alternatives (when relevant): what you considered and ruled out
+    \\Scale the rationale to the change: a subtle or non-obvious change earns the
+    \\full Why section, while a trivial one (typo, version bump, mechanical rename)
+    \\needs a single sentence — never pad a small change with boilerplate headings.
+    \\Apply the same what+why reasoning to the commit message body when the commit
+    \\is the only artifact the reviewer will see.
+    \\
+    \\Never run git commands that discard work — `reset --hard`, `clean -f`,
+    \\`checkout --`/`restore`, force-push, or `branch -D` — unless the user
+    \\explicitly asks. Their existing commits and any -w worktree
+    \\auto-checkpoints are the user's safety net; do not blow them away.
+    \\
+    \\Assume the user wants the work done, not described. Keep going until the
+    \\task is genuinely handled: the change applied, verified with the project's
+    \\own build, test, or lint commands rather than declared done from the diff,
+    \\and the failure you were chasing gone. Never stop at a plan, a half-applied
+    \\edit, or an untested guess, and never leave the last step for the user. If
+    \\a real ambiguity blocks you, ask; otherwise decide and go.
+    \\Run the target project through its OWN environment — its package manager,
+    \\task runner, test command, container or virtualenv — rather than a
+    \\substitute you assembled; a failure there is the relevant result, and a
+    \\green run somewhere else is not evidence.
+    \\
+    \\Before a large chunk of work, give a one- or two-sentence heads-up on what
+    \\you are about to do; on long tasks, drop a brief note as each phase lands.
+    \\With todo_write, mark an item in_progress when you start it and completed
+    \\as it lands, not in a batch at the end.
+    \\
+    \\Fix root causes, not symptoms — a patch that only hides a failure is not a
+    \\fix. Match the surrounding file's style and keep diffs minimal: no drive-by
+    \\refactors, renames, or reformatting the task did not require.
+    \\
+    \\The moment the user rejects, forbids, or vetoes something ("no dots", "not vanilla JS", "stop adding scroll hints"), call note_constraint with one short imperative line recording it, then carry on — recorded constraints are injected into every later subagent, workflow and pipeline brief and survive compaction, so a rejection you leave unrecorded is one your fresh workers will repeat.
+    \\
+    \\Write the final message as an update to a teammate who has not seen your
+    \\screen. Cite evidence as `path:line` instead of pasting file bodies — never
+    \\dump large file contents into an answer — and backtick-wrap commands, paths,
+    \\and identifiers. Scale it to the change: a typo fix is one sentence, a
+    \\feature is a short structured summary. Close with the next steps that
+    \\genuinely exist — tests to run, follow-ups you left — and nothing more.
+    \\Be direct and concise.
+    \\
+    \\Parallelize tool calls whenever possible: when several reads or checks are
+    \\independent, issue them in ONE response instead of one per turn. Reads and
+    \\searches are the common case (read_file, codedb, grep-style bash) and they
+    \\run concurrently. Keep a call in its own turn when it depends on an earlier
+    \\call's result, or when two calls would write to the same file.
+;
+
+/// Every capability configuration the gates can actually produce, plus the
+/// all-off floor. `.{}` is full capability (the Caps defaults).
+const matrix = [_]struct { name: []const u8, caps: prompts.Caps }{
+    .{ .name = "full", .caps = .{} },
+    .{ .name = "no-local-tools (#330 embedder)", .caps = .{ .local_tools = false } },
+    .{ .name = "no-subagents", .caps = .{ .subagents = false } },
+    .{ .name = "no-todos", .caps = .{ .todos = false } },
+    .{ .name = "no-constraints", .caps = .{ .constraints = false } },
+    .{ .name = "floor", .caps = .{ .local_tools = false, .subagents = false, .todos = false, .constraints = false } },
+};
+
+test "#421 golden: the full-capability root prompt is exactly this, byte for byte" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    try std.testing.expectEqualStrings(golden_full_prompt, prompts.main_system_prompt);
+    // The segment table composes to the same bytes the comptime constant does,
+    // so a reordered or forgotten segment cannot hide behind the fast path.
+    try std.testing.expectEqualStrings(golden_full_prompt, try prompts.composeSegments(a, .{}));
+    // ...and the fast path really is a fast path: full capability allocates nothing.
+    var b_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer b_state.deinit();
+    try std.testing.expectEqualStrings(golden_full_prompt, try prompts.composeBase(b_state.allocator(), .{}));
+    try std.testing.expectEqual(@as(usize, 0), b_state.queryCapacity());
+
+    // The strict/ultra variants still compose ONTO this base rather than
+    // replacing it (#326), which the segmentation must not have disturbed.
+    try std.testing.expect(std.mem.startsWith(u8, prompts.main_system_prompt_strict, golden_full_prompt));
+}
+
+test "#421: an absent capability contributes ZERO instruction text, in every configuration" {
+    for (matrix) |row| {
+        var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer a_state.deinit();
+        const out = try prompts.composeSegments(a_state.allocator(), row.caps);
+
+        var expected: usize = 0;
+        for (prompts.segments) |seg| {
+            if (row.caps.has(seg.gate)) expected += seg.text.len;
+        }
+        std.testing.expectEqual(expected, out.len) catch |err| {
+            std.debug.print("config '{s}': composed {d} bytes, expected {d}\n", .{ row.name, out.len, expected });
+            return err;
+        };
+        // Exact length is necessary but not sufficient: prove each dropped
+        // segment's own bytes are unfindable, and each kept one is still there.
+        for (prompts.segments) |seg| {
+            const present = std.mem.indexOf(u8, out, seg.text) != null;
+            std.testing.expectEqual(row.caps.has(seg.gate), present) catch |err| {
+                std.debug.print("config '{s}': segment '{s}' present={} expected={}\n", .{ row.name, seg.name, present, row.caps.has(seg.gate) });
+                return err;
+            };
+        }
+    }
+}
+
+test "#421: a gated-off capability's tool names disappear from the prompt entirely" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    // #330 embedder mode: bash, read_file, edit_file, write_file and codedb are
+    // hard-removed from every catalog, so no sentence may still name them.
+    const embedder = try prompts.composeSegments(a, .{ .local_tools = false });
+    for ([_][]const u8{ "read_file", "edit_file", "write_file", "codedb", "bash grep", "/trace", "gh issue create", ".graff/traces" }) |dead|
+        try std.testing.expect(std.mem.indexOf(u8, embedder, dead) == null);
+
+    const no_subs = try prompts.composeSegments(a, .{ .subagents = false });
+    for ([_][]const u8{ "subagent tool", "workflow tool", "{{prev}}" }) |dead|
+        try std.testing.expect(std.mem.indexOf(u8, no_subs, dead) == null);
+
+    const no_todos = try prompts.composeSegments(a, .{ .todos = false });
+    try std.testing.expect(std.mem.indexOf(u8, no_todos, "todo_write") == null);
+
+    const no_constraints = try prompts.composeSegments(a, .{ .constraints = false });
+    try std.testing.expect(std.mem.indexOf(u8, no_constraints, "note_constraint") == null);
+
+    // What survives EVERY gate: identity, the two prompt-doctrine lines, the
+    // git/PR discipline, the do-not-discard-work rail, and the closing style.
+    for (matrix) |row| {
+        const out = try prompts.composeSegments(a, row.caps);
+        for ([_][]const u8{
+            "You are a coding agent",
+            "never invent", // #421 doctrine 1: no wrapper APIs, no assumed capabilities
+            "its OWN environment", // #421 doctrine 2: verify where the project lives
+            "## What changed",
+            "Co-Authored-By: Codegraff",
+            "Never run git commands that discard work",
+            "Parallelize tool calls",
+            "Be direct and concise",
+        }) |keep| {
+            std.testing.expect(std.mem.indexOf(u8, out, keep) != null) catch |err| {
+                std.debug.print("config '{s}' lost '{s}'\n", .{ row.name, keep });
+                return err;
+            };
+        }
+    }
+}
+
+test "#421: detectCaps reads the same gates dispatch refuses a call with" {
+    const saved = no_local_tools.enabled;
+    defer no_local_tools.enabled = saved;
+
+    no_local_tools.enabled = false;
+    try std.testing.expect(prompts.detectCaps().full());
+
+    no_local_tools.enabled = true;
+    const caps = prompts.detectCaps();
+    try std.testing.expect(!caps.local_tools);
+    // #330 keeps the orchestration and meta tools: the CHILD inherits the gate,
+    // so the fan-out guidance is still guidance for a tool that exists.
+    try std.testing.expect(caps.subagents);
+    try std.testing.expect(caps.todos);
+    try std.testing.expect(caps.constraints);
+
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const gated = try prompts.baseForSession(a_state.allocator());
+    try std.testing.expect(gated.len < prompts.main_system_prompt.len);
+    try std.testing.expect(std.mem.indexOf(u8, gated, "read_file") == null);
+}
+
+test "#410: the transcript line appears exactly when a durable session exists" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    // No durable session (a subagent, a stub, a future --no-session): no line.
+    try std.testing.expectEqualStrings("", prompts.sessionTranscriptNote(a, ""));
+
+    const note = prompts.sessionTranscriptNote(a, "session-1750000000000");
+    // The path is the one session_index actually writes, not a hand-written twin.
+    try std.testing.expect(std.mem.indexOf(u8, note, try session_index.sessionPath(a, "session-1750000000000")) != null);
+    try std.testing.expect(std.mem.indexOf(u8, note, "lags") != null); // the caveat #410 asks for
+    try std.testing.expect(std.mem.indexOf(u8, note, "JSON object") != null);
+    // NOT JSONL: that is the .graff/traces event stream, a different file. A
+    // wrong format claim costs the model a turn discovering it.
+    try std.testing.expect(std.mem.indexOf(u8, note, "JSONL") == null);
+    try std.testing.expect(std.mem.indexOf(u8, prompts.main_system_prompt, "durable transcript") == null); // session-scoped, never comptime
+}
+
+test "#410: the transcript line rides the funnel, so a persona swap cannot drop it" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+    var agent: agent_mod.Agent = undefined;
+    defer prompts.armSessionTranscript(a, "", .{}); // leave the global as the rest of the suite expects it
+
+    prompts.armSessionTranscript(a, "session-42", .{});
+    try prompts.setSystemPrompts(&agent, "BASE", a);
+    for ([_][]const u8{ agent.sys_normal, agent.sys_strict, agent.sys_ultra, agent.sys_ultra_strict }) |v| {
+        try std.testing.expect(std.mem.indexOf(u8, v, "BASE") != null);
+        try std.testing.expect(std.mem.indexOf(u8, v, "session-42.session.json") != null);
+    }
+    // A later /agent persona or set_system_prompt goes through the same funnel
+    // and keeps it — the #326 staleness class, closed by construction.
+    try prompts.setSystemPrompts(&agent, "PERSONA", a);
+    try std.testing.expect(std.mem.indexOf(u8, agent.sys_normal, "session-42.session.json") != null);
+    // sys_base stays the pure base: the next refresh composes from it, once.
+    try std.testing.expectEqualStrings("PERSONA", agent.sys_base);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, agent.sys_normal, "session-42.session.json"));
+
+    // Unreadable session file (#330 removed read_file/bash): no line at all.
+    prompts.armSessionTranscript(a, "session-42", .{ .local_tools = false });
+    try prompts.setSystemPrompts(&agent, "BASE", a);
+    try std.testing.expectEqualStrings("BASE", agent.sys_normal);
+}
+
+test "#421: MCP, skill and optional-tool guidance all cost zero when absent" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    // MCP: startup.buildSystemPrompt injects a server's note only when that
+    // server actually connected, and nothing is baked into the base prompt.
+    for (skills.mcp_notes) |mn| {
+        try std.testing.expect(!skills.mcpServerConnected(&.{}, mn.server));
+        try std.testing.expect(std.mem.indexOf(u8, prompts.main_system_prompt, mn.note) == null);
+    }
+    // Markdown skills: an empty catalog is the empty string, not a header.
+    try std.testing.expectEqualStrings("", skill_docs.promptCatalog(a, &.{}));
+    // #352 optional tools: no availability, no advertisement, and the base
+    // prompt never mentions imagegen either way (its guidance is the skill).
+    const saved = imagegen.available;
+    defer imagegen.available = saved;
+    imagegen.available = false;
+    try std.testing.expect(!tool_gates.advertised(imagegen.tool_name));
+    try std.testing.expect(std.mem.indexOf(u8, prompts.main_system_prompt, "imagegen") == null);
+}
+
+test "#421: goal steering is empty outside a goal run" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+    try std.testing.expectEqualStrings("", try repl_glue.goalSteeringNote(a, null));
+    // ...and a goal that is no longer active steers nobody either (#223).
+    try std.testing.expectEqualStrings("", try repl_glue.goalSteeringNote(a, .{ .objective = "ship it", .status = .complete }));
+    try std.testing.expect((try repl_glue.goalSteeringNote(a, .{ .objective = "ship it", .status = .active })).len > 0);
+}

--- a/src/prompt_text.zig
+++ b/src/prompt_text.zig
@@ -1,0 +1,236 @@
+//! The root system prompt's TEXT, one const per capability-scoped segment
+//! (#421). Nothing here decides anything: prompts.zig owns the `segments`
+//! table that gives each of these a gate, the comptime full-capability
+//! `main_system_prompt` they concatenate to, and the runtime composition that
+//! drops the ones this session cannot use. Split out so prompts.zig has room
+//! for that machinery under the 600-line cap (#123).
+//!
+//! Read this file as the prompt itself; read prompts.zig for when each part of
+//! it is sent.
+
+// ── ROOT PROMPT BEGIN ── examples/prepare_graff_tournament.py extracts every
+// multiline-literal line between these two markers as the seed root policy, so
+// this comment deliberately carries no literal marker of its own.
+
+/// Always present: every configuration has tools of *some* kind. The closing
+/// sentence is #421's prompt doctrine, adopted from the prime-agent analysis —
+/// gating removes the invitation to call an absent capability, but only an
+/// explicit ban stops the model improvising a wrapper around one.
+pub const intro_note =
+    \\You are a coding agent running in a minimal terminal harness on the
+    \\user's machine. Use the provided tools to inspect and modify the current
+    \\working directory and to run commands.
+    \\Use the tools exactly as this session's catalog defines them: never invent
+    \\a tool, a parameter, or a wrapper API around one, and never assume a
+    \\capability that is not listed for you — when the thing you want is absent,
+    \\say so and finish the task with what is here.
+;
+
+/// Gate: `caps.local_tools`. #330 `--no-local-tools` hard-removes bash,
+/// read_file, edit_file, write_file and codedb from every catalog AND refuses
+/// them at dispatch, so under that gate every sentence here describes tools the
+/// provider is never told exist.
+pub const local_tools_note =
+    \\
+    \\read_file before editing; prefer
+    \\edit_file for changes to existing files and write_file only for new
+    \\files or full rewrites. To navigate code — finding symbols, callers,
+    \\definitions, or where logic lives — prefer the codedb tool (it's indexed
+    \\and structural) over bash grep/find/ls. Before an exact edit, read one current uncompressed target span, apply the smallest edit that preserves terminal-newline state, do not verify after success, and reread/retry only on stale source, ambiguity, or failure. Some bash commands need user approval — if one
+    \\is declined, try another approach or ask. Native file tools deliberately
+    \\stay inside the current working directory. If the user explicitly names
+    \\a repository or path outside it, the root agent may inspect and modify
+    \\that target with permission-gated bash: quote every path, inspect its git
+    \\status first, preserve existing changes, and explain that those edits are
+    \\not covered by /rewind. Do not claim a relaunch is required. Never extend
+    \\this exception to an inferred path or to a subagent.
+;
+
+/// Gate: `caps.subagents` — the `subagent`/`workflow` tools as the catalog
+/// actually reports them, not as this file assumes them.
+pub const orchestration_note =
+    \\
+    \\For independent,
+    \\self-contained chunks of work — exploring several directories, running
+    \\unrelated checks, summarizing multiple files — fan out: call the
+    \\subagent tool several times in a single response and the subagents run
+    \\in parallel. For larger fan-out work that needs a synthesis step, use
+    \\the workflow tool: sequential phases of parallel subagents, with
+    \\{{prev}} carrying each phase's results into the next.
+;
+
+/// Gate: `caps.todos` — the `todo_write` tool.
+pub const todo_note =
+    \\
+    \\Use todo_write to
+    \\track multi-step work. Work directly for small sequential steps.
+;
+
+/// Gate: `caps.local_tools`. The instruction is "read and analyze it": the
+/// trace is a file on the host graff runs on, and with the native file/shell
+/// tools removed there is no way to open it (an MCP sandbox is a different
+/// filesystem).
+pub const trace_note =
+    \\
+    \\
+    \\The harness writes this run's JSONL event trace beneath
+    \\.graff/traces in the working directory (`/trace` shows its exact path):
+    \\one object per line with
+    \\"ev" of "api" (model round trips: ms latency, request/response bytes,
+    \\context_tokens) or "tool" (tool executions: name, ms, result bytes,
+    \\errors), and "t" = ms since session start. When asked to debug, profile,
+    \\or explain the harness's own behavior — including your own — use `/trace`
+    \\to locate that run's file, then read and analyze it.
+;
+
+/// Gate: `caps.local_tools`. `gh issue create` is a bash invocation, and bash
+/// is in `no_local_tools.gated_tools`.
+pub const harness_issue_note =
+    \\
+    \\
+    \\If you hit a bug or limitation in the harness itself (this graff/codegraff
+    \\agent — its tools, prompts, streaming, sessions, or behavior — as opposed
+    \\to the project you happen to be working in), report it by opening a GitHub
+    \\issue at justrach/codegraff (`gh issue create --repo justrach/codegraff
+    \\...`), never in the current working repository's issue tracker.
+;
+
+/// Always present. Deliberately NOT gated on `caps.local_tools`: an embedder
+/// that removed the local tools still reaches a sandbox where git may run, and
+/// "never discard the user's work" is the wrong instruction to make optional.
+pub const git_note =
+    \\
+    \\
+    \\When making git commits on behalf of the user, commit as the USER's own git
+    \\identity — do NOT override GIT_AUTHOR_*/GIT_COMMITTER_*; their configured
+    \\name + email (matching their GitHub account) must be the commit Author, just
+    \\as when they commit by hand. Credit the assist with a trailer at the very end
+    \\of the commit message, after a blank line:
+    \\Co-Authored-By: Codegraff <blackfloofie@codegraff.com>
+    \\
+    \\A pull request description you author must explain WHY the change was made,
+    \\not only what it does — a reviewer cannot reconstruct the reasoning from the
+    \\diff. Cover both halves:
+    \\## What changed
+    \\- concise summary of the implementation
+    \\## Why
+    \\- Problem/failure mode: the concrete bug, gap, or symptom that motivated it
+    \\- Reason for this approach: why this design over the obvious one
+    \\- Constraints or trade-offs: what the fix had to work around, and its costs
+    \\- Rejected alternatives (when relevant): what you considered and ruled out
+    \\Scale the rationale to the change: a subtle or non-obvious change earns the
+    \\full Why section, while a trivial one (typo, version bump, mechanical rename)
+    \\needs a single sentence — never pad a small change with boilerplate headings.
+    \\Apply the same what+why reasoning to the commit message body when the commit
+    \\is the only artifact the reviewer will see.
+    \\
+    \\Never run git commands that discard work — `reset --hard`, `clean -f`,
+    \\`checkout --`/`restore`, force-push, or `branch -D` — unless the user
+    \\explicitly asks. Their existing commits and any -w worktree
+    \\auto-checkpoints are the user's safety net; do not blow them away.
+;
+
+/// Always present. The closing sentence is the second prompt-doctrine line
+/// adopted from the prime-agent analysis (#421): verification has to happen in
+/// the target project's own environment to mean anything.
+pub const work_note =
+    \\
+    \\
+    \\Assume the user wants the work done, not described. Keep going until the
+    \\task is genuinely handled: the change applied, verified with the project's
+    \\own build, test, or lint commands rather than declared done from the diff,
+    \\and the failure you were chasing gone. Never stop at a plan, a half-applied
+    \\edit, or an untested guess, and never leave the last step for the user. If
+    \\a real ambiguity blocks you, ask; otherwise decide and go.
+    \\Run the target project through its OWN environment — its package manager,
+    \\task runner, test command, container or virtualenv — rather than a
+    \\substitute you assembled; a failure there is the relevant result, and a
+    \\green run somewhere else is not evidence.
+;
+
+/// Always present: narration is a habit, not a capability.
+pub const headsup_note =
+    \\
+    \\
+    \\Before a large chunk of work, give a one- or two-sentence heads-up on what
+    \\you are about to do; on long tasks, drop a brief note as each phase lands.
+;
+
+/// Gate: `caps.todos`. Same tool as `todo_note`; separate because it sits in a
+/// different paragraph.
+pub const todo_progress_note =
+    \\
+    \\With todo_write, mark an item in_progress when you start it and completed
+    \\as it lands, not in a batch at the end.
+;
+
+/// Always present: how to change code at all, whichever tool applies it.
+pub const root_cause_note =
+    \\
+    \\
+    \\Fix root causes, not symptoms — a patch that only hides a failure is not a
+    \\fix. Match the surrounding file's style and keep diffs minimal: no drive-by
+    \\refactors, renames, or reformatting the task did not require.
+;
+
+/// Gate: `caps.constraints` — the `note_constraint` tool.
+pub const constraint_note =
+    \\
+    \\
+    \\The moment the user rejects, forbids, or vetoes something ("no dots", "not vanilla JS", "stop adding scroll hints"), call note_constraint with one short imperative line recording it, then carry on — recorded constraints are injected into every later subagent, workflow and pipeline brief and survive compaction, so a rejection you leave unrecorded is one your fresh workers will repeat.
+;
+
+/// Always present: how to write the final message.
+pub const closing_note =
+    \\
+    \\
+    \\Write the final message as an update to a teammate who has not seen your
+    \\screen. Cite evidence as `path:line` instead of pasting file bodies — never
+    \\dump large file contents into an answer — and backtick-wrap commands, paths,
+    \\and identifiers. Scale it to the change: a typo fix is one sentence, a
+    \\feature is a short structured summary. Close with the next steps that
+    \\genuinely exist — tests to run, follow-ups you left — and nothing more.
+    \\Be direct and concise.
+;
+
+/// Appended to BOTH the root and subagent prompts. openai/codex carries this
+/// instruction verbatim in its base instructions ("Parallelize tool calls
+/// whenever possible - especially file reads"); graff had no equivalent on
+/// either prompt, so batching was left entirely to the model's own initiative.
+///
+/// The executor has always been ready for it: agent_tools.zig dispatches every
+/// external call in a batch as a future BEFORE awaiting any of them, with no
+/// cap and no root-vs-subagent branch. So this asks for nothing the harness
+/// does not already do - it only stops the capability going unused.
+///
+/// The last sentence is the load-bearing half. Batching two edits to one file,
+/// or a read whose path comes from the previous call's output, is wrong: graff
+/// (unlike codex, which takes a write lock for non-parallel-safe tools) runs
+/// the whole batch concurrently, so an unsafe batch really does race.
+pub const parallel_core_note =
+    \\
+    \\
+    \\Parallelize tool calls whenever possible: when several reads or checks are
+    \\independent, issue them in ONE response instead of one per turn. Reads and
+    \\searches are the common case
+;
+
+/// The one clause of the batching note that is NOT capability-free: all three
+/// examples are tools #330 hard-removes. The instruction survives the gate; its
+/// illustration does not.
+pub const parallel_examples_note =
+    \\ (read_file, codedb, grep-style bash)
+;
+
+pub const parallel_tail_note =
+    \\ and they
+    \\run concurrently. Keep a call in its own turn when it depends on an earlier
+    \\call's result, or when two calls would write to the same file.
+;
+
+/// The whole note, for `sub_system_prompt` — which is a comptime constant, so
+/// a subagent still carries the examples. Same residue, different prompt; the
+/// child inherits #330 too, so gating it is a follow-up, not this change.
+pub const parallel_tools_note = parallel_core_note ++ parallel_examples_note ++ parallel_tail_note;
+
+// ── ROOT PROMPT END ─────────────────────────────────────────────────────────

--- a/src/prompts.zig
+++ b/src/prompts.zig
@@ -9,129 +9,163 @@
 //! variants are pre-built strings exactly like sys_normal/sys_strict, so
 //! this is the one place that derives all four from a base, next to the
 //! constants it composes them from.
+//!
+//! #421: the root prompt is no longer one frozen wall of text. It is a list of
+//! capability-scoped SEGMENTS whose full-capability concatenation is still the
+//! comptime `main_system_prompt` (an Agent struct default, so it has to stay
+//! comptime), while composeBase() drops the segments whose capability this
+//! process does not have. A session is never handed instructions for a tool the
+//! provider was never told about, and every gate is the same predicate dispatch
+//! refuses a hallucinated call with — never a second opinion about what exists.
+//!
+//! #410: setRootSystemPrompts also composes the one line naming this session's
+//! durable transcript. It rides in the funnel, not at the call site, so a
+//! persona swap or a `set_system_prompt` cannot silently drop it.
 
 const std = @import("std");
+const Io = std.Io;
 const Allocator = std.mem.Allocator;
 const shapes = @import("shapes.zig");
+const text = @import("prompt_text.zig"); // #421: the segment TEXT; this file owns their gates
 const Agent = @import("agent.zig").Agent;
 const playbook = @import("playbook.zig"); // #381: the user-constraint block composed onto the ROOT's base prompt
+const no_local_tools = @import("no_local_tools.zig"); // #330's subtractive gate — one half of every capability answer below
+const tool_gates = @import("tool_gates.zig"); // #352's additive gate — the other half
+const session_index = @import("session_index.zig"); // #410: where the durable transcript lives
 
-pub const main_system_prompt =
-    \\You are a coding agent running in a minimal terminal harness on the
-    \\user's machine. Use the provided tools to inspect and modify the current
-    \\working directory and to run commands. read_file before editing; prefer
-    \\edit_file for changes to existing files and write_file only for new
-    \\files or full rewrites. To navigate code — finding symbols, callers,
-    \\definitions, or where logic lives — prefer the codedb tool (it's indexed
-    \\and structural) over bash grep/find/ls. Before an exact edit, read one current uncompressed target span, apply the smallest edit that preserves terminal-newline state, do not verify after success, and reread/retry only on stale source, ambiguity, or failure. Some bash commands need user approval — if one
-    \\is declined, try another approach or ask. Native file tools deliberately
-    \\stay inside the current working directory. If the user explicitly names
-    \\a repository or path outside it, the root agent may inspect and modify
-    \\that target with permission-gated bash: quote every path, inspect its git
-    \\status first, preserve existing changes, and explain that those edits are
-    \\not covered by /rewind. Do not claim a relaunch is required. Never extend
-    \\this exception to an inferred path or to a subagent. For independent,
-    \\self-contained chunks of work — exploring several directories, running
-    \\unrelated checks, summarizing multiple files — fan out: call the
-    \\subagent tool several times in a single response and the subagents run
-    \\in parallel. For larger fan-out work that needs a synthesis step, use
-    \\the workflow tool: sequential phases of parallel subagents, with
-    \\{{prev}} carrying each phase's results into the next. Use todo_write to
-    \\track multi-step work. Work directly for small sequential steps.
-    \\
-    \\The harness writes this run's JSONL event trace beneath
-    \\.graff/traces in the working directory (`/trace` shows its exact path):
-    \\one object per line with
-    \\"ev" of "api" (model round trips: ms latency, request/response bytes,
-    \\context_tokens) or "tool" (tool executions: name, ms, result bytes,
-    \\errors), and "t" = ms since session start. When asked to debug, profile,
-    \\or explain the harness's own behavior — including your own — use `/trace`
-    \\to locate that run's file, then read and analyze it.
-    \\
-    \\If you hit a bug or limitation in the harness itself (this graff/codegraff
-    \\agent — its tools, prompts, streaming, sessions, or behavior — as opposed
-    \\to the project you happen to be working in), report it by opening a GitHub
-    \\issue at justrach/codegraff (`gh issue create --repo justrach/codegraff
-    \\...`), never in the current working repository's issue tracker.
-    \\
-    \\When making git commits on behalf of the user, commit as the USER's own git
-    \\identity — do NOT override GIT_AUTHOR_*/GIT_COMMITTER_*; their configured
-    \\name + email (matching their GitHub account) must be the commit Author, just
-    \\as when they commit by hand. Credit the assist with a trailer at the very end
-    \\of the commit message, after a blank line:
-    \\Co-Authored-By: Codegraff <blackfloofie@codegraff.com>
-    \\
-    \\A pull request description you author must explain WHY the change was made,
-    \\not only what it does — a reviewer cannot reconstruct the reasoning from the
-    \\diff. Cover both halves:
-    \\## What changed
-    \\- concise summary of the implementation
-    \\## Why
-    \\- Problem/failure mode: the concrete bug, gap, or symptom that motivated it
-    \\- Reason for this approach: why this design over the obvious one
-    \\- Constraints or trade-offs: what the fix had to work around, and its costs
-    \\- Rejected alternatives (when relevant): what you considered and ruled out
-    \\Scale the rationale to the change: a subtle or non-obvious change earns the
-    \\full Why section, while a trivial one (typo, version bump, mechanical rename)
-    \\needs a single sentence — never pad a small change with boilerplate headings.
-    \\Apply the same what+why reasoning to the commit message body when the commit
-    \\is the only artifact the reviewer will see.
-    \\
-    \\Never run git commands that discard work — `reset --hard`, `clean -f`,
-    \\`checkout --`/`restore`, force-push, or `branch -D` — unless the user
-    \\explicitly asks. Their existing commits and any -w worktree
-    \\auto-checkpoints are the user's safety net; do not blow them away.
-    \\
-    \\Assume the user wants the work done, not described. Keep going until the
-    \\task is genuinely handled: the change applied, verified with the project's
-    \\own build, test, or lint commands rather than declared done from the diff,
-    \\and the failure you were chasing gone. Never stop at a plan, a half-applied
-    \\edit, or an untested guess, and never leave the last step for the user. If
-    \\a real ambiguity blocks you, ask; otherwise decide and go.
-    \\
-    \\Before a large chunk of work, give a one- or two-sentence heads-up on what
-    \\you are about to do; on long tasks, drop a brief note as each phase lands.
-    \\With todo_write, mark an item in_progress when you start it and completed
-    \\as it lands, not in a batch at the end.
-    \\
-    \\Fix root causes, not symptoms — a patch that only hides a failure is not a
-    \\fix. Match the surrounding file's style and keep diffs minimal: no drive-by
-    \\refactors, renames, or reformatting the task did not require.
-    \\
-    \\The moment the user rejects, forbids, or vetoes something ("no dots", "not vanilla JS", "stop adding scroll hints"), call note_constraint with one short imperative line recording it, then carry on — recorded constraints are injected into every later subagent, workflow and pipeline brief and survive compaction, so a rejection you leave unrecorded is one your fresh workers will repeat.
-    \\
-    \\Write the final message as an update to a teammate who has not seen your
-    \\screen. Cite evidence as `path:line` instead of pasting file bodies — never
-    \\dump large file contents into an answer — and backtick-wrap commands, paths,
-    \\and identifiers. Scale it to the change: a typo fix is one sentence, a
-    \\feature is a short structured summary. Close with the next steps that
-    \\genuinely exist — tests to run, follow-ups you left — and nothing more.
-    \\Be direct and concise.
-++ parallel_tools_note;
+/// The prompt text itself lives next door; this file owns when each part
+/// of it is sent. `parallel_tools_note` is re-exported because
+/// `sub_system_prompt` composes it as a comptime whole.
+pub const parallel_tools_note = text.parallel_tools_note;
 
-/// Appended to BOTH the root and subagent prompts. openai/codex carries this
-/// instruction verbatim in its base instructions ("Parallelize tool calls
-/// whenever possible - especially file reads"); graff had no equivalent on
-/// either prompt, so batching was left entirely to the model's own initiative.
-///
-/// The executor has always been ready for it: agent_tools.zig dispatches every
-/// external call in a batch as a future BEFORE awaiting any of them, with no
-/// cap and no root-vs-subagent branch. So this asks for nothing the harness
-/// does not already do - it only stops the capability going unused.
-///
-/// The last sentence is the load-bearing half. Batching two edits to one file,
-/// or a read whose path comes from the previous call's output, is wrong: graff
-/// (unlike codex, which takes a write lock for non-parallel-safe tools) runs
-/// the whole batch concurrently, so an unsafe batch really does race.
-pub const parallel_tools_note =
-    \\
-    \\
-    \\Parallelize tool calls whenever possible: when several reads or checks are
-    \\independent, issue them in ONE response instead of one per turn. Reads and
-    \\searches are the common case (read_file, codedb, grep-style bash) and they
-    \\run concurrently. Keep a call in its own turn when it depends on an earlier
-    \\call's result, or when two calls would write to the same file.
-;
+/// The capability a segment needs. `.always` is what survives every gate.
+pub const Gate = enum { always, local_tools, subagents, todos, constraints };
+
+/// `name` exists for the snapshot tests: it lets an assertion say WHICH
+/// segment a gate dropped instead of only how many bytes went missing.
+pub const Segment = struct { name: []const u8, text: []const u8, gate: Gate };
+
+/// THE root prompt, in order. This table is the single source of both the
+/// comptime full-capability constant and the runtime gated composition, so the
+/// two can never drift apart or reorder relative to each other.
+pub const segments = [_]Segment{
+    .{ .name = "intro", .text = text.intro_note, .gate = .always },
+    .{ .name = "local_tools", .text = text.local_tools_note, .gate = .local_tools },
+    .{ .name = "orchestration", .text = text.orchestration_note, .gate = .subagents },
+    .{ .name = "todo", .text = text.todo_note, .gate = .todos },
+    .{ .name = "trace", .text = text.trace_note, .gate = .local_tools },
+    .{ .name = "harness_issue", .text = text.harness_issue_note, .gate = .local_tools },
+    .{ .name = "git", .text = text.git_note, .gate = .always },
+    .{ .name = "work", .text = text.work_note, .gate = .always },
+    .{ .name = "headsup", .text = text.headsup_note, .gate = .always },
+    .{ .name = "todo_progress", .text = text.todo_progress_note, .gate = .todos },
+    .{ .name = "root_cause", .text = text.root_cause_note, .gate = .always },
+    .{ .name = "constraint", .text = text.constraint_note, .gate = .constraints },
+    .{ .name = "closing", .text = text.closing_note, .gate = .always },
+    .{ .name = "parallel_core", .text = text.parallel_core_note, .gate = .always },
+    .{ .name = "parallel_examples", .text = text.parallel_examples_note, .gate = .local_tools },
+    .{ .name = "parallel_tail", .text = text.parallel_tail_note, .gate = .always },
+};
+
+pub const main_system_prompt = blk: {
+    var out: []const u8 = "";
+    for (segments) |seg| out = out ++ seg.text;
+    break :blk out;
+};
+
+/// #421: what this session can actually do, exactly as the tool catalog
+/// reports it. Defaults are "everything", so a caller that only cares about
+/// one gate names one field.
+pub const Caps = struct {
+    /// bash + the native file/index tools. Off under #330 `--no-local-tools`.
+    local_tools: bool = true,
+    /// The `subagent`/`workflow` fan-out pair.
+    subagents: bool = true,
+    /// `todo_write`.
+    todos: bool = true,
+    /// `note_constraint`.
+    constraints: bool = true,
+
+    pub fn has(self: Caps, gate: Gate) bool {
+        return switch (gate) {
+            .always => true,
+            .local_tools => self.local_tools,
+            .subagents => self.subagents,
+            .todos => self.todos,
+            .constraints => self.constraints,
+        };
+    }
+
+    /// Nothing gated: composeBase may hand back the comptime constant.
+    pub fn full(self: Caps) bool {
+        return self.local_tools and self.subagents and self.todos and self.constraints;
+    }
+};
+
+/// Is this tool advertised to the provider this session? The two gates that
+/// can remove a built-in, and nothing else — the same pair `exec.zig` refuses
+/// a hallucinated call with, so the prompt can never disagree with dispatch.
+pub fn toolAdvertised(name: []const u8) bool {
+    return !no_local_tools.blocks(name) and !tool_gates.blocks(name);
+}
+
+/// The live gates. Every flag and env knob feeding them is settled before
+/// startup.buildSystemPrompt runs (args.parse, then setupSkillsAndTheme).
+pub fn detectCaps() Caps {
+    return .{
+        .local_tools = toolAdvertised("read_file") and toolAdvertised("bash"),
+        .subagents = toolAdvertised("subagent"),
+        .todos = toolAdvertised("todo_write"),
+        .constraints = toolAdvertised("note_constraint"),
+    };
+}
+
+/// The segment list in `main_system_prompt` order, minus every segment whose
+/// capability is absent. Always allocates; composeBase is the caller that
+/// short-circuits. Kept public so the snapshot tests can prove the
+/// full-capability composition IS `main_system_prompt`, byte for byte.
+pub fn composeSegments(arena: Allocator, caps: Caps) ![]const u8 {
+    var aw: Io.Writer.Allocating = .init(arena);
+    for (segments) |seg| {
+        if (caps.has(seg.gate)) try aw.writer.writeAll(seg.text);
+    }
+    return aw.writer.buffered();
+}
+
+/// The built-in base for `caps`. Full capability returns the comptime constant
+/// itself, so the common path allocates nothing and stays byte-identical to the
+/// prompt this harness has always sent (mirrors no_local_tools.filterRootSpecs).
+pub fn composeBase(arena: Allocator, caps: Caps) ![]const u8 {
+    if (caps.full()) return main_system_prompt;
+    return composeSegments(arena, caps);
+}
+
+/// startup.buildSystemPrompt's entry point: the built-in base, gated on what
+/// this process can actually do.
+pub fn baseForSession(arena: Allocator) ![]const u8 {
+    return composeBase(arena, detectCaps());
+}
+
+/// #410: the transcript line for THIS session, composed once by
+/// setRootSystemPrompts and re-applied by every later setSystemPrompts call so
+/// a persona swap cannot drop it. Empty for every non-root agent and every
+/// unit test — the same arming discipline playbook.g_root_inject uses.
+var g_transcript_note: []const u8 = "";
+
+/// One line naming the durable transcript. Deliberately NOT described as
+/// JSONL: `.graff/sessions/<name>.session.json` is a single JSON object (the
+/// JSONL files are the `.graff/traces` event streams the paragraph above
+/// covers), and it is not an archive of what compaction discarded either —
+/// compaction rewrites the retained history and the next autosave persists
+/// that. Promising either would cost the model turns discovering otherwise.
+pub fn sessionTranscriptNote(arena: Allocator, session_name: []const u8) []const u8 {
+    if (session_name.len == 0) return "";
+    return std.fmt.allocPrint(
+        arena,
+        "\n\nThis session's durable transcript is {s}/{s}{s} — one JSON object whose \"messages\" array holds the retained conversation. It is rewritten only after a turn completes, so it always lags the turn in progress, and compaction rewrites it in place: it is the resume artifact, not an append-only archive. Read it when you need the exact earlier wording of something this conversation no longer shows you.",
+        .{ session_index.sessions_dir, session_name, session_index.session_ext },
+    ) catch "";
+}
 
 pub const strict_note =
     \\
@@ -187,7 +221,11 @@ pub fn ultracodeActive(agent: *const Agent) bool {
 /// tests and for every non-root agent.
 pub fn setSystemPrompts(agent: *Agent, base: []const u8, arena: Allocator) !void {
     agent.sys_base = base;
-    const composed = if (playbook.g_root_inject) playbook.composeRoot(agent.io, arena, base) else base;
+    const with_playbook = if (playbook.g_root_inject) playbook.composeRoot(agent.io, arena, base) else base;
+    // #410: the transcript line is a fact about the SESSION, not about the
+    // persona, so it re-composes here rather than being baked into a base a
+    // later set_agent/set_system_prompt would replace (the #326 staleness class).
+    const composed = if (g_transcript_note.len == 0) with_playbook else try std.fmt.allocPrint(arena, "{s}{s}", .{ with_playbook, g_transcript_note });
     agent.sys_normal = composed;
     agent.sys_strict = try std.fmt.allocPrint(arena, "{s}{s}", .{ composed, strict_note });
     agent.sys_ultra = try std.fmt.allocPrint(arena, "{s}{s}", .{ composed, ultracode_system_note });
@@ -201,7 +239,19 @@ pub fn setSystemPrompts(agent: *Agent, base: []const u8, arena: Allocator) !void
 /// a bare `Agent` in a unit test gets neither.
 pub fn setRootSystemPrompts(agent: *Agent, base: []const u8, arena: Allocator) !void {
     playbook.g_root_inject = true;
+    // #410: only the root has a durable session, and only a session file this
+    // process can still open is worth a line of context — with the native file
+    // and shell tools removed (#330) the path is unreadable from here.
+    armSessionTranscript(arena, agent.session_name, detectCaps());
     return setSystemPrompts(agent, base, arena);
+}
+
+/// #410's arming step, split out so the funnel is testable without the
+/// filesystem read setRootSystemPrompts also performs (playbook.composeRoot).
+/// An empty `session_name`, or a session whose file this process can no longer
+/// open, both arm to "" — the line is only worth context when it is actionable.
+pub fn armSessionTranscript(arena: Allocator, session_name: []const u8, caps: Caps) void {
+    g_transcript_note = if (caps.local_tools) sessionTranscriptNote(arena, session_name) else "";
 }
 
 pub const sub_system_prompt =
@@ -219,6 +269,10 @@ pub const compact_instruction =
     \\task checklist and each item's status, and any pending or unfinished
     \\work. Be thorough but compact. Reply with only the summary.
 ;
+
+test { // #421/#410: the capability matrix + the full-capability golden. An unreferenced module's tests never run.
+    _ = @import("prompt_snapshot_tests.zig");
+}
 
 // The harness has always run a returned tool batch concurrently, for subagents
 // exactly as for the root (agent_tools.zig dispatches every external call as a

--- a/src/session_lock.zig
+++ b/src/session_lock.zig
@@ -9,9 +9,49 @@
 //! save. Only real contention — another live graff holding this very session —
 //! is reported, as `error.SessionOpenInAnotherGraff`; /save and the one-shot
 //! saver already print the error name, so the user sees which failure it was.
+//!
+//! On that degraded path there is no lock to hold, so since #413 the writers
+//! coordinate through a sidecar owner record instead — `<session>.owner`,
+//! carrying `{pid, start_id}`. It is stamped for the duration of ONE write and
+//! removed after, so an idle graff never blocks anybody; a graff that crashes
+//! mid-write leaves it behind, and the start identity is what lets the next
+//! writer PROVE the holder is gone instead of guessing with a timeout — a
+//! recycled pid would otherwise look like a live owner forever.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const Io = std.Io;
+
+const proc_identity = @import("proc_identity.zig");
+
+/// Suffix of the sidecar that stands in for the advisory lock on a filesystem
+/// that has none. Only the degraded path touches it, so the ordinary flock
+/// path pays nothing for it.
+pub const owner_suffix = ".owner";
+
+/// Longest session path we will stamp a sidecar for; a longer one simply
+/// writes as it did before #413 rather than failing the save.
+const owner_path_max = 512;
+
+fn ownerPath(buf: *[owner_path_max]u8, path: []const u8) ?[]const u8 {
+    return std.fmt.bufPrint(buf, "{s}{s}", .{ path, owner_suffix }) catch null;
+}
+
+/// Take the sidecar for one unlocked write, or report the live foreign writer.
+/// A path too long to name simply skips the sidecar: it is a best-effort
+/// stand-in for a lock the filesystem could not give us, and must never become
+/// the reason a session is lost.
+fn claimOwner(io: Io, dir: Io.Dir, path: []const u8) error{SessionOpenInAnotherGraff}!void {
+    var name_buf: [owner_path_max]u8 = undefined;
+    const owner = ownerPath(&name_buf, path) orelse return;
+    proc_identity.claimOwnerFile(io, dir, owner) catch return error.SessionOpenInAnotherGraff;
+}
+
+fn releaseOwner(io: Io, dir: Io.Dir, path: []const u8) void {
+    var name_buf: [owner_path_max]u8 = undefined;
+    const owner = ownerPath(&name_buf, path) orelse return;
+    proc_identity.releaseOwnerFile(io, dir, owner);
+}
 
 /// Write `data` to `path` under `dir` while holding an exclusive advisory lock
 /// on the session file, creating the parent directory chain first.
@@ -37,7 +77,11 @@ pub fn writeSession(io: Io, dir: Io.Dir, path: []const u8, data: []const u8) !vo
         // #289: locking is advisory. A filesystem with no working locks (some
         // network mounts report either of these) must still save the session —
         // degrade to the pre-#289 unlocked write instead of losing the file.
+        // #413: with no lock to hold, the sidecar owner record is the only
+        // thing keeping two writers apart, so it brackets the write.
         error.FileLocksUnsupported, error.SystemResources => {
+            try claimOwner(io, dir, path);
+            defer releaseOwner(io, dir, path);
             return dir.writeFile(io, .{ .sub_path = path, .data = data });
         },
         else => return err,
@@ -76,4 +120,54 @@ test "a second graff reports contention instead of clobbering the session (#289)
     const now = try tmp.dir.readFileAlloc(io, path, std.testing.allocator, .limited(4096));
     defer std.testing.allocator.free(now);
     try std.testing.expectEqualStrings(second, now);
+}
+
+test "the unlocked fallback waits for a live writer and reclaims a crashed one (#413)" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest; // no pid 1
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = "wf.session.json";
+    const owner = path ++ owner_suffix;
+    var buf: [proc_identity.record_max]u8 = undefined;
+
+    // pid 1 (init/launchd) is alive on every unix and is never us. A record
+    // with NO start identity is what a graff older than #413 wrote: it must
+    // still block, or the upgrade would brick an in-flight lock.
+    try tmp.dir.writeFile(io, .{ .sub_path = owner, .data = "graff-owner 1 pid=1\n" });
+    try std.testing.expectError(error.SessionOpenInAnotherGraff, claimOwner(io, tmp.dir, path));
+
+    switch (proc_identity.probe(io, 1)) {
+        .id => |live| {
+            // Same pid, provably a different process: a recycled pid may never
+            // keep the lock, so the crashed writer's record is reclaimed…
+            const stale = proc_identity.formatRecord(&buf, .{ .pid = 1, .start_id = live +% 1 });
+            try tmp.dir.writeFile(io, .{ .sub_path = owner, .data = stale });
+            try claimOwner(io, tmp.dir, path);
+            // …and the sidecar now names us.
+            var back: [proc_identity.record_max]u8 = undefined;
+            const rec = proc_identity.parseRecord(try tmp.dir.readFile(io, owner, &back)) orelse return error.ExpectedRecord;
+            try std.testing.expectEqual(proc_identity.selfPid(), rec.pid);
+
+            // Same pid AND the same identity: a genuinely live holder is never
+            // stolen from.
+            const held = proc_identity.formatRecord(&buf, .{ .pid = 1, .start_id = live });
+            try tmp.dir.writeFile(io, .{ .sub_path = owner, .data = held });
+            try std.testing.expectError(error.SessionOpenInAnotherGraff, claimOwner(io, tmp.dir, path));
+        },
+        // pid 1 is opaque to an unprivileged user on macOS. Unreadable is
+        // held, never stolen — which the legacy assertion above already
+        // proved on this platform.
+        .unknown => {},
+        .gone => return error.InitProcessReportedGone,
+    }
+
+    // A record nobody owns any more: the write goes through and the sidecar is
+    // released rather than left behind for the next writer to trip over.
+    try tmp.dir.deleteFile(io, owner);
+    try writeSession(io, tmp.dir, path, "{}");
+    try claimOwner(io, tmp.dir, path);
+    releaseOwner(io, tmp.dir, path);
+    var gone: [proc_identity.record_max]u8 = undefined;
+    try std.testing.expectError(error.FileNotFound, tmp.dir.readFile(io, owner, &gone));
 }

--- a/src/session_run.zig
+++ b/src/session_run.zig
@@ -256,12 +256,13 @@ pub fn buildRootAgent(
         .tools_openai = "",
         .tools_responses = "",
     };
+    // #410: the durable session's name is settled BEFORE the prompt funnel runs — setRootSystemPrompts composes the transcript line out of it.
+    const fresh_session_name = try std.fmt.allocPrint(arena, "session-{d}", .{util.unixMs(io)});
+    root.session_name = if (flags.resume_flag) |name| (if (!flags.new_session_flag and !flags.no_resume_flag) name else fresh_session_name) else fresh_session_name;
     try prompts.setRootSystemPrompts(&root, sys_normal, arena); // #381: same funnel + the live .graff/playbook.jsonl constraint block
     // Startup pays for one provider format, not all three. Other formats are
     // rendered on first switch with the same built-in + live MCP inputs.
     try root.ensureRootTools(default_provider.kind);
-    const fresh_session_name = try std.fmt.allocPrint(arena, "session-{d}", .{util.unixMs(io)});
-    root.session_name = if (flags.resume_flag) |name| (if (!flags.new_session_flag and !flags.no_resume_flag) name else fresh_session_name) else fresh_session_name;
     repl_glue.loadThinkingSettings(io, arena, &root); // {"effort":...,"fast":...} persisted by /effort and /fast
     if (flags.goal_flag) |g| { // --goal is STANDING (#318): every turn (incl. --json/-p/SDK), never model-retired
         root.goal_flag = try arena.dupe(u8, g); // kept: re-applied over every loadSession, incl. /resume

--- a/src/session_start.zig
+++ b/src/session_start.zig
@@ -38,6 +38,7 @@ const mcp = @import("mcp.zig");
 const mcp_cli = @import("mcp_cli.zig");
 const mcp_config = @import("mcp_config.zig");
 const jobs = @import("jobs.zig");
+const tool_spill = @import("tool_spill.zig"); // #409: where an over-cap tool output's full bytes go
 const trace = @import("trace.zig");
 const scoring = @import("scoring.zig");
 const telemetry = @import("telemetry.zig");
@@ -128,6 +129,12 @@ pub fn setupWorktreeAndBanner(
         try arena.dupe(u8, cwd_buf[0..n])
     else |_|
         try arena.dupe(u8, environ_map.get("PWD") orelse ".");
+    // #409: the oversized-tool-output cap spills the full bytes into this
+    // workspace before eliding them. Wired here because this is where the cwd
+    // (post `-w` chdir) is first known absolutely, and the marker hands the
+    // model an ABSOLUTE path. Left unwired in tests, where the cap stays the
+    // pre-#409 plain truncation.
+    tool_spill.enable(.{ .io = io, .dir = .cwd(), .base_abs = main_mod.g_cwd_display });
 
     if (!main_mod.json_mode and flags.oneshot_prompt == null) {
         try out.print("{s}codegraff{s} · folder: {s}{s}{s} · / for commands · @ picks a file · esc interrupts · ↑/↓ history · tab completes · ctrl-d quits · trace → {s}\n", .{ style.bold, style.reset, style.accent, main_mod.g_cwd_display, style.reset, trace_path });

--- a/src/startup.zig
+++ b/src/startup.zig
@@ -348,7 +348,7 @@ pub fn buildSystemPrompt(
         try out.flush();
     };
     const base_prompt: []const u8 = system_prompt_flag orelse
-        if (learned) |policy| policy.prompt else prompts.main_system_prompt;
+        if (learned) |policy| policy.prompt else try prompts.baseForSession(arena); // #421: built-in base minus the segments whose capability this process lacks
     var sys_normal: []const u8 = base_prompt;
     for ([_][]const u8{ "AGENTS.md", "HARNESS.md", "CLAUDE.md" }) |fname| {
         const body = Io.Dir.cwd().readFileAlloc(io, fname, arena, .limited(64 * 1024)) catch continue;

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -130,6 +130,10 @@ const credential_store = @import("credential_store.zig");
 const engine_events = @import("engine_events.zig");
 const engine_sink = @import("engine_sink.zig");
 
+// #412: the worktree fingerprint behind the no-progress verify guard.
+// agent_eval.zig reaches it through a CALL only, which analyses nothing.
+const verify_fingerprint = @import("verify_fingerprint.zig");
+
 test {
     _ = learn_holdout;
     _ = learn_receipt;
@@ -169,6 +173,7 @@ test {
     _ = credential_store;
     _ = engine_events;
     _ = engine_sink;
+    _ = verify_fingerprint;
     _ = escalation;
     _ = escalation_tests;
     _ = edit_contract;

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -130,6 +130,12 @@ const credential_store = @import("credential_store.zig");
 const engine_events = @import("engine_events.zig");
 const engine_sink = @import("engine_sink.zig");
 
+// #413: process START identity, the half of a lock owner record a recycled pid
+// cannot forge. session_lock.zig and worktree_lease.zig reach it only through
+// calls, and it is the kind of module whose tests must never go quiet: every
+// cross-process lock in graff decides "stale or held" with it.
+const proc_identity = @import("proc_identity.zig");
+
 test {
     _ = learn_holdout;
     _ = learn_receipt;
@@ -169,6 +175,7 @@ test {
     _ = credential_store;
     _ = engine_events;
     _ = engine_sink;
+    _ = proc_identity;
     _ = escalation;
     _ = escalation_tests;
     _ = edit_contract;

--- a/src/tool_spill.zig
+++ b/src/tool_spill.zig
@@ -304,9 +304,16 @@ test "spill writes the full output and the marker points at it (#409)" {
     enable(.{ .io = io, .dir = tmp.dir, .base_abs = "/work" });
 
     const cap: usize = 1024;
+    // A needle past the cap: only the artifact can still hold it. It has to be
+    // a STRING, not a bare 'N' — the marker embeds the artifact's real absolute
+    // path, and std.testing.tmpDir names its directory with 16 random
+    // base64-url characters. One of those is 'N' about 22% of the time, so a
+    // single-character needle made this test fail on ~1 run in 5 for reasons
+    // that had nothing to do with spilling.
+    const needle = "NEEDLE409";
     const big = try a.alloc(u8, 8192);
     @memset(big, 'x');
-    big[8000] = 'N'; // a needle past the cap: only the artifact can still hold it
+    @memcpy(big[8000..][0..needle.len], needle);
 
     var fco: std.json.ObjectMap = .empty;
     try fco.put(a, "type", .{ .string = "function_call_output" });
@@ -328,8 +335,8 @@ test "spill writes the full output and the marker points at it (#409)" {
     try std.testing.expect(std.mem.indexOf(u8, stub, "8192 bytes") != null);
     try std.testing.expect(std.mem.indexOf(u8, stub, "truncated") != null);
     // the needle is gone from the transcript and recoverable only from the file
-    try std.testing.expect(std.mem.indexOf(u8, stub, "N") == null);
-    try std.testing.expect(std.mem.indexOfScalar(u8, spilled, 'N') != null);
+    try std.testing.expect(std.mem.indexOf(u8, stub, needle) == null);
+    try std.testing.expect(std.mem.indexOf(u8, spilled, needle) != null);
 }
 
 test "the per-session byte cap bounds the spill, and over it the cap truncates as before (#409)" {

--- a/src/tool_spill.zig
+++ b/src/tool_spill.zig
@@ -1,0 +1,363 @@
+//! #409: spill, don't truncate. The per-output cap (#193/#196) bounds any single
+//! tool output before send; this is where the ORIGINAL bytes go first, so the
+//! elision is addressable instead of destructive. The marker that replaces them
+//! carries the ABSOLUTE path and the full byte count, so the next turn can read
+//! or grep exactly the slice it needs instead of re-running the tool.
+//!
+//! Layout: `.graff/sessions/<session>/artifacts/tool-<n>.txt`, a sibling of that
+//! session's `<session>.session.json`. Two bounds keep it from growing without
+//! limit: `session_cap_bytes` per session, and reclamation of the artifact dirs
+//! whose session file is gone (`sweepOnce`) — the session FILE is the ground
+//! truth for "this session was deleted", so an `rm`, the AI-title rename, or a
+//! `/new` all reclaim what they left behind.
+//!
+//! Spilling is off until `enable` wires a target, and never happens for a
+//! subagent: its history is not persisted, so there is no durable session to
+//! attach an artifact to and the cap stays a plain truncation.
+//!
+//! Also the home of the cap's truncation primitives (moved here from
+//! agent_compact.zig, which sits at the 600-line cap): the spill has to happen
+//! inside `truncateStrField`, the one place that still holds the pre-truncation
+//! string.
+
+const std = @import("std");
+const Io = std.Io;
+const Value = std.json.Value;
+const Allocator = std.mem.Allocator;
+
+const util = @import("util.zig");
+const utf8Prefix = util.utf8Prefix;
+const session_index = @import("session_index.zig");
+
+/// Ceiling on what one session may leave on disk. Every artifact is a tool
+/// output that ALREADY exceeded the per-output cap, so a runaway tool loop is
+/// exactly the case that would otherwise fill a disk one oversized result at a
+/// time. `pub var` so a test can shrink it without writing 64 MiB.
+pub var session_cap_bytes: usize = 64 * 1024 * 1024;
+
+/// How stale an orphaned artifact dir must be before it is reclaimed. A second
+/// graff can spill during its first turn, before its own session file has been
+/// autosaved; the grace window means that window never costs it its artifacts.
+pub var orphan_grace_ms: i64 = std.time.ms_per_hour;
+
+/// Where the artifacts go. Null until `enable` wires it, so unit tests and any
+/// run without a workspace get the pre-#409 plain truncation.
+pub const Sink = struct {
+    io: Io,
+    /// The directory `.graff` lives under: the cwd in production, a tmp dir in tests.
+    dir: Io.Dir,
+    /// Absolute path of `dir`. The marker names an absolute path so the model can
+    /// open it from anywhere (a subagent may be running inside a worktree).
+    base_abs: []const u8,
+};
+
+var g_sink: ?Sink = null;
+var g_used: std.atomic.Value(usize) = .init(0);
+var g_seq: std.atomic.Value(u64) = .init(0);
+var g_swept: std.atomic.Value(bool) = .init(false);
+
+pub fn enable(sink: Sink) void {
+    g_sink = sink;
+}
+
+pub fn resetForTest() void {
+    g_sink = null;
+    g_used.store(0, .monotonic);
+    g_seq.store(0, .monotonic);
+    g_swept.store(false, .monotonic);
+}
+
+/// The session an agent's spills belong to, or "" for plain truncation. Only a
+/// root agent has one: a subagent's history is never written to disk, which is
+/// the issue's "only spill when a durable session exists".
+pub fn sessionFor(sub: bool, session_name: []const u8) []const u8 {
+    return if (sub) "" else session_name;
+}
+
+/// The byte-budget half of the spill decision, pure. An artifact is written
+/// whole or not at all — a partial one would make the marker lie about its byte
+/// count — so an output that would overrun the remaining budget is truncated the
+/// old way instead.
+pub fn withinBudget(used: usize, len: usize, cap: usize) bool {
+    return len > 0 and used +| len <= cap;
+}
+
+/// An artifact dir is reclaimable once its session file is gone AND it is older
+/// than the grace window. An unreadable mtime is never "age 0" (worktree_prune's
+/// rule): it keeps the directory.
+pub fn reclaimable(session_file_exists: bool, age_ms: i64, grace_ms: i64) bool {
+    if (session_file_exists or age_ms < 0) return false;
+    return age_ms >= grace_ms;
+}
+
+/// A session name that can only ever name a directory INSIDE `.graff/sessions`.
+/// Session names reach us from /save and from AI titles; a '/' or a ".." in one
+/// must never become a write outside the sessions dir.
+pub fn safeName(session: []const u8) bool {
+    if (session.len == 0 or session.len > 128) return false;
+    if (std.mem.indexOfAny(u8, session, "/\\") != null) return false;
+    return !std.mem.eql(u8, session, ".") and !std.mem.eql(u8, session, "..");
+}
+
+/// What replaces the elided bytes. `session` empty (a subagent, an unwired
+/// process) means plain truncation with `fallback`.
+pub const Note = struct {
+    fallback: []const u8,
+    session: []const u8 = "",
+
+    /// The marker for an output of `full`, bounded by the same `cap` as the stub
+    /// it goes into: a marker that cannot fit falls back to the short one rather
+    /// than growing an output the cap just shrank.
+    pub fn text(self: Note, arena: Allocator, full: []const u8, cap: usize) []const u8 {
+        const path = spill(arena, self.session, full) orelse return self.fallback;
+        const marker = std.fmt.allocPrint(arena, "[tool output truncated at this model's per-result cap — the FULL {d} bytes are at {s}; read or grep that file for the slice you need instead of re-running the tool (#409)]", .{ full.len, path }) catch return self.fallback;
+        return if (marker.len + 1 > cap) self.fallback else marker;
+    }
+};
+
+/// Write `full` to this session's artifact dir; the ABSOLUTE path on success.
+/// Null — i.e. plain truncation — when no durable session is wired, when the
+/// per-session budget is spent, or when any part of the write fails.
+fn spill(arena: Allocator, session: []const u8, full: []const u8) ?[]const u8 {
+    const sink = g_sink orelse return null;
+    if (!safeName(session)) return null;
+    if (!reserve(full.len)) return null;
+    const dir = std.fmt.allocPrint(arena, "{s}/{s}/artifacts", .{ session_index.sessions_dir, session }) catch return refund(full.len);
+    sweepOnce(sink, arena, session);
+    sink.dir.createDirPath(sink.io, dir) catch return refund(full.len);
+    const seq = g_seq.fetchAdd(1, .monotonic);
+    const rel = std.fmt.allocPrint(arena, "{s}/tool-{d}.txt", .{ dir, seq }) catch return refund(full.len);
+    sink.dir.writeFile(sink.io, .{ .sub_path = rel, .data = full, .flags = .{ .exclusive = true } }) catch return refund(full.len);
+    if (sink.base_abs.len == 0) return rel;
+    return std.fmt.allocPrint(arena, "{s}/{s}", .{ sink.base_abs, rel }) catch rel;
+}
+
+fn reserve(len: usize) bool {
+    const prev = g_used.fetchAdd(len, .monotonic);
+    if (withinBudget(prev, len, session_cap_bytes)) return true;
+    _ = g_used.fetchSub(len, .monotonic);
+    return false;
+}
+
+fn refund(len: usize) ?[]const u8 {
+    _ = g_used.fetchSub(len, .monotonic);
+    return null;
+}
+
+/// Reclaim the artifact dirs of sessions that no longer exist. Once per process,
+/// at the FIRST spill: a run that never spills does no extra I/O at all, and by
+/// then this session's own dir is either current (skipped by name) or still
+/// young enough for the grace window.
+fn sweepOnce(sink: Sink, arena: Allocator, current: []const u8) void {
+    if (g_swept.swap(true, .monotonic)) return;
+    var names: std.ArrayList([]const u8) = .empty; // collect first: deleting mid-iteration is not portable
+    {
+        var dir = sink.dir.openDir(sink.io, session_index.sessions_dir, .{ .iterate = true }) catch return;
+        defer dir.close(sink.io);
+        var it = dir.iterate();
+        while (it.next(sink.io) catch null) |entry| {
+            if (entry.kind != .directory or std.mem.eql(u8, entry.name, current)) continue;
+            names.append(arena, arena.dupe(u8, entry.name) catch continue) catch continue;
+        }
+    }
+    const now = util.unixMs(sink.io);
+    for (names.items) |name| {
+        const path = std.fmt.allocPrint(arena, "{s}/{s}", .{ session_index.sessions_dir, name }) catch continue;
+        const file = std.fmt.allocPrint(arena, "{s}{s}", .{ path, session_index.session_ext }) catch continue;
+        const live = if (sink.dir.statFile(sink.io, file, .{})) |_| true else |_| false;
+        if (!reclaimable(live, ageMs(sink, path, now), orphan_grace_ms)) continue;
+        sink.dir.deleteTree(sink.io, path) catch {};
+    }
+}
+
+fn ageMs(sink: Sink, path: []const u8, now_ms: i64) i64 {
+    const st = sink.dir.statFile(sink.io, path, .{}) catch return -1;
+    const mtime_ms: i64 = @intCast(@divTrunc(st.mtime.nanoseconds, std.time.ns_per_ms));
+    const age = now_ms - mtime_ms;
+    return if (age < 0) 0 else age; // clock skew, not a stale artifact dir
+}
+
+/// True if `m` is a tool-output message whose payload can be truncated to
+/// reclaim context: responses `function_call_output`, openai `role:"tool"`, or an
+/// anthropic user message carrying `tool_result` blocks (#163).
+pub fn isToolOutputMsg(m: Value) bool {
+    if (m != .object) return false;
+    if (m.object.get("type")) |t| if (t == .string and std.mem.eql(u8, t.string, "function_call_output")) return true;
+    if (m.object.get("role")) |r| if (r == .string) {
+        if (std.mem.eql(u8, r.string, "tool")) return true;
+        if (std.mem.eql(u8, r.string, "user")) if (m.object.get("content")) |c| if (c == .array)
+            for (c.array.items) |blk| {
+                if (blk == .object) if (blk.object.get("type")) |bt|
+                    if (bt == .string and std.mem.eql(u8, bt.string, "tool_result")) return true;
+            };
+    };
+    return false;
+}
+
+fn truncateStrField(arena: Allocator, o: *std.json.ObjectMap, key: []const u8, cap: usize, note: Note) usize {
+    const v = o.get(key) orelse return 0;
+    if (v != .string or v.string.len <= cap) return 0;
+    const orig = v.string.len;
+    // The full bytes go to an artifact first (when the session is durable), so
+    // the marker below can point at them instead of only announcing the loss.
+    const marker = note.text(arena, v.string, cap);
+    // Keep the prefix short enough that prefix + '\n' + marker <= cap, so the
+    // marker never grows an output that was only barely over the cap.
+    const stub = std.fmt.allocPrint(arena, "{s}\n{s}", .{ utf8Prefix(v.string, cap -| (marker.len + 1)), marker }) catch return 0;
+    o.put(arena, key, .{ .string = stub }) catch return 0;
+    return orig -| stub.len;
+}
+
+/// Truncate an over-large tool-output payload in `m` in place to ~`cap` bytes,
+/// preserving the message and its call/output pairing. Returns bytes reclaimed.
+pub fn truncateToolOutput(arena: Allocator, m: *Value, cap: usize, note: Note) usize {
+    if (m.* != .object) return 0;
+    if (m.object.get("type")) |t| if (t == .string and std.mem.eql(u8, t.string, "function_call_output"))
+        return truncateStrField(arena, &m.object, "output", cap, note);
+    if (m.object.get("role")) |r| if (r == .string) {
+        if (std.mem.eql(u8, r.string, "tool")) return truncateStrField(arena, &m.object, "content", cap, note);
+        if (std.mem.eql(u8, r.string, "user")) if (m.object.get("content")) |c| if (c == .array) {
+            var saved: usize = 0;
+            for (m.object.get("content").?.array.items) |*blk| {
+                if (blk.* != .object) continue;
+                const bt = blk.object.get("type") orelse continue;
+                if (bt == .string and std.mem.eql(u8, bt.string, "tool_result"))
+                    saved += truncateStrField(arena, &blk.object, "content", cap, note);
+            }
+            return saved;
+        };
+    };
+    return 0;
+}
+
+test "spill decision (#409): durable session, non-empty payload, room in the budget" {
+    // A subagent has no persisted history, so it has no artifact to attach to.
+    try std.testing.expectEqualStrings("", sessionFor(true, "session-17"));
+    try std.testing.expectEqualStrings("session-17", sessionFor(false, "session-17"));
+    // All-or-nothing at the budget edge.
+    try std.testing.expect(withinBudget(0, 100, 100));
+    try std.testing.expect(withinBudget(90, 10, 100));
+    try std.testing.expect(!withinBudget(91, 10, 100));
+    try std.testing.expect(!withinBudget(0, 0, 100)); // nothing to spill
+    try std.testing.expect(!withinBudget(std.math.maxInt(usize), 8, 100)); // no wraparound
+    // A name that could escape .graff/sessions never becomes a directory.
+    try std.testing.expect(safeName("session-1770000000000"));
+    try std.testing.expect(!safeName(""));
+    try std.testing.expect(!safeName("../../etc"));
+    try std.testing.expect(!safeName(".."));
+    try std.testing.expect(!safeName("a/b"));
+}
+
+test "reclaimable (#409): the session file is the ground truth, and an unknown age keeps" {
+    try std.testing.expect(!reclaimable(true, 999_999, 0)); // session still exists
+    try std.testing.expect(reclaimable(false, 3_600_000, 3_600_000)); // gone and past the grace
+    try std.testing.expect(!reclaimable(false, 60_000, 3_600_000)); // gone but still young
+    try std.testing.expect(!reclaimable(false, -1, 0)); // unreadable mtime keeps
+}
+
+test "no durable session (#409): the cap stays a plain truncation" {
+    resetForTest();
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    const note: Note = .{ .fallback = "[truncated]", .session = "" };
+    // Unwired process AND empty session: both fall back, and neither writes.
+    try std.testing.expectEqualStrings("[truncated]", note.text(a, &util.repeatBytes("x", 4096), 1024));
+}
+
+test "spill writes the full output and the marker points at it (#409)" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    resetForTest();
+    defer resetForTest();
+    enable(.{ .io = io, .dir = tmp.dir, .base_abs = "/work" });
+
+    const cap: usize = 1024;
+    const big = try a.alloc(u8, 8192);
+    @memset(big, 'x');
+    big[8000] = 'N'; // a needle past the cap: only the artifact can still hold it
+
+    var fco: std.json.ObjectMap = .empty;
+    try fco.put(a, "type", .{ .string = "function_call_output" });
+    try fco.put(a, "output", .{ .string = big });
+    var m: Value = .{ .object = fco };
+    const reclaimed = truncateToolOutput(a, &m, cap, .{ .fallback = "[truncated]", .session = "s1" });
+    try std.testing.expect(reclaimed > 0);
+
+    // (a) the artifact holds the FULL original bytes
+    const rel = ".graff/sessions/s1/artifacts/tool-0.txt";
+    const spilled = try tmp.dir.readFileAlloc(io, rel, std.testing.allocator, .limited(1 << 20));
+    defer std.testing.allocator.free(spilled);
+    try std.testing.expectEqualStrings(big, spilled);
+    // (b) the capped message stays within the cap and cites path + byte count
+    const stub = m.object.get("output").?.string;
+    try std.testing.expect(stub.len <= cap);
+    try std.testing.expect(std.mem.indexOf(u8, stub, "/work/" ++ rel) != null);
+    try std.testing.expect(std.mem.indexOf(u8, stub, "8192 bytes") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stub, "truncated") != null);
+    // the needle is gone from the transcript and recoverable only from the file
+    try std.testing.expect(std.mem.indexOf(u8, stub, "N") == null);
+    try std.testing.expect(std.mem.indexOfScalar(u8, spilled, 'N') != null);
+}
+
+test "the per-session byte cap bounds the spill, and over it the cap truncates as before (#409)" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    resetForTest();
+    const saved_cap = session_cap_bytes;
+    defer {
+        session_cap_bytes = saved_cap;
+        resetForTest();
+    }
+    session_cap_bytes = 9000;
+    enable(.{ .io = io, .dir = tmp.dir, .base_abs = "" });
+
+    const note: Note = .{ .fallback = "[truncated]", .session = "s2" };
+    const big = try a.alloc(u8, 8192);
+    @memset(big, 'x');
+    // First spill fits the budget; the second would overrun it whole, so it is
+    // truncated the pre-#409 way rather than half-written.
+    try std.testing.expect(std.mem.indexOf(u8, note.text(a, big, 1024), "tool-0.txt") != null);
+    try std.testing.expectEqualStrings("[truncated]", note.text(a, big, 1024));
+    try std.testing.expect(tmp.dir.statFile(io, ".graff/sessions/s2/artifacts/tool-1.txt", .{}) == error.FileNotFound);
+}
+
+test "artifacts are reclaimed with their session, and a live session keeps its own (#409)" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    resetForTest();
+    const saved_grace = orphan_grace_ms;
+    defer {
+        orphan_grace_ms = saved_grace;
+        resetForTest();
+    }
+    orphan_grace_ms = 0; // every orphan is old enough
+    enable(.{ .io = io, .dir = tmp.dir, .base_abs = "" });
+
+    // A session that was deleted (no .session.json), one that is still saved,
+    // and the one doing the spilling.
+    try tmp.dir.createDirPath(io, ".graff/sessions/dead/artifacts");
+    try tmp.dir.writeFile(io, .{ .sub_path = ".graff/sessions/dead/artifacts/tool-9.txt", .data = "stale" });
+    try tmp.dir.createDirPath(io, ".graff/sessions/alive/artifacts");
+    try tmp.dir.writeFile(io, .{ .sub_path = ".graff/sessions/alive/artifacts/tool-9.txt", .data = "keep" });
+    try tmp.dir.writeFile(io, .{ .sub_path = ".graff/sessions/alive.session.json", .data = "{}" });
+
+    const note: Note = .{ .fallback = "[truncated]", .session = "current" };
+    try std.testing.expect(std.mem.indexOf(u8, note.text(a, &util.repeatBytes("y", 4096), 1024), "tool-0.txt") != null);
+
+    try std.testing.expect(tmp.dir.statFile(io, ".graff/sessions/dead", .{}) == error.FileNotFound);
+    _ = try tmp.dir.statFile(io, ".graff/sessions/alive/artifacts/tool-9.txt", .{});
+    _ = try tmp.dir.statFile(io, ".graff/sessions/current/artifacts/tool-0.txt", .{});
+}

--- a/src/tool_spill.zig
+++ b/src/tool_spill.zig
@@ -54,7 +54,14 @@ pub const Sink = struct {
 var g_sink: ?Sink = null;
 var g_used: std.atomic.Value(usize) = .init(0);
 var g_seq: std.atomic.Value(u64) = .init(0);
+var g_spills: std.atomic.Value(u64) = .init(0);
 var g_swept: std.atomic.Value(bool) = .init(false);
+
+/// Artifacts written this process. The caller's user-facing note reads it so a
+/// cap that PRESERVED the bytes cannot read like one that destroyed them (#202).
+pub fn spillCount() u64 {
+    return g_spills.load(.monotonic);
+}
 
 pub fn enable(sink: Sink) void {
     g_sink = sink;
@@ -64,6 +71,7 @@ pub fn resetForTest() void {
     g_sink = null;
     g_used.store(0, .monotonic);
     g_seq.store(0, .monotonic);
+    g_spills.store(0, .monotonic);
     g_swept.store(false, .monotonic);
 }
 
@@ -128,6 +136,19 @@ fn spill(arena: Allocator, session: []const u8, full: []const u8) ?[]const u8 {
     const seq = g_seq.fetchAdd(1, .monotonic);
     const rel = std.fmt.allocPrint(arena, "{s}/tool-{d}.txt", .{ dir, seq }) catch return refund(full.len);
     sink.dir.writeFile(sink.io, .{ .sub_path = rel, .data = full, .flags = .{ .exclusive = true } }) catch return refund(full.len);
+    _ = g_spills.fetchAdd(1, .monotonic);
+    return absolute(sink, arena, rel);
+}
+
+/// The path the marker hands the model. Resolved through the same dir handle the
+/// artifact was written with, so it names the file that actually exists — the
+/// declared `base_abs` is only a fallback, and it is derived from $PWD when the
+/// cwd cannot be resolved, which a caller that inherited a stale PWD gets wrong.
+fn absolute(sink: Sink, arena: Allocator, rel: []const u8) []const u8 {
+    var buf: [4096]u8 = undefined;
+    if (sink.dir.realPathFile(sink.io, rel, &buf)) |n| {
+        return arena.dupe(u8, buf[0..n]) catch rel;
+    } else |_| {}
     if (sink.base_abs.len == 0) return rel;
     return std.fmt.allocPrint(arena, "{s}/{s}", .{ sink.base_abs, rel }) catch rel;
 }
@@ -296,7 +317,8 @@ test "spill writes the full output and the marker points at it (#409)" {
     // (b) the capped message stays within the cap and cites path + byte count
     const stub = m.object.get("output").?.string;
     try std.testing.expect(stub.len <= cap);
-    try std.testing.expect(std.mem.indexOf(u8, stub, "/work/" ++ rel) != null);
+    try std.testing.expect(std.mem.indexOf(u8, stub, "are at /") != null); // absolute, resolved through the dir handle
+    try std.testing.expect(std.mem.indexOf(u8, stub, rel) != null);
     try std.testing.expect(std.mem.indexOf(u8, stub, "8192 bytes") != null);
     try std.testing.expect(std.mem.indexOf(u8, stub, "truncated") != null);
     // the needle is gone from the transcript and recoverable only from the file

--- a/src/tool_spill.zig
+++ b/src/tool_spill.zig
@@ -169,6 +169,12 @@ fn refund(len: usize) ?[]const u8 {
 /// at the FIRST spill: a run that never spills does no extra I/O at all, and by
 /// then this session's own dir is either current (skipped by name) or still
 /// young enough for the grace window.
+///
+/// Reclaiming late is deliberate. The AI-title rename deletes the old session
+/// file mid-conversation; MOVING that session's artifacts with it (or deleting
+/// them there and then) would strand every path already handed to the model in
+/// this transcript. Leaving them put keeps those paths valid for the rest of the
+/// session, and the next run collects what the rename left behind.
 fn sweepOnce(sink: Sink, arena: Allocator, current: []const u8) void {
     if (g_swept.swap(true, .monotonic)) return;
     var names: std.ArrayList([]const u8) = .empty; // collect first: deleting mid-iteration is not portable

--- a/src/tool_spill.zig
+++ b/src/tool_spill.zig
@@ -330,8 +330,14 @@ test "spill writes the full output and the marker points at it (#409)" {
     // (b) the capped message stays within the cap and cites path + byte count
     const stub = m.object.get("output").?.string;
     try std.testing.expect(stub.len <= cap);
-    try std.testing.expect(std.mem.indexOf(u8, stub, "are at /") != null); // absolute, resolved through the dir handle
-    try std.testing.expect(std.mem.indexOf(u8, stub, rel) != null);
+    // The cited path is absolute on every OS ("/…" on posix, "C:\…" or
+    // "\\?\…" on Windows), and the separators are the platform's — so
+    // extract the path from the marker and assert absoluteness, rather than
+    // matching a leading slash or posix separators (broke on windows CI).
+    const at = (std.mem.indexOf(u8, stub, "are at ") orelse return error.TestUnexpectedResult) + "are at ".len;
+    const semi = std.mem.indexOfScalarPos(u8, stub, at, ';') orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.fs.path.isAbsolute(stub[at..semi]));
+    try std.testing.expect(std.mem.indexOf(u8, stub, "tool-0.txt") != null);
     try std.testing.expect(std.mem.indexOf(u8, stub, "8192 bytes") != null);
     try std.testing.expect(std.mem.indexOf(u8, stub, "truncated") != null);
     // the needle is gone from the transcript and recoverable only from the file

--- a/src/verify_fingerprint.zig
+++ b/src/verify_fingerprint.zig
@@ -1,0 +1,282 @@
+//! #412: the no-progress guard in front of a repeated verification.
+//!
+//! A /goal (or /loop) run is plan-act-VERIFY, and the verifier is the `eval`
+//! tool: it runs the --eval command, optionally spawns an LLM judge subagent,
+//! and a RED verdict blocks attempt_completion until a fresh green one
+//! (agent_tools.handleMeta). So a continuation turn's obvious move is to call
+//! eval again - and a model that has not edited anything since the last RED
+//! does exactly that, repeatedly. Every one of those re-runs costs the wall
+//! clock of the whole scoring command, a judge model call when --judge is set,
+//! and 1500 bytes of output tail in the context window, to re-derive a verdict
+//! that cannot have changed.
+//!
+//! So before a re-verify, fingerprint the worktree. Identical to the tree the
+//! last verification failed on means nothing can be different, so the verifier
+//! is not run at all: the attempt still counts (a no-progress loop must
+//! converge on the iteration cap, not spin for free) and the model is steered
+//! at the actual blocker - it has to change something first. Straight from the
+//! prime agent's `core/autonomous.ts` gate.
+//!
+//! The fingerprint answers one question - could this verification produce a
+//! different result than the last one? - so it folds every input to that
+//! answer: the verifier itself, plus the three streams that together describe
+//! every uncommitted byte.
+//!   * the verifier's own identity (the --eval command text). A session that
+//!     re-points --eval is running a DIFFERENT check, and it must run.
+//!   * `git status --porcelain -z -uall` - which paths are dirty, and how;
+//!   * `git diff --binary HEAD` - the exact content of every TRACKED change;
+//!   * the contents of every untracked file the status listed - which the
+//!     other two streams do NOT cover. Editing an untracked file leaves both
+//!     of them byte-identical (`?? notes.md` says nothing about its bytes), so
+//!     without this third stream the guard would skip a verify over real work.
+//!
+//! FAIL-OPEN is the whole safety story: no repo, no git, a timed-out probe, a
+//! truncated stream, an unreadable file, an absurd number of untracked files -
+//! every one of them yields "unknown", and an unknown fingerprint never
+//! matches, so the verifier runs. The guard can only ever cost a skipped
+//! re-run when it is certain nothing moved; it can never invent a pass.
+//!
+//! The fold and the decision are PURE (digestOf / untrackedPaths /
+//! skipReverify) and unit-tested without a repo; only capture() touches git.
+//! Reached through the test-root hook in test_hooks.zig - without that line
+//! these tests silently compile to nothing and the suite still reports green.
+
+const std = @import("std");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+const process_runner = @import("process_runner.zig");
+
+/// A worktree fingerprint. `null` anywhere in this module means UNKNOWN, which
+/// is always treated as "changed".
+pub const Digest = [32]u8;
+
+/// The sentence the model is steered with when a re-verify is skipped. Kept as
+/// its own decl so the tests assert on the contract, not on a format string.
+pub const no_progress_steer =
+    "the workspace has not changed since the last failed verification — edit source files or tests before attempting to finish again";
+
+/// One labelled byte stream folded into a fingerprint.
+pub const Part = struct { label: []const u8, bytes: []const u8 };
+
+/// Per-git-stream output ceiling. Above it the probe reports unknown rather
+/// than fingerprinting a truncated diff - a change past the cut would be
+/// invisible, which is the one way this guard could wrongly skip a verify.
+pub const max_stream_bytes: usize = 8 << 20;
+/// Untracked-file ceilings. A workspace carrying a whole vendored tree as
+/// untracked files is not worth hashing on every eval; report unknown and let
+/// the verifier run.
+pub const max_untracked_files: usize = 512;
+pub const max_untracked_bytes: usize = 8 << 20;
+
+/// PURE fold. Every field is length-prefixed, so no two different part lists
+/// can produce the same byte stream: ("ab","") and ("a","b") must not collide,
+/// or moving a byte across a file boundary would read as no change at all.
+pub fn digestOf(parts: []const Part) Digest {
+    var h = std.crypto.hash.sha2.Sha256.init(.{});
+    var len: [8]u8 = undefined;
+    for (parts) |p| {
+        std.mem.writeInt(u64, &len, p.label.len, .little);
+        h.update(&len);
+        h.update(p.label);
+        std.mem.writeInt(u64, &len, p.bytes.len, .little);
+        h.update(&len);
+        h.update(p.bytes);
+    }
+    var out: Digest = undefined;
+    h.final(&out);
+    return out;
+}
+
+/// PURE parse of `git status --porcelain -z -uall` into the untracked paths
+/// whose CONTENTS still have to be folded in. NUL-separated records, so paths
+/// are never quoted or escaped - which is exactly why -z is used instead of
+/// the human porcelain. A rename/copy record carries its origin path as a
+/// second NUL field; that field is consumed here so it can never be mistaken
+/// for a record of its own.
+pub fn untrackedPaths(arena: Allocator, status_z: []const u8) ![]const []const u8 {
+    var out: std.ArrayList([]const u8) = .empty;
+    var it = std.mem.splitScalar(u8, status_z, 0);
+    while (it.next()) |rec| {
+        if (rec.len < 4 or rec[2] != ' ') continue;
+        const x = rec[0];
+        const y = rec[1];
+        if (x == 'R' or x == 'C' or y == 'R' or y == 'C') _ = it.next();
+        if (x == '?' and y == '?') try out.append(arena, rec[3..]);
+    }
+    return out.items;
+}
+
+/// One git stream, or null on ANY failure: spawn error, nonzero exit, timeout,
+/// or a stdout cap hit. Allocated on `arena`; nothing here outlives the turn.
+fn gitStream(arena: Allocator, gpa: Allocator, io: Io, argv: []const []const u8) ?[]const u8 {
+    const r = process_runner.runCapped(gpa, io, argv, max_stream_bytes, 8192, 30_000) catch return null;
+    defer gpa.free(r.stdout);
+    defer gpa.free(r.stderr);
+    if (!process_runner.ranOk(r) or r.stdout_truncated or r.timed_out) return null;
+    return arena.dupe(u8, r.stdout) catch null;
+}
+
+/// Fingerprint the verification about to run: `verifier` (the --eval command
+/// text) over the working tree at the PROCESS cwd, which is where runEval
+/// spawns it. Returns null (unknown, i.e. "changed") for anything that is not
+/// a clean, complete read.
+///
+/// Everything read here is scratch and only the 32-byte digest escapes, so it
+/// is folded in a PRIVATE arena rather than the caller's: an eval loop calls
+/// this once per iteration, and an 8 MiB diff parked on the session arena
+/// every time would outlive the whole run.
+pub fn capture(gpa: Allocator, io: Io, verifier: []const u8) ?Digest {
+    var scratch = std.heap.ArenaAllocator.init(gpa);
+    defer scratch.deinit();
+    const arena = scratch.allocator();
+    const status = gitStream(arena, gpa, io, &.{ "git", "status", "--porcelain", "-z", "-uall" }) orelse return null;
+    const diff = gitStream(arena, gpa, io, &.{ "git", "diff", "--binary", "HEAD" }) orelse return null;
+    const paths = untrackedPaths(arena, status) catch return null;
+    if (paths.len > max_untracked_files) return null;
+    var parts: std.ArrayList(Part) = .empty;
+    parts.append(arena, .{ .label = "verifier", .bytes = verifier }) catch return null;
+    parts.append(arena, .{ .label = "status", .bytes = status }) catch return null;
+    parts.append(arena, .{ .label = "diff", .bytes = diff }) catch return null;
+    var budget: usize = max_untracked_bytes;
+    for (paths) |p| {
+        // A file that will not read - deleted between the two probes, a fifo,
+        // a symlink to nowhere, or simply bigger than what is left of the
+        // budget - makes the whole fingerprint unknown rather than partial.
+        const body = Io.Dir.cwd().readFileAlloc(io, p, arena, .limited(budget)) catch return null;
+        budget -= body.len;
+        parts.append(arena, .{ .label = p, .bytes = body }) catch return null;
+    }
+    return digestOf(parts.items);
+}
+
+/// PURE decision: skip the verifier only when the LAST attempt failed and both
+/// fingerprints are known and equal. Unknown on either side is "changed".
+pub fn skipReverify(last_failed: bool, last: ?Digest, current: ?Digest) bool {
+    if (!last_failed) return false;
+    const a = last orelse return false;
+    const b = current orelse return false;
+    return std.mem.eql(u8, &a, &b);
+}
+
+/// The tool result a skipped re-verify hands back. It names the iteration (the
+/// attempt is counted either way) and says plainly that nothing ran, so the
+/// model cannot read it as a fresh verdict.
+pub fn noProgressText(arena: Allocator, iter: u32) ![]const u8 {
+    return std.fmt.allocPrint(
+        arena,
+        "eval #{d} was not run: {s}. The previous RED verdict stands and completion is still blocked; a verifier re-run over an identical tree can only repeat it.",
+        .{ iter, no_progress_steer },
+    );
+}
+
+test "digestOf: identical evidence folds identically, and every stream moves it" {
+    const base = [_]Part{
+        .{ .label = "verifier", .bytes = "zig build test" },
+        .{ .label = "status", .bytes = "?? notes.md\x00" },
+        .{ .label = "diff", .bytes = "diff --git a/x b/x\n+one\n" },
+        .{ .label = "notes.md", .bytes = "first draft" },
+    };
+    try std.testing.expectEqual(digestOf(&base), digestOf(&base));
+
+    // A different VERIFIER moves it: a re-pointed --eval is a different check
+    // over the same tree, and it has to run.
+    var reverifier = base;
+    reverifier[0].bytes = "pytest -q";
+    try std.testing.expect(!std.mem.eql(u8, &digestOf(&base), &digestOf(&reverifier)));
+
+    // A TRACKED edit moves it (the diff stream changed).
+    var tracked = base;
+    tracked[2].bytes = "diff --git a/x b/x\n+two\n";
+    try std.testing.expect(!std.mem.eql(u8, &digestOf(&base), &digestOf(&tracked)));
+
+    // An UNTRACKED-ONLY edit moves it too, and this is the case the other two
+    // streams cannot see: `?? notes.md` and `git diff HEAD` are byte-identical
+    // whatever that file contains. Without folding the contents in, editing an
+    // untracked file would read as "nothing changed" and skip a real verify.
+    var untracked = base;
+    untracked[3].bytes = "second draft";
+    try std.testing.expect(!std.mem.eql(u8, &digestOf(&untracked), &digestOf(&base)));
+    try std.testing.expectEqualStrings(base[1].bytes, untracked[1].bytes);
+    try std.testing.expectEqualStrings(base[2].bytes, untracked[2].bytes);
+
+    // A new untracked file is a change even when it is empty.
+    const grown = base ++ [_]Part{.{ .label = "scratch", .bytes = "" }};
+    try std.testing.expect(!std.mem.eql(u8, &digestOf(&grown), &digestOf(&base)));
+}
+
+test "digestOf: length-prefixed, so a byte moved across a boundary is not a collision" {
+    // Plain concatenation would make these three indistinguishable - i.e. a
+    // rename, or one file's tail becoming the next file's head, would fold to
+    // "unchanged" and skip a verification over real work.
+    const a = [_]Part{ .{ .label = "f", .bytes = "ab" }, .{ .label = "g", .bytes = "" } };
+    const b = [_]Part{ .{ .label = "f", .bytes = "a" }, .{ .label = "g", .bytes = "b" } };
+    const c = [_]Part{ .{ .label = "f", .bytes = "" }, .{ .label = "g", .bytes = "ab" } };
+    try std.testing.expect(!std.mem.eql(u8, &digestOf(&a), &digestOf(&b)));
+    try std.testing.expect(!std.mem.eql(u8, &digestOf(&b), &digestOf(&c)));
+    // And the LABEL is part of the identity: the same bytes under a different
+    // path is a different worktree.
+    const renamed = [_]Part{ .{ .label = "f2", .bytes = "ab" }, .{ .label = "g", .bytes = "" } };
+    try std.testing.expect(!std.mem.eql(u8, &digestOf(&renamed), &digestOf(&a)));
+    try std.testing.expectEqual(digestOf(&[_]Part{}), digestOf(&[_]Part{}));
+}
+
+test "untrackedPaths: only ?? records, and a rename's origin field is consumed" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const ar = arena_state.allocator();
+
+    // A realistic -z porcelain: modified, staged-add, a rename (two fields),
+    // two untracked files, one of them with a space in its name (unquoted,
+    // which is the reason -z is used at all).
+    const status = " M src/main.zig\x00A  src/new.zig\x00R  dst.zig\x00src.zig\x00?? notes.md\x00?? a b.txt\x00";
+    const paths = try untrackedPaths(ar, status);
+    try std.testing.expectEqual(@as(usize, 2), paths.len);
+    try std.testing.expectEqualStrings("notes.md", paths[0]);
+    try std.testing.expectEqualStrings("a b.txt", paths[1]);
+
+    // The rename's ORIGIN field must not be read as a record of its own: a
+    // path beginning "?? " would otherwise be picked up out of it.
+    const trap = "R  dst\x00?? not-a-record\x00?? real.txt\x00";
+    const trapped = try untrackedPaths(ar, trap);
+    try std.testing.expectEqual(@as(usize, 1), trapped.len);
+    try std.testing.expectEqualStrings("real.txt", trapped[0]);
+
+    // Empty, all-tracked, and malformed input all yield nothing rather than
+    // erroring: a clean tree has no untracked contents to fold.
+    try std.testing.expectEqual(@as(usize, 0), (try untrackedPaths(ar, "")).len);
+    try std.testing.expectEqual(@as(usize, 0), (try untrackedPaths(ar, " M a\x00")).len);
+    try std.testing.expectEqual(@as(usize, 0), (try untrackedPaths(ar, "??\x00?x\x00")).len);
+}
+
+test "skipReverify fails OPEN: only a known, equal fingerprint after a failure skips" {
+    const a = digestOf(&[_]Part{.{ .label = "s", .bytes = "one" }});
+    const b = digestOf(&[_]Part{.{ .label = "s", .bytes = "two" }});
+
+    // The one case that skips.
+    try std.testing.expect(skipReverify(true, a, a));
+    // A changed tree re-arms it.
+    try std.testing.expect(!skipReverify(true, a, b));
+    // The last attempt did not fail: there is nothing to re-verify, so the
+    // guard is inert (a green eval must never be turned into a skip).
+    try std.testing.expect(!skipReverify(false, a, a));
+    // Fail-open: a git error, a truncated stream or an unreadable untracked
+    // file lands here as null on either side, and never matches. A repo the
+    // probe cannot read must never be able to suppress a verification.
+    try std.testing.expect(!skipReverify(true, null, a));
+    try std.testing.expect(!skipReverify(true, a, null));
+    try std.testing.expect(!skipReverify(true, null, null));
+}
+
+test "noProgressText names the iteration, carries the steer, and never reads as a verdict" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const ar = arena_state.allocator();
+    const text = try noProgressText(ar, 4);
+    try std.testing.expect(std.mem.startsWith(u8, text, "eval #4 was not run:"));
+    try std.testing.expect(std.mem.indexOf(u8, text, no_progress_steer) != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "completion is still blocked") != null);
+    // No score, no "TARGET MET": the model must not be able to mistake a
+    // skipped run for a fresh green one.
+    try std.testing.expect(std.mem.indexOf(u8, text, "score") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "TARGET MET") == null);
+}

--- a/src/verify_fingerprint.zig
+++ b/src/verify_fingerprint.zig
@@ -101,7 +101,11 @@ pub fn untrackedPaths(arena: Allocator, status_z: []const u8) ![]const []const u
         const x = rec[0];
         const y = rec[1];
         if (x == 'R' or x == 'C' or y == 'R' or y == 'C') _ = it.next();
-        if (x == '?' and y == '?') try out.append(arena, rec[3..]);
+        // graff's own bookkeeping (.graff/ eval-log, traces, sessions) moves on
+        // every iteration by construction; counting it as workspace progress
+        // would fail the guard open in any repo that does not gitignore it.
+        if (x == '?' and y == '?' and !std.mem.startsWith(u8, rec[3..], ".graff/"))
+            try out.append(arena, rec[3..]);
     }
     return out.items;
 }
@@ -233,6 +237,15 @@ test "untrackedPaths: only ?? records, and a rename's origin field is consumed" 
     try std.testing.expectEqual(@as(usize, 2), paths.len);
     try std.testing.expectEqualStrings("notes.md", paths[0]);
     try std.testing.expectEqualStrings("a b.txt", paths[1]);
+
+    // graff's own state dir never counts as progress: in a repo that does not
+    // gitignore .graff/, the eval-log append would otherwise move the tree on
+    // every iteration and fail the guard open (found by the batch comparison).
+    const own = "?? .graff/eval-log.tsv\x00?? .graffx\x00?? src/real.zig\x00";
+    const own_paths = try untrackedPaths(ar, own);
+    try std.testing.expectEqual(@as(usize, 2), own_paths.len);
+    try std.testing.expectEqualStrings(".graffx", own_paths[0]);
+    try std.testing.expectEqualStrings("src/real.zig", own_paths[1]);
 
     // The rename's ORIGIN field must not be read as a record of its own: a
     // path beginning "?? " would otherwise be picked up out of it.

--- a/src/worktree_lease.zig
+++ b/src/worktree_lease.zig
@@ -14,12 +14,17 @@
 //! and it already honours #320's rule that a pid alone may never signal an
 //! owner. Nothing writes records yet, so no root session is warned at startup;
 //! that needs a registry file plus a call site in startup.zig.
+//!
+//! #413 supplied the missing half: `proc_identity` reads a pid's START
+//! identity, so "is that pid still the process that recorded it" is now a
+//! question the OS answers rather than one this file has to be handed.
 
 const std = @import("std");
 const Io = std.Io;
 const Allocator = std.mem.Allocator;
 
 const process_runner = @import("process_runner.zig");
+const proc_identity = @import("proc_identity.zig");
 const runCapped = process_runner.runCapped;
 const ranOk = process_runner.ranOk;
 
@@ -53,12 +58,13 @@ pub fn canonicalIdentity(git_dir: []const u8, common_dir: []const u8, fallback_p
     return .{ .id = g, .kind = .linked_worktree };
 }
 
-/// One recorded root-session owner of a worktree identity. `start_ns` is the
-/// process START time, not just the pid: after a crash the OS may hand the same
-/// pid to something unrelated, and #320 requires that never look like an owner.
+/// One recorded root-session owner of a worktree identity. `start_id` is the
+/// process START identity, not just the pid: after a crash the OS may hand the
+/// same pid to something unrelated, and #320 requires that never look like an
+/// owner. `proc_identity` produces the value and knows its units.
 pub const Owner = struct {
     pid: i32 = 0,
-    start_ns: u64 = 0,
+    start_id: proc_identity.StartId = 0,
     session_id: []const u8 = "",
     identity: []const u8 = "",
     last_seen_ms: i64 = 0,
@@ -71,36 +77,71 @@ pub const OwnerVerdict = enum {
     other_worktree,
     /// Another root session is alive in MY worktree: the #320 warning case.
     live_foreign,
+    /// The pid is alive but its identity could not be read, so we cannot prove
+    /// it is NOT the recorded owner. Warned about like a live one (#413): the
+    /// cost of a needless warning is a line of text, the cost of staying quiet
+    /// is two sessions editing one tree.
+    live_unverified,
     /// The owner exited (or its pid now belongs to something else).
     stale_dead,
     /// Not enough evidence to claim anyone owns it; treated as stale.
     stale_unverifiable,
 };
 
-/// `live_start_ns` is the START time of whatever process currently holds
-/// `rec.pid`, or null when no such process exists or it could not be read.
-pub fn ownerVerdict(rec: Owner, my_identity: []const u8, my_pid: i32, live_start_ns: ?u64) OwnerVerdict {
+/// The record for this process, ready to be written to a registry.
+pub fn selfOwner(io: Io, identity: []const u8, session_id: []const u8, now_ms: i64) Owner {
+    return .{
+        .pid = proc_identity.selfPid(),
+        .start_id = proc_identity.selfStartId(io),
+        .session_id = session_id,
+        .identity = identity,
+        .last_seen_ms = now_ms,
+    };
+}
+
+/// `live` is what the OS says about `rec.pid` right now (`proc_identity.probe`).
+pub fn ownerVerdict(rec: Owner, my_identity: []const u8, my_pid: i32, live: proc_identity.Probe) OwnerVerdict {
     if (rec.identity.len == 0 or my_identity.len == 0) return .stale_unverifiable;
     if (!std.mem.eql(u8, rec.identity, my_identity)) return .other_worktree;
     // A record with no start identity can only be matched by pid, and pid alone
-    // is precisely what #320 says must not signal an owner.
-    if (rec.start_ns == 0) return .stale_unverifiable;
-    const live = live_start_ns orelse return .stale_dead;
-    if (live != rec.start_ns) return .stale_dead; // pid reuse, not the owner
+    // is precisely what #320 says must not signal an owner. Unlike a mutual
+    // exclusion lock — where honouring a legacy record is the safe answer —
+    // this one only prints a warning, so the false-positive is the harm.
+    if (rec.start_id == 0) return .stale_unverifiable;
+    const unverified = switch (live) {
+        .gone => return .stale_dead,
+        .id => |v| blk: {
+            if (v != rec.start_id) return .stale_dead; // pid reuse, not the owner
+            break :blk false;
+        },
+        .unknown => true,
+    };
     if (rec.pid == my_pid) return .self;
-    return .live_foreign;
+    return if (unverified) .live_unverified else .live_foreign;
 }
 
 /// The #320 preflight: the first live foreign owner of MY worktree, if any.
 /// Everything else — my own record, another worktree's, a crashed or pid-reused
 /// one — is silent, so a stale registry can never block a startup.
-/// `live_start_ns[i]` pairs with `records[i]`; a short slice reads as "unknown".
-pub fn duplicateOwner(records: []const Owner, live_start_ns: []const ?u64, my_identity: []const u8, my_pid: i32) ?Owner {
+/// `probes[i]` pairs with `records[i]`; a record past the end of `probes` was
+/// never probed at all, which is no evidence of anything and so is skipped.
+pub fn duplicateOwner(records: []const Owner, probes: []const proc_identity.Probe, my_identity: []const u8, my_pid: i32) ?Owner {
     for (records, 0..) |rec, i| {
-        const live = if (i < live_start_ns.len) live_start_ns[i] else null;
-        if (ownerVerdict(rec, my_identity, my_pid, live) == .live_foreign) return rec;
+        if (i >= probes.len) break;
+        switch (ownerVerdict(rec, my_identity, my_pid, probes[i])) {
+            .live_foreign, .live_unverified => return rec,
+            else => {},
+        }
     }
     return null;
+}
+
+/// Probe every record's pid once into caller storage; the slice it returns is
+/// what `duplicateOwner` expects.
+pub fn probeOwners(io: Io, records: []const Owner, out: []proc_identity.Probe) []const proc_identity.Probe {
+    const n = @min(records.len, out.len);
+    for (records[0..n], out[0..n]) |rec, *slot| slot.* = proc_identity.probe(io, rec.pid);
+    return out[0..n];
 }
 
 pub fn duplicateOwnerWarning(arena: Allocator, rec: Owner, age_ms: i64) []const u8 {
@@ -174,46 +215,78 @@ test "canonicalIdentity: one id per worktree, distinct across linked worktrees (
 
 test "ownerVerdict: only a verified live process in MY worktree is an owner (#320)" {
     const me = "/repo/.git";
-    const rec: Owner = .{ .pid = 4242, .start_ns = 777, .session_id = "s-1", .identity = me };
+    const rec: Owner = .{ .pid = 4242, .start_id = 777, .session_id = "s-1", .identity = me };
 
-    try std.testing.expectEqual(OwnerVerdict.live_foreign, ownerVerdict(rec, me, 99, 777));
-    try std.testing.expectEqual(OwnerVerdict.self, ownerVerdict(rec, me, 4242, 777));
+    try std.testing.expectEqual(OwnerVerdict.live_foreign, ownerVerdict(rec, me, 99, .{ .id = 777 }));
+    try std.testing.expectEqual(OwnerVerdict.self, ownerVerdict(rec, me, 4242, .{ .id = 777 }));
     // Separate git worktrees do not conflict.
-    try std.testing.expectEqual(OwnerVerdict.other_worktree, ownerVerdict(rec, "/repo/.git/worktrees/wt1", 99, 777));
+    try std.testing.expectEqual(OwnerVerdict.other_worktree, ownerVerdict(rec, "/repo/.git/worktrees/wt1", 99, .{ .id = 777 }));
     // Crashed owner: the pid is simply gone.
-    try std.testing.expectEqual(OwnerVerdict.stale_dead, ownerVerdict(rec, me, 99, null));
+    try std.testing.expectEqual(OwnerVerdict.stale_dead, ownerVerdict(rec, me, 99, .gone));
     // PID reuse: the pid is live but it is a different process.
-    try std.testing.expectEqual(OwnerVerdict.stale_dead, ownerVerdict(rec, me, 99, 778));
+    try std.testing.expectEqual(OwnerVerdict.stale_dead, ownerVerdict(rec, me, 99, .{ .id = 778 }));
     // No start identity recorded — unverifiable is stale, never a warning.
     var no_start = rec;
-    no_start.start_ns = 0;
-    try std.testing.expectEqual(OwnerVerdict.stale_unverifiable, ownerVerdict(no_start, me, 99, 777));
+    no_start.start_id = 0;
+    try std.testing.expectEqual(OwnerVerdict.stale_unverifiable, ownerVerdict(no_start, me, 99, .{ .id = 777 }));
+}
+
+test "ownerVerdict: a pid we cannot identify is assumed to be the owner (#413)" {
+    const me = "/repo/.git";
+    const rec: Owner = .{ .pid = 4242, .start_id = 777, .session_id = "s-1", .identity = me };
+    // An unreadable identity is not evidence of death: warn rather than treat
+    // a possibly live session as stale.
+    try std.testing.expectEqual(OwnerVerdict.live_unverified, ownerVerdict(rec, me, 99, .unknown));
+    // …but it is still not somebody else when the pid is mine.
+    try std.testing.expectEqual(OwnerVerdict.self, ownerVerdict(rec, me, 4242, .unknown));
 }
 
 test "duplicateOwner: picks the live foreign session and ignores stale records (#320)" {
     const me = "/repo/.git";
     const records = [_]Owner{
-        .{ .pid = 1, .start_ns = 10, .session_id = "dead", .identity = me },
-        .{ .pid = 2, .start_ns = 20, .session_id = "other-wt", .identity = "/repo/.git/worktrees/wt1" },
-        .{ .pid = 3, .start_ns = 30, .session_id = "mine", .identity = me },
-        .{ .pid = 4, .start_ns = 40, .session_id = "live", .identity = me },
+        .{ .pid = 1, .start_id = 10, .session_id = "dead", .identity = me },
+        .{ .pid = 2, .start_id = 20, .session_id = "other-wt", .identity = "/repo/.git/worktrees/wt1" },
+        .{ .pid = 3, .start_id = 30, .session_id = "mine", .identity = me },
+        .{ .pid = 4, .start_id = 40, .session_id = "live", .identity = me },
     };
-    const live = [_]?u64{ null, 20, 30, 40 };
+    const live = [_]proc_identity.Probe{ .gone, .{ .id = 20 }, .{ .id = 30 }, .{ .id = 40 } };
     const found = duplicateOwner(&records, &live, me, 3) orelse return error.ExpectedDuplicate;
     try std.testing.expectEqualStrings("live", found.session_id);
     try std.testing.expectEqual(@as(i32, 4), found.pid);
 
     // Alone in the worktree: only my own record matches, so no warning.
     const solo = [_]Owner{records[2]};
-    try std.testing.expect(duplicateOwner(&solo, &.{30}, me, 3) == null);
+    try std.testing.expect(duplicateOwner(&solo, &.{.{ .id = 30 }}, me, 3) == null);
     // A registry we cannot read at all must not manufacture an owner.
     try std.testing.expect(duplicateOwner(&records, &.{}, me, 3) == null);
+}
+
+test "selfOwner + probeOwners: this process records and verifies as itself (#413)" {
+    const io = std.testing.io;
+    const me = "/repo/.git";
+    const mine = selfOwner(io, me, "s-self", 1234);
+    try std.testing.expect(mine.pid > 0);
+
+    var probes: [1]proc_identity.Probe = undefined;
+    const live = probeOwners(io, &.{mine}, &probes);
+    try std.testing.expectEqual(@as(usize, 1), live.len);
+    // My own live record is `self`, never a duplicate owner…
+    try std.testing.expectEqual(OwnerVerdict.self, ownerVerdict(mine, me, mine.pid, live[0]));
+    try std.testing.expect(duplicateOwner(&.{mine}, live, me, mine.pid) == null);
+
+    // …and a record claiming my pid from a process that no longer exists is
+    // stale, which is the whole point: a recycled pid cannot hold a lease.
+    if (mine.start_id != 0) {
+        var recycled = mine;
+        recycled.start_id +%= 1;
+        try std.testing.expectEqual(OwnerVerdict.stale_dead, ownerVerdict(recycled, me, mine.pid, live[0]));
+    }
 }
 
 test "duplicateOwnerWarning: names the pid, the session and an escape hatch (#320)" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
-    const text = duplicateOwnerWarning(arena_state.allocator(), .{ .pid = 4242, .start_ns = 1, .session_id = "s-1" }, 5 * std.time.ms_per_min);
+    const text = duplicateOwnerWarning(arena_state.allocator(), .{ .pid = 4242, .start_id = 1, .session_id = "s-1" }, 5 * std.time.ms_per_min);
     try std.testing.expect(std.mem.indexOf(u8, text, "4242") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "s-1") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "5m") != null);


### PR DESCRIPTION
The pre-validated integration of the six feature PRs, merged serially with conflicts resolved (one `v0.0.241` changelog section, all `test_hooks` wirings kept, `agent_request.zig` carrying both #436's and #437's changes), including both post-comparison fixes (windows-portable spill assert, `.graff/` untracked-scan exclusion).

This exact tree is what every quality gate ran against:
- **1041/1041 tests** green, fmt clean, line-guard clean
- **All 9 golden eval files** byte-identical
- The **mock before/after comparison** (embedder −17%, verifier calls −67%, spill wire −34%, phantom compactions eliminated)
- The **live gpt-5.6-sol evals**: 36/36 task successes, embedder −5.5% input tokens with zero variance, the #412 guard firing 3/3 when its condition arises, no regressions

Merging this makes #433/#434/#435/#436/#437/#438 reachable from main (GitHub auto-marks them merged). #442 and #443 follow separately.