### PR TITLE
fix(sdk): ./ path prefix for native-package publish (EALLOWGIT on npm@latest)

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -88,7 +88,7 @@ jobs:
             }
             echo "$package@$version already published; keeping immutable package"
           else
-            npm publish "native-packages/${{ matrix.package_dir }}" --access public
+            npm publish "./native-packages/${{ matrix.package_dir }}" --access public
           fi
 
   publish:


### PR DESCRIPTION
One-line workflow fix: `npm publish "native-packages/${{ matrix.package_dir }}"` is parsed by current npm as a `github:` shorthand spec and refused (`EALLOWGIT`), which failed all six native jobs on the sdk-v0.4.0 publish run. `./` prefix restores directory semantics. Verified guard chain otherwise green on that run: GRAFF_NATIVE_RELEASE=v0.0.262 resolves, protocol 0.12 matches, sha256 verifies.