### PR TITLE
feat(gui): agent overview panel — active agents, status chips, recent subagents (#419)

### DIFF
--- a/gui/src/app/App.tsx
+++ b/gui/src/app/App.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 
 import { NewChatTrigger } from "../components/NewChatTrigger";
+import { AgentOverviewPanel } from "../components/agent-overview/AgentOverviewPanel";
 import { GeneralSettingsPane } from "../components/general-settings/GeneralSettingsPane";
 import { McpSettingsPane } from "../components/mcp-settings/McpSettingsPane";
 import { ProvidersSettingsPane } from "../components/providers-settings/ProvidersSettingsPane";
@@ -373,7 +374,12 @@ function AppShell() {
                     <SidebarVisibilityContext.Provider
                       value={isDesktopSidebarVisible}
                     >
-                      <WorkspaceBoard />
+                      <div className="flex h-full min-w-0 flex-1 overflow-hidden">
+                        <div className="min-w-0 flex-1">
+                          <WorkspaceBoard />
+                        </div>
+                        <AgentOverviewPanel />
+                      </div>
                     </SidebarVisibilityContext.Provider>
                   </SettingsNavigationProvider>
                 )}

--- a/gui/src/components/agent-overview/AgentOverviewPanel.tsx
+++ b/gui/src/components/agent-overview/AgentOverviewPanel.tsx
@@ -1,0 +1,223 @@
+import { useMemo, useState } from "react";
+import {
+  BotIcon,
+  CheckIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CircleAlertIcon,
+  CircleDotIcon,
+  NetworkIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+
+import { getConversationStoreKey } from "@/app/sessionStoreHelpers";
+import {
+  useBoardSelection,
+  useSessionActions,
+  useSessionStore,
+} from "@/hooks/useSession";
+import { Button } from "@/components/ui/Button";
+
+import {
+  buildAgentOverview,
+  type AgentOverviewItem,
+  type AgentOverviewStatus,
+} from "./agentOverview";
+
+const STATUS_LABELS: Record<AgentOverviewStatus, string> = {
+  running: "Working",
+  "needs-input": "Needs input",
+  completed: "Completed",
+  failed: "Failed",
+  idle: "Ready",
+};
+
+function StatusIcon({ status }: { status: AgentOverviewStatus }) {
+  if (status === "running") {
+    return <CircleDotIcon aria-hidden="true" className="size-3.5" />;
+  }
+  if (status === "needs-input") {
+    return <CircleAlertIcon aria-hidden="true" className="size-3.5" />;
+  }
+  if (status === "failed") {
+    return <TriangleAlertIcon aria-hidden="true" className="size-3.5" />;
+  }
+  if (status === "completed") {
+    return <CheckIcon aria-hidden="true" className="size-3.5" />;
+  }
+  return <BotIcon aria-hidden="true" className="size-3.5" />;
+}
+
+function workspaceName(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/\/$/, "");
+  return normalized.split("/").at(-1) || path;
+}
+
+function AgentCard({
+  item,
+  onSelect,
+}: {
+  item: AgentOverviewItem;
+  onSelect: (item: AgentOverviewItem) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`agent-overview-card${item.isCurrentConversation ? " is-current" : ""}`}
+      onClick={() => onSelect(item)}
+      aria-label={`Open ${item.conversationTitle}`}
+    >
+      <span className={`agent-overview-status is-${item.status}`}>
+        <StatusIcon status={item.status} />
+      </span>
+      <span className="min-w-0 flex-1 text-left">
+        <span className="flex items-center gap-2">
+          <span className="truncate text-xs font-semibold text-foreground">
+            {item.label}
+          </span>
+          <span className={`agent-overview-state is-${item.status}`}>
+            {STATUS_LABELS[item.status]}
+          </span>
+        </span>
+        <span className="mt-1 block truncate text-[11px] text-muted-foreground">
+          {item.detail}
+        </span>
+        <span className="mt-1.5 flex items-center gap-1.5 text-[10px] text-muted-foreground/70">
+          <span className="truncate">{item.conversationTitle}</span>
+          <span aria-hidden="true">·</span>
+          <span className="shrink-0">{workspaceName(item.workspacePath)}</span>
+        </span>
+      </span>
+    </button>
+  );
+}
+
+export function AgentOverviewPanel() {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const selection = useBoardSelection();
+  const views = useSessionStore((state) => state.conversationViewsByKey);
+  const summaries = useSessionStore(
+    (state) => state.conversationSummariesByKey,
+  );
+  const { selectConversation } = useSessionActions();
+
+  const currentBinding =
+    selection.kind === "single-chat"
+      ? selection.chat
+      : selection.kind === "saved-workspace"
+        ? selection.activeChat
+        : null;
+  const currentConversationKey =
+    currentBinding == null
+      ? null
+      : getConversationStoreKey(
+          currentBinding.workspacePath,
+          currentBinding.conversationId,
+        );
+
+  const overview = useMemo(
+    () =>
+      buildAgentOverview({
+        views,
+        summaries,
+        currentConversationKey,
+      }),
+    [currentConversationKey, summaries, views],
+  );
+
+  function handleSelect(item: AgentOverviewItem) {
+    if (item.isCurrentConversation) return;
+    void selectConversation(item.workspacePath, item.conversationId);
+  }
+
+  if (isCollapsed) {
+    return (
+      <aside className="agent-overview is-collapsed" aria-label="Agent overview">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="agent-overview-expand"
+          onClick={() => setIsCollapsed(false)}
+          aria-label="Show agent overview"
+        >
+          <ChevronLeftIcon className="size-3.5" />
+        </Button>
+        <NetworkIcon aria-hidden="true" className="size-4 text-foreground/65" />
+        {overview.totalActive > 0 ? (
+          <span className="agent-overview-count" aria-label={`${overview.totalActive} active agents`}>
+            {overview.totalActive}
+          </span>
+        ) : null}
+        {overview.needsInput > 0 ? (
+          <span className="agent-overview-attention" aria-label="An agent needs input" />
+        ) : null}
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="agent-overview" aria-label="Agent overview">
+      <header className="agent-overview-header">
+        <div className="flex min-w-0 items-center gap-2">
+          <NetworkIcon aria-hidden="true" className="size-3.5 text-foreground/70" />
+          <div className="min-w-0">
+            <h2 className="text-[11px] font-semibold uppercase tracking-[0.12em] text-foreground/75">
+              Agents
+            </h2>
+            <p className="mt-0.5 text-[10px] text-muted-foreground">
+              {overview.totalActive === 0
+                ? "No active work"
+                : `${overview.totalActive} active${overview.needsInput > 0 ? ` · ${overview.needsInput} needs input` : ""}`}
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => setIsCollapsed(true)}
+          aria-label="Hide agent overview"
+        >
+          <ChevronRightIcon className="size-3.5" />
+        </Button>
+      </header>
+
+      <div className="agent-overview-scroll">
+        <section aria-labelledby="active-agents-heading">
+          <h3 id="active-agents-heading" className="agent-overview-section-title">
+            Current
+          </h3>
+          <div className="space-y-1.5">
+            {overview.active.length > 0 ? (
+              overview.active.map((item) => (
+                <AgentCard key={item.id} item={item} onSelect={handleSelect} />
+              ))
+            ) : (
+              <div className="agent-overview-empty">
+                <BotIcon aria-hidden="true" className="size-4" />
+                <p>Agents appear here when work begins.</p>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {overview.recent.length > 0 ? (
+          <section className="mt-5" aria-labelledby="recent-agents-heading">
+            <h3 id="recent-agents-heading" className="agent-overview-section-title">
+              Recent
+            </h3>
+            <div className="space-y-1.5">
+              {overview.recent.map((item) => (
+                <AgentCard key={item.id} item={item} onSelect={handleSelect} />
+              ))}
+            </div>
+          </section>
+        ) : null}
+      </div>
+
+      <footer className="agent-overview-footer">
+        <span className="size-1.5 rounded-full bg-success" aria-hidden="true" />
+        Live activity across conversations
+      </footer>
+    </aside>
+  );
+}

--- a/gui/src/components/agent-overview/agentOverview.test.ts
+++ b/gui/src/components/agent-overview/agentOverview.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  ConversationViewSnapshot,
+  SessionMessage,
+} from "@/services/desktop/types/contracts";
+
+import { buildAgentOverview } from "./agentOverview";
+
+function view(messages: SessionMessage[]): ConversationViewSnapshot {
+  return {
+    workspacePath: "/code/project",
+    conversationId: "conversation-1",
+    messages,
+    activeRequestIds: [],
+    requestAgentIds: {},
+    todos: [],
+    followup: null,
+  };
+}
+
+function taskStart(
+  id: string,
+  callId: string,
+): Extract<SessionMessage, { kind: "tool_start" }> {
+  return {
+    kind: "tool_start",
+    id,
+    requestId: "request-1",
+    name: "subagent",
+    callId,
+    detail: {
+      kind: "task",
+      agentId: `agent-${id}`,
+      label: "Review implementation",
+    },
+  };
+}
+
+function taskEnd(
+  id: string,
+  callId: string,
+  isError = false,
+): Extract<SessionMessage, { kind: "tool_end" }> {
+  return {
+    kind: "tool_end",
+    id,
+    requestId: "request-1",
+    name: "subagent",
+    callId,
+    summary: isError ? "Review failed" : "Review complete",
+    isError,
+    detail: null,
+  };
+}
+
+describe("buildAgentOverview", () => {
+  test("shows the current orchestrator and running subagents as active", () => {
+    const current = view([taskStart("start-1", "call-1")]);
+    current.activeRequestIds = ["request-1"];
+    current.requestAgentIds = { "request-1": "forge" };
+
+    const overview = buildAgentOverview({
+      views: { current },
+      summaries: {},
+      currentConversationKey: "current",
+    });
+
+    expect(overview.active).toHaveLength(2);
+    expect(overview.totalActive).toBe(2);
+    expect(overview.active.map((item) => item.label)).toEqual([
+      "forge",
+      "Review implementation",
+    ]);
+    expect(overview.recent).toHaveLength(0);
+  });
+
+  test("moves completed subagents into recent activity", () => {
+    const current = view([
+      taskStart("start-1", "call-1"),
+      taskEnd("end-1", "call-1"),
+    ]);
+
+    const overview = buildAgentOverview({
+      views: { current },
+      summaries: {},
+      currentConversationKey: "current",
+    });
+
+    expect(overview.active).toHaveLength(1);
+    expect(overview.active[0].status).toBe("idle");
+    expect(overview.recent).toHaveLength(1);
+    expect(overview.recent[0]).toMatchObject({
+      label: "Review implementation",
+      detail: "Review complete",
+      status: "completed",
+    });
+  });
+
+  test("prioritizes conversations waiting for human input", () => {
+    const waiting = view([]);
+    waiting.followup = {
+      followupId: "followup-1",
+      workspacePath: waiting.workspacePath,
+      conversationId: waiting.conversationId,
+      requestId: "request-1",
+      question: "Choose a direction",
+      kind: "single",
+      options: [],
+    };
+
+    const overview = buildAgentOverview({
+      views: { waiting },
+      summaries: {},
+      currentConversationKey: null,
+    });
+
+    expect(overview.needsInput).toBe(1);
+    expect(overview.active[0].status).toBe("needs-input");
+  });
+
+  test("marks failed subagent calls truthfully", () => {
+    const failed = view([
+      taskStart("start-1", "call-1"),
+      taskEnd("end-1", "call-1", true),
+    ]);
+
+    const overview = buildAgentOverview({
+      views: { failed },
+      summaries: {},
+      currentConversationKey: null,
+    });
+
+    expect(overview.recent[0]).toMatchObject({
+      status: "failed",
+      detail: "Review failed",
+    });
+  });
+});

--- a/gui/src/components/agent-overview/agentOverview.ts
+++ b/gui/src/components/agent-overview/agentOverview.ts
@@ -1,0 +1,211 @@
+import type {
+  ConversationSessionSummary,
+  ConversationViewSnapshot,
+  SessionMessage,
+} from "@/services/desktop/types/contracts";
+
+export type AgentOverviewStatus =
+  | "running"
+  | "needs-input"
+  | "completed"
+  | "failed"
+  | "idle";
+
+export interface AgentOverviewItem {
+  id: string;
+  agentId: string;
+  conversationId: string;
+  conversationTitle: string;
+  workspacePath: string;
+  kind: "orchestrator" | "subagent";
+  label: string;
+  detail: string;
+  status: AgentOverviewStatus;
+  isCurrentConversation: boolean;
+  sequence: number;
+}
+
+export interface AgentOverviewSnapshot {
+  active: AgentOverviewItem[];
+  recent: AgentOverviewItem[];
+  totalActive: number;
+  needsInput: number;
+}
+
+interface BuildAgentOverviewInput {
+  views: Record<string, ConversationViewSnapshot>;
+  summaries: Record<string, ConversationSessionSummary>;
+  currentConversationKey: string | null;
+}
+
+type ToolStartMessage = Extract<SessionMessage, { kind: "tool_start" }>;
+type ToolEndMessage = Extract<SessionMessage, { kind: "tool_end" }>;
+
+function findToolEnd(
+  messages: SessionMessage[],
+  start: ToolStartMessage,
+  startIndex: number,
+): ToolEndMessage | null {
+  for (let index = startIndex + 1; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (
+      message.kind === "tool_end" &&
+      message.requestId === start.requestId &&
+      message.name === start.name &&
+      message.callId === start.callId
+    ) {
+      return message;
+    }
+  }
+  return null;
+}
+
+function latestUserPrompt(messages: SessionMessage[]): string | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.kind === "user" && message.text.trim().length > 0) {
+      return message.text.trim();
+    }
+  }
+  return null;
+}
+
+function latestRequestAgent(view: ConversationViewSnapshot): string | null {
+  for (let index = view.activeRequestIds.length - 1; index >= 0; index -= 1) {
+    const agentId = view.requestAgentIds[view.activeRequestIds[index]];
+    if (agentId != null && agentId.length > 0) {
+      return agentId;
+    }
+  }
+  return null;
+}
+
+function titleForConversation(
+  key: string,
+  view: ConversationViewSnapshot,
+  summaries: Record<string, ConversationSessionSummary>,
+): string {
+  return summaries[key]?.title ?? latestUserPrompt(view.messages) ?? "Untitled task";
+}
+
+function buildOrchestrator(
+  key: string,
+  view: ConversationViewSnapshot,
+  summaries: Record<string, ConversationSessionSummary>,
+  isCurrentConversation: boolean,
+): AgentOverviewItem {
+  const activeAgent = latestRequestAgent(view);
+  const lastMessage = view.messages.at(-1);
+  let status: AgentOverviewStatus = "idle";
+
+  if (view.followup != null) {
+    status = "needs-input";
+  } else if (view.activeRequestIds.length > 0) {
+    status = "running";
+  } else if (lastMessage?.kind === "error") {
+    status = "failed";
+  }
+
+  return {
+    id: `${key}:orchestrator`,
+    agentId: activeAgent ?? "root",
+    conversationId: view.conversationId,
+    conversationTitle: titleForConversation(key, view, summaries),
+    workspacePath: view.workspacePath,
+    kind: "orchestrator",
+    label: activeAgent ?? "Main agent",
+    detail: view.goal ?? latestUserPrompt(view.messages) ?? "Ready for direction",
+    status,
+    isCurrentConversation,
+    sequence: view.messages.length,
+  };
+}
+
+function buildSubagents(
+  key: string,
+  view: ConversationViewSnapshot,
+  summaries: Record<string, ConversationSessionSummary>,
+  isCurrentConversation: boolean,
+): AgentOverviewItem[] {
+  const items: AgentOverviewItem[] = [];
+
+  view.messages.forEach((message, index) => {
+    if (message.kind !== "tool_start" || message.detail.kind !== "task") {
+      return;
+    }
+
+    const end = findToolEnd(view.messages, message, index);
+    const status: AgentOverviewStatus =
+      end == null ? "running" : end.isError ? "failed" : "completed";
+
+    items.push({
+      id: `${key}:subagent:${message.callId ?? message.id}`,
+      agentId: message.detail.agentId,
+      conversationId: view.conversationId,
+      conversationTitle: titleForConversation(key, view, summaries),
+      workspacePath: view.workspacePath,
+      kind: "subagent",
+      label: message.detail.label || message.detail.agentId,
+      detail:
+        end?.summary ??
+        (status === "running" ? "Working in the background" : "Task finished"),
+      status,
+      isCurrentConversation,
+      sequence: index,
+    });
+  });
+
+  return items;
+}
+
+function priority(item: AgentOverviewItem): number {
+  if (item.status === "needs-input") return 0;
+  if (item.status === "running") return 1;
+  if (item.status === "failed") return 2;
+  if (item.status === "idle") return 3;
+  return 4;
+}
+
+export function buildAgentOverview({
+  views,
+  summaries,
+  currentConversationKey,
+}: BuildAgentOverviewInput): AgentOverviewSnapshot {
+  const items = Object.entries(views).flatMap(([key, view]) => {
+    const isCurrentConversation = key === currentConversationKey;
+    return [
+      buildOrchestrator(key, view, summaries, isCurrentConversation),
+      ...buildSubagents(key, view, summaries, isCurrentConversation),
+    ];
+  });
+
+  const active = items
+    .filter(
+      (item) =>
+        item.status === "running" ||
+        item.status === "needs-input" ||
+        (item.kind === "orchestrator" && item.isCurrentConversation),
+    )
+    .sort(
+      (left, right) =>
+        priority(left) - priority(right) ||
+        Number(right.isCurrentConversation) -
+          Number(left.isCurrentConversation) ||
+        right.sequence - left.sequence,
+    );
+
+  const activeIds = new Set(active.map((item) => item.id));
+  const recent = items
+    .filter((item) => !activeIds.has(item.id) && item.kind === "subagent")
+    .sort((left, right) => right.sequence - left.sequence)
+    .slice(0, 6);
+
+  return {
+    active,
+    recent,
+    totalActive: active.filter(
+      (item) => item.status === "running" || item.status === "needs-input",
+    ).length,
+    needsInput: active.filter((item) => item.status === "needs-input").length,
+  };
+}

