### PR TITLE
fix(release): attach assets to existing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,5 +61,20 @@ jobs:
             printf '%s\n' "$section" > changelog-notes.md
             notes=(--notes-file changelog-notes.md)
           fi
-          gh release create "$GITHUB_REF_NAME" graff-*.tar.gz SHA256SUMS install.sh \
-            --title "$GITHUB_REF_NAME" --draft "${notes[@]}"
+          assets=(graff-*.tar.gz SHA256SUMS install.sh)
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            # A maintainer may publish the notes while cross-compilation is still
+            # running. Attach to that release instead of creating an untagged draft.
+            gh release upload "$GITHUB_REF_NAME" "${assets[@]}" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" "${assets[@]}" \
+              --title "$GITHUB_REF_NAME" --draft "${notes[@]}"
+          fi
+
+          uploaded="$(gh release view "$GITHUB_REF_NAME" --json assets --jq '.assets[].name')"
+          for asset in "${assets[@]}"; do
+            grep -Fxq "$(basename "$asset")" <<<"$uploaded" || {
+              echo "release is missing asset: $asset" >&2
+              exit 1
+            }
+          done


### PR DESCRIPTION
## What changed

- Reuse a tagged GitHub release when it already exists and upload the workflow-built artifacts with `--clobber` for safe reruns.
- Keep the existing draft-creation path when no release exists yet.
- Fail the release job unless every expected archive, checksum file, and installer is visible on the selected release.

## Why

### Problem / failure mode

A maintainer published `v0.0.251` while cross-compilation was still running. The workflow then ran `gh release create --draft`, which silently created an untagged draft containing all eight assets. The published release remained assetless, so `graff update` followed `/releases/latest/download/install.sh` to a 404 even though the release job was green.

### Reason for this approach

The tagged release is the stable identity consumers already resolve through `/releases/latest`. Attaching deterministic build outputs to it handles either ordering—manual publication before or after compilation—without changing release notes or tags. Explicit asset assertions keep the workflow from reporting success when the consumer-visible release is incomplete.

### Constraints and trade-offs

`--clobber` intentionally replaces same-name assets on reruns; release builds for one immutable tag are expected to be deterministic. The workflow still creates a draft by default and does not change when maintainers publish it.

### Rejected alternative

Documenting “wait for CI before publishing” leaves the updater vulnerable to the same timing mistake. Creating another tag or release would also break the stable latest-release URL instead of repairing the publication race.

## Verification

- Parsed the workflow YAML successfully.
- Exercised both shell branches with a fake `gh`: existing release uploads; missing release creates a draft; both pass the asset assertion.
- Repaired `v0.0.251` with the checksummed workflow artifacts and confirmed all eight assets are present.
- Ran the real updater from `v0.0.250` to `v0.0.251`; the installed binary reports `graff 0.0.251`.
