### PR TITLE
release: v0.0.257 — composer box + interrupt/CSI hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
+## v0.0.257 (2026-08-15)
+
+- Composer box corners line up with the sides, wrap at word boundaries, and
+  the hint row is clipped so it no longer ends on a stray "E".
+
 ## v0.0.256 (2026-08-15)
 
 - Leftover Kitty keyboard CSI (`3u7444;9u`) is ignored instead of typed or

--- a/TUI/chrome.zig
+++ b/TUI/chrome.zig
@@ -24,7 +24,8 @@ pub fn topBar(self: *const Model, a: std.mem.Allocator, width: usize) ![]const u
 pub fn promptBox(self: *const Model, a: std.mem.Allocator, width: usize) ![]const u8 {
     const th = self.theme();
     const cols = if (width < 24) @as(usize, 80) else width;
-    const inner = if (cols > 4) cols - 4 else cols;
+    // Between the │ │. Top/footer use the same inner so corners line up.
+    const inner = if (cols > 2) cols - 2 else cols;
     const focused = self.focus == .prompt and self.overlay == .none;
     const border = if (focused) th.focus else th.border;
     var out = std.array_list.Managed(u8).init(a);
@@ -46,7 +47,7 @@ pub fn promptBox(self: *const Model, a: std.mem.Allocator, width: usize) ![]cons
         try body.appendSlice("  ");
     }
     try body.appendSlice(try self.input.view(a));
-    const wrapped = try theme_mod.wrapToWidth(a, body.items, inner);
+    const wrapped = try theme_mod.wrapPreferWords(a, body.items, inner);
     var lines = std.array_list.Managed([]const u8).init(a);
     var it = std.mem.splitScalar(u8, wrapped, '\n');
     while (it.next()) |ln| try lines.append(ln);
