### PR TITLE
feat(prompt): defer the #410 transcript line to the first compaction (#445)

### DIFF
--- a/src/agent_compact.zig
+++ b/src/agent_compact.zig
@@ -206,6 +206,13 @@ pub fn compact(self: *Agent) anyerror!usize {
     self.goal_note_fp = 0; // the injected goal note died with the old history - re-state in full (#318)
     self.history_rewrites +%= 1; // readers of pasted state (the /loop checklist gate) re-carry it (#318)
     installed_summary = true;
+    // #445: the history the model was reading is gone and the durable file is
+    // now the only place its exact wording survives, so THIS is where the #410
+    // transcript line starts being worth its tokens. It rides this boundary
+    // deliberately: the rewrite above already invalidated the provider's cached
+    // prefix, so mutating the system prompt here costs nothing extra. Root-only
+    // and once per session — prompts.noteSessionCompacted owns both rules.
+    prompts.noteSessionCompacted(self, self.arena);
     if (!main_mod.json_mode) try self.say("[history compacted to a {d}-char summary]\n", .{summary.len});
     return summary.len;
 }
@@ -553,6 +560,12 @@ pub fn compactOrRecover(self: *Agent, trim_on_fail: bool) void {
         if (dropped > 0) {
             self.compact_transport_failures = 0;
             self.compact_summary_failures = 0;
+            // #445: a trim is the harsher half of the same boundary — the model
+            // lost that history WITHOUT even a summary standing in for it, so
+            // the transcript line is worth more here, not less. Hooked at this
+            // call site rather than inside emergencyTrim() because the direct
+            // emergencyTrim callers drive partially-initialized test agents.
+            prompts.noteSessionCompacted(self, self.arena);
             if (main_mod.json_mode)
                 self.emit(.{ .type = "compact", .ok = true, .trimmed = dropped })
             else

--- a/src/commands_misc.zig
+++ b/src/commands_misc.zig
@@ -30,6 +30,7 @@ const style = &ansi.style;
 
 const goal_state = @import("goal_state.zig");
 const goal_flow = @import("goal_flow.zig");
+const prompts = @import("prompts.zig"); // #445: the transcript line's compaction flag resets with the conversation
 const jobs = @import("jobs.zig");
 const subagent = @import("subagent.zig"); // #276 P0-3: g_agent_jobs, for /jobs
 
@@ -509,6 +510,10 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             return true;
         };
         root.session_name = name;
+        // #445: after the rename, so the re-arm reads the resumed session. The
+        // history just loaded IS that file's contents, so the #410 line would
+        // again only describe what the live window already holds.
+        prompts.resetSessionCompacted(root, arena);
         // The third restore path (#318): --goal outranks the restored goal here
         // too, idempotently, or /resume was the one door that silently dropped it.
         if (root.goal_flag) |g| root.pending_goal_note = goal_flow.reapplyFlagGoal(arena, root, g, util.unixMs(root.io)) catch null;

--- a/src/commands_session.zig
+++ b/src/commands_session.zig
@@ -15,6 +15,7 @@ const tools_mod = @import("tools.zig");
 const session_mod = @import("session.zig");
 const goal_state = @import("goal_state.zig");
 const goal_flow = @import("goal_flow.zig");
+const prompts = @import("prompts.zig"); // #445: the transcript line's compaction flag resets with the conversation
 const Agent = agent_mod.Agent;
 const Keys = provider_mod.Keys;
 const ToolCall = tools_mod.ToolCall;
@@ -58,7 +59,7 @@ const setTerminalTitle = title_mod.setTerminalTitle;
 /// standing goal containing the word "ultracode" was re-appended to every
 /// assembled prompt and kept re-triggering the explicit-codeword banner
 /// after "context cleared" (#178).
-fn resetConversationSteering(root: *Agent) void {
+pub fn resetConversationSteering(root: *Agent) void {
     root.goal = null;
     root.completion_gate_armed = false; // a dropped goal re-arms the completion double-check (#318)
     root.todos_dirty = false; // the conversation's checklist dies with it; nothing survives as /loop evidence (#318)
@@ -72,31 +73,6 @@ fn resetConversationSteering(root: *Agent) void {
     // the user set a fresh /goal, got a RETIRABLE one, and the next
     // attempt_completion ended their steering - #318 through the /clear door.
     if (root.goal_flag) |g| root.goal = goal_flow.standingGoalFromFlag(g, null, root.todos.items, 0);
-}
-
-test "/clear + /new reset conversation steering — goal and ultracode_mode don't survive (#178)" {
-    var root: Agent = undefined;
-    root.goal = .{ .objective = "ultracode: index the statutes" };
-    root.ultracode_mode = true;
-    root.goal_flag = null; // no --goal: the conversation's goal dies with it
-    root.todos = .empty;
-    resetConversationSteering(&root);
-    try std.testing.expect(root.goal == null);
-    try std.testing.expect(!root.ultracode_mode);
-}
-
-test "/clear keeps a --goal standing objective standing (#318 through the /clear door)" {
-    var root: Agent = undefined;
-    root.ultracode_mode = false;
-    root.todos = .empty;
-    root.goal_flag = "keep the tree green"; // the user passed --goal
-    root.goal = .{ .objective = "keep the tree green", .standing = true, .epoch = 1 };
-    resetConversationSteering(&root);
-    // Before this, /clear dropped it, the user typed a fresh /goal, got a
-    // RETIRABLE one, and the next attempt_completion ended their steering.
-    const g = root.goal orelse return error.TestExpectedNonNull;
-    try std.testing.expect(g.standing);
-    try std.testing.expectEqualStrings("keep the tree green", g.objective);
 }
 
 /// Try to handle a session/environment slash command. Returns false (line
@@ -117,6 +93,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         root.todos.clearRetainingCapacity();
         const had_goal = root.goal != null;
         resetConversationSteering(root);
+        prompts.resetSessionCompacted(root, arena); // #445: the save below empties the file the #410 line names
         saveSession(root, arena, root.session_name) catch {};
         setTerminalTitle(out, "Chat", main_mod.g_cwd_display);
         try out.writeAll("context cleared — fresh conversation\n");
@@ -137,6 +114,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         root.title_generation +%= 1;
         root.tui_header_shown = false;
         root.session_name = try std.fmt.allocPrint(arena, "session-{d}", .{unixMs(root.io)});
+        prompts.resetSessionCompacted(root, arena); // #445: after the rename, so the re-arm reads the NEW session
         saveSession(root, arena, root.session_name) catch {};
         try out.print("new session → {s}{s}\n", .{ root.session_name, session_ext });
         try out.flush();

--- a/src/commands_session_test.zig
+++ b/src/commands_session_test.zig
@@ -1,0 +1,34 @@
+//! Tests for commands_session.zig's conversation-reset helper. They live in a
+//! sibling because commands_session.zig sits at the 600-line cap (AGENTS.md)
+//! and #445 needed room in it for the transcript-line reset call sites.
+//! Reachability is wired in test_hooks.zig — an unreferenced module's tests
+//! compile to nothing and the suite still reports green.
+
+const std = @import("std");
+const Agent = @import("agent.zig").Agent;
+const resetConversationSteering = @import("commands_session.zig").resetConversationSteering;
+
+test "/clear + /new reset conversation steering — goal and ultracode_mode don't survive (#178)" {
+    var root: Agent = undefined;
+    root.goal = .{ .objective = "ultracode: index the statutes" };
+    root.ultracode_mode = true;
+    root.goal_flag = null; // no --goal: the conversation's goal dies with it
+    root.todos = .empty;
+    resetConversationSteering(&root);
+    try std.testing.expect(root.goal == null);
+    try std.testing.expect(!root.ultracode_mode);
+}
+
+test "/clear keeps a --goal standing objective standing (#318 through the /clear door)" {
+    var root: Agent = undefined;
+    root.ultracode_mode = false;
+    root.todos = .empty;
+    root.goal_flag = "keep the tree green"; // the user passed --goal
+    root.goal = .{ .objective = "keep the tree green", .standing = true, .epoch = 1 };
+    resetConversationSteering(&root);
+    // Before this, /clear dropped it, the user typed a fresh /goal, got a
+    // RETIRABLE one, and the next attempt_completion ended their steering.
+    const g = root.goal orelse return error.TestExpectedNonNull;
+    try std.testing.expect(g.standing);
+    try std.testing.expectEqualStrings("keep the tree green", g.objective);
+}

--- a/src/prompt_snapshot_tests.zig
+++ b/src/prompt_snapshot_tests.zig
@@ -365,6 +365,72 @@ test "#445: the transcript line is absent until the first compaction, then rides
     try std.testing.expectEqualStrings("CHILD-BASE", child.sys_normal);
 }
 
+// #445: one PROCESS can host several root conversations. /new mints a fresh
+// session_name and /clear empties the history and saves over the file, so both
+// put the durable file back to holding no more than the live window. A flag
+// that only ever went true made one compaction arm the line for the rest of
+// the process — the exact per-call waste this issue exists to remove, walked
+// back in through the commonest flow there is.
+test "#445: /new and /clear disarm the transcript line again, and a later compaction re-arms it" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+    const saved = prompts.g_session_compacted;
+    defer prompts.g_session_compacted = saved;
+    defer prompts.armSessionTranscript(a, "", .{}, false); // leave the global as the rest of the suite expects it
+
+    var agent: agent_mod.Agent = undefined;
+    agent.sub = false;
+    agent.session_name = "session-long";
+    prompts.g_session_compacted = false;
+    prompts.armSessionTranscript(a, agent.session_name, .{}, false);
+    try prompts.setSystemPrompts(&agent, "BASE", a);
+
+    // A long session compacts: the line arms, as #445's forward boundary says.
+    prompts.noteSessionCompacted(&agent, a);
+    try std.testing.expect(std.mem.indexOf(u8, agent.sys_normal, "session-long.session.json") != null);
+
+    // /new: a brand-new conversation under a brand-new name, in the SAME
+    // process. commands_session calls the reset AFTER the rename, so the
+    // re-arm reads the session that exists now — and finds nothing to say.
+    agent.session_name = "session-new";
+    prompts.resetSessionCompacted(&agent, a);
+    try std.testing.expect(!prompts.g_session_compacted);
+    try std.testing.expectEqualStrings("BASE", agent.sys_normal);
+    for ([_][]const u8{ agent.sys_normal, agent.sys_strict, agent.sys_ultra, agent.sys_ultra_strict }) |v| {
+        try std.testing.expect(std.mem.indexOf(u8, v, "session-long.session.json") == null); // no stale name either
+        try std.testing.expect(std.mem.indexOf(u8, v, "session-new.session.json") == null);
+    }
+
+    // ...and the new conversation earns the line back on its own first
+    // compaction, naming ITS file. The flag is a boundary, not a one-way latch.
+    prompts.noteSessionCompacted(&agent, a);
+    try std.testing.expect(std.mem.indexOf(u8, agent.sys_normal, "session-new.session.json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, agent.sys_normal, "session-long.session.json") == null);
+
+    // /clear: same name, but the immediate saveSession rewrites the durable
+    // file down to an empty history, so the line again describes nothing.
+    prompts.resetSessionCompacted(&agent, a);
+    try std.testing.expect(!prompts.g_session_compacted);
+    try std.testing.expectEqualStrings("BASE", agent.sys_normal);
+
+    // Already false: a second /clear must not touch the prompt at all.
+    agent.sys_normal = "SENTINEL";
+    prompts.resetSessionCompacted(&agent, a);
+    try std.testing.expectEqualStrings("SENTINEL", agent.sys_normal);
+
+    // A subagent's own /clear-equivalent can never disarm the ROOT's line.
+    prompts.g_session_compacted = true;
+    var child: agent_mod.Agent = undefined;
+    child.sub = true;
+    child.session_name = "session-child";
+    child.sys_base = "CHILD-BASE";
+    child.sys_normal = "CHILD-SENTINEL";
+    prompts.resetSessionCompacted(&child, a);
+    try std.testing.expect(prompts.g_session_compacted);
+    try std.testing.expectEqualStrings("CHILD-SENTINEL", child.sys_normal);
+}
+
 test "#421: MCP, skill and optional-tool guidance all cost zero when absent" {
     var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer a_state.deinit();

--- a/src/prompt_snapshot_tests.zig
+++ b/src/prompt_snapshot_tests.zig
@@ -431,6 +431,47 @@ test "#445: /new and /clear disarm the transcript line again, and a later compac
     try std.testing.expectEqualStrings("CHILD-SENTINEL", child.sys_normal);
 }
 
+// #445: /resume is the third door onto the same state. loadSession replaces
+// the live history with a COPY of the file it just read, so the transcript
+// line is redundant for exactly the reason it is redundant on a fresh session
+// — and worse than redundant if left armed, since it would still be naming the
+// conversation the user resumed AWAY from.
+test "#445: /resume disarms the transcript line and leaves no stale session path" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+    const saved = prompts.g_session_compacted;
+    defer prompts.g_session_compacted = saved;
+    defer prompts.armSessionTranscript(a, "", .{}, false); // leave the global as the rest of the suite expects it
+
+    var agent: agent_mod.Agent = undefined;
+    agent.sub = false;
+    agent.session_name = "session-before";
+    prompts.g_session_compacted = false;
+    prompts.armSessionTranscript(a, agent.session_name, .{}, false);
+    try prompts.setSystemPrompts(&agent, "BASE", a);
+
+    // The conversation the user is about to leave compacted, so it is armed.
+    prompts.noteSessionCompacted(&agent, a);
+    try std.testing.expect(std.mem.indexOf(u8, agent.sys_normal, "session-before.session.json") != null);
+
+    // /resume: commands_misc assigns the new name, THEN resets — the ordering
+    // the reset's doc comment requires, so the re-arm sees the resumed session.
+    agent.session_name = "session-resumed";
+    prompts.resetSessionCompacted(&agent, a);
+    try std.testing.expect(!prompts.g_session_compacted);
+    try std.testing.expectEqualStrings("BASE", agent.sys_normal);
+    for ([_][]const u8{ agent.sys_normal, agent.sys_strict, agent.sys_ultra, agent.sys_ultra_strict }) |v| {
+        try std.testing.expect(std.mem.indexOf(u8, v, "session-before.session.json") == null); // the stale path is gone
+        try std.testing.expect(std.mem.indexOf(u8, v, "session-resumed.session.json") == null); // and the new one is not owed one yet
+    }
+
+    // The resumed conversation earns the line back on its OWN first compaction.
+    prompts.noteSessionCompacted(&agent, a);
+    try std.testing.expect(std.mem.indexOf(u8, agent.sys_normal, "session-resumed.session.json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, agent.sys_normal, "session-before.session.json") == null);
+}
+
 test "#421: MCP, skill and optional-tool guidance all cost zero when absent" {
     var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer a_state.deinit();

--- a/src/prompt_snapshot_tests.zig
+++ b/src/prompt_snapshot_tests.zig
@@ -284,9 +284,10 @@ test "#410: the transcript line rides the funnel, so a persona swap cannot drop 
     defer a_state.deinit();
     const a = a_state.allocator();
     var agent: agent_mod.Agent = undefined;
-    defer prompts.armSessionTranscript(a, "", .{}); // leave the global as the rest of the suite expects it
+    defer prompts.armSessionTranscript(a, "", .{}, false); // leave the global as the rest of the suite expects it
 
-    prompts.armSessionTranscript(a, "session-42", .{});
+    // Armed as #445 arms it in production: after the first compaction.
+    prompts.armSessionTranscript(a, "session-42", .{}, true);
     try prompts.setSystemPrompts(&agent, "BASE", a);
     for ([_][]const u8{ agent.sys_normal, agent.sys_strict, agent.sys_ultra, agent.sys_ultra_strict }) |v| {
         try std.testing.expect(std.mem.indexOf(u8, v, "BASE") != null);
@@ -300,10 +301,68 @@ test "#410: the transcript line rides the funnel, so a persona swap cannot drop 
     try std.testing.expectEqualStrings("PERSONA", agent.sys_base);
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, agent.sys_normal, "session-42.session.json"));
 
-    // Unreadable session file (#330 removed read_file/bash): no line at all.
-    prompts.armSessionTranscript(a, "session-42", .{ .local_tools = false });
+    // Unreadable session file (#330 removed read_file/bash): no line at all,
+    // compacted or not — the capability half of the gate is independent.
+    prompts.armSessionTranscript(a, "session-42", .{ .local_tools = false }, true);
     try prompts.setSystemPrompts(&agent, "BASE", a);
     try std.testing.expectEqualStrings("BASE", agent.sys_normal);
+}
+
+// #445: the measured cost of the #421/#410 prompt additions was ~240 input
+// tokens on EVERY call, and the transcript line's share of it buys nothing
+// until the live window stops being a superset of the file it names. So the
+// line is deferred to the first compaction, and this pins both ends of that:
+// absent on a fresh session, present once the boundary has been crossed.
+test "#445: the transcript line is absent until the first compaction, then rides every variant" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+    const saved = prompts.g_session_compacted;
+    defer prompts.g_session_compacted = saved;
+    defer prompts.armSessionTranscript(a, "", .{}, false); // leave the global as the rest of the suite expects it
+
+    var agent: agent_mod.Agent = undefined;
+    agent.sub = false;
+    agent.session_name = "session-445";
+    prompts.g_session_compacted = false;
+
+    // A fresh session: setRootSystemPrompts arms with the flag as it stands,
+    // so every variant is exactly the base and the session pays nothing.
+    prompts.armSessionTranscript(a, agent.session_name, .{}, prompts.g_session_compacted);
+    try prompts.setSystemPrompts(&agent, "BASE", a);
+    try std.testing.expectEqualStrings("BASE", agent.sys_normal);
+    for ([_][]const u8{ agent.sys_normal, agent.sys_strict, agent.sys_ultra, agent.sys_ultra_strict }) |v|
+        try std.testing.expect(std.mem.indexOf(u8, v, "session-445.session.json") == null);
+
+    // The compaction boundary re-derives all four, in place, from sys_base.
+    prompts.noteSessionCompacted(&agent, a);
+    try std.testing.expect(prompts.g_session_compacted);
+    for ([_][]const u8{ agent.sys_normal, agent.sys_strict, agent.sys_ultra, agent.sys_ultra_strict }) |v| {
+        try std.testing.expect(std.mem.indexOf(u8, v, "BASE") != null);
+        try std.testing.expect(std.mem.indexOf(u8, v, "session-445.session.json") != null);
+    }
+    try std.testing.expectEqualStrings("BASE", agent.sys_base); // still the pure base
+
+    // Idempotent: a session that compacts ten times still carries ONE line.
+    prompts.noteSessionCompacted(&agent, a);
+    prompts.noteSessionCompacted(&agent, a);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, agent.sys_normal, "session-445.session.json"));
+    // And a later persona swap keeps it — the #326 staleness class stays closed.
+    try prompts.setSystemPrompts(&agent, "PERSONA", a);
+    try std.testing.expect(std.mem.indexOf(u8, agent.sys_normal, "session-445.session.json") != null);
+
+    // A compacting SUBAGENT has no durable session of its own, and must not
+    // spend the root's tokens on a line about a file it never wrote.
+    prompts.g_session_compacted = false;
+    prompts.armSessionTranscript(a, "", .{}, false);
+    var child: agent_mod.Agent = undefined;
+    child.sub = true;
+    child.session_name = "session-child";
+    child.sys_base = "CHILD-BASE";
+    prompts.noteSessionCompacted(&child, a);
+    try std.testing.expect(!prompts.g_session_compacted);
+    try prompts.setSystemPrompts(&child, "CHILD-BASE", a);
+    try std.testing.expectEqualStrings("CHILD-BASE", child.sys_normal);
 }
 
 test "#421: MCP, skill and optional-tool guidance all cost zero when absent" {

--- a/src/prompts.zig
+++ b/src/prompts.zig
@@ -313,6 +313,25 @@ pub fn noteSessionCompacted(agent: *Agent, arena: Allocator) void {
     setSystemPrompts(agent, agent.sys_base, arena) catch {};
 }
 
+/// #445's inverse boundary, and it is NOT optional: one process can host
+/// several root conversations. `/new` mints a fresh `session_name` and `/clear`
+/// empties the history and saves immediately, so in both cases the durable file
+/// again holds no more than the live window — the exact state the line is not
+/// worth its tokens in. Without this, one compaction armed the line for the
+/// remaining life of the process and a user who compacted, then hit `/new`,
+/// paid for it forever pointing at a file with nothing to recover.
+///
+/// Same idiom as noteSessionCompacted: root-only, a no-op when already false,
+/// and best-effort. Call it AFTER any `session_name` reassignment, so the
+/// re-arm reads the conversation that actually exists now.
+pub fn resetSessionCompacted(agent: *Agent, arena: Allocator) void {
+    if (agent.sub or !g_session_compacted) return;
+    g_session_compacted = false;
+    armSessionTranscript(arena, agent.session_name, detectCaps(), false);
+    if (agent.sys_base.len == 0) return;
+    setSystemPrompts(agent, agent.sys_base, arena) catch {};
+}
+
 pub const sub_system_prompt =
     \\You are a subagent spawned by an orchestrator agent inside a terminal
     \\harness. Complete the assigned task using your tools, without asking

--- a/src/prompts.zig
+++ b/src/prompts.zig
@@ -21,6 +21,10 @@
 //! #410: setRootSystemPrompts also composes the one line naming this session's
 //! durable transcript. It rides in the funnel, not at the call site, so a
 //! persona swap or a `set_system_prompt` cannot silently drop it.
+//!
+//! #445: ...but not from turn one. That line only helps a model recover
+//! wording the live window no longer holds, so it waits for the first
+//! compaction and rides that boundary — see transcriptLineWanted below.
 
 const std = @import("std");
 const Io = std.Io;
@@ -152,6 +156,12 @@ pub fn baseForSession(arena: Allocator) ![]const u8 {
 /// unit test — the same arming discipline playbook.g_root_inject uses.
 var g_transcript_note: []const u8 = "";
 
+/// #445: has THIS process's root session compacted at least once? False at
+/// startup, set once by noteSessionCompacted, never lowered again. Public only
+/// so a test can save and restore it, exactly like playbook.g_root_inject —
+/// noteSessionCompacted is the sole production writer.
+pub var g_session_compacted: bool = false;
+
 /// One line naming the durable transcript. Deliberately NOT described as
 /// JSONL: `.graff/sessions/<name>.session.json` is a single JSON object (the
 /// JSONL files are the `.graff/traces` event streams the paragraph above
@@ -242,16 +252,65 @@ pub fn setRootSystemPrompts(agent: *Agent, base: []const u8, arena: Allocator) !
     // #410: only the root has a durable session, and only a session file this
     // process can still open is worth a line of context — with the native file
     // and shell tools removed (#330) the path is unreadable from here.
-    armSessionTranscript(arena, agent.session_name, detectCaps());
+    // #445: and a session that has not compacted yet gets nothing at all. A
+    // RESUMED session starts false too: the earlier compactions belong to a
+    // dead process, and what that process left in the file is exactly the
+    // context this one loaded, so the line would again describe what is here.
+    armSessionTranscript(arena, agent.session_name, detectCaps(), g_session_compacted);
     return setSystemPrompts(agent, base, arena);
 }
 
 /// #410's arming step, split out so the funnel is testable without the
 /// filesystem read setRootSystemPrompts also performs (playbook.composeRoot).
-/// An empty `session_name`, or a session whose file this process can no longer
-/// open, both arm to "" — the line is only worth context when it is actionable.
-pub fn armSessionTranscript(arena: Allocator, session_name: []const u8, caps: Caps) void {
-    g_transcript_note = if (caps.local_tools) sessionTranscriptNote(arena, session_name) else "";
+/// An empty `session_name`, a session whose file this process cannot open, and
+/// a session that has not compacted yet all arm to "" — the line is only worth
+/// context when it is both actionable and not already redundant.
+pub fn armSessionTranscript(arena: Allocator, session_name: []const u8, caps: Caps, compacted: bool) void {
+    g_transcript_note = if (transcriptLineWanted(caps, compacted)) sessionTranscriptNote(arena, session_name) else "";
+}
+
+/// #445: the transcript line's gate, in one predicate, ANDing two conditions
+/// that are different in kind and neither of which is sufficient alone:
+///
+///   - `caps.local_tools` is a CAPABILITY, read from the same catalog every
+///     other segment gate is read from: with #330's native file and shell
+///     tools removed, nothing in the session can open the path the line names.
+///   - `compacted` is session STATE, and it is why this predicate exists.
+///     Before the first compaction the live context is a SUPERSET of the
+///     transcript file — the line can only point the model at wording it can
+///     already see, and compaction rewrites the file in place anyway, so its
+///     marginal value there is ~zero. Live A/B evals put the #421/#410 prompt
+///     additions at +960 chars ≈ +240 input tokens on every single call at
+///     full capability, which the overwhelming majority of sessions (the ones
+///     that never compact at all) were paying for nothing. After a compaction
+///     the file holds wording the window no longer does: the case #410 is for.
+///
+/// Deliberately NOT a `Caps` field. `Caps` is what the tool catalog reports,
+/// and `detectCaps()` is settled before startup.buildSystemPrompt runs; this
+/// flips mid-session, by definition after the first request. Folding it in
+/// would make both of those statements false, and would put a non-segment
+/// condition into the predicate `composeBase`/`full()` short-circuit on.
+pub fn transcriptLineWanted(caps: Caps, compacted: bool) bool {
+    return caps.has(.local_tools) and compacted;
+}
+
+/// #445: the compaction boundary — the one moment the line starts earning its
+/// tokens, and the one moment mutating the system prompt is free. Compaction
+/// has already replaced the history sitting behind any cached KV prefix, so
+/// re-composing here adds no SECOND invalidation point; deferring to the next
+/// turn boundary instead would throw away a live cache for the same text.
+///
+/// Root-only (a subagent has no durable session file of its own, and must not
+/// flip the flag for the root) and idempotent: a session that compacts ten
+/// times re-derives its prompt once. Best-effort, exactly like
+/// playbook_glue.refreshRoot — a failed re-compose leaves the previous, still
+/// valid prompt in place and the next mutation through the funnel picks it up.
+pub fn noteSessionCompacted(agent: *Agent, arena: Allocator) void {
+    if (agent.sub or g_session_compacted) return;
+    g_session_compacted = true;
+    armSessionTranscript(arena, agent.session_name, detectCaps(), true);
+    if (agent.sys_base.len == 0) return; // never went through the funnel: nothing to re-derive from
+    setSystemPrompts(agent, agent.sys_base, arena) catch {};
 }
 
 pub const sub_system_prompt =

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -70,6 +70,10 @@ const scoring_slot_test = @import("scoring_slot_test.zig");
 // #273: session.zig's own tests, moved off it for the same reason.
 const session_tests = @import("session_tests.zig");
 
+// #445: moved off commands_session.zig when the transcript-line reset needed
+// three lines there and the file was at exactly 600. The tests are unchanged.
+const commands_session_test = @import("commands_session_test.zig");
+
 // #375: `graff acp` (Zed's Agent Client Protocol over stdio). args.zig calls
 // one predicate from it, which analyses the file but does not run its tests.
 const acp = @import("acp.zig");
@@ -170,6 +174,7 @@ test {
     _ = serve_create;
     _ = scoring_slot_test;
     _ = session_tests;
+    _ = commands_session_test;
     _ = mcp_config;
     _ = acp;
     _ = agent_eval_control_tests;


### PR DESCRIPTION
Closes #445. Data-driven refinement of #410 (PR #438), from the live before/after evals.

## The economics

The #421/#410 prompt additions measured at **+960 chars ≈ +240 input tokens per API call** at full capability. The transcript line's value is almost entirely post-compaction: before any compaction the live context is a **superset** of the file, so the line can only point the model at wording it can already see, and compaction rewrites the file in place anyway. Short sessions — the overwhelming majority, since most never compact at all — were paying that on every call for nothing.

The line now arms on the first compaction and rides that boundary deliberately: the history behind any cached KV prefix has already been replaced there, so re-composing the system prompt costs no *second* cache invalidation. #421's always-on doctrine paragraphs are untouched; they are behavioural rails and earn their keep unconditionally.

## Deliberate design deviation

`compacted` is **not** a `Caps` field or `Gate` value, though that was the obvious first guess. `Caps` is documented as what the tool catalog reports and `detectCaps()` as settled before `startup.buildSystemPrompt` runs; a mid-session flag falsifies both, and it would put a non-segment condition into the predicate `composeBase`/`full()` short-circuit on, risking a needless allocation and the loss of the byte-identical comptime fast path. Instead the two conditions compose in one named predicate, `transcriptLineWanted(caps, compacted)`, and the capability half still comes from the existing mechanism.

## Three disarm sites, found in review

The first implementation armed the flag process-globally and never lowered it, which quietly defeated the whole feature: a process can host more than one root session, so one compaction armed the line for the rest of the process. Fixed across all three doors, each with a test:

- **`/new`** mints a fresh session name in the same process, so the line would have named a brand-new file with nothing to recover.
- **`/clear`** keeps the name but empties `messages` and immediately saves, so the durable file is rewritten down to an empty history.
- **`/resume`** loads a file into the live history and repoints the name, making the window equal the file again.

Every fix carries a **break-and-revert proof**: with `resetSessionCompacted` stubbed to `if (true) return;` the guarding test fails at a named line; reverted, green. So the tests genuinely guard the behaviour rather than passing incidentally.

## Verification

`zig build test` → **1046/1046, exit 0**, with the count moving by exactly +1 per new test (1043 → 1044 → 1045 → 1046) and reachability confirmed by the tier-1 gate (1011 declared tests compiled in). `scripts/eval-tier1.sh` green: fmt, 600-line ceiling, reach, build, invariants, SDK.

`commands_session.zig` sat at exactly 600 lines, so its two `resetConversationSteering` tests moved verbatim to a new `commands_session_test.zig` with reachability hooked in `test_hooks.zig` — the same move `agent_eval_control_tests` made off `agent_tools.zig`. No production logic moved; the file ends at 578.

## Known gap

All five production call sites (two in `agent_compact.zig`, three in the command handlers) are **compile-and-read-verified only**. `compact()` needs a live request, so deleting any one call would leave the suite green — the orphaning class `agent_compact.zig`'s own `compactPrelude` comment warns about. Pinning them needs a tier-2 behaviour case, which is the gap #102 already tracks.

Related: #453 (a session rename still invalidates an armed line — pre-existing #410 bug, narrowed but not closed by this change). Once #441 lands an append-only transcript, this line's *text* needs revisiting, since it currently claims to name the resume artifact rather than an append-only archive; that trade-off is recorded in the commit body.