### PR TITLE
release: v0.0.260 — composer-wipe hotfix (stale modifier latch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
+## v0.0.260 (2026-08-15)
+
+- Fixed the composer silently wiping mid-typing: switching apps with Cmd+Tab
+  latched a phantom Super modifier (the release went to the other app), so
+  the next Backspace acted as Cmd+Backspace and deleted to the start of the
+  line. A plain keypress now clears stale modifier latches.
+
 ## v0.0.259 (2026-08-15)
 
 - Grok now defaults to xAI's Responses wire: WebSocket turns (with the SSE

--- a/TUI/key.zig
+++ b/TUI/key.zig
@@ -269,9 +269,14 @@ fn kitty(params: []const u8) Key {
     const ev = eventOf(params);
     if (code >= 57344 and code <= 57454) return functional(code, mods, ev);
     if (ev == 3) return .ignore;
-    // A live key with an explicit mods field is ground truth for held
-    // modifiers — resync so a missed release can't latch alt/super forever.
-    if (has_mods) held = mods & 10;
+    // A live key is ground truth for held modifiers — resync so a missed
+    // release can't latch alt/super forever. The ABSENT mods field is ground
+    // truth too: kitty omits it exactly when no modifiers are down, so a
+    // plain keypress must clear the latch. Before this, Cmd+Tab-ing away
+    // mid-composition latched super (the release went to the other app) and
+    // the next plain Backspace became Cmd+Backspace = delete-to-start,
+    // silently wiping the composer.
+    held = if (has_mods) mods & 10 else 0;
     return mapCode(code, mods);
 }
 

--- a/TUI/key_tests.zig
+++ b/TUI/key_tests.zig
@@ -243,3 +243,23 @@ test "Shift+9 is open-paren, Shift+0 is close-paren" {
     i = 0;
     try std.testing.expectEqual(Key{ .char = '(' }, next("\x1b[27;2;57~", &i).?);
 }
+
+test "a plain CSI-u keypress clears a stale super latch — Backspace stays Backspace" {
+    // Cmd+Tab mid-composition: the super PRESS arrives, focus leaves, the
+    // RELEASE goes to the other app. Typing resumes with plain CSI-u keys
+    // (no mods field). Those must resync held to 0, or the next Backspace
+    // reads as Cmd+Backspace = delete_to_start and wipes the composer.
+    key.held = 8; // stale Super
+    var i: usize = 0;
+    try std.testing.expectEqual(Key{ .char = 'h' }, next("\x1b[104u", &i).?);
+    try std.testing.expectEqual(@as(u32, 0), key.held);
+    i = 0;
+    try std.testing.expectEqual(Key.backspace, next("\x7f", &i).?);
+    // Stale alt is the same class of bug (backspace -> delete_word).
+    key.held = 2;
+    i = 0;
+    try std.testing.expectEqual(Key{ .char = 'a' }, next("\x1b[97u", &i).?);
+    i = 0;
+    try std.testing.expectEqual(Key.backspace, next("\x7f", &i).?);
+    key.held = 0;
+}

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -21,6 +21,9 @@ const harness_version = root.harness_version;
 pub const changelog_text =
     \\What's new
     \\──────────
+    \\0.0.260
+    \\  • Fixed the composer wiping itself mid-typing after a Cmd+Tab (stale Super latch made Backspace act as Cmd+Backspace)
+    \\
     \\0.0.259
     \\  • Grok defaults to xAI's Responses wire: WebSocket turns, lossless server-side compaction, structured outputs — no env needed (GRAFF_XAI_WIRE=chat opts out)
     \\  • Fixed duplicate MCP tool definitions that made strict Responses endpoints reject every turn


### PR DESCRIPTION
Merge-back of v0.0.260 (tagged, notarized, published as latest). Single fix: a plain kitty keypress clears a stale alt/super latch, so Cmd+Tab-ing away mid-composition can no longer turn the next Backspace into delete-to-start.