### PR TITLE
release: v0.0.259 — Responses wire + WS by default for grok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
+## v0.0.259 (unreleased)
+
+- Grok now defaults to xAI's Responses wire: WebSocket turns (with the SSE
+  fallback ladder), lossless first-party server compaction, and structured
+  outputs work out of the box on a SuperGrok subscription. Set
+  `GRAFF_XAI_WIRE=chat` to return to chat completions.
+- Fixed duplicate MCP tool definitions when a deferred server start raced the
+  eager codedb-pro companion; strict Responses endpoints rejected every turn
+  over the duplicate.
+
 ## v0.0.258 (2026-08-15)
 
 - Full Grok support on a SuperGrok subscription (#502): opt into xAI's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
-## v0.0.259 (unreleased)
+## v0.0.259 (2026-08-15)
 
 - Grok now defaults to xAI's Responses wire: WebSocket turns (with the SSE
   fallback ladder), lossless first-party server compaction, and structured

--- a/docs/adr/0002-xai-defaults-to-the-responses-wire.md
+++ b/docs/adr/0002-xai-defaults-to-the-responses-wire.md
@@ -1,0 +1,43 @@
+# 0002. xAI defaults to the Responses wire (WS + server compaction)
+
+Status: accepted 2026-08-15
+
+## Context
+
+grok support (#502) landed with the Responses wire behind
+`GRAFF_XAI_WIRE=responses` while a harder-recall A/B decided the default.
+The A/B (24 planted identifiers in ~13k-token conversations, 12 quizzed,
+both compaction paths): with salience cues both arms recalled 12/12; with
+facts buried as incidental asides the server blob stayed 12/12 while the
+client summary dropped the earliest fact (11/12, blank rather than
+hallucinated). Wall-clock and cost were equivalent per turn (blob replay
+costs more input tokens than a summary but is lossless by construction).
+The one blocker was #505: duplicate MCP tool definitions (a deferred server
+start racing the eager codedb-pro companion) made strict Responses
+endpoints reject every request; fixed alongside the flip.
+
+## Decision
+
+`g_xai_responses` defaults to true: xAI sessions run on
+api.x.ai/v1/responses, which gives WebSocket turns (with the WS→SSE
+fallback ladder), first-party server-side compaction for both
+autocompaction and manual `/compact` (#503), and structured outputs.
+`GRAFF_XAI_WIRE=chat` (any value other than `responses`) opts a session
+back onto chat completions.
+
+## Consequences
+
+- Lossless compaction by default; the intent-aware client summary remains
+  the fallback when the endpoint refuses or fails, and the chat wire keeps
+  it as primary.
+- WS eligibility stays an explicit provider list (codex, xai) — Platform
+  OpenAI is Responses-kind but has no WS server and must never probe one.
+- Chaining via previous_response_id stays codex-only: xAI's store:false +
+  previous_response_id stalls server-side (probed live), so xai rides
+  full-resend over the held socket.
+- Revisit if xAI's wire diverges from OpenAI Responses semantics or the
+  compact endpoint's blob replay pricing changes the cost picture.
+
+Evidence: #502, #503, #505, the recall A/B kit (session scratchpad
+recall-ab/), ADR [0001](0001-structured-outputs-are-a-formatting-step.md)
+for the structured-outputs half of the wire.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,7 @@ record only when you need the evidence or the edge cases.
 | ADR | The rule |
 |---|---|
 | [0001](0001-structured-outputs-are-a-formatting-step.md) | Structured output is a final formatting step. Never constrain the agentic phase with a schema grammar, and do not use `--output-schema` unless a program consumes the result. |
+| [0002](0002-xai-defaults-to-the-responses-wire.md) | xAI runs on the Responses wire by default (WS turns, lossless server compaction). `GRAFF_XAI_WIRE=chat` opts out; WS stays an explicit provider list. |
 
 ## When to write one
 

--- a/src/agent_server_compact_tests.zig
+++ b/src/agent_server_compact_tests.zig
@@ -309,8 +309,9 @@ test "manualCompact (#503): a blob-anchored history on an explicit-compact provi
     defer arena_state.deinit();
     const a = arena_state.allocator();
     var agent = testAgent(a, .responses);
