### PR TITLE
feat(tui): grok-build UI parity — syntax highlighting, sticky header, auto light/dark, synced paints

### DIFF
--- a/TUI/app.zig
+++ b/TUI/app.zig
@@ -43,6 +43,9 @@ pub const Model = struct {
     theme_id: theme_mod.Id = .night,
     /// Set once the user picks a theme; blocks the OSC-11 auto polarity.
     theme_explicit: bool = false,
+    /// Rows of sticky-header chrome at the top of the viewport this frame —
+    /// keys.zig must treat them as inert instead of clicking what they occlude.
+    sticky_rows: usize = 0,
     mode: AgentMode = .normal,
     effort: engine.Effort = .medium,
     fast: bool = false,

--- a/TUI/app.zig
+++ b/TUI/app.zig
@@ -41,6 +41,8 @@ pub const Model = struct {
     slash_sel: usize = 0,
 
     theme_id: theme_mod.Id = .night,
+    /// Set once the user picks a theme; blocks the OSC-11 auto polarity.
+    theme_explicit: bool = false,
     mode: AgentMode = .normal,
     effort: engine.Effort = .medium,
     fast: bool = false,

--- a/TUI/chrome.zig
+++ b/TUI/chrome.zig
@@ -424,3 +424,31 @@ test "prompt box wraps a long draft onto several rows" {
     try std.testing.expect(std.mem.count(u8, box, "│") >= 6);
     try std.testing.expect(std.mem.indexOf(u8, box, "can we make") != null);
 }
+
+test "the composer's right border holds its column for ambiguous and wide glyphs" {
+    // rowInner pads from visibleLen, so a mis-measured glyph moves the wall.
+    // ✓/⚙ draw one cell (they used to claim two, pulling the border in); emoji
+    // and CJK draw two and must not push it out.
+    const drafts = [_][]const u8{
+        "✓ done ⚙ running ✗ failed ❯ next",
+        "🚀 ship it 🚀🚀 and keep typing until this wraps onto another row 🚀",
+        "你好世界你好世界你好世界你好世界你好世界你好世界你好世界你好世界",
+        "mixed ✓ 🚀 漢字 tail",
+    };
+    for (drafts) |draft| {
+        for ([_]usize{ 40, 41, 57, 80 }) |w| {
+            var m: Model = undefined;
+            m.setup(std.testing.allocator);
+            defer m.deinit();
+            try m.input.setValue(draft);
+            var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+            defer arena.deinit();
+            const box = try promptBox(&m, arena.allocator(), w);
+            var it = std.mem.splitScalar(u8, box, '\n');
+            while (it.next()) |ln| {
+                if (ln.len == 0) continue;
+                try std.testing.expectEqual(w, theme_mod.visibleLen(ln));
+            }
+        }
+    }
+}

--- a/TUI/dispatch.zig
+++ b/TUI/dispatch.zig
@@ -69,6 +69,7 @@ pub fn runCommand(self: *Model, line: []const u8) Effect {
             self.openOverlay(.theme);
         } else if (theme_mod.parse(arg)) |id| {
             self.theme_id = id;
+            self.theme_explicit = true;
             self.pushFmt(.system, "theme: {s}", .{id.label()}) catch {};
         } else {
             self.pushFmt(.err, "unknown theme '{s}' — night|day|tokyo|rose|oscura", .{arg}) catch {};

--- a/TUI/image.zig
+++ b/TUI/image.zig
@@ -199,7 +199,7 @@ pub fn mouse(self: *Model, ev: key_mod.Mouse) bool {
         }
         return false;
     };
-    const hist = if (y >= self.prompt_origin) null else @import("scrollback.zig").indexAtVisual(self, y -| self.mid_origin + self.mid_skip, self.last_term_width);
+    const hist = if (y >= self.prompt_origin or y < self.mid_origin + self.sticky_rows) null else @import("scrollback.zig").indexAtVisual(self, y -| self.mid_origin + self.mid_skip, self.last_term_width);
     const path = pathForChip(self, n, hist);
     show(self, path, n, click);
     return true;
@@ -220,6 +220,7 @@ fn chipAt(self: *const Model, x: usize, y: usize) ?u32 {
     }
     if (y >= self.prompt_origin) return null;
     if (y < self.mid_origin) return null;
+    if (y < self.mid_origin + self.sticky_rows) return null; // sticky chrome is inert
     const vis = y - self.mid_origin + self.mid_skip;
     const idx = @import("scrollback.zig").indexAtVisual(self, vis, self.last_term_width) orelse return null;
     if (self.history.items[idx].kind != .user) return null;

--- a/TUI/key.zig
+++ b/TUI/key.zig
@@ -6,6 +6,32 @@ const std = @import("std");
 /// often arrives as a bare DEL after Super-down).
 pub var held: u32 = 0;
 
+/// Armed by the read loop when it throws away a partial escape sequence that
+/// never finished (run.zig's stall path) — the NEXT read can then legitimately
+/// open with that sequence's orphaned tail. Cleared by the first token that is
+/// not orphan debris.
+pub var orphan_armed: bool = false;
+
+/// End offset of the last orphan fragment consumed from the buffer currently
+/// being parsed, so back-to-back debris keeps being eaten while a digit run
+/// that follows real input never is. `maxInt` = no run in progress.
+var orphan_end: usize = std.math.maxInt(usize);
+
+/// Inside `CSI 200~ … CSI 201~`. Every byte between them is literal text by
+/// definition, and a long paste spans several reads — so the debris guard must
+/// stay out of it or a chunk that happens to start `39;7;32M` gets eaten.
+var in_paste: bool = false;
+
+/// Drop every latched parser bit. The globals live for one input loop, so a
+/// fresh session (or a headless sim.Term) must not inherit a held modifier, an
+/// unclosed bracketed paste, or an arm from whatever ran before it.
+pub fn resetInputState() void {
+    held = 0;
+    orphan_armed = false;
+    orphan_end = std.math.maxInt(usize);
+    in_paste = false;
+}
+
 pub const Key = union(enum) {
     char: u8,
     /// Non-ASCII codepoint delivered via kitty CSI-u (é and friends).
@@ -53,7 +79,29 @@ pub const Mouse = struct {
 
 pub fn next(bytes: []const u8, i: *usize) ?Key {
     if (i.* >= bytes.len) return null;
-    if (takeOrphanCsi(bytes, i)) |k| return k;
+    // Orphan CSI debris can only ever be the HEAD of a read: the ESC that
+    // opened the sequence was lost BETWEEN reads (the loop dropped a truncated
+    // pending head, or the tty input queue overflowed while a slow frame
+    // painted). A digit run anywhere else is typed or pasted TEXT — swallowing
+    // it ate `0x1f`, `[12]`, `1e5` and every version string.
+    if (!in_paste and (i.* == 0 or i.* == orphan_end)) {
+        switch (takeOrphanCsi(bytes, i)) {
+            .took => |k| {
+                orphan_end = i.*;
+                return k;
+            },
+            // Debris cut short at the read boundary: hold the bytes so the loop
+            // carries them into the next read instead of typing the digits. The
+            // held bytes ARE the carry-over, so the arm has done its job.
+            .partial => {
+                orphan_armed = false;
+                return null;
+            },
+            .none => {},
+        }
+    }
+    orphan_end = std.math.maxInt(usize);
+    orphan_armed = false;
     const b = bytes[i.*];
     i.* += 1;
     if (b == 0x1b) return escapeSeq(bytes, i);
@@ -255,8 +303,14 @@ fn decodeCsi(params: []const u8, final: u8) Key {
             6 => .page_down,
             11 => .f1,
             12 => .f2,
-            200 => .paste_start,
-            201 => .paste_end,
+            200 => blk: {
+                in_paste = true;
+                break :blk .paste_start;
+            },
+            201 => blk: {
+                in_paste = false;
+                break :blk .paste_end;
+            },
             27 => fixterms(params),
             // 2 (Insert), 13-24 (F3-F12) and friends: inert, never Escape.
             else => .ignore,
@@ -420,20 +474,41 @@ fn sgrMouse(params: []const u8, down: bool) Key {
     } };
 }
 
-/// CSI debris after a split ESC (`7444;9u`, `39;33;23M`, `3u`). Never a
+const Orphan = union(enum) {
+    /// Not debris — hand the bytes to the normal parser (typed text).
+    none,
+    /// Debris shape, cut short by the read boundary: hold, do not type it.
+    partial,
+    took: Key,
+};
+
+/// CSI debris after a lost ESC (`7444;9u`, `39;33;23M`, `<35;80;24M`). Never a
 /// letter and never Escape/Ctrl-C — those cancel or kill the turn.
-fn takeOrphanCsi(bytes: []const u8, i: *usize) ?Key {
+///
+/// Strictly shaped, because this runs against text a human may have typed: an
+/// optional `<`, then digits with `;`/`:` separators, then a MOUSE or CSI-u
+/// final (`M`/`m`/`u`/`~`). Any other terminator is text — accepting the whole
+/// 0x40..0x7e range ate `0x1f` (final `x`), `[12]` (final `]`) and `1e5`
+/// (final `e`). A run with neither `<` nor a separator (`3u`) is debris only
+/// while `orphan_armed` says the loop really did drop a truncated sequence.
+fn takeOrphanCsi(bytes: []const u8, i: *usize) Orphan {
     const start = i.*;
-    if (start >= bytes.len) return null;
+    if (start >= bytes.len) return .none;
     var j = start;
-    if (bytes[j] == '<') j += 1;
-    if (j >= bytes.len or bytes[j] < '0' or bytes[j] > '9') return null;
+    const lt = bytes[j] == '<';
+    if (lt) j += 1;
+    if (j >= bytes.len or bytes[j] < '0' or bytes[j] > '9') return .none;
+    var sep = false;
     var k = j;
     while (k < bytes.len) : (k += 1) {
         const c = bytes[k];
         if (c >= '0' and c <= '9') continue;
-        if (c == ';' or c == ':') continue;
-        if (c >= 0x40 and c <= 0x7e) {
+        if (c == ';' or c == ':') {
+            sep = true;
+            continue;
+        }
+        if (c == 'M' or c == 'm' or c == 'u' or c == '~') {
+            if (!lt and !sep and !orphan_armed) return .none;
             i.* = k + 1;
             if (c == 'M' or c == 'm') {
                 const body = bytes[j..k];
@@ -441,18 +516,21 @@ fn takeOrphanCsi(bytes: []const u8, i: *usize) ?Key {
                 const btn = leadingInt(it.next() orelse "0");
                 const x = leadingInt(it.next() orelse "1");
                 const y = leadingInt(it.next() orelse "1");
-                return .{ .mouse = .{
+                return .{ .took = .{ .mouse = .{
                     .btn = @intCast(@min(btn, 255)),
                     .x = @intCast(@min(x, 999)),
                     .y = @intCast(@min(y, 999)),
                     .down = c == 'M',
-                } };
+                } } };
             }
-            return .ignore;
+            return .{ .took = .ignore };
         }
-        return null;
+        return .none;
     }
-    return null;
+    // Ran off the end mid-fragment. Hold it when it already reads as a CSI
+    // parameter list, or when the loop armed us; a bare unarmed digit run is
+    // somebody typing, and holding it would strand the keystrokes.
+    return if (lt or sep or orphan_armed) .partial else .none;
 }
 
 fn leadingInt(s: []const u8) u32 {

--- a/TUI/key.zig
+++ b/TUI/key.zig
@@ -10,6 +10,8 @@ pub const Key = union(enum) {
     char: u8,
     /// Non-ASCII codepoint delivered via kitty CSI-u (é and friends).
     codepoint: u21,
+    /// OSC 11 reply: the terminal's background RGB (auto light/dark).
+    bg_report: [3]u8,
     ctrl: u8,
     ignore,
     enter,
@@ -141,17 +143,24 @@ fn escapeSeq(bytes: []const u8, i: *usize) ?Key {
 /// OSC/DCS/APC/PM/SOS reply on stdin (e.g. a color query answer) — consume
 /// through BEL or ST so the payload is never typed into the prompt.
 fn stringSeq(bytes: []const u8, i: *usize) ?Key {
+    const start = i.*; // bytes[start] is ']' for OSC
     var j = i.* + 1;
     while (j < bytes.len) : (j += 1) {
         if (bytes[j] == 0x07) {
+            const body = bytes[start + 1 .. j];
             i.* = j + 1;
-            return .ignore;
+            return oscReply(bytes[start], body);
         }
         if (bytes[j] == 0x1b) {
             if (j + 1 < bytes.len) {
                 // ST (ESC \) ends the string; any other ESC starts a new
                 // sequence — leave it for the next parse.
-                i.* = if (bytes[j + 1] == '\\') j + 2 else j;
+                if (bytes[j + 1] == '\\') {
+                    const body = bytes[start + 1 .. j];
+                    i.* = j + 2;
+                    return oscReply(bytes[start], body);
+                }
+                i.* = j;
                 return .ignore;
             }
             break; // ST split across reads — wait for the backslash
@@ -159,6 +168,30 @@ fn stringSeq(bytes: []const u8, i: *usize) ?Key {
     }
     i.* -= 1; // rewind to the ESC; the terminator is still in flight
     return null;
+}
+
+/// A terminated OSC body. The only reply we act on is OSC 11 (background
+/// color, answering run.zig's startup query) — everything else stays inert.
+fn oscReply(kind: u8, body: []const u8) Key {
+    if (kind != ']') return .ignore;
+    if (!std.mem.startsWith(u8, body, "11;")) return .ignore;
+    const rgb = parseXColor(body[3..]) orelse return .ignore;
+    return .{ .bg_report = rgb };
+}
+
+/// `rgb:RRRR/GGGG/BBBB` (high byte) or `rgb:RR/GG/BB`.
+fn parseXColor(s: []const u8) ?[3]u8 {
+    if (!std.mem.startsWith(u8, s, "rgb:")) return null;
+    var out: [3]u8 = undefined;
+    var it = std.mem.splitScalar(u8, s[4..], '/');
+    for (0..3) |n| {
+        const part = it.next() orelse return null;
+        if (part.len != 2 and part.len != 4) return null;
+        const v = std.fmt.parseInt(u16, part, 16) catch return null;
+        out[n] = if (part.len == 4) @intCast(v >> 8) else @intCast(v);
+    }
+    if (it.next() != null) return null;
+    return out;
 }
 
 /// ESC O <final> — SS3 application keys (tmux/screen, macOS Terminal).

--- a/TUI/key_tests.zig
+++ b/TUI/key_tests.zig
@@ -176,8 +176,14 @@ test "non-ASCII CSI-u codepoints type text instead of Escape" {
 
 test "OSC and APC replies on stdin are consumed, never typed" {
     var i: usize = 0;
-    try std.testing.expectEqual(Key.ignore, next("\x1b]11;rgb:14/14/14\x07", &i).?);
+    // OSC 11 replies now carry the terminal background (auto light/dark).
+    try std.testing.expectEqual(Key{ .bg_report = .{ 0x14, 0x14, 0x14 } }, next("\x1b]11;rgb:14/14/14\x07", &i).?);
     try std.testing.expectEqual(@as(usize, 18), i);
+    i = 0;
+    // 4-digit form takes the high byte; other OSC bodies stay inert.
+    try std.testing.expectEqual(Key{ .bg_report = .{ 0xf6, 0xf6, 0xf6 } }, next("\x1b]11;rgb:f6f6/f6f6/f6f6\x1b\\", &i).?);
+    i = 0;
+    try std.testing.expectEqual(Key.ignore, next("\x1b]10;rgb:14/14/14\x07", &i).?);
     i = 0;
     try std.testing.expectEqual(Key.ignore, next("\x1b_Gi=1;OK\x1b\\", &i).?);
     try std.testing.expectEqual(@as(usize, 11), i);

--- a/TUI/key_tests.zig
+++ b/TUI/key_tests.zig
@@ -222,6 +222,11 @@ test "SGR mouse flood does not leak digits" {
 test "orphan kitty CSI-u is ignore, never letters or Escape" {
     var i: usize = 0;
     const seq = "3u7444;9u7441;10u";
+    // `3u` carries neither a `<` nor a `;`, so on its own it reads as somebody
+    // typing. The loop arms us when it drops a truncated sequence — which is
+    // the only way this tail can exist.
+    key.orphan_armed = true;
+    defer key.orphan_armed = false;
     var n: usize = 0;
     while (next(seq, &i)) |k| {
         try std.testing.expect(k == .ignore);
@@ -231,6 +236,112 @@ test "orphan kitty CSI-u is ignore, never letters or Escape" {
     try std.testing.expectEqual(seq.len, i);
     i = 0;
     try std.testing.expectEqual(Key{ .char = 'h' }, next("hi", &i).?);
+}
+
+/// run.zig's read loop, minus the terminal: fixed input buffer, parse to
+/// exhaustion, carry the unparsed tail into the next read. Regressions in the
+/// carry/rewind contract only show up across a read boundary, so the debris
+/// tests have to drive the real thing.
+const Loop = struct {
+    inbuf: [4096]u8 = undefined,
+    pending: usize = 0,
+    typed: std.array_list.Managed(u8),
+    mice: usize = 0,
+
+    fn init(a: std.mem.Allocator) Loop {
+        key.resetInputState();
+        return .{ .typed = std.array_list.Managed(u8).init(a) };
+    }
+    fn deinit(self: *Loop) void {
+        self.typed.deinit();
+    }
+
+    fn read(self: *Loop, bytes: []const u8) !void {
+        @memcpy(self.inbuf[self.pending .. self.pending + bytes.len], bytes);
+        const n = self.pending + bytes.len;
+        var i: usize = 0;
+        while (next(self.inbuf[0..n], &i)) |k| switch (k) {
+            .char => |c| try self.typed.append(c),
+            .codepoint => try self.typed.append('?'),
+            .mouse => self.mice += 1,
+            .escape => try self.typed.append('E'), // a phantom Escape cancels the turn
+            else => {},
+        };
+        self.pending = if (i < n) blk: {
+            const rest = n - i;
+            std.mem.copyForwards(u8, self.inbuf[0..rest], self.inbuf[i..n]);
+            break :blk rest;
+        } else 0;
+    }
+};
+
+test "SGR motion flood chopped at every byte offset never types a character" {
+    key.orphan_armed = false;
+    // The exact bytes the user saw on the bottom row, plus one hover report.
+    const flood = "\x1b[<39;7;32M\x1b[<39;4;32M\x1b[<39;3;33M\x1b[<39;1;33M\x1b[<35;80;24M";
+    var cut: usize = 0;
+    while (cut <= flood.len) : (cut += 1) {
+        var loop = Loop.init(std.testing.allocator);
+        defer loop.deinit();
+        try loop.read(flood[0..cut]);
+        try loop.read(flood[cut..]);
+        try std.testing.expectEqualStrings("", loop.typed.items);
+        try std.testing.expectEqual(@as(usize, 5), loop.mice);
+        try std.testing.expectEqual(@as(usize, 0), loop.pending);
+    }
+}
+
+test "debris after a dropped ESC head is consumed, not typed — even split again" {
+    // run.zig drops a pending head that never completed and arms us; the tail
+    // arrives alone, and may itself straddle the next read boundary.
+    const tail = "39;7;32M\x1b[<39;4;32M";
+    var cut: usize = 0;
+    while (cut <= tail.len) : (cut += 1) {
+        var loop = Loop.init(std.testing.allocator);
+        defer loop.deinit();
+        key.orphan_armed = true;
+        defer key.orphan_armed = false;
+        try loop.read(tail[0..cut]);
+        try loop.read(tail[cut..]);
+        try std.testing.expectEqualStrings("", loop.typed.items);
+        try std.testing.expectEqual(@as(usize, 2), loop.mice);
+    }
+}
+
+test "typed and pasted text survives the debris guard (0x1f, [12], 1e5)" {
+    key.orphan_armed = false;
+    const cases = [_][]const u8{
+        "const x = 0x1f;",
+        "v1e5 [12] 2xM",
+        "1.5]",
+        "0x1f",
+        "[12]",
+        "1e5",
+        "grep -n '39;7;32M' log", // debris-shaped text, but not at a read head
+        "step 3 of 10 (2m30s)",
+    };
+    for (cases) |text| {
+        var loop = Loop.init(std.testing.allocator);
+        defer loop.deinit();
+        try loop.read(text);
+        try std.testing.expectEqualStrings(text, loop.typed.items);
+        try std.testing.expectEqual(@as(usize, 0), loop.mice);
+    }
+    // Byte-at-a-time typing is the same string.
+    var slow = Loop.init(std.testing.allocator);
+    defer slow.deinit();
+    for ("0x1f + [12] = 1e5") |c| try slow.read(&[_]u8{c});
+    try std.testing.expectEqualStrings("0x1f + [12] = 1e5", slow.typed.items);
+}
+
+test "bracketed paste of debris-shaped code reaches the composer intact" {
+    key.orphan_armed = false;
+    var loop = Loop.init(std.testing.allocator);
+    defer loop.deinit();
+    try loop.read("\x1b[200~");
+    try loop.read("39;7;32M and 0x1f");
+    try loop.read("\x1b[201~");
+    try std.testing.expectEqualStrings("39;7;32M and 0x1f", loop.typed.items);
 }
 
 test "Shift+9 is open-paren, Shift+0 is close-paren" {

--- a/TUI/keys.zig
+++ b/TUI/keys.zig
@@ -230,8 +230,13 @@ fn mouseKey(self: *Model, ev: key_mod.Mouse) Effect {
         return .stay;
     }
     if (y < self.mid_origin) return .stay;
+    // Sticky-header chrome occludes the top content rows — a click there must
+    // not toggle whatever is hidden underneath it.
+    if (y < self.mid_origin + self.sticky_rows) return .stay;
     const vis = y - self.mid_origin + self.mid_skip;
-    const idx = scrollback.indexAtVisual(self, vis, self.last_term_width) orelse lastToolIdx(self);
+    // No fallback on a miss: clicking blank space below the transcript used to
+    // silently expand the LAST tool run (audit: easiest bug to hit).
+    const idx = scrollback.indexAtVisual(self, vis, self.last_term_width);
     self.focus = .scrollback;
     if (idx) |i| {
         self.selected = i;

--- a/TUI/keys.zig
+++ b/TUI/keys.zig
@@ -23,6 +23,15 @@ pub fn handle(self: *Model, k: Key) Effect {
         if (self.input.undo()) self.setToast("undone");
         return .stay;
     }
+    if (k == .bg_report) {
+        // Startup OSC 11 reply: adopt the terminal's polarity unless the user
+        // explicitly picked a theme. Fixed palettes, 1-bit decision (grok).
+        if (!self.theme_explicit) {
+            const want: @import("theme.zig").Id = if (@import("theme.zig").classifyLight(k.bg_report[0], k.bg_report[1], k.bg_report[2])) .day else .night;
+            self.theme_id = want;
+        }
+        return .stay;
+    }
     if (k == .mouse) return mouseKey(self, k.mouse);
     if (k == .paste_start) {
         self.pasting = true;

--- a/TUI/markdown.zig
+++ b/TUI/markdown.zig
@@ -51,6 +51,7 @@ pub fn renderThemed(a: std.mem.Allocator, src: []const u8, th: theme_mod.Theme, 
                 try out.appendSlice(line);
             }
             try out.appendSlice(theme_mod.reset);
+            try out.appendSlice(th.bg); // the no-49 reset keeps codeBg alive — restore the canvas
             i += 1;
             continue;
         }
@@ -196,6 +197,7 @@ fn inlineSpans(out: *std.array_list.Managed(u8), line: []const u8, accent: []con
             if (std.mem.indexOfPos(u8, line, i + 2, "**")) |end| {
                 try out.appendSlice(theme_mod.bold);
                 try out.appendSlice(line[i + 2 .. end]);
+                try out.appendSlice("\x1b[22m"); // bold OFF — a 38;2 fg alone cannot clear SGR 1
                 try out.appendSlice(text);
                 i = end + 2;
                 continue;
@@ -249,23 +251,14 @@ fn splitCells(line: []const u8, out: [][]const u8) usize {
     return n;
 }
 
-fn cellWidth(s: []const u8) usize {
-    var n: usize = 0;
-    var i: usize = 0;
-    while (i < s.len) {
-        if (s[i] == '`') {
-            i += 1;
-            continue;
-        }
-        if (s[i] == '*' and i + 1 < s.len and s[i + 1] == '*') {
-            i += 2;
-            continue;
-        }
-        const w = std.unicode.utf8ByteSequenceLength(s[i]) catch 1;
-        i += @min(w, s.len - i);
-        n += 1;
-    }
-    return n;
+/// Visible width of a cell AS RENDERED: run it through inlineSpans and count.
+/// Guessing at markers went wrong on every unmatched ` or ** (the render kept
+/// them, the measure dropped them, the pad math sheared the grid).
+fn cellWidth(a: std.mem.Allocator, s: []const u8) usize {
+    var scratch = std.array_list.Managed(u8).init(a);
+    defer scratch.deinit();
+    inlineSpans(&scratch, s, "", "") catch return s.len;
+    return theme_mod.visibleLen(scratch.items);
 }
 
 fn emitRule(out: *std.array_list.Managed(u8), muted: []const u8, widths: []const usize, left: []const u8, mid: []const u8, right: []const u8) !void {
@@ -298,7 +291,7 @@ fn emitTable(
         if (n > ncol) ncol = n;
         var c: usize = 0;
         while (c < n) : (c += 1) {
-            const w = @min(cellWidth(cells[c]), @as(usize, 36));
+            const w = @min(cellWidth(a, cells[c]), @as(usize, 36));
             if (w > widths[c]) widths[c] = w;
         }
     }
@@ -350,7 +343,7 @@ fn emitTable(
                 try scratch.appendSlice(text);
                 try inlineSpans(&scratch, cell, accent, text);
             }
-            const vis = cellWidth(cell);
+            const vis = cellWidth(a, cell);
             if (vis > want) {
                 try out.appendSlice(theme_mod.takeCols(scratch.items, if (want > 1) want - 1 else want));
                 if (want > 1) try out.appendSlice("\u{2026}");

--- a/TUI/markdown.zig
+++ b/TUI/markdown.zig
@@ -2,10 +2,85 @@
 
 const std = @import("std");
 const theme_mod = @import("theme.zig");
+const syntax = @import("syntax.zig");
 
 /// Headers, fences, bullets, `code`, **bold**, and `/slash` tokens.
 pub fn render(a: std.mem.Allocator, src: []const u8, accent: []const u8) ![]const u8 {
     return renderTinted(a, src, accent, theme_mod.zinc400, theme_mod.zinc200);
+}
+
+/// Theme-aware render: grok-style code fences — markers hidden behind a blank
+/// separator row, a full-width background band (clear-to-EOL under the code
+/// bg), and token colors from syntax.zig in the theme's polarity. Everything
+/// else matches renderTinted.
+pub fn renderThemed(a: std.mem.Allocator, src: []const u8, th: theme_mod.Theme) ![]const u8 {
+    const light = th.id == .day;
+    var lines = std.array_list.Managed([]const u8).init(a);
+    defer lines.deinit();
+    var split = std.mem.splitScalar(u8, src, '\n');
+    while (split.next()) |line| try lines.append(line);
+
+    var out = std.array_list.Managed(u8).init(a);
+    var in_fence = false;
+    var lang: ?*const syntax.Lang = null;
+    var lex: syntax.State = .{};
+    var first = true;
+    var i: usize = 0;
+    while (i < lines.items.len) {
+        const line = lines.items[i];
+        if (!first) try out.append('\n');
+        first = false;
+        const t = std.mem.trimStart(u8, line, " ");
+        if (std.mem.startsWith(u8, t, "```")) {
+            in_fence = !in_fence;
+            if (in_fence) {
+                lang = syntax.resolve(t[3..]);
+                lex = .{};
+            }
+            // Hidden fence markers; the empty row is the grok separator.
+            i += 1;
+            continue;
+        }
+        if (in_fence) {
+            try out.appendSlice(syntax.codeBg(light));
+            try out.appendSlice("\x1b[K");
+            if (lang) |l| {
+                try syntax.highlightLine(&out, line, l, &lex, light);
+            } else {
+                try out.appendSlice(th.text);
+                try out.appendSlice(line);
+            }
+            try out.appendSlice(theme_mod.reset);
+            i += 1;
+            continue;
+        }
+        if (tableLen(lines.items[i..])) |n| {
+            try emitTable(&out, a, lines.items[i .. i + n], th.accent, th.muted, th.text);
+            i += n;
+            continue;
+        }
+        if (std.mem.startsWith(u8, t, "#")) {
+            var h = t;
+            while (h.len > 0 and h[0] == '#') h = h[1..];
+            try out.appendSlice(theme_mod.bold);
+            try out.appendSlice(th.accent);
+            try out.appendSlice(std.mem.trimStart(u8, h, " "));
+            try out.appendSlice(theme_mod.reset);
+            i += 1;
+            continue;
+        }
+        try out.appendSlice(th.text);
+        var rest = line;
+        if (std.mem.startsWith(u8, t, "- ") or std.mem.startsWith(u8, t, "* ")) {
+            try out.appendSlice(th.accent);
+            try out.appendSlice("  • ");
+            try out.appendSlice(th.text);
+            rest = t[2..];
+        }
+        try inlineSpans(&out, rest, th.accent, th.text);
+        i += 1;
+    }
+    return out.toOwnedSlice();
 }
 
 pub fn renderTinted(a: std.mem.Allocator, src: []const u8, accent: []const u8, muted: []const u8, text: []const u8) ![]const u8 {

--- a/TUI/markdown.zig
+++ b/TUI/markdown.zig
@@ -13,7 +13,7 @@ pub fn render(a: std.mem.Allocator, src: []const u8, accent: []const u8) ![]cons
 /// separator row, a full-width background band (clear-to-EOL under the code
 /// bg), and token colors from syntax.zig in the theme's polarity. Everything
 /// else matches renderTinted.
-pub fn renderThemed(a: std.mem.Allocator, src: []const u8, th: theme_mod.Theme) ![]const u8 {
+pub fn renderThemed(a: std.mem.Allocator, src: []const u8, th: theme_mod.Theme, width: usize) ![]const u8 {
     const light = th.id == .day;
     var lines = std.array_list.Managed([]const u8).init(a);
     defer lines.deinit();
@@ -55,7 +55,7 @@ pub fn renderThemed(a: std.mem.Allocator, src: []const u8, th: theme_mod.Theme) 
             continue;
         }
         if (tableLen(lines.items[i..])) |n| {
-            try emitTable(&out, a, lines.items[i .. i + n], th.accent, th.muted, th.text);
+            try emitTable(&out, a, lines.items[i .. i + n], th.accent, th.muted, th.text, width);
             i += n;
             continue;
         }
@@ -116,7 +116,7 @@ pub fn renderTinted(a: std.mem.Allocator, src: []const u8, accent: []const u8, m
             continue;
         }
         if (tableLen(lines.items[i..])) |n| {
-            try emitTable(&out, a, lines.items[i .. i + n], accent, muted, text);
+            try emitTable(&out, a, lines.items[i .. i + n], accent, muted, text, 0);
             i += n;
             continue;
         }
@@ -287,8 +287,8 @@ fn emitTable(
     accent: []const u8,
     muted: []const u8,
     text: []const u8,
+    width: usize,
 ) !void {
-    _ = a;
     var widths: [max_table_cols]usize = @splat(0);
     var ncol: usize = 0;
     for (rows, 0..) |row, ri| {
@@ -304,6 +304,24 @@ fn emitTable(
     }
     if (ncol == 0) return;
     const cols = widths[0..ncol];
+    // Fit the grid into the terminal: every row costs ncol*3+1 border/pad
+    // columns on top of the content. Shave the widest column until it fits
+    // (floor 5), then clamp each CELL to its column so an over-long cell can
+    // never blow the grid — before this, content was emitted unclamped and
+    // the line-wrapper sheared tables apart at narrow widths.
+    const chrome_cost = ncol * 3 + 1;
+    const budget = if (width == 0) 76 else if (width > chrome_cost) width - chrome_cost else ncol * 5;
+    var total: usize = 0;
+    for (cols) |w| total += w;
+    while (total > budget) {
+        var widest: usize = 0;
+        for (cols, 0..) |w, ci| {
+            if (w > cols[widest]) widest = ci;
+        }
+        if (cols[widest] <= 5) break;
+        cols[widest] -= 1;
+        total -= 1;
+    }
     try emitRule(out, muted, cols, "┌", "┬", "┐");
     try out.append('\n');
     for (rows, 0..) |row, ri| {
@@ -321,21 +339,27 @@ fn emitTable(
             try out.appendSlice(theme_mod.reset);
             try out.append(' ');
             const cell = if (c < n) cells[c] else "";
+            const want = cols[c];
+            var scratch = std.array_list.Managed(u8).init(a);
+            defer scratch.deinit();
             if (ri == 0) {
-                try out.appendSlice(theme_mod.bold);
-                try out.appendSlice(accent);
-                try inlineSpans(out, cell, accent, accent);
-                try out.appendSlice(theme_mod.reset);
+                try scratch.appendSlice(theme_mod.bold);
+                try scratch.appendSlice(accent);
+                try inlineSpans(&scratch, cell, accent, accent);
             } else {
-                try out.appendSlice(text);
-                try inlineSpans(out, cell, accent, text);
+                try scratch.appendSlice(text);
+                try inlineSpans(&scratch, cell, accent, text);
             }
             const vis = cellWidth(cell);
-            const want = cols[c];
-            if (vis < want) {
+            if (vis > want) {
+                try out.appendSlice(theme_mod.takeCols(scratch.items, if (want > 1) want - 1 else want));
+                if (want > 1) try out.appendSlice("\u{2026}");
+            } else {
+                try out.appendSlice(scratch.items);
                 var p: usize = 0;
                 while (p < want - vis) : (p += 1) try out.append(' ');
             }
+            try out.appendSlice(theme_mod.reset);
             try out.append(' ');
         }
         try out.appendSlice(muted);
@@ -379,4 +403,18 @@ test "render paints a Grok-style box table and hides raw pipes" {
     try std.testing.expect(std.mem.indexOf(u8, text, "pager") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "| --- |") == null);
     try std.testing.expect(std.mem.indexOf(u8, text, "| Path |") == null);
+}
+
+test "a wide table fits the terminal: grid intact, one visual line per row (#tables)" {
+    const th = theme_mod.of(.night);
+    const md = "| Transport | Grok (this wire) | Codex / Claude |\n|---|---|---|\n| Item delta (previous_response_id) with a very long explanation cell that used to blow the grid | no (stalls) everywhere on narrow terminals | yes, if props match and the moon is right |";
+    const out = try renderThemed(std.testing.allocator, md, th, 60);
+    defer std.testing.allocator.free(out);
+    var it = std.mem.splitScalar(u8, out, '\n');
+    var rows: usize = 0;
+    while (it.next()) |ln| : (rows += 1) {
+        try std.testing.expect(theme_mod.visibleLen(ln) <= 60);
+    }
+    try std.testing.expectEqual(@as(usize, 5), rows); // top rule, header, mid rule, body, bottom rule
+    try std.testing.expect(std.mem.indexOf(u8, out, "\u{2026}") != null); // over-long cells clip with an ellipsis
 }

--- a/TUI/markdown.zig
+++ b/TUI/markdown.zig
@@ -25,13 +25,24 @@ pub fn renderThemed(a: std.mem.Allocator, src: []const u8, th: theme_mod.Theme, 
     var lang: ?*const syntax.Lang = null;
     var lex: syntax.State = .{};
     var first = true;
+    // The previous line ended inside the code band, so codeBg is still the
+    // active canvas and the next line that is NOT band content has to reclaim
+    // it. Restoring on the fence line's own tail instead ended the band at the
+    // last code glyph: run.zig pads the rest of the row from wherever the line
+    // left the background, so the band has to stay open until the row ends.
+    var band = false;
     var i: usize = 0;
     while (i < lines.items.len) {
         const line = lines.items[i];
         if (!first) try out.append('\n');
         first = false;
         const t = std.mem.trimStart(u8, line, " ");
-        if (std.mem.startsWith(u8, t, "```")) {
+        const marker = std.mem.startsWith(u8, t, "```");
+        if (band and !(in_fence and !marker)) {
+            try out.appendSlice(th.bg); // leave the band before anything paints
+            band = false;
+        }
+        if (marker) {
             in_fence = !in_fence;
             if (in_fence) {
                 lang = syntax.resolve(t[3..]);
@@ -50,8 +61,8 @@ pub fn renderThemed(a: std.mem.Allocator, src: []const u8, th: theme_mod.Theme, 
                 try out.appendSlice(th.text);
                 try out.appendSlice(line);
             }
-            try out.appendSlice(theme_mod.reset);
-            try out.appendSlice(th.bg); // the no-49 reset keeps codeBg alive — restore the canvas
+            try out.appendSlice(theme_mod.reset); // fg/weight only: the band survives to the row end
+            band = true;
             i += 1;
             continue;
         }
@@ -376,6 +387,88 @@ test "render paints headers, code, bold, and bullets" {
     try std.testing.expect(std.mem.indexOf(u8, text, "bold") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "▏ ") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, theme_mod.emerald) != null);
+}
+
+test "the code band stays open to the row end and is released on the next line" {
+    const th = theme_mod.of(.night);
+    const code_bg = syntax.codeBg(false);
+    const out = try renderThemed(std.testing.allocator, "intro\n```\nabc\ndef\n```\nafter", th, 40);
+    defer std.testing.allocator.free(out);
+    var it = std.mem.splitScalar(u8, out, '\n');
+    var rows: usize = 0;
+    var was_band = false;
+    var band_rows: usize = 0;
+    while (it.next()) |ln| : (rows += 1) {
+        const band = std.mem.indexOf(u8, ln, code_bg) != null;
+        if (band) {
+            // run.zig pads a row from whatever background the line left active,
+            // so a band row must NOT hand the canvas back before it ends.
+            try std.testing.expect(std.mem.indexOf(u8, ln, th.bg) == null);
+            band_rows += 1;
+        } else if (was_band) {
+            // The first row off the band reclaims the theme canvas up front.
+            try std.testing.expect(std.mem.startsWith(u8, ln, th.bg));
+        }
+        was_band = band;
+    }
+    try std.testing.expectEqual(@as(usize, 2), band_rows); // abc, def
+    // intro, opening separator, abc, def, closing separator, after
+    try std.testing.expectEqual(@as(usize, 6), rows);
+}
+
+test "a wrapped fence line carries its band onto every continuation row" {
+    const th = theme_mod.of(.night);
+    const bg = syntax.codeBg(false);
+    const src =
+        \\```zig
+        \\const message = try std.fmt.allocPrint(gpa, "hello {s} world", .{name});
+        \\```
+    ;
+    const body = try renderThemed(std.testing.allocator, src, th, 36);
+    defer std.testing.allocator.free(body);
+    const wrapped = try theme_mod.wrapToWidth(std.testing.allocator, body, 36);
+    defer std.testing.allocator.free(wrapped);
+    var it = std.mem.splitScalar(u8, wrapped, '\n');
+    var code_rows: usize = 0;
+    while (it.next()) |ln| {
+        if (theme_mod.visibleLen(ln) == 0) continue; // fence separators
+        code_rows += 1;
+        // A syntax-coloured line spends an SGR per token; the old byte-capped
+        // tracker had dropped the background long before the wrap point.
+        try std.testing.expect(std.mem.indexOf(u8, ln, bg) != null);
+    }
+    try std.testing.expect(code_rows > 1); // it really did wrap
+}
+
+test "no code background leaks past a closed fence or off the last fence row" {
+    const th = theme_mod.of(.night);
+    const code_bg = syntax.codeBg(false);
+    const closed = try renderThemed(std.testing.allocator, "```\nx\n```\ntail", th, 40);
+    defer std.testing.allocator.free(closed);
+    // The band ends with the fence, the next row takes the canvas back, and no
+    // later row re-opens codeBg.
+    var it = std.mem.splitScalar(u8, closed, '\n');
+    var seen_band = false;
+    var restored = false;
+    while (it.next()) |ln| {
+        const band = std.mem.indexOf(u8, ln, code_bg) != null;
+        if (band) {
+            try std.testing.expect(!restored); // never re-opened
+            seen_band = true;
+            continue;
+        }
+        if (seen_band and !restored) {
+            try std.testing.expect(std.mem.startsWith(u8, ln, th.bg));
+            restored = true;
+        }
+    }
+    try std.testing.expect(seen_band and restored);
+    // A message that ends mid-fence keeps its band (that row IS code) and adds
+    // no stray row after it for the theme bg to land on.
+    const open = try renderThemed(std.testing.allocator, "```\nx", th, 40);
+    defer std.testing.allocator.free(open);
+    try std.testing.expect(std.mem.indexOf(u8, open, th.bg) == null);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, open, "\n"));
 }
 
 test "renderUser chips @[path] and paints slash commands" {

--- a/TUI/nav.zig
+++ b/TUI/nav.zig
@@ -69,13 +69,22 @@ pub fn jumpTo(self: *Model, idx: usize) void {
     const width = if (self.last_term_width == 0) 80 else self.last_term_width;
     const total = sb.totalVisualLines(self, width);
     const at = sb.visualOfIndex(self, idx, width) orelse return;
-    const view_h = if (self.prompt_origin > self.mid_origin) self.prompt_origin - self.mid_origin else 8;
+    // prompt_origin - mid_origin includes the image-card rows render subtracts
+    // from the transcript, and the sticky header occludes the top two viewport
+    // rows — without both corrections /jump parked the target off-screen or
+    // exactly under the pinned chrome (audit: the jumped-to turn was ALWAYS
+    // hidden, with the PREVIOUS prompt pinned above it).
+    const gross = if (self.prompt_origin > self.mid_origin) self.prompt_origin - self.mid_origin else 8;
+    const view_h = gross -| self.preview_rows;
     if (total <= view_h) {
         self.scroll = 0;
         return;
     }
     const max_scroll = total - view_h;
-    self.scroll = if (at >= max_scroll) 0 else max_scroll - at;
+    // Land the target at the row below the sticky slot (row 2) so it is the
+    // first fully visible line; at the extremes fall back to the edges.
+    const want = at -| 2;
+    self.scroll = if (want >= max_scroll) 0 else max_scroll - want;
 }
 
 fn jumpTurn(self: *Model, dir: i32) void {

--- a/TUI/render.zig
+++ b/TUI/render.zig
@@ -8,6 +8,7 @@ const app = @import("app.zig");
 const chrome = @import("chrome.zig");
 const engine = @import("engine.zig");
 const scrollback = @import("scrollback.zig");
+const theme_mod = @import("theme.zig");
 const welcome = @import("welcome.zig");
 const Model = app.Model;
 
@@ -79,7 +80,31 @@ pub fn render(self: *Model, gpa: std.mem.Allocator, width: usize, height: usize,
         if (self.scroll > max_scroll) self.scroll = max_scroll;
         const start = max_scroll - self.scroll;
         self.mid_skip = start;
-        for (mid_lines.items[start .. start + view_h]) |ln| {
+        // grok sticky header (minimal single slot): once the last user prompt
+        // scrolls past the viewport top, its first line stays pinned as row 0
+        // with a blank separator row under it. The two chrome rows OCCLUDE the
+        // two top content lines instead of shifting them, so the row↔line map
+        // for everything below is unchanged and the bottom line stays put.
+        var chrome_rows: usize = 0;
+        if (view_h >= 5) {
+            if (scrollback.stickyUserAbove(self, start, width)) |utext| {
+                const th = self.theme();
+                var head = std.array_list.Managed(u8).init(a);
+                try head.appendSlice(th.accent);
+                try head.appendSlice("\u{276F} ");
+                try head.appendSlice(th.text);
+                var one = utext;
+                if (std.mem.indexOfScalar(u8, utext, '\n')) |nl| one = utext[0..nl];
+                try head.appendSlice(one);
+                const cols = if (width > 2) width - 2 else 1;
+                try out.appendSlice(theme_mod.takeCols(head.items, cols));
+                try out.appendSlice(theme_mod.reset);
+                try out.append('\n');
+                try out.append('\n');
+                chrome_rows = 2;
+            }
+        }
+        for (mid_lines.items[start + chrome_rows .. start + view_h]) |ln| {
             try out.appendSlice(ln);
             try out.append('\n');
         }
@@ -227,4 +252,32 @@ test "debug overlay keeps the observability HUD and adds layout" {
     try std.testing.expect(std.mem.indexOf(u8, text, "mid-origin") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "images") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "pending") != null);
+}
+
+test "sticky header pins the last scrolled-past user prompt with a blank separator" {
+    var m: Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    try m.push(.user, "how do I frobnicate the widget?");
+    var i: usize = 0;
+    while (i < 40) : (i += 1) try m.push(.assistant, "a long explanation line that fills the scrollback with content");
+    // follow-mode bottom: prompt is far above, so it pins.
+    const frame = try render(&m, std.testing.allocator, 80, 24, 0);
+    defer std.testing.allocator.free(frame);
+    var it = std.mem.splitScalar(u8, frame, '\n');
+    var row: usize = 0;
+    var pin_row: ?usize = null;
+    while (it.next()) |ln| : (row += 1) {
+        if (std.mem.indexOf(u8, ln, "\u{276F} ") != null and std.mem.indexOf(u8, ln, "frobnicate") != null) {
+            pin_row = row;
+            break;
+        }
+    }
+    try std.testing.expect(pin_row != null);
+    // scrolled fully back to the top, the prompt is inline: no pin.
+    m.follow = false;
+    m.scroll = 100000;
+    const top_frame = try render(&m, std.testing.allocator, 80, 24, 0);
+    defer std.testing.allocator.free(top_frame);
+    try std.testing.expect(std.mem.indexOf(u8, top_frame, "\u{276F} ") == null);
 }

--- a/TUI/render.zig
+++ b/TUI/render.zig
@@ -27,7 +27,10 @@ pub fn render(self: *Model, gpa: std.mem.Allocator, width: usize, height: usize,
         try chrome.overlay(self, a, width)
     else
         "";
-    const mid = if (self.overlay != .none and self.overlay != .image)
+    // The image overlay is a card ABOVE the composer, so `mid` stays the
+    // transcript; every other overlay replaces it with its own body.
+    const overlay_body = self.overlay != .none and self.overlay != .image;
+    const mid = if (overlay_body)
         try chrome.overlay(self, a, width)
     else if (self.screen == .welcome and self.userTurnCount() == 0)
         try welcome.render(self, a, width)
@@ -90,7 +93,10 @@ pub fn render(self: *Model, gpa: std.mem.Allocator, width: usize, height: usize,
         // two top content lines instead of shifting them, so the row↔line map
         // for everything below is unchanged and the bottom line stays put.
         var chrome_rows: usize = 0;
-        if (view_h >= 5) {
+        // Only the transcript gets a pinned prompt. On an overlay screen `mid`
+        // is the overlay's own body, and a long one (/help, /models) scrolls
+        // too — ungated, this pinned a user prompt over its first two rows.
+        if (!overlay_body and view_h >= 5) {
             if (scrollback.stickyUserAbove(self, start, width)) |utext| {
                 const th = self.theme();
                 var head = std.array_list.Managed(u8).init(a);
@@ -257,6 +263,34 @@ test "debug overlay keeps the observability HUD and adds layout" {
     try std.testing.expect(std.mem.indexOf(u8, text, "mid-origin") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "images") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "pending") != null);
+}
+
+test "the sticky header never pins a prompt over an overlay" {
+    var m: Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    try m.push(.user, "SECRETPROMPT about widgets");
+    var i: usize = 0;
+    while (i < 40) : (i += 1) try m.push(.assistant, "filler assistant prose to make the transcript long");
+    // It engages on the transcript...
+    const transcript = try render(&m, std.testing.allocator, 80, 24, 0);
+    std.testing.allocator.free(transcript);
+    try std.testing.expectEqual(@as(usize, 2), m.sticky_rows);
+    // ...and stands down once `mid` is an overlay body long enough to scroll:
+    // ungated, the pin ate the overlay's own first two rows.
+    m.openOverlay(.help);
+    const overlay_frame = try render(&m, std.testing.allocator, 80, 24, 0);
+    defer std.testing.allocator.free(overlay_frame);
+    try std.testing.expectEqual(@as(usize, 0), m.sticky_rows);
+    try std.testing.expect(std.mem.indexOf(u8, overlay_frame, "SECRETPROMPT") == null);
+    // The image overlay is a card, not a body: the transcript keeps its pin.
+    m.closeOverlay();
+    m.preview_path = "/tmp/shot.png";
+    m.preview_n = 1;
+    m.openOverlay(.image);
+    const card_frame = try render(&m, std.testing.allocator, 80, 24, 0);
+    defer std.testing.allocator.free(card_frame);
+    try std.testing.expectEqual(@as(usize, 2), m.sticky_rows);
 }
 
 test "sticky header pins the last scrolled-past user prompt with a blank separator" {

--- a/TUI/render.zig
+++ b/TUI/render.zig
@@ -48,7 +48,10 @@ pub fn render(self: *Model, gpa: std.mem.Allocator, width: usize, height: usize,
 
     const bottom_lines = countLines(bottom.items);
     const top_lines = countLines(top);
-    const card_lines = countLines(image_card);
+    // countLines counts a trailing '\n' as an extra line but the append below
+    // adds no newline of its own — the off-by-one shifted the whole frame up
+    // one row and broke composer clicks (prompt_origin pointed past the box).
+    const card_lines = if (image_card.len == 0) 0 else countLines(image_card) - @intFromBool(image_card[image_card.len - 1] == '\n');
     self.preview_rows = card_lines;
     self.mid_origin = top_lines;
     self.prompt_origin = if (height > bottom_lines) height - bottom_lines else 0;
@@ -65,6 +68,7 @@ pub fn render(self: *Model, gpa: std.mem.Allocator, width: usize, height: usize,
     if (top.len > 0 and top[top.len - 1] != '\n') try out.append('\n');
 
     const n = mid_lines.items.len;
+    self.sticky_rows = 0;
     if (n <= view_h) {
         self.scroll = 0;
         self.mid_skip = 0;
@@ -102,6 +106,7 @@ pub fn render(self: *Model, gpa: std.mem.Allocator, width: usize, height: usize,
                 try out.append('\n');
                 try out.append('\n');
                 chrome_rows = 2;
+                self.sticky_rows = 2;
             }
         }
         for (mid_lines.items[start + chrome_rows .. start + view_h]) |ln| {

--- a/TUI/restore.zig
+++ b/TUI/restore.zig
@@ -11,7 +11,7 @@ const tty = @import("tty.zig");
 /// autowrap on, mouse off (1006/1003/1000), bracketed paste off, cursor
 /// visible. The alt-screen exit stays last so everything lands on the
 /// primary screen.
-pub const seq = "\x1b[>4;0m\x1b[<u\x1b[?7h\x1b[?1006l\x1b[?1003l\x1b[?1000l\x1b[?2004l\x1b[?25h\x1b[?1049l";
+pub const seq = "\x1b[?2026l\x1b[>4;0m\x1b[<u\x1b[?7h\x1b[?1006l\x1b[?1003l\x1b[?1000l\x1b[?2004l\x1b[?25h\x1b[?1049l";
 
 var armed = std.atomic.Value(bool).init(false);
 var saved: tty.RawState = undefined;

--- a/TUI/root.zig
+++ b/TUI/root.zig
@@ -45,6 +45,7 @@ test {
     _ = @import("chrome.zig");
     _ = @import("models.zig");
     _ = @import("markdown.zig");
+    _ = @import("syntax.zig");
     _ = @import("dump.zig");
     _ = @import("effort.zig");
     _ = @import("sim.zig");

--- a/TUI/run.zig
+++ b/TUI/run.zig
@@ -88,6 +88,8 @@ pub fn run(
     var saw_gfx: bool = false;
     var prev: []u8 = &.{};
     var prev_rows: usize = 0;
+    var prev_cols: usize = 0;
+    var prev_theme = m.theme_id;
     defer if (prev.len != 0) gpa.free(prev);
     while (m.running and !m.quit_requested) {
         m.now_ms = @intCast(@divTrunc(@max(@as(i128, 0), Io.Timestamp.now(io, .real).nanoseconds), 1_000_000));
@@ -104,7 +106,12 @@ pub fn run(
         const hash = std.hash.Wyhash.hash(0, frame);
         if (hash != last_hash) {
             const has_gfx = std.mem.indexOf(u8, frame, "\x1b_G") != null;
-            const full = prev.len == 0 or rows != prev_rows or saw_gfx or has_gfx;
+            // The theme bg is painted per ROW, not baked into the frame, and
+            // blank rows are byte-identical across themes/widths — the diff
+            // path skips them, stranding old-bg rows after /theme or the
+            // startup OSC-11 polarity flip, and stale columns after a
+            // width-only resize. Both must force a full paint.
+            const full = prev.len == 0 or rows != prev_rows or cols != prev_cols or m.theme_id != prev_theme or saw_gfx or has_gfx;
             // Kitty images sit above the cell grid and survive \x1b[K / dirty
             // paints — delete before every redraw that might have shown one.
             // ?2026 synchronized output: the terminal buffers everything
@@ -119,6 +126,8 @@ pub fn run(
             if (prev.len != 0) gpa.free(prev);
             prev = gpa.dupe(u8, frame) catch &.{};
             prev_rows = rows;
+            prev_cols = cols;
+            prev_theme = m.theme_id;
             last_hash = hash;
             saw_gfx = has_gfx;
         }
@@ -227,7 +236,14 @@ fn paint(w: *Io.Writer, frame: []const u8, rows: usize, cols: usize, prev: []con
         try w.writeAll(bg);
         const ln = nthLine(frame, row);
         try w.writeAll(ln);
-        try fillRow(w, ln, cols);
+        const vis = theme_mod.visibleLen(ln);
+        if (vis < cols) {
+            try fillRow(w, ln, cols);
+        } else {
+            // Row is exactly full: the cursor is ON the last column and EL
+            // erases it inclusive — that ate the composer's right border.
+            continue;
+        }
         try w.writeAll(bg);
         try w.writeAll("\x1b[K");
     }

--- a/TUI/run.zig
+++ b/TUI/run.zig
@@ -139,7 +139,18 @@ pub fn run(
             if (pending_len > 0) {
                 esc_stall += 1;
                 if (esc_stall >= 2) {
-                    if (inbuf[0] == 0x1b and keys.handle(&m, .escape) == .quit) m.running = false;
+                    switch (stalledPending(inbuf[0..pending_len])) {
+                        .escape_key => if (keys.handle(&m, .escape) == .quit) {
+                            m.running = false;
+                        },
+                        // A sequence the terminal never finished. Delivering
+                        // Escape here cancelled the running turn on a
+                        // half-arrived mouse report; dropping it silently
+                        // leaves its tail to arrive alone on the next read, so
+                        // tell key.zig to expect orphan debris there.
+                        .truncated_sequence => key_mod.orphan_armed = true,
+                        .discard => {},
+                    }
                     pending_len = 0;
                     esc_stall = 0;
                 }
@@ -186,6 +197,20 @@ pub fn run(
         defer if (vis.ptr != prev.ptr) gpa.free(vis);
         traj.snap(io, m.now_ms, vis);
     }
+}
+
+/// What to do with bytes still pending after the input stalled (#94). A LONE
+/// ESC that nothing followed is the Escape KEY. Anything longer is a real
+/// escape sequence the terminal never finished — a half-arrived SGR mouse
+/// report under 1003 hover tracking is the common one, and reading it as
+/// Escape cancelled the user's running turn while its tail leaked into the
+/// composer as `39;7;32M`-shaped text on the next read.
+pub const StallAction = enum { escape_key, truncated_sequence, discard };
+
+pub fn stalledPending(pending: []const u8) StallAction {
+    if (pending.len == 0) return .discard;
+    if (pending[0] != 0x1b) return .truncated_sequence;
+    return if (pending.len == 1) .escape_key else .truncated_sequence;
 }
 
 fn parkToShell(io: Io, w: *Io.Writer, raw: *tty.RawState) void {
@@ -292,6 +317,20 @@ test "run loop enables click+hover tracking and bracketed paste" {
     try std.testing.expect(std.mem.indexOf(u8, src, &kitty_on) != null);
     try std.testing.expect(std.mem.indexOf(u8, src, &wrap_off) != null);
     try std.testing.expect(std.mem.indexOf(u8, src, "a=d,d=A") != null);
+}
+
+test "stalled pending: only a LONE ESC is the Escape key" {
+    // #94: a bare ESC nothing followed is the Escape keypress.
+    try std.testing.expectEqual(StallAction.escape_key, stalledPending("\x1b"));
+    // A half-arrived SGR mouse report under 1003 hover tracking. Reading these
+    // as Escape cancelled the running turn, and dropping them silently left
+    // `39;7;32M`-shaped debris to land alone on the next read.
+    try std.testing.expectEqual(StallAction.truncated_sequence, stalledPending("\x1b["));
+    try std.testing.expectEqual(StallAction.truncated_sequence, stalledPending("\x1b[<"));
+    try std.testing.expectEqual(StallAction.truncated_sequence, stalledPending("\x1b[<39;7"));
+    try std.testing.expectEqual(StallAction.truncated_sequence, stalledPending("\x1bO"));
+    try std.testing.expectEqual(StallAction.truncated_sequence, stalledPending("39;7"));
+    try std.testing.expectEqual(StallAction.discard, stalledPending(""));
 }
 
 test "rowChanged only flags the line that actually moved" {

--- a/TUI/run.zig
+++ b/TUI/run.zig
@@ -294,6 +294,39 @@ test "run loop enables click+hover tracking and bracketed paste" {
     try std.testing.expect(std.mem.indexOf(u8, src, "a=d,d=A") != null);
 }
 
+fn paintToBuf(a: std.mem.Allocator, frame: []const u8, rows: usize, cols: usize, prev: []const u8) ![]u8 {
+    var aw = Io.Writer.Allocating.init(a);
+    errdefer aw.deinit();
+    try paint(&aw.writer, frame, rows, cols, prev, "\x1b[48;2;20;20;20m");
+    return aw.toOwnedSlice();
+}
+
+test "paint keeps a full row's last glyph but still erases every shorter row" {
+    const a = std.testing.allocator;
+    // Row 0 is exactly 10 columns: ESC[K sits ON the last cell and would eat
+    // the composer's right border, so a full row gets neither pad nor erase.
+    // Row 1 is short and must get both.
+    const out = try paintToBuf(a, "╭────────╮\nshort", 2, 10, "XXXXXXXXXX\nold row!!");
+    defer a.free(out);
+    const border = std.mem.indexOf(u8, out, "╭────────╮").?;
+    const short = std.mem.indexOf(u8, out, "short").?;
+    const erase = std.mem.indexOfPos(u8, out, border, "\x1b[K");
+    try std.testing.expect(erase != null and erase.? > short);
+    try std.testing.expect(std.mem.indexOfPos(u8, out, short, "     ") != null);
+}
+
+test "paint erases a row whose glyphs are ambiguous width" {
+    const a = std.testing.allocator;
+    // "  ✓ bash finished ok" draws 20 cells. When visibleLen claimed 21 it
+    // measured full at cols=21, so paint skipped the pad AND the erase and the
+    // 21st cell kept the previous frame. Both must still happen.
+    const frame = "  \u{2713} bash finished ok";
+    try std.testing.expectEqual(@as(usize, 20), theme_mod.visibleLen(frame));
+    const out = try paintToBuf(a, frame, 1, 21, "RESIDUE RESIDUE RESIDU");
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b[K") != null);
+}
+
 test "rowChanged only flags the line that actually moved" {
     const prev = "top\nmiddle\nbottom";
     const next = "top\nmiddle\nBOTTOM";

--- a/TUI/run.zig
+++ b/TUI/run.zig
@@ -72,6 +72,7 @@ pub fn run(
     var stdout = Io.File.stdout().writer(io, &out_buf);
     const w = &stdout.interface;
     w.writeAll(enable_seq) catch {};
+    w.writeAll("\x1b]11;?\x07") catch {}; // background query -> auto light/dark (key.zig bg_report)
     w.flush() catch {};
     traj.open(io);
     defer {
@@ -106,8 +107,15 @@ pub fn run(
             const full = prev.len == 0 or rows != prev_rows or saw_gfx or has_gfx;
             // Kitty images sit above the cell grid and survive \x1b[K / dirty
             // paints — delete before every redraw that might have shown one.
+            // ?2026 synchronized output: the terminal buffers everything
+            // between begin/end and swaps atomically, so a diff paint can
+            // never show a half-updated frame (grok-build does the same).
+            // Terminals without it ignore the pair — strictly no worse.
+            w.writeAll("\x1b[?2026h") catch {};
             if (saw_gfx or has_gfx) w.writeAll("\x1b_Ga=d,d=A,q=2\x1b\\") catch {};
             paint(w, frame, rows, cols, if (full) &.{} else prev, m.theme().bg) catch {};
+            w.writeAll("\x1b[?2026l") catch {};
+            w.flush() catch {};
             if (prev.len != 0) gpa.free(prev);
             prev = gpa.dupe(u8, frame) catch &.{};
             prev_rows = rows;
@@ -180,6 +188,7 @@ fn parkToShell(io: Io, w: *Io.Writer, raw: *tty.RawState) void {
     }
     raw.* = tty.enterRaw() orelse raw.*;
     w.writeAll(enable_seq) catch {};
+    w.writeAll("\x1b]11;?\x07") catch {}; // background query -> auto light/dark (key.zig bg_report)
     w.flush() catch {};
     _ = io;
 }

--- a/TUI/scrollback.zig
+++ b/TUI/scrollback.zig
@@ -134,6 +134,40 @@ pub fn visualOfIndex(self: *const Model, idx: usize, width: usize) ?usize {
     return null;
 }
 
+/// The last user prompt whose first visual row sits strictly above
+/// `top_line` — the grok sticky-header candidate. Same row math as
+/// visualOfIndex so the pin agrees with what the viewport actually shows.
+pub fn stickyUserAbove(self: *const Model, top_line: usize, width: usize) ?[]const u8 {
+    if (top_line == 0) return null;
+    var arena = std.heap.ArenaAllocator.init(self.alloc);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var best: ?[]const u8 = null;
+    var v: usize = 0;
+    var i: usize = 0;
+    while (i < self.history.items.len and v < top_line) {
+        const e = self.history.items[i];
+        if (e.kind == .tool) {
+            const run = self.toolRun(i);
+            if (self.history.items[run.start].folded) {
+                v += lineCount(summary(self, a, run.start, run.end, false) catch "");
+            } else {
+                var t = run.start;
+                while (t < run.end) {
+                    v += lineCount(toolVisual(self, a, t, run.end, width, self.now_ms, false) catch "");
+                    t = nextTool(self, t, run.end);
+                }
+            }
+            i = run.end;
+            continue;
+        }
+        if (e.kind == .user and v < top_line) best = e.text;
+        v += lineCount(row(self, a, i, e, width, self.now_ms, false) catch "");
+        i += 1;
+    }
+    return best;
+}
+
 fn lineCount(s: []const u8) usize {
     if (s.len == 0) return 1;
     return std.mem.count(u8, s, "\n") + 1;
@@ -213,7 +247,7 @@ fn row(self: *const Model, a: std.mem.Allocator, idx: usize, e: app.Entry, width
     else
         e.text;
     const body = switch (e.kind) {
-        .assistant => try @import("markdown.zig").renderTinted(a, raw, th.accent, th.muted, th.text),
+        .assistant => try @import("markdown.zig").renderThemed(a, raw, th),
         .user => try @import("markdown.zig").renderUser(a, raw, th.accent, th.text),
         else => raw,
     };

--- a/TUI/scrollback.zig
+++ b/TUI/scrollback.zig
@@ -100,6 +100,7 @@ pub fn totalVisualLines(self: *const Model, width: usize) usize {
     var arena = std.heap.ArenaAllocator.init(self.alloc);
     defer arena.deinit();
     const text = render(self, arena.allocator(), width, self.now_ms) catch return 0;
+    if (text.len == 0) return 0; // render.zig pops the empty tail; agree with it
     return lineCount(text);
 }
 
@@ -247,7 +248,7 @@ fn row(self: *const Model, a: std.mem.Allocator, idx: usize, e: app.Entry, width
     else
         e.text;
     const body = switch (e.kind) {
-        .assistant => try @import("markdown.zig").renderThemed(a, raw, th, width),
+        .assistant => try @import("markdown.zig").renderThemed(a, raw, th, width -| 4), // the "  ● " gutter costs 4 cols
         .user => try @import("markdown.zig").renderUser(a, raw, th.accent, th.text),
         else => raw,
     };
@@ -258,10 +259,11 @@ fn row(self: *const Model, a: std.mem.Allocator, idx: usize, e: app.Entry, width
     }
     if (e.kind == .pending) {
         const fg = if (flickerOn(now_ms)) th.accent else th.muted;
-        const line = try std.fmt.allocPrint(a, "{s}{s}❙{s} {s}{s}", .{ sel, fg, theme_mod.reset, body, theme_mod.reset });
+        const line = try std.fmt.allocPrint(a, "{s}{s}❙{s}{s} {s}{s}", .{ sel, fg, theme_mod.reset, th.muted, body, theme_mod.reset });
         return theme_mod.wrapToWidth(a, line, width);
     }
-    const line = try std.fmt.allocPrint(a, "{s}{s}{s}{s} {s}{s}", .{ sel, color, mark, theme_mod.reset, body, theme_mod.reset });
+    const body_fg = if (e.kind == .err) th.error_fg else th.text;
+    const line = try std.fmt.allocPrint(a, "{s}{s}{s}{s}{s} {s}{s}", .{ sel, color, mark, theme_mod.reset, body_fg, body, theme_mod.reset });
     return theme_mod.wrapToWidth(a, line, width);
 }
 
@@ -346,7 +348,7 @@ fn toolCard(a: std.mem.Allocator, th: theme_mod.Theme, start_text: []const u8, d
     const sel: []const u8 = if (selected) "› " else "  ";
     const title = try toolTitle(a, start_text);
     const preview = toolPreview(done_text);
-    const head = try std.fmt.allocPrint(a, "{s}{s}◆{s} {s}", .{ sel, if (selected) th.accent else th.muted, theme_mod.reset, title });
+    const head = try std.fmt.allocPrint(a, "{s}{s}◆{s}{s} {s}", .{ sel, if (selected) th.accent else th.muted, theme_mod.reset, th.text, title });
     if (preview == null) return theme_mod.wrapToWidth(a, head, width);
     const body = try std.fmt.allocPrint(a, "{s}{s}│  {s}{s}", .{ sel, th.muted, preview.?, theme_mod.reset });
     const joined = try std.fmt.allocPrint(a, "{s}\n{s}", .{ try theme_mod.wrapToWidth(a, head, width), try theme_mod.wrapToWidth(a, body, width) });

--- a/TUI/scrollback.zig
+++ b/TUI/scrollback.zig
@@ -247,7 +247,7 @@ fn row(self: *const Model, a: std.mem.Allocator, idx: usize, e: app.Entry, width
     else
         e.text;
     const body = switch (e.kind) {
-        .assistant => try @import("markdown.zig").renderThemed(a, raw, th),
+        .assistant => try @import("markdown.zig").renderThemed(a, raw, th, width),
         .user => try @import("markdown.zig").renderUser(a, raw, th.accent, th.text),
         else => raw,
     };

--- a/TUI/sim.zig
+++ b/TUI/sim.zig
@@ -38,6 +38,8 @@ pub const Term = struct {
     rows: usize = 24,
     now_ms: u64 = 0,
     last_effect: Effect = .stay,
+    inbuf: [4096]u8 = undefined,
+    pending: usize = 0,
 
     pub fn init(self: *Term, alloc: std.mem.Allocator, cols: usize, rows: usize) void {
         self.alloc = alloc;
@@ -45,6 +47,8 @@ pub const Term = struct {
         self.rows = if (rows < 12) 24 else rows;
         self.now_ms = 0;
         self.last_effect = .stay;
+        self.pending = 0;
+        key_mod.resetInputState();
         self.model.setup(alloc);
     }
 
@@ -52,16 +56,36 @@ pub const Term = struct {
         self.model.deinit();
     }
 
-    /// Raw Ghostty/xterm bytes. Incomplete CSI is left unconsumed (same as the live loop).
+    /// Raw Ghostty/xterm bytes. An incomplete sequence is CARRIED into the next
+    /// feed, exactly like run.zig's pending buffer — dropping it here let a
+    /// split CSI vanish, which is the one thing these harness tests exist to
+    /// catch.
     pub fn feed(self: *Term, bytes: []const u8) Effect {
+        const room = self.inbuf.len - self.pending;
+        const take = @min(bytes.len, room);
+        @memcpy(self.inbuf[self.pending .. self.pending + take], bytes[0..take]);
+        const n = self.pending + take;
         var i: usize = 0;
         var last: Effect = .stay;
-        while (key_mod.next(bytes, &i)) |k| {
+        while (key_mod.next(self.inbuf[0..n], &i)) |k| {
             last = keys.handle(&self.model, k);
             if (last != .stay) break;
         }
+        self.pending = if (i < n) blk: {
+            const rest = n - i;
+            std.mem.copyForwards(u8, self.inbuf[0..rest], self.inbuf[i..n]);
+            break :blk rest;
+        } else 0;
         self.last_effect = last;
         return last;
+    }
+
+    /// The live loop gives up on a pending sequence that never finished and
+    /// tells key.zig to expect its orphaned tail (run.zig's stall path).
+    pub fn stallDropPending(self: *Term) void {
+        if (self.pending == 0) return;
+        self.pending = 0;
+        key_mod.orphan_armed = true;
     }
 
     pub fn press(self: *Term, k: Key) Effect {
@@ -226,6 +250,50 @@ test "hoverText on an image chip opens the preview" {
     try std.testing.expect(try term.hoverText("[Image #1]"));
     try std.testing.expectEqual(app.Overlay.image, term.model.overlay);
     try std.testing.expectEqualStrings("/tmp/shot.png", term.model.preview_path);
+}
+
+test "a 1003 hover flood during a live turn never types itself into the frame" {
+    const engine = @import("engine.zig");
+    key_mod.orphan_armed = false;
+    defer key_mod.orphan_armed = false;
+    var term: Term = undefined;
+    term.init(std.testing.allocator, 80, 24);
+    defer term.deinit();
+    try term.model.push(.user, "explain this");
+    const job = try std.testing.allocator.create(engine.Job);
+    defer std.testing.allocator.destroy(job);
+    job.* = .{
+        .gpa = std.testing.allocator,
+        .history = &.{},
+        .params = .{},
+        .stream = .{},
+        .threaded = false,
+    };
+    try term.model.push(.pending, "");
+    term.model.pending = job;
+    defer term.model.pending = null;
+
+    // The exact bytes off the user's terminal: SGR motion reports under
+    // ?1003h, arriving in ragged chunks while a slow frame paints, with the
+    // loop giving up on the head that never finished.
+    const flood = "\x1b[<39;7;32M\x1b[<39;4;32M\x1b[<39;3;33M\x1b[<39;1;33M";
+    var cut: usize = 1;
+    while (cut < flood.len) : (cut += 1) {
+        _ = term.feed(flood[0..cut]);
+        _ = term.feed(flood[cut..]);
+        term.stallDropPending();
+        _ = term.feed(flood);
+    }
+    try std.testing.expectEqualStrings("", term.model.input.getValue());
+    try std.testing.expectEqual(@as(usize, 0), term.model.steer_queue.items.len);
+    // A half-arrived report must not read as Escape either — that cancelled
+    // the turn under the user.
+    try std.testing.expect(!term.model.cancel_requested);
+    const vis = try term.screen();
+    defer std.testing.allocator.free(vis);
+    try std.testing.expect(std.mem.indexOf(u8, vis, "39;7;32M") == null);
+    try std.testing.expect(std.mem.indexOf(u8, vis, ";32M") == null);
+    try std.testing.expect(std.mem.indexOf(u8, vis, "Enter:queue") != null);
 }
 
 test "annotated dump prefixes 1-based rows" {

--- a/TUI/syntax.zig
+++ b/TUI/syntax.zig
@@ -1,0 +1,347 @@
+//! Code-fence syntax highlighting — grok-build's token classes and colors
+//! (grok-night / grok-day tmThemes), driven by a small line-resumable lexer
+//! instead of syntect. One `State` threads across a fence's lines so block
+//! comments and multiline strings survive line breaks; clone it for a
+//! streaming tail the way grok's open-fence cache does.
+
+const std = @import("std");
+
+pub const Class = enum { text, comment, string, escape, number, keyword, type_name, builtin, function, operator, bracket, property };
+
+/// grok-night (dark) token colors, verbatim from the tmTheme.
+fn darkColor(c: Class) []const u8 {
+    return switch (c) {
+        .text => "\x1b[38;2;200;200;200m", // #c8c8c8
+        .comment => "\x1b[38;2;81;89;125m", // #51597d
+        .string => "\x1b[38;2;158;206;106m", // #9ece6a
+        .escape => "\x1b[38;2;137;221;255m", // #89ddff
+        .number => "\x1b[38;2;255;158;100m", // #ff9e64
+        .keyword => "\x1b[38;2;187;154;247m", // #bb9af7
+        .type_name => "\x1b[38;2;13;185;215m", // #0db9d7
+        .builtin => "\x1b[38;2;13;185;215m", // #0db9d7
+        .function => "\x1b[38;2;122;162;247m", // #7aa2f7
+        .operator => "\x1b[38;2;137;221;255m", // #89ddff
+        .bracket => "\x1b[38;2;154;189;245m", // #9abdf5
+        .property => "\x1b[38;2;125;207;255m", // #7dcfff
+    };
+}
+
+/// grok-day (light) token colors, verbatim from the tmTheme.
+fn lightColor(c: Class) []const u8 {
+    return switch (c) {
+        .text => "\x1b[38;2;68;68;68m", // #444444
+        .comment => "\x1b[38;2;144;144;144m", // #909090
+        .string => "\x1b[38;2;55;142;35m", // #378E23
+        .escape => "\x1b[38;2;85;128;168m", // #5580A8
+        .number => "\x1b[38;2;195;105;30m", // #C3691E
+        .keyword => "\x1b[38;2;125;75;198m", // #7D4BC6
+        .type_name => "\x1b[38;2;15;135;162m", // #0F87A2
+        .builtin => "\x1b[38;2;15;135;162m", // #0F87A2
+        .function => "\x1b[38;2;47;100;210m", // #2F64D2
+        .operator => "\x1b[38;2;85;128;168m", // #5580A8
+        .bracket => "\x1b[38;2;74;114;176m", // #4A72B0
+        .property => "\x1b[38;2;0;130;170m", // #0082AA
+    };
+}
+
+pub fn color(c: Class, light: bool) []const u8 {
+    return if (light) lightColor(c) else darkColor(c);
+}
+
+/// Code-block background band (grok `md_code_bg`): #1c1c1c dark / #e4e4e4 light.
+pub fn codeBg(light: bool) []const u8 {
+    return if (light) "\x1b[48;2;228;228;228m" else "\x1b[48;2;28;28;28m";
+}
+
+pub const Lang = struct {
+    names: []const []const u8, // fence tokens AND file extensions
+    line_comment: []const u8,
+    block_open: []const u8 = "",
+    block_close: []const u8 = "",
+    keywords: []const []const u8,
+    types: []const []const u8,
+    builtins: []const []const u8 = &.{},
+    hash_types_upper: bool = false, // Capitalized identifiers are types (Zig/Rust/Go style)
+};
+
+const zig_lang: Lang = .{
+    .names = &.{ "zig", "ziglang" },
+    .line_comment = "//",
+    .keywords = &.{ "const", "var", "fn", "pub", "return", "if", "else", "while", "for", "switch", "defer", "errdefer", "try", "catch", "orelse", "break", "continue", "struct", "enum", "union", "error", "test", "comptime", "inline", "export", "extern", "and", "or", "unreachable", "usingnamespace", "async", "await", "threadlocal", "packed", "volatile", "align", "callconv", "noalias" },
+    .types = &.{ "u8", "u16", "u32", "u64", "usize", "i8", "i16", "i32", "i64", "isize", "f32", "f64", "bool", "void", "type", "anytype", "anyerror", "noreturn", "u21", "c_int", "null", "undefined", "true", "false" },
+    .hash_types_upper = true,
+};
+const rust_lang: Lang = .{
+    .names = &.{ "rust", "rs" },
+    .line_comment = "//",
+    .block_open = "/*",
+    .block_close = "*/",
+    .keywords = &.{ "fn", "let", "mut", "pub", "use", "mod", "struct", "enum", "impl", "trait", "return", "if", "else", "while", "for", "loop", "match", "break", "continue", "move", "ref", "where", "async", "await", "dyn", "unsafe", "extern", "crate", "self", "Self", "super", "static", "const", "type", "in", "as" },
+    .types = &.{ "u8", "u16", "u32", "u64", "usize", "i8", "i16", "i32", "i64", "isize", "f32", "f64", "bool", "str", "String", "Vec", "Option", "Result", "Box", "true", "false", "None", "Some", "Ok", "Err" },
+    .hash_types_upper = true,
+};
+const py_lang: Lang = .{
+    .names = &.{ "python", "py", "python3" },
+    .line_comment = "#",
+    .keywords = &.{ "def", "class", "return", "if", "elif", "else", "while", "for", "in", "import", "from", "as", "with", "try", "except", "finally", "raise", "pass", "break", "continue", "lambda", "yield", "global", "nonlocal", "assert", "del", "not", "and", "or", "is", "async", "await", "match", "case" },
+    .types = &.{ "int", "float", "str", "bool", "list", "dict", "set", "tuple", "bytes", "None", "True", "False", "self", "object" },
+    .builtins = &.{ "print", "len", "range", "open", "enumerate", "zip", "map", "filter", "sorted", "isinstance", "super", "type", "getattr", "setattr", "hasattr" },
+};
+const js_lang: Lang = .{
+    .names = &.{ "javascript", "js", "typescript", "ts", "jsx", "tsx", "mjs", "cjs" },
+    .line_comment = "//",
+    .block_open = "/*",
+    .block_close = "*/",
+    .keywords = &.{ "function", "const", "let", "var", "return", "if", "else", "while", "for", "of", "in", "class", "extends", "new", "import", "export", "from", "default", "async", "await", "try", "catch", "finally", "throw", "switch", "case", "break", "continue", "typeof", "instanceof", "delete", "yield", "static", "get", "set", "interface", "implements", "enum", "declare", "readonly", "as", "satisfies" },
+    .types = &.{ "string", "number", "boolean", "object", "any", "unknown", "never", "undefined", "null", "true", "false", "this", "void", "Promise", "Array", "Map", "Set" },
+    .builtins = &.{ "console", "require", "module", "process", "JSON", "Math", "Object", "window", "document" },
+    .hash_types_upper = true,
+};
+const go_lang: Lang = .{
+    .names = &.{ "go", "golang" },
+    .line_comment = "//",
+    .block_open = "/*",
+    .block_close = "*/",
+    .keywords = &.{ "func", "var", "const", "type", "struct", "interface", "map", "chan", "return", "if", "else", "for", "range", "switch", "case", "default", "break", "continue", "go", "defer", "select", "package", "import", "fallthrough", "goto" },
+    .types = &.{ "string", "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64", "byte", "rune", "float32", "float64", "bool", "error", "any", "nil", "true", "false", "iota" },
+    .builtins = &.{ "make", "len", "cap", "append", "copy", "new", "delete", "panic", "recover", "print", "println" },
+    .hash_types_upper = true,
+};
+const c_lang: Lang = .{
+    .names = &.{ "c", "h", "cpp", "cc", "cxx", "hpp", "c++" },
+    .line_comment = "//",
+    .block_open = "/*",
+    .block_close = "*/",
+    .keywords = &.{ "if", "else", "while", "for", "return", "break", "continue", "switch", "case", "default", "struct", "enum", "union", "typedef", "static", "extern", "const", "inline", "sizeof", "goto", "do", "class", "public", "private", "protected", "template", "typename", "namespace", "using", "new", "delete", "virtual", "override", "nullptr", "auto", "constexpr" },
+    .types = &.{ "int", "char", "long", "short", "unsigned", "signed", "float", "double", "void", "bool", "size_t", "uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t", "true", "false", "NULL" },
+    .hash_types_upper = true,
+};
+const sh_lang: Lang = .{
+    .names = &.{ "bash", "sh", "shell", "zsh", "console" },
+    .line_comment = "#",
+    .keywords = &.{ "if", "then", "else", "elif", "fi", "for", "while", "do", "done", "case", "esac", "function", "return", "local", "export", "source", "in", "select", "until", "declare", "readonly", "shift", "exit", "set", "unset", "trap" },
+    .types = &.{"true"},
+    .builtins = &.{ "echo", "cd", "ls", "grep", "sed", "awk", "cat", "curl", "git", "rm", "cp", "mv", "mkdir", "printf", "read", "test", "which", "find", "xargs", "sort", "head", "tail" },
+};
+const json_lang: Lang = .{
+    .names = &.{"json"},
+    .line_comment = "",
+    .keywords = &.{},
+    .types = &.{ "true", "false", "null" },
+};
+const yaml_lang: Lang = .{
+    .names = &.{ "yaml", "yml" },
+    .line_comment = "#",
+    .keywords = &.{},
+    .types = &.{ "true", "false", "null", "yes", "no" },
+};
+const sql_lang: Lang = .{
+    .names = &.{ "sql", "sqlite", "postgres", "mysql" },
+    .line_comment = "--",
+    .block_open = "/*",
+    .block_close = "*/",
+    .keywords = &.{ "select", "from", "where", "insert", "into", "values", "update", "set", "delete", "create", "table", "index", "join", "left", "right", "inner", "outer", "on", "group", "by", "order", "having", "limit", "offset", "as", "and", "or", "not", "in", "is", "like", "between", "union", "all", "distinct", "primary", "key", "foreign", "references", "drop", "alter", "add", "SELECT", "FROM", "WHERE", "INSERT", "INTO", "VALUES", "UPDATE", "SET", "DELETE", "CREATE", "TABLE", "INDEX", "JOIN", "LEFT", "RIGHT", "INNER", "OUTER", "ON", "GROUP", "BY", "ORDER", "HAVING", "LIMIT", "AS", "AND", "OR", "NOT", "IN", "IS", "LIKE", "UNION", "PRIMARY", "KEY", "DROP", "ALTER", "ADD" },
+    .types = &.{ "integer", "text", "real", "blob", "varchar", "boolean", "date", "timestamp", "INTEGER", "TEXT", "REAL", "BLOB", "VARCHAR", "BOOLEAN", "NULL" },
+};
+
+const langs = [_]*const Lang{ &zig_lang, &rust_lang, &py_lang, &js_lang, &go_lang, &c_lang, &sh_lang, &json_lang, &yaml_lang, &sql_lang };
+
+/// Fence-info resolution, grok order: `start:end:path` citation form first
+/// (extension lookup), then the whole info string as a token. Unknown → null
+/// (the fence still gets the background band, just uncolored text).
+pub fn resolve(fence_info: []const u8) ?*const Lang {
+    const info = std.mem.trim(u8, fence_info, " \t");
+    if (info.len == 0) return null;
+    blk: {
+        var it = std.mem.splitScalar(u8, info, ':');
+        const a = it.next() orelse break :blk;
+        const b = it.next() orelse break :blk;
+        const path = it.rest();
+        if (a.len == 0 or b.len == 0 or path.len == 0) break :blk;
+        for (a) |ch| if (!std.ascii.isDigit(ch)) break :blk;
+        for (b) |ch| if (!std.ascii.isDigit(ch)) break :blk;
+        const dot = std.mem.lastIndexOfScalar(u8, path, '.') orelse break :blk;
+        if (byName(path[dot + 1 ..])) |l| return l;
+        break :blk;
+    }
+    return byName(info);
+}
+
+fn byName(token: []const u8) ?*const Lang {
+    var buf: [24]u8 = undefined;
+    if (token.len == 0 or token.len > buf.len) return null;
+    const lower = std.ascii.lowerString(&buf, token);
+    for (&langs) |l| {
+        for (l.names) |n| if (std.mem.eql(u8, lower, n)) return l;
+    }
+    return null;
+}
+
+/// Lexer state threaded across a fence's lines.
+pub const State = struct {
+    in_block_comment: bool = false,
+};
+
+fn isIdent(c: u8) bool {
+    return std.ascii.isAlphanumeric(c) or c == '_' or c == '@';
+}
+
+fn listHas(list: []const []const u8, word: []const u8) bool {
+    for (list) |w| if (std.mem.eql(u8, w, word)) return true;
+    return false;
+}
+
+/// Highlight one line into `out` as SGR spans. Emits fg colors only — the
+/// caller owns the background band and the trailing reset.
+pub fn highlightLine(out: *std.array_list.Managed(u8), line: []const u8, lang: *const Lang, st: *State, light: bool) !void {
+    var i: usize = 0;
+    var cls: ?Class = null;
+    while (i < line.len) {
+        if (st.in_block_comment) {
+            const close = std.mem.indexOf(u8, line[i..], lang.block_close);
+            const end = if (close) |c| i + c + lang.block_close.len else line.len;
+            try emit(out, &cls, .comment, line[i..end], light);
+            if (close != null) st.in_block_comment = false;
+            i = end;
+            continue;
+        }
+        const c = line[i];
+        // comments
+        if (lang.line_comment.len > 0 and std.mem.startsWith(u8, line[i..], lang.line_comment)) {
+            try emit(out, &cls, .comment, line[i..], light);
+            break;
+        }
+        if (lang.block_open.len > 0 and std.mem.startsWith(u8, line[i..], lang.block_open)) {
+            st.in_block_comment = true;
+            try emit(out, &cls, .comment, line[i .. i + lang.block_open.len], light);
+            i += lang.block_open.len;
+            continue;
+        }
+        // strings (single-line; escapes highlighted inside)
+        if (c == '"' or c == '\'' or c == '`') {
+            const quote = c;
+            var j = i + 1;
+            try emit(out, &cls, .string, line[i .. i + 1], light);
+            while (j < line.len) {
+                if (line[j] == '\\' and j + 1 < line.len) {
+                    try emit(out, &cls, .escape, line[j .. j + 2], light);
+                    j += 2;
+                    continue;
+                }
+                if (line[j] == quote) break;
+                const k = std.mem.indexOfAnyPos(u8, line, j, &.{ '\\', quote }) orelse line.len;
+                try emit(out, &cls, .string, line[j..k], light);
+                j = k;
+            }
+            if (j < line.len) {
+                try emit(out, &cls, .string, line[j .. j + 1], light);
+                j += 1;
+            }
+            i = j;
+            continue;
+        }
+        // numbers
+        if (std.ascii.isDigit(c)) {
+            var j = i + 1;
+            while (j < line.len and (std.ascii.isHex(line[j]) or line[j] == '.' or line[j] == 'x' or line[j] == '_' or line[j] == 'o' or line[j] == 'b')) j += 1;
+            try emit(out, &cls, .number, line[i..j], light);
+            i = j;
+            continue;
+        }
+        // identifiers
+        if (std.ascii.isAlphabetic(c) or c == '_' or c == '@') {
+            var j = i + 1;
+            while (j < line.len and isIdent(line[j])) j += 1;
+            const word = line[i..j];
+            const wc: Class = if (listHas(lang.keywords, word))
+                .keyword
+            else if (listHas(lang.types, word))
+                .type_name
+            else if (listHas(lang.builtins, word))
+                .builtin
+            else if (word[0] == '@')
+                .builtin
+            else if (j < line.len and line[j] == '(')
+                .function
+            else if (lang.hash_types_upper and std.ascii.isUpper(word[0]))
+                .type_name
+            else if (j < line.len and line[j] == ':' and lang == &json_lang)
+                .property
+            else
+                .text;
+            try emit(out, &cls, wc, word, light);
+            i = j;
+            continue;
+        }
+        // brackets vs operators vs plain
+        const oc: Class = switch (c) {
+            '(', ')', '[', ']', '{', '}' => .bracket,
+            '+', '-', '*', '/', '=', '<', '>', '!', '&', '|', '^', '%', '~', '?', ';', ':', ',', '.' => .operator,
+            else => .text,
+        };
+        try emit(out, &cls, oc, line[i .. i + 1], light);
+        i += 1;
+    }
+}
+
+fn emit(out: *std.array_list.Managed(u8), current: *?Class, cls: Class, text: []const u8, light: bool) !void {
+    if (text.len == 0) return;
+    if (current.* != cls) {
+        try out.appendSlice(color(cls, light));
+        current.* = cls;
+    }
+    try out.appendSlice(text);
+}
+
+test "zig line: keywords, types, strings, numbers, comment take grok-night colors" {
+    var out = std.array_list.Managed(u8).init(std.testing.allocator);
+    defer out.deinit();
+    var st: State = .{};
+    try highlightLine(&out, "const x: u32 = 0x1f; // note \"quoted\"", &zig_lang, &st, false);
+    const s = out.items;
+    try std.testing.expect(std.mem.indexOf(u8, s, "\x1b[38;2;187;154;247mconst") != null); // keyword
+    try std.testing.expect(std.mem.indexOf(u8, s, "\x1b[38;2;13;185;215mu32") != null); // type
+    try std.testing.expect(std.mem.indexOf(u8, s, "\x1b[38;2;255;158;100m0x1f") != null); // number
+    try std.testing.expect(std.mem.indexOf(u8, s, "\x1b[38;2;81;89;125m// note \"quoted\"") != null); // comment eats the rest
+}
+
+test "block comment state survives across lines" {
+    var out = std.array_list.Managed(u8).init(std.testing.allocator);
+    defer out.deinit();
+    var st: State = .{};
+    try highlightLine(&out, "let a = 1; /* open", &js_lang, &st, false);
+    try std.testing.expect(st.in_block_comment);
+    out.clearRetainingCapacity();
+    try highlightLine(&out, "still comment */ let b = 2;", &js_lang, &st, false);
+    try std.testing.expect(!st.in_block_comment);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[38;2;81;89;125mstill comment */") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[38;2;187;154;247mlet") != null);
+}
+
+test "fence info resolution: token, citation path, unknown" {
+    try std.testing.expect(resolve("rust") == &rust_lang);
+    try std.testing.expect(resolve("py") == &py_lang);
+    try std.testing.expect(resolve("37:65:crates/foo/src/bar.rs") == &rust_lang);
+    try std.testing.expect(resolve("rust title=x") == null); // whole-string token, grok semantics
+    try std.testing.expect(resolve("") == null);
+    try std.testing.expect(resolve("madeuplang") == null);
+}
+
+test "light polarity swaps to grok-day colors" {
+    var out = std.array_list.Managed(u8).init(std.testing.allocator);
+    defer out.deinit();
+    var st: State = .{};
+    try highlightLine(&out, "def f():", &py_lang, &st, true);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[38;2;125;75;198mdef") != null); // #7D4BC6
+}
+
+test "strings color their escapes separately" {
+    var out = std.array_list.Managed(u8).init(std.testing.allocator);
+    defer out.deinit();
+    var st: State = .{};
+    try highlightLine(&out, "s = \"a\\nb\"", &py_lang, &st, false);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[38;2;137;221;255m\\n") != null);
+    // the opening quote and 'a' share one string span; 'b' re-opens it after the escape
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[38;2;158;206;106m\"a") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[38;2;158;206;106mb") != null);
+}

--- a/TUI/syntax.zig
+++ b/TUI/syntax.zig
@@ -150,7 +150,7 @@ const langs = [_]*const Lang{ &zig_lang, &rust_lang, &py_lang, &js_lang, &go_lan
 /// (extension lookup), then the whole info string as a token. Unknown → null
 /// (the fence still gets the background band, just uncolored text).
 pub fn resolve(fence_info: []const u8) ?*const Lang {
-    const info = std.mem.trim(u8, fence_info, " \t");
+    const info = std.mem.trim(u8, fence_info, " \t\r"); // CRLF fences must still resolve
     if (info.len == 0) return null;
     blk: {
         var it = std.mem.splitScalar(u8, info, ':');
@@ -223,9 +223,13 @@ pub fn highlightLine(out: *std.array_list.Managed(u8), line: []const u8, lang: *
             var j = i + 1;
             try emit(out, &cls, .string, line[i .. i + 1], light);
             while (j < line.len) {
-                if (line[j] == '\\' and j + 1 < line.len) {
-                    try emit(out, &cls, .escape, line[j .. j + 2], light);
-                    j += 2;
+                if (line[j] == '\\') {
+                    // A trailing backslash (shell continuation) has no pair —
+                    // consume it alone or the scanner loops forever (P0: froze
+                    // the whole TUI at 100% CPU on `echo "a \` fences).
+                    const esc_end = @min(j + 2, line.len);
+                    try emit(out, &cls, .escape, line[j..esc_end], light);
+                    j = esc_end;
                     continue;
                 }
                 if (line[j] == quote) break;
@@ -344,4 +348,14 @@ test "strings color their escapes separately" {
     // the opening quote and 'a' share one string span; 'b' re-opens it after the escape
     try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[38;2;158;206;106m\"a") != null);
     try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[38;2;158;206;106mb") != null);
+}
+
+test "P0 regression: a trailing backslash inside a string terminates" {
+    var out = std.array_list.Managed(u8).init(std.testing.allocator);
+    defer out.deinit();
+    var st: State = .{};
+    try highlightLine(&out, "echo \"hello \\", &sh_lang, &st, false);
+    try highlightLine(&out, "s = 'unterminated \\", &py_lang, &st, false);
+    try std.testing.expect(out.items.len > 0);
+    try std.testing.expect(resolve("zig\r") == &zig_lang);
 }

--- a/TUI/theme.zig
+++ b/TUI/theme.zig
@@ -94,6 +94,25 @@ pub fn next(id: Id) Id {
     return @enumFromInt((@intFromEnum(id) + 1) % all.len);
 }
 
+/// grok's polarity test: BT.709 luminance over sRGB-linearized channels,
+/// light at >= 0.5. Only the 1-bit answer is kept — the palette stays fixed.
+pub fn classifyLight(r: u8, g: u8, b: u8) bool {
+    const lum = 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+    return lum >= 0.5;
+}
+
+fn linear(c: u8) f64 {
+    const s = @as(f64, @floatFromInt(c)) / 255.0;
+    return if (s <= 0.04045) s / 12.92 else std.math.pow(f64, (s + 0.055) / 1.055, 2.4);
+}
+
+test "classifyLight: grok-night bg is dark, grok-day bg is light" {
+    try std.testing.expect(!classifyLight(0x14, 0x14, 0x14));
+    try std.testing.expect(!classifyLight(0x24, 0x28, 0x3b)); // tokyo storm
+    try std.testing.expect(classifyLight(0xf6, 0xf6, 0xf6));
+    try std.testing.expect(classifyLight(0xee, 0xee, 0xee));
+}
+
 /// Index just past the escape sequence starting at `start` (s[start] == 0x1b).
 /// Skips CSI, OSC/DCS/APC/PM/SOS (to BEL or ST), SS3, and ESC+char — a
 /// truncation mid-sequence would emit broken escapes into the frame.

--- a/TUI/theme.zig
+++ b/TUI/theme.zig
@@ -144,7 +144,29 @@ pub fn skipEsc(s: []const u8, start: usize) usize {
     return i;
 }
 
-/// Columns in `s`, skipping SGR. Assumes 1-col codepoints (no CJK/emoji width).
+/// Terminal column width of one codepoint: 2 for East Asian Wide/Fullwidth
+/// and emoji presentation, 0 for combining marks and zero-width joiners, 1
+/// otherwise. Coarse ranges, but every box border and pad in the TUI keys on
+/// this — counting 🚀 as one column pushed the composer's right wall two
+/// cells past its corners.
+pub fn charWidth(cp: u21) u2 {
+    return switch (cp) {
+        0x0300...0x036F, 0x1AB0...0x1AFF, 0x1DC0...0x1DFF, 0x20D0...0x20FF, 0xFE20...0xFE2F => 0, // combining
+        0x200B...0x200D, 0xFE0E...0xFE0F, 0x2060 => 0, // zero-width + variation selectors
+        0x1100...0x115F, 0x2E80...0x303E, 0x3041...0x33FF, 0x3400...0x4DBF, 0x4E00...0x9FFF, 0xA000...0xA4CF, 0xAC00...0xD7A3, 0xF900...0xFAFF, 0xFE30...0xFE4F, 0xFF00...0xFF60, 0xFFE0...0xFFE6 => 2, // East Asian Wide
+        0x1F300...0x1FAFF, 0x2600...0x27BF, 0x2B00...0x2BFF, 0x20000...0x3FFFD => 2, // emoji + supplementary ideographs
+        else => 1,
+    };
+}
+
+fn cpAt(s: []const u8, i: usize) struct { w: u2, step: usize } {
+    const len = std.unicode.utf8ByteSequenceLength(s[i]) catch return .{ .w = 1, .step = 1 };
+    const step = @min(@as(usize, len), s.len - i);
+    const cp = std.unicode.utf8Decode(s[i .. i + step]) catch return .{ .w = 1, .step = step };
+    return .{ .w = charWidth(cp), .step = step };
+}
+
+/// Columns in `s`, skipping SGR; CJK/emoji count 2, combining marks 0.
 pub fn visibleLen(s: []const u8) usize {
     var n: usize = 0;
     var i: usize = 0;
@@ -153,9 +175,9 @@ pub fn visibleLen(s: []const u8) usize {
             i = skipEsc(s, i);
             continue;
         }
-        const w = std.unicode.utf8ByteSequenceLength(s[i]) catch 1;
-        i += @min(w, s.len - i);
-        n += 1;
+        const c = cpAt(s, i);
+        i += c.step;
+        n += c.w;
     }
     return n;
 }
@@ -163,15 +185,15 @@ pub fn visibleLen(s: []const u8) usize {
 pub fn takeCols(s: []const u8, max: usize) []const u8 {
     var n: usize = 0;
     var i: usize = 0;
-    while (i < s.len and n < max) {
+    while (i < s.len) {
         if (s[i] == 0x1b) {
             i = skipEsc(s, i);
             continue;
         }
-        const w = std.unicode.utf8ByteSequenceLength(s[i]) catch 1;
-        const step = @min(w, s.len - i);
-        i += step;
-        n += 1;
+        const c = cpAt(s, i);
+        if (n + c.w > max) break; // a wide glyph that would straddle the edge stays out
+        i += c.step;
+        n += c.w;
     }
     return s[0..i];
 }
@@ -216,15 +238,33 @@ test "day uses the Codegraff light palette; dark themes match their tokens" {
     try std.testing.expectEqualStrings("\x1b[38;2;155;126;206m", of(.oscura).accent);
 }
 
-/// Wrap `s` so no row is wider than `width` columns. SGR is preserved.
+/// Active-SGR tracker for the wrappers: remember styling since the last full
+/// reset so an inserted line break can re-open it — the diff painter repaints
+/// rows independently, so a continuation row with no SGR of its own renders
+/// in whatever style the previous paint left behind.
+fn trackSgr(active: *std.array_list.Managed(u8), seq: []const u8) void {
+    if (seq.len < 3 or seq[1] != '[' or seq[seq.len - 1] != 'm') return;
+    if (std.mem.eql(u8, seq, "\x1b[0m") or std.mem.eql(u8, seq, "\x1b[m")) {
+        active.clearRetainingCapacity();
+        return;
+    }
+    if (active.items.len > 96) active.clearRetainingCapacity(); // bound pathological runs
+    active.appendSlice(seq) catch {};
+}
+
+/// Wrap `s` so no row is wider than `width` columns. SGR is preserved AND
+/// re-emitted on continuation rows; wide glyphs never straddle the edge.
 pub fn wrapToWidth(a: std.mem.Allocator, s: []const u8, width: usize) ![]const u8 {
     if (width == 0) return a.dupe(u8, s);
     var out = std.array_list.Managed(u8).init(a);
+    var active = std.array_list.Managed(u8).init(a);
+    defer active.deinit();
     var col: usize = 0;
     var i: usize = 0;
     while (i < s.len) {
         if (s[i] == '\n') {
             try out.append('\n');
+            try out.appendSlice(active.items);
             col = 0;
             i += 1;
             continue;
@@ -233,17 +273,18 @@ pub fn wrapToWidth(a: std.mem.Allocator, s: []const u8, width: usize) ![]const u
             const start = i;
             i = skipEsc(s, i);
             try out.appendSlice(s[start..i]);
+            trackSgr(&active, s[start..i]);
             continue;
         }
-        const w = std.unicode.utf8ByteSequenceLength(s[i]) catch 1;
-        const step = @min(w, s.len - i);
-        if (col >= width) {
+        const c = cpAt(s, i);
+        if (col + c.w > width and col > 0) {
             try out.append('\n');
+            try out.appendSlice(active.items);
             col = 0;
         }
-        try out.appendSlice(s[i .. i + step]);
-        col += 1;
-        i += step;
+        try out.appendSlice(s[i .. i + c.step]);
+        col += c.w;
+        i += c.step;
     }
     return out.toOwnedSlice();
 }
@@ -252,12 +293,15 @@ pub fn wrapToWidth(a: std.mem.Allocator, s: []const u8, width: usize) ![]const u
 pub fn wrapPreferWords(a: std.mem.Allocator, s: []const u8, width: usize) ![]const u8 {
     if (width == 0) return a.dupe(u8, s);
     var out = std.array_list.Managed(u8).init(a);
+    var active = std.array_list.Managed(u8).init(a);
+    defer active.deinit();
     var col: usize = 0;
     var last_sp: ?usize = null;
     var i: usize = 0;
     while (i < s.len) {
         if (s[i] == '\n') {
             try out.append('\n');
+            try out.appendSlice(active.items);
             col = 0;
             last_sp = null;
             i += 1;
@@ -265,31 +309,28 @@ pub fn wrapPreferWords(a: std.mem.Allocator, s: []const u8, width: usize) ![]con
         }
         if (s[i] == 0x1b) {
             const start = i;
-            i += 1;
-            if (i < s.len and s[i] == '[') {
-                i += 1;
-                while (i < s.len and (s[i] < 0x40 or s[i] > 0x7e)) : (i += 1) {}
-                if (i < s.len) i += 1;
-            }
+            i = skipEsc(s, i); // full skip: hand-rolled CSI-only parsing broke a \n INTO an OSC hyperlink
             try out.appendSlice(s[start..i]);
+            trackSgr(&active, s[start..i]);
             continue;
         }
-        const w = std.unicode.utf8ByteSequenceLength(s[i]) catch 1;
-        const step = @min(w, s.len - i);
-        if (col + 1 > width) {
+        const c = cpAt(s, i);
+        if (col + c.w > width) {
             if (last_sp) |sp| {
                 out.items[sp] = '\n';
+                try out.insertSlice(sp + 1, active.items);
                 col = visibleLen(out.items[sp + 1 ..]);
                 last_sp = null;
             } else {
                 try out.append('\n');
+                try out.appendSlice(active.items);
                 col = 0;
             }
         }
         if (s[i] == ' ') last_sp = out.items.len;
-        try out.appendSlice(s[i .. i + step]);
-        col += 1;
-        i += step;
+        try out.appendSlice(s[i .. i + c.step]);
+        col += c.w;
+        i += c.step;
     }
     return out.toOwnedSlice();
 }
@@ -322,4 +363,27 @@ test "visibleLen and takeCols treat OSC/APC as invisible" {
     try std.testing.expectEqual(@as(usize, 2), visibleLen("\x1b_Ga=d,d=A\x1b\\ok"));
     const cut = takeCols("\x1b]8;;u\x07ab", 1);
     try std.testing.expectEqualStrings("\x1b]8;;u\x07a", cut);
+}
+
+test "wide glyphs: 2 columns, never straddling a wrap or a takeCols edge" {
+    try std.testing.expectEqual(@as(usize, 2), visibleLen("\u{1F680}"));
+    try std.testing.expectEqual(@as(usize, 4), visibleLen("\u{4F60}\u{597D}"));
+    try std.testing.expectEqual(@as(usize, 1), visibleLen("e\u{0301}"));
+    try std.testing.expectEqualStrings("a", takeCols("a\u{1F680}", 2)); // rocket won't fit in 1 col
+}
+
+test "wrap re-emits active SGR on continuation rows" {
+    const got = try wrapToWidth(std.testing.allocator, "\x1b[32mabcdefgh\x1b[0m", 4);
+    defer std.testing.allocator.free(got);
+    var it = std.mem.splitScalar(u8, got, '\n');
+    _ = it.next();
+    const row2 = it.next().?;
+    try std.testing.expect(std.mem.startsWith(u8, row2, "\x1b[32m"));
+}
+
+test "wrapPreferWords keeps OSC strings intact" {
+    const link = "\x1b]8;;http://example.com/long/url\x07go\x1b]8;;\x07 tail words here";
+    const got = try wrapPreferWords(std.testing.allocator, link, 10);
+    defer std.testing.allocator.free(got);
+    try std.testing.expect(std.mem.indexOf(u8, got, "http://example.com/long/url") != null); // URL unbroken
 }

--- a/TUI/theme.zig
+++ b/TUI/theme.zig
@@ -144,26 +144,53 @@ pub fn skipEsc(s: []const u8, start: usize) usize {
     return i;
 }
 
-/// Terminal column width of one codepoint: 2 for East Asian Wide/Fullwidth
-/// and emoji presentation, 0 for combining marks and zero-width joiners, 1
-/// otherwise. Coarse ranges, but every box border and pad in the TUI keys on
-/// this — counting 🚀 as one column pushed the composer's right wall two
-/// cells past its corners.
+/// Terminal column width of one codepoint: 2 for East Asian Wide/Fullwidth and
+/// for emoji whose DEFAULT presentation is emoji, 0 for combining marks and
+/// zero-width joiners, 1 otherwise. Every box border and pad in the TUI keys on
+/// this — counting 🚀 as one column pushed the composer's right wall two cells
+/// past its corners.
+///
+/// The symbol blocks are enumerated, never taken wholesale. U+2600..U+27BF and
+/// U+2B00..U+2BFF are mostly East-Asian-Ambiguous glyphs that terminals draw in
+/// ONE cell, and the TUI paints five of them itself (⚙ ✓ ✗ ❙ ❯). Claiming two
+/// columns for those under-padded every chrome row by one and — because
+/// run.zig skips the pad AND the erase once a row measures full — stranded the
+/// previous frame's last cell. Only Emoji_Presentation=Yes is wide here; the
+/// text-presentation symbols reach two columns via a VS16 selector (see cpAt).
 pub fn charWidth(cp: u21) u2 {
     return switch (cp) {
         0x0300...0x036F, 0x1AB0...0x1AFF, 0x1DC0...0x1DFF, 0x20D0...0x20FF, 0xFE20...0xFE2F => 0, // combining
         0x200B...0x200D, 0xFE0E...0xFE0F, 0x2060 => 0, // zero-width + variation selectors
         0x1100...0x115F, 0x2E80...0x303E, 0x3041...0x33FF, 0x3400...0x4DBF, 0x4E00...0x9FFF, 0xA000...0xA4CF, 0xAC00...0xD7A3, 0xF900...0xFAFF, 0xFE30...0xFE4F, 0xFF00...0xFF60, 0xFFE0...0xFFE6 => 2, // East Asian Wide
-        0x1F300...0x1FAFF, 0x2600...0x27BF, 0x2B00...0x2BFF, 0x20000...0x3FFFD => 2, // emoji + supplementary ideographs
+        0x1F300...0x1FAFF, 0x20000...0x3FFFD => 2, // emoji planes + supplementary ideographs
+        // Emoji_Presentation=Yes inside the BMP symbol blocks.
+        0x231A...0x231B, 0x23E9...0x23EC, 0x23F0, 0x23F3, 0x25FD...0x25FE => 2,
+        0x2614...0x2615, 0x2648...0x2653, 0x267F, 0x2693, 0x26A1 => 2,
+        0x26AA...0x26AB, 0x26BD...0x26BE, 0x26C4...0x26C5, 0x26CE, 0x26D4 => 2,
+        0x26EA, 0x26F2...0x26F3, 0x26F5, 0x26FA, 0x26FD => 2,
+        0x2705, 0x270A...0x270B, 0x2728, 0x274C, 0x274E => 2,
+        0x2753...0x2755, 0x2757, 0x2795...0x2797, 0x27B0, 0x27BF => 2,
+        0x2B1B...0x2B1C, 0x2B50, 0x2B55 => 2,
         else => 1,
     };
 }
 
+/// Width and byte length of the codepoint at `i`, honouring a trailing VS16:
+/// `✓\u{FE0F}` asks for emoji presentation and does take two cells, while a
+/// bare `✓` takes one. The selector itself stays zero-width, so the pair still
+/// measures two in total.
 fn cpAt(s: []const u8, i: usize) struct { w: u2, step: usize } {
     const len = std.unicode.utf8ByteSequenceLength(s[i]) catch return .{ .w = 1, .step = 1 };
     const step = @min(@as(usize, len), s.len - i);
     const cp = std.unicode.utf8Decode(s[i .. i + step]) catch return .{ .w = 1, .step = step };
-    return .{ .w = charWidth(cp), .step = step };
+    const w = charWidth(cp);
+    if (w == 1 and emojiPresentationNext(s, i + step)) return .{ .w = 2, .step = step };
+    return .{ .w = w, .step = step };
+}
+
+fn emojiPresentationNext(s: []const u8, at: usize) bool {
+    if (at + 3 > s.len) return false;
+    return std.mem.eql(u8, s[at .. at + 3], "\u{FE0F}");
 }
 
 /// Columns in `s`, skipping SGR; CJK/emoji count 2, combining marks 0.
@@ -238,33 +265,130 @@ test "day uses the Codegraff light palette; dark themes match their tokens" {
     try std.testing.expectEqualStrings("\x1b[38;2;155;126;206m", of(.oscura).accent);
 }
 
-/// Active-SGR tracker for the wrappers: remember styling since the last full
-/// reset so an inserted line break can re-open it — the diff painter repaints
-/// rows independently, so a continuation row with no SGR of its own renders
-/// in whatever style the previous paint left behind.
-fn trackSgr(active: *std.array_list.Managed(u8), seq: []const u8) void {
-    if (seq.len < 3 or seq[1] != '[' or seq[seq.len - 1] != 'm') return;
-    if (std.mem.eql(u8, seq, "\x1b[0m") or std.mem.eql(u8, seq, "\x1b[m")) {
-        active.clearRetainingCapacity();
-        return;
+/// Active-SGR tracker for the wrappers: remember styling since the last reset
+/// so an inserted line break can re-open it — the diff painter repaints rows
+/// independently, so a continuation row with no SGR of its own renders in
+/// whatever style the previous paint left behind.
+///
+/// State is kept PER CATEGORY, last writer wins. Concatenating the raw
+/// sequences instead grew without bound, so it needed a byte cap — and the cap
+/// CLEARED the tracker rather than trimming it. The background is set first on
+/// a code fence, so it was always the first casualty: a syntax-highlighted line
+/// carries a colour per token, and by the wrap point the band was long gone and
+/// the continuation row painted on the plain canvas.
+pub const Sgr = struct {
+    fg: Slot = .{},
+    bg: Slot = .{},
+    weight: Slot = .{},
+    italic: Slot = .{},
+    underline: Slot = .{},
+
+    /// Longest parameter list a slot holds: "48;2;255;255;255".
+    const Slot = struct {
+        buf: [20]u8 = undefined,
+        len: u8 = 0,
+
+        fn set(s: *Slot, p: []const u8) void {
+            if (p.len == 0 or p.len > s.buf.len) return;
+            @memcpy(s.buf[0..p.len], p);
+            s.len = @intCast(p.len);
+        }
+        fn drop(s: *Slot) void {
+            s.len = 0;
+        }
+        fn params(s: *const Slot) []const u8 {
+            return s.buf[0..s.len];
+        }
+    };
+
+    /// Five slots at "\x1b[" + 16 params + "m" apiece, rounded up.
+    pub const max_render = 5 * 20;
+
+    pub fn clear(self: *Sgr) void {
+        self.* = .{};
     }
-    if (active.items.len > 96) active.clearRetainingCapacity(); // bound pathological runs
-    active.appendSlice(seq) catch {};
-}
+
+    /// Re-emit the active state into `buf`. Background first so a continuation
+    /// row establishes its canvas before anything paints on it.
+    pub fn render(self: *const Sgr, buf: *[max_render]u8) []const u8 {
+        var n: usize = 0;
+        const order = [_]*const Slot{ &self.bg, &self.fg, &self.weight, &self.italic, &self.underline };
+        for (order) |slot| {
+            const p = slot.params();
+            if (p.len == 0) continue;
+            buf[n] = 0x1b;
+            buf[n + 1] = '[';
+            n += 2;
+            @memcpy(buf[n .. n + p.len], p);
+            n += p.len;
+            buf[n] = 'm';
+            n += 1;
+        }
+        return buf[0..n];
+    }
+
+    /// Fold one escape sequence into the state. Non-SGR escapes (OSC links,
+    /// kitty graphics, ESC[K) are ignored: they carry no style.
+    pub fn note(self: *Sgr, seq: []const u8) void {
+        if (seq.len < 3 or seq[1] != '[' or seq[seq.len - 1] != 'm') return;
+        const body = seq[2 .. seq.len - 1];
+        if (body.len == 0) { // "\x1b[m" is "\x1b[0m"
+            self.clear();
+            return;
+        }
+        var parts: [16][]const u8 = undefined;
+        var n: usize = 0;
+        var it = std.mem.splitScalar(u8, body, ';');
+        while (it.next()) |p| {
+            if (n == parts.len) return; // pathological: leave the state alone
+            parts[n] = p;
+            n += 1;
+        }
+        var i: usize = 0;
+        while (i < n) : (i += 1) {
+            const code = std.fmt.parseInt(u16, parts[i], 10) catch continue;
+            switch (code) {
+                0 => self.clear(),
+                1, 2 => self.weight.set(parts[i]),
+                3 => self.italic.set(parts[i]),
+                4 => self.underline.set(parts[i]),
+                22 => self.weight.drop(),
+                23 => self.italic.drop(),
+                24 => self.underline.drop(),
+                39 => self.fg.drop(),
+                49 => self.bg.drop(),
+                30...37, 90...97 => self.fg.set(parts[i]),
+                40...47, 100...107 => self.bg.set(parts[i]),
+                38, 48 => {
+                    // 38/48 own the parameters that follow: ";5;n" or ";2;r;g;b".
+                    const want: usize = if (i + 1 < n and std.mem.eql(u8, parts[i + 1], "5")) 2 else 4;
+                    if (i + want >= n) return;
+                    const start = @intFromPtr(parts[i].ptr) - @intFromPtr(body.ptr);
+                    const last = parts[i + want];
+                    const end = @intFromPtr(last.ptr) - @intFromPtr(body.ptr) + last.len;
+                    const slot = if (code == 38) &self.fg else &self.bg;
+                    slot.set(body[start..end]);
+                    i += want;
+                },
+                else => {},
+            }
+        }
+    }
+};
 
 /// Wrap `s` so no row is wider than `width` columns. SGR is preserved AND
 /// re-emitted on continuation rows; wide glyphs never straddle the edge.
 pub fn wrapToWidth(a: std.mem.Allocator, s: []const u8, width: usize) ![]const u8 {
     if (width == 0) return a.dupe(u8, s);
     var out = std.array_list.Managed(u8).init(a);
-    var active = std.array_list.Managed(u8).init(a);
-    defer active.deinit();
+    var active: Sgr = .{};
+    var sgr_buf: [Sgr.max_render]u8 = undefined;
     var col: usize = 0;
     var i: usize = 0;
     while (i < s.len) {
         if (s[i] == '\n') {
             try out.append('\n');
-            try out.appendSlice(active.items);
+            try out.appendSlice(active.render(&sgr_buf));
             col = 0;
             i += 1;
             continue;
@@ -273,13 +397,13 @@ pub fn wrapToWidth(a: std.mem.Allocator, s: []const u8, width: usize) ![]const u
             const start = i;
             i = skipEsc(s, i);
             try out.appendSlice(s[start..i]);
-            trackSgr(&active, s[start..i]);
+            active.note(s[start..i]);
             continue;
         }
         const c = cpAt(s, i);
         if (col + c.w > width and col > 0) {
             try out.append('\n');
-            try out.appendSlice(active.items);
+            try out.appendSlice(active.render(&sgr_buf));
             col = 0;
         }
         try out.appendSlice(s[i .. i + c.step]);
@@ -293,15 +417,15 @@ pub fn wrapToWidth(a: std.mem.Allocator, s: []const u8, width: usize) ![]const u
 pub fn wrapPreferWords(a: std.mem.Allocator, s: []const u8, width: usize) ![]const u8 {
     if (width == 0) return a.dupe(u8, s);
     var out = std.array_list.Managed(u8).init(a);
-    var active = std.array_list.Managed(u8).init(a);
-    defer active.deinit();
+    var active: Sgr = .{};
+    var sgr_buf: [Sgr.max_render]u8 = undefined;
     var col: usize = 0;
     var last_sp: ?usize = null;
     var i: usize = 0;
     while (i < s.len) {
         if (s[i] == '\n') {
             try out.append('\n');
-            try out.appendSlice(active.items);
+            try out.appendSlice(active.render(&sgr_buf));
             col = 0;
             last_sp = null;
             i += 1;
@@ -311,19 +435,21 @@ pub fn wrapPreferWords(a: std.mem.Allocator, s: []const u8, width: usize) ![]con
             const start = i;
             i = skipEsc(s, i); // full skip: hand-rolled CSI-only parsing broke a \n INTO an OSC hyperlink
             try out.appendSlice(s[start..i]);
-            trackSgr(&active, s[start..i]);
+            active.note(s[start..i]);
             continue;
         }
         const c = cpAt(s, i);
-        if (col + c.w > width) {
+        // `col > 0` matches wrapToWidth: a glyph wider than the whole width has
+        // nowhere to go, and breaking before it only opened with a blank row.
+        if (col + c.w > width and col > 0) {
             if (last_sp) |sp| {
                 out.items[sp] = '\n';
-                try out.insertSlice(sp + 1, active.items);
+                try out.insertSlice(sp + 1, active.render(&sgr_buf));
                 col = visibleLen(out.items[sp + 1 ..]);
                 last_sp = null;
             } else {
                 try out.append('\n');
-                try out.appendSlice(active.items);
+                try out.appendSlice(active.render(&sgr_buf));
                 col = 0;
             }
         }
@@ -363,6 +489,71 @@ test "visibleLen and takeCols treat OSC/APC as invisible" {
     try std.testing.expectEqual(@as(usize, 2), visibleLen("\x1b_Ga=d,d=A\x1b\\ok"));
     const cut = takeCols("\x1b]8;;u\x07ab", 1);
     try std.testing.expectEqualStrings("\x1b]8;;u\x07a", cut);
+}
+
+test "charWidth: the TUI's own glyphs measure one cell" {
+    // ⚙ ✓ ✗ ❙ ❯ are painted by scrollback/render themselves and are ambiguous
+    // width: terminals give them one cell. A blanket 2600..27BF range called
+    // them two, which under-padded every chrome row and — once a row measured
+    // full — cost it both the pad and the erase-to-EOL in run.zig.
+    for ([_]u21{ '⚙', '✓', '✗', '❙', '❯', '⊘', '●', '◆', '·', '›', '…', '│', '╭', '─', '▏', '↳', '→' }) |cp| {
+        try std.testing.expectEqual(@as(u2, 1), charWidth(cp));
+    }
+    // Real emoji and CJK stay two.
+    for ([_]u21{ '🚀', '✅', '❌', '⭐', '⌚', '你', '한' }) |cp| {
+        try std.testing.expectEqual(@as(u2, 2), charWidth(cp));
+    }
+    try std.testing.expectEqual(@as(usize, 20), visibleLen("  \u{2713} bash finished ok"));
+}
+
+test "charWidth: a VS16 selector promotes a text-presentation symbol" {
+    try std.testing.expectEqual(@as(usize, 1), visibleLen("\u{2713}"));
+    try std.testing.expectEqual(@as(usize, 2), visibleLen("\u{2713}\u{FE0F}"));
+    try std.testing.expectEqual(@as(usize, 1), visibleLen("\u{2713}\u{FE0E}")); // VS15 stays text
+    try std.testing.expectEqualStrings("", takeCols("\u{2713}\u{FE0F}", 1)); // never half a cell
+}
+
+test "Sgr keeps the background through a colour-heavy line" {
+    // One bg then six token colours: concatenating these passed 96 bytes, and
+    // the cap CLEARED the tracker, so the continuation row of a wrapped code
+    // fence lost its band. Per-slot tracking cannot lose the oldest slot.
+    const s = "\x1b[48;2;28;28;28m" ++
+        "\x1b[38;2;101;101;101m\x1b[38;2;102;102;102m\x1b[38;2;103;103;103m" ++
+        "\x1b[38;2;104;104;104m\x1b[38;2;105;105;105m\x1b[38;2;106;106;106m" ++
+        "ABCDEFGHIJ";
+    const got = try wrapToWidth(std.testing.allocator, s, 4);
+    defer std.testing.allocator.free(got);
+    var it = std.mem.splitScalar(u8, got, '\n');
+    var n: usize = 0;
+    while (it.next()) |ln| : (n += 1) {
+        if (n == 0) continue;
+        try std.testing.expect(std.mem.startsWith(u8, ln, "\x1b[48;2;28;28;28m"));
+        try std.testing.expect(std.mem.indexOf(u8, ln, "\x1b[38;2;106;106;106m") != null);
+    }
+    try std.testing.expect(n > 1);
+}
+
+test "Sgr: each reset code drops only its own slot" {
+    var st: Sgr = .{};
+    var buf: [Sgr.max_render]u8 = undefined;
+    st.note("\x1b[48;2;1;2;3m");
+    st.note("\x1b[38;5;9m");
+    st.note("\x1b[1m");
+    try std.testing.expectEqualStrings("\x1b[48;2;1;2;3m\x1b[38;5;9m\x1b[1m", st.render(&buf));
+    st.note(reset); // 39;22;23;24 — fg and weight go, the background stays
+    try std.testing.expectEqualStrings("\x1b[48;2;1;2;3m", st.render(&buf));
+    st.note("\x1b[31m");
+    try std.testing.expectEqualStrings("\x1b[48;2;1;2;3m\x1b[31m", st.render(&buf));
+    st.note("\x1b[0m");
+    try std.testing.expectEqualStrings("", st.render(&buf));
+    st.note("\x1b[K"); // not SGR: ignored
+    try std.testing.expectEqualStrings("", st.render(&buf));
+}
+
+test "wrapPreferWords does not open with a blank row for an oversized glyph" {
+    const got = try wrapPreferWords(std.testing.allocator, "\u{1F680}ab", 1);
+    defer std.testing.allocator.free(got);
+    try std.testing.expect(got[0] != '\n');
 }
 
 test "wide glyphs: 2 columns, never straddling a wrap or a takeCols edge" {

--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -15,7 +15,7 @@
     "src/repl.zig",
     "TUI/root.zig"
   ],
-  "test_count_baseline": 1279,
+  "test_count_baseline": 1281,
   "test_count_slack": 25,
   "required_invariants": [
     {

--- a/scripts/eval/tier1_test_binary.py
+++ b/scripts/eval/tier1_test_binary.py
@@ -52,25 +52,65 @@ class ArtifactError(Exception):
     """No usable test artifact, or one that would not say how many tests it holds."""
 
 
+def _names_in(path: pathlib.Path) -> list[str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    # The source carries Zig escapes; the binary carries the resolved bytes.
+    # Unescape so a name containing a quote still matches.
+    return [
+        m.group(1).replace('\\"', '"').replace("\\\\", "\\")
+        for m in TEST_NAME.finditer(text)
+    ]
+
+
 def declared_tests() -> dict[str, str]:
     """Every `test "name"` in src/*.zig, mapped to the file that declares it."""
     out: dict[str, str] = {}
     for path in sorted(SRC.glob("*.zig")):
-        for match in TEST_NAME.finditer(path.read_text(encoding="utf-8")):
-            # The source carries Zig escapes; the binary carries the resolved
-            # bytes. Unescape so a name containing a quote still matches.
-            name = match.group(1).replace('\\"', '"').replace("\\\\", "\\")
+        for name in _names_in(path):
             out[name] = path.name
     return out
+
+
+def foreign_tests(declared: dict[str, str]) -> set[str]:
+    """Test names that belong to a DIFFERENT test root than src/.
+
+    The name set alone cannot tell the src floor build (a filter matching
+    nothing, so zero declared names survive) apart from a `zig build tui-test`
+    artifact, which also holds zero src names - and being newer, the TUI binary
+    won the tie and reported its 138 tests as the floor. Tier 1 then measured
+    9 invariants against a 138 floor and called a green suite red.
+
+    Any name declared outside src/ is proof the artifact is not the src root,
+    whatever the filters were, so it settles that tie the other way.
+    """
+    out: set[str] = set()
+    for path in sorted(ROOT.rglob("*.zig")):
+        rel = path.relative_to(ROOT)
+        if rel.parts[0] in ("src", "vendor", ".zig-cache", "zig-out"):
+            continue
+        out.update(_names_in(path))
+    return out - set(declared)
 
 
 class Selection:
     """One candidate artifact, scored against the build we asked for."""
 
-    def __init__(self, path: pathlib.Path, present: set[str], expected: set[str]):
+    def __init__(
+        self,
+        path: pathlib.Path,
+        present: set[str],
+        expected: set[str],
+        foreign: set[str] | None = None,
+    ):
         self.path = path
         self.present = present
         self.expected = expected
+        # Names from another test root found in this binary: nonzero means the
+        # artifact is not a build of src/ at all.
+        self.foreign = foreign or set()
         self.considered = 1
         self.was_newest = True
 
@@ -102,13 +142,17 @@ def select(filters: list[str], declared: dict[str, str] | None = None) -> Select
 
     Zig's filters are substring matches on the test name, so the set of declared
     names a filtered build keeps is computable from the source alone. Rank every
-    candidate by how far it is from that set - missing names first, then names it
-    should not have - and the full build wins the unfiltered question even when a
-    filtered build is newer.
+    candidate by how far it is from that set - missing names first, then names
+    from a foreign test root, then names it should not have - and the full build
+    wins the unfiltered question even when a filtered build is newer.
+
+    The foreign term is what keeps a `zig build tui-test` artifact out of the
+    answer when `expected` is empty and every candidate ties at zero missing.
     """
     if declared is None:
         declared = declared_tests()
     expected = {n for n in declared if not filters or any(f in n for f in filters)}
+    outsiders = foreign_tests(declared)
 
     ranked: list[Selection] = []
     # candidates() is newest first and sort() below is stable, so ties stay in
@@ -116,14 +160,15 @@ def select(filters: list[str], declared: dict[str, str] | None = None) -> Select
     for path in candidates():
         blob = path.read_bytes()
         present = {n for n in declared if n.encode("utf-8") in blob}
-        ranked.append(Selection(path, present, expected))
+        alien = {n for n in outsiders if n.encode("utf-8") in blob}
+        ranked.append(Selection(path, present, expected, alien))
     if not ranked:
         raise ArtifactError(
             "no compiled test binary under .zig-cache/o - run `zig build test` first"
         )
 
     newest = ranked[0].path
-    ranked.sort(key=lambda s: (len(s.missing), len(s.extra)))
+    ranked.sort(key=lambda s: (len(s.missing), len(s.foreign), len(s.extra)))
     best = ranked[0]
     best.considered = len(ranked)
     best.was_newest = best.path == newest


### PR DESCRIPTION
Four visual-parity items studied from xai-org/grok-build source (three extraction passes over open_code_highlighter/colors/tmThemes, scrollback/sticky.rs, and the theme/osc11 stack):

- **Fence syntax highlighting**: new TUI/syntax.zig — line-resumable lexer, grok's token classes with the grok-night/grok-day tmTheme colors verbatim, grok's fence-info resolution order (citation `start:end:path` by extension, then whole-info token). Fences render grok-style: hidden markers, blank separation, full-width background band, 10 languages, unknown languages keep the band uncolored.
- **Sticky prompt header**: minimal single-slot port of grok's sticky.rs — the last user prompt scrolled past the top pins as row 0 + blank separator; occludes rather than shifts so row↔line mapping and the bottom line are unchanged.
- **Auto light/dark**: OSC 11 query at startup → `Key.bg_report` → BT.709 classification (0.5 threshold) → Grok Night/Day unless `/theme` was explicit. Fixed palettes, 1-bit decision, exactly grok's model.
- **?2026 synchronized output** around frame paints — atomic swaps, no half-painted diffs.

133 TUI tests (7 new), tier-1 green.