--- a/gui/src/styles/agent-overview.css
+++ b/gui/src/styles/agent-overview.css
@@ -1,0 +1,196 @@
+.agent-overview {
+    display: flex;
+    width: 17.5rem;
+    min-width: 17.5rem;
+    height: 100%;
+    flex-direction: column;
+    overflow: hidden;
+    border-left: 1px solid color-mix(in oklab, var(--border) 76%, transparent);
+    background:
+        linear-gradient(
+            180deg,
+            color-mix(in oklab, var(--sidebar) 72%, var(--background)) 0%,
+            color-mix(in oklab, var(--background) 94%, var(--sidebar)) 100%
+        );
+    transition:
+        width 220ms cubic-bezier(0.16, 1, 0.3, 1),
+        min-width 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.agent-overview.is-collapsed {
+    width: 2.75rem;
+    min-width: 2.75rem;
+    align-items: center;
+    gap: 1rem;
+    padding-top: 0.5rem;
+}
+
+.agent-overview-header {
+    display: flex;
+    min-height: 3.5rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border-bottom: 1px solid color-mix(in oklab, var(--border) 68%, transparent);
+    padding: 0.625rem 0.625rem 0.625rem 0.875rem;
+}
+
+.agent-overview-scroll {
+    min-height: 0;
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.875rem 0.625rem 1rem;
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in oklab, var(--foreground) 18%, transparent)
+        transparent;
+}
+
+.agent-overview-section-title {
+    margin-bottom: 0.5rem;
+    padding-inline: 0.25rem;
+    color: color-mix(in oklab, var(--foreground) 48%, transparent);
+    font-size: 0.625rem;
+    font-weight: 650;
+    letter-spacing: 0.12em;
+    line-height: 1rem;
+    text-transform: uppercase;
+}
+
+.agent-overview-card {
+    display: flex;
+    width: 100%;
+    align-items: flex-start;
+    gap: 0.625rem;
+    border: 1px solid transparent;
+    border-radius: calc(var(--radius) - 0.125rem);
+    padding: 0.625rem;
+    color: inherit;
+    transition:
+        border-color 140ms ease,
+        background-color 140ms ease;
+}
+
+.agent-overview-card:hover {
+    border-color: color-mix(in oklab, var(--border) 72%, transparent);
+    background: color-mix(in oklab, var(--foreground) 4%, transparent);
+}
+
+.agent-overview-card.is-current {
+    border-color: color-mix(in oklab, var(--accent) 26%, var(--border));
+    background: color-mix(in oklab, var(--accent) 7%, transparent);
+}
+
+.agent-overview-status {
+    display: grid;
+    width: 1.625rem;
+    height: 1.625rem;
+    flex: none;
+    place-items: center;
+    border: 1px solid color-mix(in oklab, currentColor 20%, transparent);
+    border-radius: 999px;
+    background: color-mix(in oklab, currentColor 8%, transparent);
+    color: var(--muted-foreground);
+}
+
+.agent-overview-status.is-running {
+    color: var(--accent);
+}
+
+.agent-overview-status.is-needs-input {
+    color: var(--warn);
+}
+
+.agent-overview-status.is-completed {
+    color: var(--success);
+}
+
+.agent-overview-status.is-failed {
+    color: var(--destructive);
+}
+
+.agent-overview-state {
+    flex: none;
+    border-radius: 999px;
+    padding: 0.125rem 0.375rem;
+    background: color-mix(in oklab, currentColor 9%, transparent);
+    color: var(--muted-foreground);
+    font-size: 0.5625rem;
+    font-weight: 650;
+    letter-spacing: 0.025em;
+    line-height: 0.875rem;
+}
+
+.agent-overview-state.is-running {
+    color: var(--accent-dim);
+}
+
+.agent-overview-state.is-needs-input {
+    color: var(--warn);
+}
+
+.agent-overview-state.is-completed {
+    color: var(--success);
+}
+
+.agent-overview-state.is-failed {
+    color: var(--destructive);
+}
+
+.agent-overview-empty {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    border: 1px dashed color-mix(in oklab, var(--border) 70%, transparent);
+    border-radius: calc(var(--radius) - 0.125rem);
+    padding: 0.75rem;
+    color: color-mix(in oklab, var(--muted-foreground) 72%, transparent);
+    font-size: 0.6875rem;
+    line-height: 1rem;
+}
+
+.agent-overview-footer {
+    display: flex;
+    min-height: 2.25rem;
+    align-items: center;
+    gap: 0.5rem;
+    border-top: 1px solid color-mix(in oklab, var(--border) 68%, transparent);
+    padding-inline: 0.875rem;
+    color: color-mix(in oklab, var(--muted-foreground) 72%, transparent);
+    font-size: 0.625rem;
+}
+
+.agent-overview-expand {
+    margin-bottom: 0.125rem;
+}
+
+.agent-overview-count {
+    display: grid;
+    min-width: 1.25rem;
+    height: 1.25rem;
+    place-items: center;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--accent) 14%, transparent);
+    color: var(--accent-dim);
+    font-size: 0.625rem;
+    font-weight: 700;
+}
+
+.agent-overview-attention {
+    width: 0.4375rem;
+    height: 0.4375rem;
+    border-radius: 999px;
+    background: var(--warn);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--warn) 14%, transparent);
+}
+
+@media (max-width: 980px) {
+    .agent-overview {
+        width: 15rem;
+        min-width: 15rem;
+    }
+
+    .agent-overview.is-collapsed {
+        width: 2.75rem;
+        min-width: 2.75rem;
+    }
+}

