### PR TITLE
release: merge v0.0.241 back to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,21 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
-## v0.0.241 (unreleased)
+## v0.0.241 (2026-08-06)
 
+- The engine separation reached the tool-execution cluster (#422): tool-call
+  announcements, results, rejections, parallel-batch brackets, and the
+  goal/todo notices now travel the typed event stream, with the inventory
+  finding that only `agent_tools.zig` ever wrote to the terminal — the rest
+  of the cluster was already clean. The wire sink is now provably unable to
+  ship a shapeless durable event or reserve sequence ids for a frontendless
+  agent.
+- A WebSocket 426 refusal latches SSE immediately (#427): the server answered
+  authoritatively, so the session falls back on the same attempt instead of
+  burning a rebuild and a redial before the two-failure latch.
+- The tier-1 gate counts tests off the compiled artifact when a cached build
+  prints no summary, selects the reachability binary by content instead of
+  mtime, and warns when its test-count ratchet goes stale (#439).
 - The system prompt is now assembled from capability-gated segments (#421):
   an instruction ships only when its capability is actually present, read
   from the same predicates dispatch uses to refuse a hallucinated call, so

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -21,6 +21,12 @@ const harness_version = root.harness_version;
 pub const changelog_text =
     \\What's new
     \\──────────
+    \\0.0.241
+    \\  • Goal/loop runs stop paying for verifications the workspace cannot have changed: an unchanged tree skips the eval command and its judge call, and the model is steered to edit first
+    \\  • Oversized tool outputs spill to a session artifact the model can read or grep instead of being destroyed at the cap; throttles no longer masquerade as context overflows, and silent overflows recover in one trim
+    \\  • The system prompt is capability-gated — embedder sessions drop ~15% of it — and a durable session's prompt names its own transcript
+    \\  • Cross-process locks key on process START identity, a 426 WebSocket refusal latches SSE at once, and tool-execution output joined the typed event stream
+    \\
     \\0.0.240
     \\  • Engine output now flows through a typed event stream behind a strict sink boundary — the start of the REPL/engine separation, with TUI and --json output proven byte-identical
     \\  • Quitting no longer strands the held Codex socket: loop exit closes the WebSocket and its response anchor, and debug builds finish with a clean allocator report
@@ -47,11 +53,6 @@ pub const changelog_text =
     \\  • The bundled skill-creator teaches the full authoring loop, from capturing intent mid-session to forward-testing with fresh subagents
     \\  • Root/subagent model shapes can keep orchestration on Sol while routing parallel workers and judges to Terra
     \\  • Remote MCP servers now support Streamable HTTP, OAuth discovery/PKCE/refresh, and an opt-out core Smolify connection
-    \\
-    \\0.0.209
-    \\  • Kimi Code now follows each live catalog model's native or Anthropic beta protocol, auth style, context, and thinking metadata
-    \\  • Native Kimi tool schemas are normalized to Moonshot's stricter validator; OAuth requests carry the current Kimi Code identity headers
-    \\  • `--model kimi` selects K3 today and automatically follows future pure Kimi generations
     \\
 ;
 


### PR DESCRIPTION
Standard post-release merge-back. v0.0.241 is published: notarized both archs (aarch64 required a re-sign — zig's ad-hoc signature survived a silently-failed codesign and passed `--verify --strict`; Authority is now asserted explicitly), fresh-download verified, `releases/latest` confirmed.