### PR TITLE
merge: Gemini default reasoning_effort onto main

### DIFF
--- a/src/agent.zig
+++ b/src/agent.zig
@@ -249,6 +249,16 @@ pub const Agent = struct {
         return schema.providerTakesEffort(self.provider.kind, self.provider.id, self.provider.model);
     }
 
+    /// Whether this turn should put reasoning_effort on the wire. Gemini 3.x
+    /// maps that field to thinking_level; the default medium makes every
+    /// turn think for seconds (2× wall vs Pi, which omits it). /effort still
+    /// applies — we only skip the unset default.
+    pub fn sendReasoningEffort(self: *const Agent) bool {
+        if (!self.effortApplies() or self.effort_rejected) return false;
+        if (std.mem.startsWith(u8, self.provider.model, "gemini") and self.reasoning == .medium) return false;
+        return true;
+    }
+
     /// #330/#352: a child's catalog is a comptime constant, so both gates just
     /// pick the pre-built twin rather than rebuilding one per subagent —
     /// schema.subToolsJson owns that choice. Root catalogs are filtered where

--- a/src/agent_request_body.zig
+++ b/src/agent_request_body.zig
@@ -178,7 +178,7 @@ pub fn buildBody(self: *Agent, tools: ?[]const u8, force_tool: bool, stream: boo
             // Reasoning-effort hint for OpenAI-compatible providers that
             // honor it (codegraff gateway, deepseek). Mirrors the
             // Responses `reasoning.effort` set in the branch below.
-            if (!is_kimi and self.effortApplies() and !self.effort_rejected) {
+            if (!is_kimi and self.sendReasoningEffort()) {
                 try s.objectField("reasoning_effort");
                 try s.write(if (self.reasoning == .ultra) "max" else @tagName(self.reasoning));
             }

--- a/src/provider_codegraff_tests.zig
+++ b/src/provider_codegraff_tests.zig
@@ -84,3 +84,47 @@ test "Codegraff Responses aliases pin a sticky prompt_cache_key" {
         try std.testing.expectEqualStrings(http_headers.promptCacheKey(root.io, root.label, &root, &buf), k1);
     }
 }
+
+test "Codegraff Gemini omits default reasoning_effort; /effort high still sends" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var messages = std.json.Array.init(arena);
+    try messages.append(.{ .object = blk: {
+        var obj: std.json.ObjectMap = .empty;
+        try obj.put(arena, "role", .{ .string = "user" });
+        try obj.put(arena, "content", .{ .string = "hello" });
+        break :blk obj;
+    } });
+    var agent: Agent = .{
+        .gpa = std.testing.allocator,
+        .arena = arena,
+        .io = std.testing.io,
+        .client = undefined,
+        .provider = build("gemini-3.7-flash"),
+        .messages = messages,
+        .sub = false,
+        .label = "main",
+        .out = null,
+        .sys_normal = "system",
+    };
+    try std.testing.expect(agent.effortApplies());
+    try std.testing.expect(!agent.sendReasoningEffort());
+    const omitted = try agent.buildBody(null, false, true, true);
+    defer std.testing.allocator.free(omitted);
+    try std.testing.expect(std.mem.indexOf(u8, omitted, "reasoning_effort") == null);
+
+    agent.reasoning = .high;
+    try std.testing.expect(agent.sendReasoningEffort());
+    const high = try agent.buildBody(null, false, true, true);
+    defer std.testing.allocator.free(high);
+    try std.testing.expect(std.mem.indexOf(u8, high, "\"reasoning_effort\":\"high\"") != null);
+
+    var deepseek: Agent = agent;
+    deepseek.provider = build("deepseek-v4-pro");
+    deepseek.reasoning = .medium;
+    try std.testing.expect(deepseek.sendReasoningEffort());
+    const ds = try deepseek.buildBody(null, false, true, true);
+    defer std.testing.allocator.free(ds);
+    try std.testing.expect(std.mem.indexOf(u8, ds, "\"reasoning_effort\":\"medium\"") != null);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fast-forward `main` to the tip of `release/v0.0.265`.

That tip is one commit ahead of current `main`: `e79dedc` — `fix(gemini): omit default reasoning_effort so evals do not think`.

Codegraff is `takes_effort`, so every Chat Completions turn was sending `reasoning_effort: medium`. Gemini maps that to `thinking_level` and spends seconds thinking per turn (the 2× wall vs Pi, which omits the field). `/effort:` still goes on the wire when it is a non-default pick. DeepSeek and GPT-5.6 are unchanged.

No other release/v0.0.265 work is missing from `main` — this is just that last push.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00e21-907e-7738-b167-6d4c0294554f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00e21-907e-7738-b167-6d4c0294554f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