--- a/gui/src/styles/index.css
+++ b/gui/src/styles/index.css
@@ -1,6 +1,7 @@
 @import "./theme-foundations.css";
 @import "./core.css";
 @import "./theme-presets.css";
+@import "./agent-overview.css";
 @import "./workspace.css";
 @import "./motion.css";
 @import "katex/dist/katex.min.css";


### PR DESCRIPTION
The client half of #419.

A side panel over the workspace board that answers "what are my agents doing" without opening each conversation.

**How it derives rows.** `buildAgentOverview` walks every conversation view and emits one orchestrator row per conversation plus one row per `task` `tool_start`. Each start is paired with its matching `tool_end` (by `requestId` + `name` + `callId`) to resolve `running` / `completed` / `failed`; a pending `followup` resolves `needs-input`.

**Attention-first ordering.** Rows sort `needs-input` > `running` > `failed` > `idle`, current conversation ahead of the rest, newest first within a tier. `recent` keeps the last 6 finished subagents so a completed task does not vanish the instant it lands.

**What is still to come.** The cheap-model session recaps land with the engine-side recap events; this panel already renders the status chips and the per-row detail line the recap will populate, so that side is a data change rather than a UI change.

Tests: 4 pass / 0 fail, 11 assertions (`bun test src/components/agent-overview/`).