+    const saved_wire = provider.g_xai_responses;
     provider.g_xai_responses = true;
-    defer provider.g_xai_responses = false;
+    defer provider.g_xai_responses = saved_wire;
     agent.provider = .{ .id = "xai", .kind = .responses, .auth = .bearer, .url = provider.xai_responses_url, .api_key = "k", .model = "grok-4.6", .context = 100_000 };
     // History = one opaque compaction item + one turn: small and blob-anchored,
     // so the anti-thrash guard refuses the endpoint before any POST — and the

--- a/src/args.zig
+++ b/src/args.zig
@@ -249,7 +249,7 @@ pub fn parse(init: std.process.Init) !Flags {
     // GRAFF_LEAN sets the same global in session_settings.applyEnvKnobs).
     if (flags.effectiveLean()) no_local_tools.lean = true;
 
-    // #502: GRAFF_XAI_WIRE=responses must land before the initial Keys.build
+    // #502: GRAFF_XAI_WIRE (default responses; =chat opts out) must land before the initial Keys.build
     // (startup.resolveKeys) or the xAI provider is built on the chat wire and
     // the knob silently no-ops; applyEnvKnobs re-parses the same value later.
     if (init.environ_map.get("GRAFF_XAI_WIRE")) |xw|

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -21,6 +21,10 @@ const harness_version = root.harness_version;
 pub const changelog_text =
     \\What's new
     \\──────────
+    \\0.0.259
+    \\  • Grok defaults to xAI's Responses wire: WebSocket turns, lossless server-side compaction, structured outputs — no env needed (GRAFF_XAI_WIRE=chat opts out)
+    \\  • Fixed duplicate MCP tool definitions that made strict Responses endpoints reject every turn
+    \\
     \\0.0.258
     \\  • Full Grok on a SuperGrok sub: GRAFF_XAI_WIRE=responses gets server-side compaction (lossless blob), WebSocket turns, and --output-schema structured outputs
     \\  • /compact on the xAI wire uses the first-party endpoint; strict schemas run two-phase so they never suppress tool use

--- a/src/mcp_boot.zig
+++ b/src/mcp_boot.zig
@@ -19,6 +19,7 @@ const Allocator = std.mem.Allocator;
 const mcp = @import("mcp.zig");
 const mcp_config = @import("mcp_config.zig");
 const mcp_rpc = @import("mcp_rpc.zig");
+const mcp_teardown = @import("mcp_teardown.zig");
 
 const Registry = mcp.Registry;
 
@@ -140,6 +141,24 @@ fn mergeOutcomes(reg: *Registry, futures: []Io.Future(StartOutcome)) void {
     for (futures) |*fut| {
         const outcome = fut.await(reg.io);
         const server = outcome.server orelse continue;
+        // A companion (eager codedb-pro) or /mcp trust can connect this server
+        // while its deferred start is still in flight. Appending the outcome
+        // anyway advertises every tool twice, and a strict Responses endpoint
+        // (xAI) rejects the whole request over one duplicate (#505). First
+        // registration wins; tear the latecomer down but keep its arena in
+        // task_arenas so its memory follows the normal teardown lifecycle.
+        var already_connected = false;
+        for (servers.items) |existing| {
+            if (std.mem.eql(u8, existing.name, server.name)) {
+                already_connected = true;
+                break;
+            }
+        }
+        if (already_connected) {
+            mcp_rpc.deinitServer(server, reg.io, .init(reg.io, mcp_teardown.teardown_grace));
+            if (outcome.arena_state) |ta| task_arenas.append(a, ta) catch {};
+            continue;
+        }
         const server_index = servers.items.len;
         servers.append(a, server) catch continue;
         for (outcome.tools) |*tool| tool.server_index = server_index;

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -24,11 +24,13 @@ pub var g_context_override: ?u64 = null;
 /// (default 80). null → 80. Unlike codex we allow lowering AND raising (1..100).
 pub var g_compact_pct_override: ?u8 = null;
 
-/// #502: GRAFF_XAI_WIRE=responses (session_settings.applyEnvKnobs) serves xAI
-/// over the OpenAI Responses wire at api.x.ai/v1/responses instead of chat
-/// completions — the prerequisite for first-party server compaction and
-/// Responses-WebSocket turns. Verified live on the SuperGrok OAuth path.
-pub var g_xai_responses: bool = false;
+/// #502: xAI rides the OpenAI Responses wire at api.x.ai/v1/responses BY
+/// DEFAULT — that unlocks first-party server compaction (lossless blob;
+/// recall A/B: blob 12/12 vs client summary 11/12 on buried facts) and
+/// WebSocket turns with the SSE/full-resend fallback ladder. Verified live
+/// on the SuperGrok OAuth path. GRAFF_XAI_WIRE=chat (or anything other than
+/// "responses") opts back into chat completions.
+pub var g_xai_responses: bool = true;
 
 pub const xai_responses_url = "https://api.x.ai/v1/responses";
 /// xAI's explicit compaction endpoint (POST {model, input} → one opaque

--- a/src/router_catalog_tests.zig
+++ b/src/router_catalog_tests.zig
@@ -306,15 +306,21 @@ test "providerFor (#377): family-prefixed spelling routes to the direct provider
     try std.testing.expectEqualStrings("codegraff", (try no_kimi.providerFor("kimi-k3")).id);
 }
 
-test "GRAFF_XAI_WIRE=responses moves xAI onto the Responses wire (#502)" {
+test "xAI defaults to the Responses wire; GRAFF_XAI_WIRE=chat opts out (#502)" {
     const Keys = provider.Keys;
     const Provider = provider.Provider;
     const all = Keys{ .values = @splat("k") };
+    const saved = provider.g_xai_responses;
+    defer provider.g_xai_responses = saved;
+    // The compiled-in default IS the responses wire — a regression here means
+    // grok silently loses server compaction, WS turns, and structured outputs.
+    try std.testing.expect(provider.g_xai_responses);
+    // GRAFF_XAI_WIRE=chat (any non-"responses" value) restores chat completions.
+    provider.g_xai_responses = false;
     const chat = try all.providerById("xai", "grok-4.3");
     try std.testing.expectEqual(Provider.Kind.openai, chat.kind);
     try std.testing.expect(chat.serverCompactUrl() == null); // chat wire: no blob replay path
     provider.g_xai_responses = true;
-    defer provider.g_xai_responses = false;
     const resp = try all.providerById("xai", "grok-4.3");
     try std.testing.expectEqual(Provider.Kind.responses, resp.kind);
     try std.testing.expectEqualStrings(provider.xai_responses_url, resp.url);

--- a/src/session_settings.zig
+++ b/src/session_settings.zig
@@ -152,9 +152,9 @@ pub fn applyEnvKnobs(arena: Allocator, environ_map: anytype) !void {
         const off = std.mem.eql(u8, v, "0") or std.ascii.eqlIgnoreCase(v, "false") or std.ascii.eqlIgnoreCase(v, "off");
         server_compact.g_server_compact_override = !off;
     }
-    // #502: GRAFF_XAI_WIRE=responses moves xAI onto the OpenAI Responses wire
-    // (api.x.ai/v1/responses) — first-party server compaction + WS turns.
-    // Anything else (or unset) keeps the chat-completions wire.
+    // #502: xAI defaults to the Responses wire (api.x.ai/v1/responses) —
+    // first-party server compaction + WS turns. GRAFF_XAI_WIRE=chat (anything
+    // but "responses") moves it back to chat completions; unset keeps the default.
     if (environ_map.get("GRAFF_XAI_WIRE")) |v| {
         provider_mod.g_xai_responses = std.ascii.eqlIgnoreCase(std.mem.trim(u8, v, " \t"), "responses");
     }


### PR DESCRIPTION
Merge-back of release/v0.0.259 (tagged, notarized, published as latest).

- Grok defaults to xAI's Responses wire: WebSocket turns (SSE fallback ladder), lossless first-party server compaction, structured outputs — no env needed; GRAFF_XAI_WIRE=chat opts out (ADR 0002)
- fix(mcp): first registration wins when a deferred start races the eager codedb-pro companion (#505) — duplicate tool definitions made strict Responses endpoints reject every turn
- CHANGELOG + what's-new entries

Pre-existing ci.yml failures tracked in #506, unchanged here.