### PR TITLE
release: v0.0.261 — grok-parity TUI + rendering audit + xAI KV caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
+## v0.0.261 (2026-08-15)
+
+- The TUI looks and behaves like grok-build where it counts: syntax-highlighted
+  code fences (grok-night/grok-day token colors on a full-width band, hidden
+  markers), a sticky header pinning the prompt you scrolled past, automatic
+  light/dark from the terminal's reported background, and flicker-free
+  synchronized painting.
+- Two dozen rendering and input bugs found by a three-pass audit and a live
+  visual-capture pipeline, headlined by: a half-arrived mouse-hover report
+  could fire a phantom Escape that silently cancelled the running turn and
+  then type its debris (`39;7;32M…`) into the composer; the orphan-sequence
+  sweeper ate pasted text like `0x1f` and `1e5`; the first `**bold**` made the
+  rest of the message bold; emoji and CJK widths bent every box border;
+  `/theme` left most rows in the old background; `/jump` hid the very turn it
+  jumped to; clicking blank space toggled the last tool run.
+- Grok requests carry `x-grok-conv-id` and `prompt_cache_key` on every wire so
+  xAI's automatic prompt caching actually hits; WebSocket sessions retire
+  before the server's 25-minute cap and classify its error frames instead of
+  burning the stall budget. `GRAFF_XAI_WS_CHAIN=1` opts into on-socket
+  delta chaining (experimental).
+
 ## v0.0.260 (2026-08-15)
 
 - Fixed the composer silently wiping mid-typing: switching apps with Cmd+Tab

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -21,6 +21,11 @@ const harness_version = root.harness_version;
 pub const changelog_text =
     \\What's new
     \\──────────
+    \\0.0.261
+    \\  • Grok-style TUI: syntax-highlighted fences, sticky prompt header, auto light/dark, flicker-free paints
+    \\  • ~24 rendering/input fixes: phantom-Escape turn cancels, debris typed into the composer, bold bleed, emoji-bent borders, /theme half-repaints
+    \\  • xAI KV-cache affinity headers + WebSocket 25-min limit handling
+    \\
     \\0.0.260
     \\  • Fixed the composer wiping itself mid-typing after a Cmd+Tab (stale Super latch made Backspace act as Cmd+Backspace)
     \\


### PR DESCRIPTION
Merge-back of v0.0.261 (tagged, notarized, published as latest). Docs-only delta vs main: the changelog + what's-new commit.