@@ -80,7 +81,7 @@ fn rowInner(a: std.mem.Allocator, border: []const u8, fg: []const u8, text: []co
     try pad.appendSlice(theme_mod.reset);
     const cols = theme_mod.visibleLen(shown);
     if (cols < inner) try pad.appendNTimes(' ', inner - cols);
-    return std.fmt.allocPrint(a, "{s}│{s} {s} {s}│{s}", .{ border, theme_mod.reset, pad.items, border, theme_mod.reset });
+    return std.fmt.allocPrint(a, "{s}│{s}{s}{s}│{s}", .{ border, theme_mod.reset, pad.items, border, theme_mod.reset });
 }
 
 fn footer(a: std.mem.Allocator, border: []const u8, muted: []const u8, label: []const u8, inner: usize) ![]const u8 {
@@ -110,13 +111,13 @@ pub fn statusBar(self: *const Model, a: std.mem.Allocator, width: usize) ![]cons
     if (self.now_ms < self.toast_until_ms and self.toast.len > 0) {
         return theme_mod.paint(a, th.accent, self.toast);
     }
-    _ = width;
     if (self.pending != null) {
-        return std.fmt.allocPrint(a, "{s} Enter:queue  |  Shift+Tab:mode  |  Esc:cancel  |  {s}[stop]{s}", .{
+        const raw = try std.fmt.allocPrint(a, "{s} Enter:queue  ·  Shift+Tab:mode  ·  Esc:cancel  ·  {s}[stop]{s}", .{
             th.muted, th.error_fg, theme_mod.reset,
         });
+        return theme_mod.takeCols(raw, if (width == 0) 80 else width);
     }
-    return theme_mod.paint(a, th.muted, " Enter:send now  |  Shift+Tab:mode  |  Esc");
+    return theme_mod.paint(a, th.muted, theme_mod.takeCols(" Enter:send  ·  Shift+Enter:newline  ·  Shift+Tab:mode", if (width == 0) 80 else width));
 }
 
 pub fn overlay(self: *const Model, a: std.mem.Allocator, width: usize) ![]const u8 {
@@ -273,8 +274,8 @@ test "composer footer shows the live agent mode" {
     try std.testing.expect(std.mem.indexOf(u8, try promptBox(&m, a, 80), "plan") != null);
     m.mode = .always_approve;
     try std.testing.expect(std.mem.indexOf(u8, try promptBox(&m, a, 80), "always-approve") != null);
-    try std.testing.expect(std.mem.indexOf(u8, try statusBar(&m, a, 80), "Enter:send now") != null);
-    try std.testing.expect(std.mem.indexOf(u8, try statusBar(&m, a, 80), "|") != null);
+    try std.testing.expect(std.mem.indexOf(u8, try statusBar(&m, a, 80), "Enter:send") != null);
+    try std.testing.expect(std.mem.indexOf(u8, try statusBar(&m, a, 80), "Shift+Tab") != null);
 }
 
 test "status paints coral [stop] while a turn is pending" {

--- a/TUI/theme.zig
+++ b/TUI/theme.zig
@@ -213,9 +213,62 @@ pub fn wrapToWidth(a: std.mem.Allocator, s: []const u8, width: usize) ![]const u
     return out.toOwnedSlice();
 }
 
+/// Like wrapToWidth, but breaks at the last space on the line when it can.
+pub fn wrapPreferWords(a: std.mem.Allocator, s: []const u8, width: usize) ![]const u8 {
+    if (width == 0) return a.dupe(u8, s);
+    var out = std.array_list.Managed(u8).init(a);
+    var col: usize = 0;
+    var last_sp: ?usize = null;
+    var i: usize = 0;
+    while (i < s.len) {
+        if (s[i] == '\n') {
+            try out.append('\n');
+            col = 0;
+            last_sp = null;
+            i += 1;
+            continue;
+        }
+        if (s[i] == 0x1b) {
+            const start = i;
+            i += 1;
+            if (i < s.len and s[i] == '[') {
+                i += 1;
+                while (i < s.len and (s[i] < 0x40 or s[i] > 0x7e)) : (i += 1) {}
+                if (i < s.len) i += 1;
+            }
+            try out.appendSlice(s[start..i]);
+            continue;
+        }
+        const w = std.unicode.utf8ByteSequenceLength(s[i]) catch 1;
+        const step = @min(w, s.len - i);
+        if (col + 1 > width) {
+            if (last_sp) |sp| {
+                out.items[sp] = '\n';
+                col = visibleLen(out.items[sp + 1 ..]);
+                last_sp = null;
+            } else {
+                try out.append('\n');
+                col = 0;
+            }
+        }
+        if (s[i] == ' ') last_sp = out.items.len;
+        try out.appendSlice(s[i .. i + step]);
+        col += 1;
+        i += step;
+    }
+    return out.toOwnedSlice();
+}
+
 test "visibleLen counts glyphs not UTF-8 bytes or SGR" {
     try std.testing.expectEqual(@as(usize, 3), visibleLen("\x1b[32mhi!\x1b[0m"));
     try std.testing.expectEqual(@as(usize, 3), visibleLen("a ·"));
+}
+
+test "wrapPreferWords breaks on spaces not mid-word" {
+    const got = try wrapPreferWords(std.testing.allocator, "little bit weird", 10);
+    defer std.testing.allocator.free(got);
+    try std.testing.expect(std.mem.indexOf(u8, got, "bit") != null);
+    try std.testing.expect(std.mem.indexOf(u8, got, "b\nit") == null);
 }
 
 test "wrapToWidth splits a long line and keeps SGR" {

--- a/docs/releases/v0.0.257.md
+++ b/docs/releases/v0.0.257.md
@@ -1,0 +1,10 @@
+# v0.0.257 (2026-08-15)
+
+The composer box no longer looks "off":
+
+- Top, sides, and footer are the same width (corners line up).
+- Long drafts wrap on spaces, so `bit` is not split as `b` / `it`.
+- The hint row is clipped to the terminal width.
+
+Also in 0.0.256: interrupt collapses Thinking, Shift+parens, Kitty CSI-u
+leftovers ignored, `.graff/tui-traj.jsonl`.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -21,6 +21,9 @@ const harness_version = root.harness_version;
 pub const changelog_text =
     \\What's new
     \\──────────
+    \\0.0.257
+    \\  • Composer box aligns and wraps on words, not mid-letter
+    \\
     \\0.0.256
     \\  • TUI swallows leftover Kitty CSI-u, types Shift+9 as (, logs stdin to .graff/tui-traj.jsonl
     \\


### PR DESCRIPTION
Composer alignment/word-wrap, Thinking collapse, Shift+parens, CSI-u traj. Notarized via notary-local.