### PR TITLE
feat(cache): see how prompt-cache max is (and isn't) earned

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ gateway rollouts appear without a restart.
 /plugins                  list Cursor/Claude/Grok/Codex plugin trees graff is reading in place
 /hooks                    list lifecycle hooks and the built-in codedb guard
 /doctor                   read-only health check: goal/todo invariants, and why steering will or will not be appended
-/btw <question>           ask one side question about this conversation: no tools, billed, never added to the session
+/btw <question>           ask one side question about this conversation: billed, never added, rides the parent cache prefix
 /compact                  compact history into a fresh context (OpenAI server-side when available)
 /rewind [n]               list past prompts; /rewind <n> drops prompt n+after & reverts its file edits
 /image <path>             attach an image to your next message (vision models only)

--- a/TUI/catalog.zig
+++ b/TUI/catalog.zig
@@ -17,6 +17,7 @@ pub const items = [_]Item{
     .{ .name = "/session-info", .desc = "Session details", .aliases = &.{ "/status", "/info" } },
     .{ .name = "/usage", .desc = "Token usage and cost", .aliases = &.{"/cost"} },
     .{ .name = "/debug", .desc = "Live observability HUD" },
+    .{ .name = "/cache", .desc = "Prompt-cache posture and remaining max levers" },
     .{ .name = "/rewind", .desc = "Undo the last turn", .aliases = &.{"/undo"} },
     .{ .name = "/quit", .desc = "Quit", .aliases = &.{ "/exit", "/q" } },
     .{ .name = "/rename", .desc = "Rename this session", .aliases = &.{"/title"} },
@@ -96,6 +97,7 @@ test "filter: slash prefix and alias" {
     try std.testing.expect(lookup("/undo") != null);
     try std.testing.expect(lookup("/yolo") != null);
     try std.testing.expect(lookup("/debug") != null);
+    try std.testing.expect(lookup("/cache") != null);
     try std.testing.expect(lookup("/cost") != null);
     try std.testing.expect(lookup("/not-a-cmd") == null);
 }

--- a/TUI/dispatch.zig
+++ b/TUI/dispatch.zig
@@ -158,7 +158,7 @@ pub fn runCommand(self: *Model, line: []const u8) Effect {
         self.pushFmt(.system, "session: {s}", .{self.session_name orelse "untitled"}) catch {};
     } else if (std.mem.eql(u8, canon, "/session-info")) {
         meters.sessionInfo(self);
-    } else if (std.mem.eql(u8, canon, "/debug")) {
+    } else if (std.mem.eql(u8, canon, "/debug") or std.mem.eql(u8, canon, "/cache")) {
         self.openOverlay(.debug);
     } else if (std.mem.eql(u8, canon, "/usage")) {
         var buf: [512]u8 = undefined;
@@ -376,6 +376,14 @@ test "/debug opens the observability overlay" {
     m.setup(std.testing.allocator);
     defer m.deinit();
     _ = applyLine(&m, "/debug");
+    try std.testing.expectEqual(app.Overlay.debug, m.overlay);
+}
+
+test "/cache opens the same observability overlay" {
+    var m: Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    _ = applyLine(&m, "/cache");
     try std.testing.expectEqual(app.Overlay.debug, m.overlay);
 }
 

--- a/TUI/overlaypane.zig
+++ b/TUI/overlaypane.zig
@@ -249,6 +249,7 @@ const help_body =
     \\  /settings         model · effort · mode · theme
     \\  /usage /cost      live token/cost line
     \\  /debug            observability HUD
+    \\  /cache            prompt-cache posture
     \\  /plan             toggle plan mode
     \\  /always-approve   skip permission prompts
     \\  /import-claude    copy Claude and Cursor MCP + skills
@@ -269,7 +270,7 @@ test "help overlay names the advertised pager commands" {
     defer arena.deinit();
     const text = try overlay(&m, arena.allocator(), 80);
     for ([_][]const u8{
-        "/quit",     "/help", "/new", "/home", "/model", "/settings", "/usage", "/debug", "/plan", "/always-approve",
+        "/quit",     "/help", "/new", "/home", "/model", "/settings", "/usage", "/debug", "/cache", "/plan", "/always-approve",
         "Shift+Tab", "PgUp",  "PgDn",
         "←",
         "→",

--- a/TUI/sim.zig
+++ b/TUI/sim.zig
@@ -277,6 +277,15 @@ test "type /help then enter opens the help overlay" {
     try std.testing.expect(std.mem.indexOf(u8, paged, "/quit") != null);
 }
 
+test "type /cache then enter opens the observability overlay" {
+    var term: Term = undefined;
+    term.init(std.testing.allocator, 80, 24);
+    defer term.deinit();
+    _ = term.typeText("/cache");
+    _ = term.enter();
+    try std.testing.expectEqual(app.Overlay.debug, term.model.overlay);
+}
+
 test "hoverText on an image chip opens the preview" {
     var term: Term = undefined;
     term.init(std.testing.allocator, 80, 24);

--- a/docs/adr/0010-prompt-cache-max-is-visible.md
+++ b/docs/adr/0010-prompt-cache-max-is-visible.md
@@ -40,4 +40,6 @@ Live Grok 4.6 (Responses, SuperGrok OAuth, 2026-08-19): same-process
 append-only turn 2 cached 3,712 of turn 1's 3,721 input tokens. A new
 process in the same folder started cold at 128 — the official first-request
 write, not a routing miss. That is the xAI contract working: sticky
-`x-grok-conv-id` / `prompt_cache_key`, exact prefix, reasoning replay.
+`x-grok-conv-id` / `x-grok-session-id` / `prompt_cache_key`, exact prefix,
+reasoning replay. Session-id is grok-build's extra sticky header: always
+the project id, even when a child isolates `x-grok-conv-id`.

--- a/docs/adr/0010-prompt-cache-max-is-visible.md
+++ b/docs/adr/0010-prompt-cache-max-is-visible.md
@@ -19,8 +19,9 @@ intentional. `/debug` counted tokens; it did not say why a miss happened.
 ## Decision
 
 - `/cache` is the content-free cache HUD: prefix hash, last read/write,
-  session hit rate, catalog mode, last bust reason, and the remaining max
-  levers. No prompt text, paths, or tool bodies.
+  session hit rate, catalog mode, last bust reason, xAI affinity
+  (`x-grok-conv-id` + `prompt_cache_key`, same project id), and the
+  remaining max levers. No prompt text, paths, or tool bodies.
 - `/debug` gets one cache row from the same snapshot.
 - Named busts (`goal`, `playbook`, `compact`, `persona`, `tools`, `mcp`) are
   recorded at the mutation site and counted only when the next request's
@@ -34,3 +35,9 @@ intentional. `/debug` counted tokens; it did not say why a miss happened.
 A `/cache` after a miss names the lever. Revisit defaulting stable-catalog
 only if a new live measurement shows load-after-load cache-read returning
 from 0% without discovery or compaction regressions.
+
+Live Grok 4.6 (Responses, SuperGrok OAuth, 2026-08-19): same-process
+append-only turn 2 cached 3,712 of turn 1's 3,721 input tokens. A new
+process in the same folder started cold at 128 — the official first-request
+write, not a routing miss. That is the xAI contract working: sticky
+`x-grok-conv-id` / `prompt_cache_key`, exact prefix, reasoning replay.

--- a/docs/adr/0010-prompt-cache-max-is-visible.md
+++ b/docs/adr/0010-prompt-cache-max-is-visible.md
@@ -29,6 +29,9 @@ intentional. `/debug` counted tokens; it did not say why a miss happened.
 - Do not default `GRAFF_STABLE_CATALOG`. Do not move playbook / compact notes
   / standing goal off the prefix — those ride the system prompt on purpose
   (ADR 0005, #381, #391) and already share the compaction boundary.
+- `/btw` is a grok-build side-call: same system prompt, same tools JSON, same
+  `prompt_cache_key` as the parent. The side-question note is appended as a
+  user message. Tools are advertised for the prefix and not executed.
 
 ## Consequences
 
@@ -42,4 +45,6 @@ process in the same folder started cold at 128 — the official first-request
 write, not a routing miss. That is the xAI contract working: sticky
 `x-grok-conv-id` / `x-grok-session-id` / `prompt_cache_key`, exact prefix,
 reasoning replay. Session-id is grok-build's extra sticky header: always
-the project id, even when a child isolates `x-grok-conv-id`.
+the project id, even when a child isolates `x-grok-conv-id`. `/btw` shares
+that key and the parent tools/system so a side question can hit the warm
+prefix instead of evicting it.

--- a/docs/adr/0010-prompt-cache-max-is-visible.md
+++ b/docs/adr/0010-prompt-cache-max-is-visible.md
@@ -1,0 +1,36 @@
+# 0010. Prompt-cache max is a visible posture, not a new default
+
+Status: accepted 2026-08-19
+
+## Context
+
+v0.0.266 already earned the cacheable prefix: sticky `prompt_cache_key`,
+names-only skill catalog pinned once, standing goal as one prefix line,
+Anthropic `cache_control`, GPT-5.6 explicit breakpoint (ADR 0009), per-agent
+partitions, no timestamps. #476 still listed cache-rate as the remaining gap
+(~45–58% vs opencode ~85%). The leftover automatic bust is `load_tool_schemas`
+rewriting tools JSON. `GRAFF_STABLE_CATALOG=1` exists for that and **measured
+empty** on the v0.0.246 audit, so it stays off.
+
+What you could not see: whether this session's prefix was still the same
+bytes, which named mutation last moved it, or which remaining levers are
+intentional. `/debug` counted tokens; it did not say why a miss happened.
+
+## Decision
+
+- `/cache` is the content-free cache HUD: prefix hash, last read/write,
+  session hit rate, catalog mode, last bust reason, and the remaining max
+  levers. No prompt text, paths, or tool bodies.
+- `/debug` gets one cache row from the same snapshot.
+- Named busts (`goal`, `playbook`, `compact`, `persona`, `tools`, `mcp`) are
+  recorded at the mutation site and counted only when the next request's
+  system+tools hash actually changes. Startup compose is not a bust.
+- Do not default `GRAFF_STABLE_CATALOG`. Do not move playbook / compact notes
+  / standing goal off the prefix — those ride the system prompt on purpose
+  (ADR 0005, #381, #391) and already share the compaction boundary.
+
+## Consequences
+
+A `/cache` after a miss names the lever. Revisit defaulting stable-catalog
+only if a new live measurement shows load-after-load cache-read returning
+from 0% without discovery or compaction regressions.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ record only when you need the evidence or the edge cases.
 | [0007](0007-plugins-are-read-in-place.md) | Cursor/Claude/Grok/Codex plugins and MCP are read in place (Claude/Cursor cache via installed_plugins.json, Codex via config.toml PluginStore, never walked); skills stay on-demand; MCP stays consent-gated. |
 | [0008](0008-synthetic-evals-use-external-verifiers.md) | Synthetic coding evals promote only external-verifier passes; model judges may tiebreak correctness, never decide it. |
 | [0009](0009-gpt-5-6-explicit-prompt-cache-boundary.md) | GPT-5.6 OpenAI Platform marks the stable prefix explicitly; Codex and xAI stay on their supported keyed automatic-cache paths. |
+| [0010](0010-prompt-cache-max-is-visible.md) | Prompt-cache max is `/cache` posture, not a new default; `GRAFF_STABLE_CATALOG` stays opt-in. |
 
 ## When to write one
 

--- a/scripts/btw-cache-showcase.py
+++ b/scripts/btw-cache-showcase.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Live /btw prefix-cache check against a warmed Grok session.
+
+    python3 scripts/btw-cache-showcase.py --bin ./zig-out/bin/graff --model grok-4.6
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PING = "Reply with only the word ping. Do not call any tools."
+BTW = "What single word did I ask you to reply with? Reply with only that word."
+
+
+def resolve_bin(explicit: str) -> str:
+    repo = Path(__file__).resolve().parent.parent
+    if explicit:
+        p = Path(explicit)
+        if not p.is_absolute():
+            p = (Path.cwd() / p).resolve()
+        return str(p)
+    cand = repo / "zig-out" / "bin" / "graff"
+    return str(cand) if cand.is_file() else "graff"
+
+
+def read_event(proc: subprocess.Popen, want: str, timeout_lines: int = 400) -> dict:
+    assert proc.stdout
+    for _ in range(timeout_lines):
+        line = proc.stdout.readline()
+        if not line:
+            err = proc.stderr.read() if proc.stderr else ""
+            raise SystemExit(f"graff closed before {want}\n{err[-800:]}")
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if ev.get("type") == want:
+            return ev
+    raise SystemExit(f"no {want} event in {timeout_lines} lines")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--bin", default="")
+    ap.add_argument("--model", default="grok-4.6")
+    args = ap.parse_args()
+    graff = resolve_bin(args.bin)
+    env = os.environ.copy()
+    env.update({"GRAFF_NO_TELEMETRY": "1", "GRAFF_FLEET": "off"})
+
+    with tempfile.TemporaryDirectory(prefix="graff-btw-cache-") as tmp:
+        proc = subprocess.Popen(
+            [graff, "--json", "--yolo", "--no-telemetry", "--model", args.model],
+            cwd=tmp,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdin
+        try:
+            proc.stdin.write(json.dumps({"type": "user", "text": PING}) + "\n")
+            proc.stdin.flush()
+            turn = read_event(proc, "turn")
+            proc.stdin.write(json.dumps({"type": "btw", "text": BTW}) + "\n")
+            proc.stdin.flush()
+            btw = read_event(proc, "btw")
+            proc.stdin.close()
+            proc.wait(timeout=30)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+
+    print(f"model {args.model}")
+    print(f"turn  cache_read={turn.get('cache_read_tokens')}  uncached={turn.get('uncached_input_tokens')}  input={turn.get('input_tokens')}  text={turn.get('text')!r}")
+    print(f"btw   cache_read={btw.get('cache_read_tokens')}  text={btw.get('text')!r}  persisted={btw.get('persisted')}")
+    cached = int(btw.get("cache_read_tokens") or 0)
+    prior = int(turn.get("input_tokens") or 0)
+    print()
+    if prior and cached >= int(prior * 0.8):
+        print(f"hit: /btw reused {cached} tokens (≥80% of the prior {prior}-token turn)")
+        return 0
+    print(f"miss-or-weak: /btw reused {cached} of the prior {prior}-token turn")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -292,6 +292,7 @@ pub const Agent = struct {
     /// active format is immediately rebuilt; inactive formats remain lazy.
     pub fn invalidateRootTools(self: *Agent) void {
         if (self.sub) return;
+        @import("prompt_cache_hud.zig").noteBust(.tools);
         self.tools_anthropic = "";
         self.tools_openai = "";
         self.tools_responses = "";

--- a/src/agent_context.zig
+++ b/src/agent_context.zig
@@ -192,6 +192,7 @@ pub fn usageInt(obj: std.json.ObjectMap, name: []const u8) i64 {
 /// $0, while an env key on that same provider is metered like any other.
 pub fn recordCost(self: *Agent, ordinary_in: i64, cache_in: i64, cache_write_in: i64, out: i64) void {
     g_cost.add(self.io, billing.forProvider(self.provider), self.provider.model, ordinary_in, cache_in, cache_write_in, out);
+    if (!self.sub) @import("prompt_cache_hud.zig").noteUsage(@intCast(@max(cache_in, 0)), @intCast(@max(cache_write_in, 0)));
 }
 
 /// #174: ~4-bytes/token estimate of the FULL history serialized as Responses

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -206,7 +206,16 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
         self.streamed_args = .none;
         const body = try self.buildBody(tools, force, live, stream_usage);
         defer self.gpa.free(body);
-        if (!self.sub) @import("prompt_cache_hud.zig").noteRequest(self.io, self.systemPrompt(), tools orelse "");
+        if (!self.sub) {
+            const hud = @import("prompt_cache_hud.zig");
+            hud.noteRequest(self.io, self.systemPrompt(), tools orelse "");
+            var aff_buf: [96]u8 = undefined;
+            hud.noteAffinity(
+                http_headers.promptCacheKey(self.io, self.label, self, &aff_buf),
+                std.mem.eql(u8, self.provider.id, "xai"),
+                self.provider.kind == .responses,
+            );
+        }
         // GRAFF_REQ_STATS=1: per-call request anatomy + body dumps (req_stats.zig).
         req_stats.report(self.io, body, tools, self.sys_normal);
         const t0: Io.Timestamp = .now(self.io, .awake);

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -206,6 +206,7 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
         self.streamed_args = .none;
         const body = try self.buildBody(tools, force, live, stream_usage);
         defer self.gpa.free(body);
+        if (!self.sub) @import("prompt_cache_hud.zig").noteRequest(self.io, self.systemPrompt(), tools orelse "");
         // GRAFF_REQ_STATS=1: per-call request anatomy + body dumps (req_stats.zig).
         req_stats.report(self.io, body, tools, self.sys_normal);
         const t0: Io.Timestamp = .now(self.io, .awake);

--- a/src/agent_ws.zig
+++ b/src/agent_ws.zig
@@ -357,9 +357,9 @@ pub fn postResponsesWs(self: *Agent, body: []const u8) ![]u8 {
     defer gpa.free(frame);
 
     const bearer = try std.fmt.allocPrint(arena, "Bearer {s}", .{provider.api_key});
-    // ChatGPT tail is codex-only (#502); xAI takes x-grok-conv-id instead —
-    // the project cache id (root/sub isolated), same sticky value as the
-    // Responses body's prompt_cache_key, not the per-process session id.
+    // ChatGPT tail is codex-only (#502); xAI takes grok-build's affinity
+    // pair: x-grok-session-id (durable project) + x-grok-conv-id (root/sub
+    // partition, same value as the Responses body's prompt_cache_key).
     var conv_buf: [96]u8 = undefined;
     const conv = http_headers.promptCacheKey(self.io, self.label, self, &conv_buf);
     var hdrs: [7]ws.Header = undefined;
@@ -373,7 +373,7 @@ pub fn postResponsesWs(self: *Agent, body: []const u8) ![]u8 {
         hdrs[5] = .{ .name = "User-Agent", .value = "codex_cli_rs/0.1 (graff)" };
         hn = 6;
     } else if (http_headers.wantsGrokConvId(provider.id)) {
-        hdrs[1] = .{ .name = "session_id", .value = http_headers.sessionId(self.io) };
+        hdrs[1] = .{ .name = "x-grok-session-id", .value = http_headers.projectRootId(self.io) };
         hdrs[2] = .{ .name = "x-grok-conv-id", .value = conv };
         hn = 3;
     }

--- a/src/command_catalog.zig
+++ b/src/command_catalog.zig
@@ -71,6 +71,7 @@ pub const commands = [_]Item{
     .{ .name = "/cost", .desc = "session token usage and cost" },
     .{ .name = "/usage", .desc = "alias for /cost" },
     .{ .name = "/debug", .desc = "live content-free observability HUD (turns, tokens, tools, last events)" },
+    .{ .name = "/cache", .desc = "prompt-cache posture: prefix hash, hit rate, last bust, remaining max levers" },
     .{ .name = "/tools", .desc = "session tool balance: codedb-pro vs zigrep vs native usage, gate refusals, skew" },
     .{ .name = "/animation", .desc = "pick the thinking animation; persists to settings" },
     .{ .name = "/theme", .usage = "/theme [name]", .desc = "pick a color theme; /theme off resets to your terminal default; persists" },

--- a/src/command_catalog.zig
+++ b/src/command_catalog.zig
@@ -54,7 +54,7 @@ pub const commands = [_]Item{
     .{ .name = "/plugins", .usage = "/plugins [list|load <name>]", .desc = "list Claude/Cursor/Grok/Codex plugin trees graff is reading in place; load names one" },
     .{ .name = "/hooks", .desc = "list lifecycle hooks and the built-in codedb guard" },
     .{ .name = "/doctor", .desc = "read-only health check: goal/todo invariants, and why steering will or will not be appended" },
-    .{ .name = "/btw", .usage = "/btw <question>", .desc = "ask one side question about this conversation — no tools, billed, never added to the session" },
+    .{ .name = "/btw", .usage = "/btw <question>", .desc = "ask one side question about this conversation — billed, never added, rides the parent cache prefix" },
     .{ .name = "/compact", .desc = "compact history into a fresh context (OpenAI server-side when available)" },
     .{ .name = "/rewind", .usage = "/rewind [n|<snapshot>]", .desc = "list past prompts; /rewind <n> drops prompt n+after & reverts its file edits; /rewind <snapshot id> restores a sandbox filesystem instead, never the conversation" },
     .{ .name = "/snapshot", .usage = "/snapshot [attach [image]|detach|list]", .desc = "capture the attached sandbox's filesystem under .graff/sessions/<session>/snapshots; attach puts this session in a Docker sandbox, list shows what it has captured" },

--- a/src/commands_misc.zig
+++ b/src/commands_misc.zig
@@ -1,7 +1,4 @@
-//! Misc slash commands + the unknown-command/help fallback, split out of
-//! main.zig's handleCommand (600-line goal, issue #123): /todo /jobs /cost
-//! /mcp /models /yolo /trace /fleet /save /resume /sessions, plus the
-//! terminal handleRest() stage (unknown command → error, or /help dump).
+//! Misc slash commands + handleRest() fallback (600-line goal, #123).
 
 const std = @import("std");
 const Io = std.Io;
@@ -45,6 +42,7 @@ test { // main.zig is the test root, so this reference is what runs its tests
 }
 const pricing = @import("pricing.zig");
 const obs = @import("obs.zig");
+const cache_hud = @import("prompt_cache_hud.zig");
 const default_context = pricing.default_context;
 const g_cost = &pricing.g_cost;
 const pricing_db = @import("pricing_db.zig"); // #557: price-DB age for the /models footer
@@ -235,8 +233,8 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
         try out.flush();
         return true;
     }
-    if (std.mem.eql(u8, line, "/debug")) {
-        try obs.renderHud(out);
+    if (std.mem.eql(u8, line, "/debug") or std.mem.eql(u8, line, "/cache")) {
+        if (std.mem.eql(u8, line, "/debug")) try obs.renderHud(out) else try cache_hud.render(out);
         try out.flush();
         return true;
     }
@@ -306,6 +304,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             // Re-render the active catalog so the new tools reach the model;
             // inactive provider formats stay lazy until a later switch.
             root.invalidateRootTools();
+            @import("prompt_cache_hud.zig").noteBust(.mcp);
             try root.ensureRootTools(root.provider.kind);
             root.rebaseContextMeter();
             const persisted = if (is_remote)

--- a/src/commands_model.zig
+++ b/src/commands_model.zig
@@ -1,7 +1,4 @@
-//! Model/provider/thinking slash commands, split out of main.zig's
-//! handleCommand (600-line goal, issue #123): /model /compact /rewind /fast
-//! /thinking /title /ultracode /effort /keepcontext /fallback /key /login /image
-//! /paste /strict.
+//! Model/provider/thinking slash commands (600-line goal, #123).
 
 const std = @import("std");
 const Io = std.Io;

--- a/src/commands_model.zig
+++ b/src/commands_model.zig
@@ -353,6 +353,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             return true;
         };
         root.ultracode_mode = next;
+        @import("prompt_cache_hud.zig").noteBust(.mode);
         const saved = saveThinkingSettings(root.io, root.gpa, root.reasoning, root.fast, root.ultracode_mode, root.show_thinking, root.ai_title);
         try out.print("ultracode mode: {s}{s}\n", .{ if (root.ultracode_mode) "on" else "off", if (saved) "" else " (not persisted)" });
         try out.flush();
@@ -587,6 +588,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
     }
     if (std.mem.eql(u8, line, "/strict")) {
         root.strict = !root.strict;
+        @import("prompt_cache_hud.zig").noteBust(.mode);
         root.rebaseContextMeter();
         try out.print("strict mode {s} — {s}\n", .{
             if (root.strict) "ON" else "off",

--- a/src/compact_note_glue.zig
+++ b/src/compact_note_glue.zig
@@ -91,6 +91,7 @@ pub fn maybeWrite(self: *Agent) Decision {
     // be re-composed to reach the next request — the same refresh a mid-
     // session `/never` performs, and for the same reason.
     prompts.armCompactNotes(self.session_name);
+    @import("prompt_cache_hud.zig").noteBust(.compact);
     playbook_glue.refreshRoot(self, self.arena);
     if (!main_mod.json_mode) self.say("  📝 wrote a pre-compaction note to self ({d} chars)\n", .{reply.len}) catch {};
     if (self.tracer) |tr| tr.note("compact", "wrote a pre-compaction note to self (#391)");

--- a/src/grok_spec_conformance.zig
+++ b/src/grok_spec_conformance.zig
@@ -77,6 +77,17 @@ test "grok spec: Chat Completions x-grok-conv-id is stable for root and isolated
     try std.testing.expectEqualStrings(va, vb);
     try std.testing.expectEqualStrings(child_id, vc);
     try std.testing.expect(!std.mem.eql(u8, va, vc));
+    // grok-build: session-id stays the conversation; conv-id isolates a child.
+    const sa = blk: {
+        for (a) |h| if (std.mem.eql(u8, h.name, "x-grok-session-id")) break :blk h.value;
+        return error.MissingGrokSessionId;
+    };
+    const sc = blk: {
+        for (c) |h| if (std.mem.eql(u8, h.name, "x-grok-session-id")) break :blk h.value;
+        return error.MissingGrokSessionId;
+    };
+    try std.testing.expectEqualStrings(root_id, sa);
+    try std.testing.expectEqualStrings(root_id, sc);
 }
 
 // The !live request path: Agent.request → promptCacheKey → postWatched → post.

--- a/src/grok_spec_conformance.zig
+++ b/src/grok_spec_conformance.zig
@@ -255,3 +255,123 @@ test "grok spec: held xAI WS chains previous_response_id + delta; drop rebuilds 
     try std.testing.expect(std.mem.indexOf(u8, rebuilt, "\"first\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, rebuilt, "third — not yet sent") != null);
 }
+
+// Official xAI prompt-caching contract
+// (docs.x.ai/developers/advanced-api-usage/prompt-caching):
+// Chat always sets x-grok-conv-id; Responses sets prompt_cache_key; same
+// routing id. Cache is an exact messages prefix — append only. Usage is
+// prompt_tokens_details.cached_tokens (Chat) /
+// input_tokens_details.cached_tokens (Responses). xAI must not receive
+// OpenAI prompt_cache_options / prompt_cache_breakpoint (ADR 0009).
+
+test "grok spec: official cache routing — Chat header and Responses body share one id" {
+    const io = std.testing.io;
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var chat = try xaiAgent(a, "main", .openai);
+    var resp = try xaiAgent(a, "main", .responses);
+    var kbuf: [96]u8 = undefined;
+    const key = http_headers.promptCacheKey(io, "main", &resp, &kbuf);
+    try std.testing.expectEqualStrings(http_headers.projectRootId(io), key);
+
+    var hbuf: [12]std.http.Header = undefined;
+    const hdrs = http_headers.providerHeadersWithConv(io, chat.provider, "Bearer k", &hbuf, key);
+    const header = blk: {
+        for (hdrs) |h| if (std.mem.eql(u8, h.name, "x-grok-conv-id")) break :blk h.value;
+        return error.MissingGrokConvId;
+    };
+    try std.testing.expectEqualStrings(key, header);
+
+    const chat_body = try chat.buildBody(null, false, false, false);
+    defer std.testing.allocator.free(chat_body);
+    const resp_body = try resp.buildBody(null, false, false, false);
+    defer std.testing.allocator.free(resp_body);
+    try std.testing.expectEqualStrings(key, cacheKeyIn(resp_body) orelse return error.MissingPromptCacheKey);
+    try std.testing.expectEqualStrings(key, cacheKeyIn(chat_body) orelse return error.MissingPromptCacheKey);
+    try std.testing.expect(std.mem.indexOf(u8, resp_body, "prompt_cache_options") == null);
+    try std.testing.expect(std.mem.indexOf(u8, resp_body, "prompt_cache_breakpoint") == null);
+    try std.testing.expect(std.mem.indexOf(u8, chat_body, "prompt_cache_options") == null);
+}
+
+test "grok spec: official cache is an exact prefix — append keeps it, edit breaks it" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var agent = try xaiAgent(a, "main", .responses);
+    const first = try agent.buildBody(null, false, false, false);
+    defer std.testing.allocator.free(first);
+    try agent.messages.append(try textMessage(a, "assistant", "pong"));
+    try agent.messages.append(try textMessage(a, "user", "next"));
+    const appended = try agent.buildBody(null, false, false, false);
+    defer std.testing.allocator.free(appended);
+    try std.testing.expect(std.mem.indexOf(u8, first, "hello") != null);
+    try std.testing.expect(std.mem.indexOf(u8, appended, "hello") != null);
+    try std.testing.expect(std.mem.indexOf(u8, appended, "next") != null);
+    try std.testing.expectEqualStrings(cacheKeyIn(first).?, cacheKeyIn(appended).?);
+
+    var edited = agent.messages.items[0].object;
+    try edited.put(a, "content", .{ .string = "HELLO-EDITED" });
+    agent.messages.items[0] = .{ .object = edited };
+    const miss = try agent.buildBody(null, false, false, false);
+    defer std.testing.allocator.free(miss);
+    try std.testing.expect(std.mem.indexOf(u8, miss, "hello") == null);
+    try std.testing.expect(std.mem.indexOf(u8, miss, "HELLO-EDITED") != null);
+    try std.testing.expectEqualStrings(cacheKeyIn(first).?, cacheKeyIn(miss).?);
+}
+
+test "grok spec: Chat replays reasoning_content (official top cache-miss cause)" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var agent = try xaiAgent(a, "main", .openai);
+    var asst: std.json.ObjectMap = .empty;
+    try asst.put(a, "role", .{ .string = "assistant" });
+    try asst.put(a, "content", .{ .string = "pong" });
+    try asst.put(a, "reasoning_content", .{ .string = "think-then-pong" });
+    try agent.messages.append(.{ .object = asst });
+    try agent.messages.append(try textMessage(a, "user", "next"));
+    const body = try agent.buildBody(null, false, false, false);
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"reasoning_content\":\"think-then-pong\"") != null);
+}
+
+test "grok spec: official usage fields become last_cache_read" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var agent = try xaiAgent(a, "main", .openai);
+    agent.last_cache_read = 0;
+    agent.last_context_tokens = 0;
+    agent.context_local_tokens = 0;
+    agent.codex_prev_id = null;
+    agent.strict = false;
+    agent.sys_strict = "";
+    agent.tools_openai = "";
+    agent.tools_responses = "";
+
+    var details: std.json.ObjectMap = .empty;
+    try details.put(a, "cached_tokens", .{ .integer = 98 });
+    var usage: std.json.ObjectMap = .empty;
+    try usage.put(a, "prompt_tokens", .{ .integer = 125 });
+    try usage.put(a, "completion_tokens", .{ .integer = 48 });
+    try usage.put(a, "prompt_tokens_details", .{ .object = details });
+    var response: std.json.ObjectMap = .empty;
+    try response.put(a, "usage", .{ .object = usage });
+    @import("agent_context.zig").recordUsage(&agent, response, 400);
+    try std.testing.expectEqual(@as(u64, 98), agent.last_cache_read);
+
+    agent.provider.kind = .responses;
+    agent.last_cache_read = 0;
+    var in_details: std.json.ObjectMap = .empty;
+    try in_details.put(a, "cached_tokens", .{ .integer = 50 });
+    var rusage: std.json.ObjectMap = .empty;
+    try rusage.put(a, "input_tokens", .{ .integer = 125 });
+    try rusage.put(a, "output_tokens", .{ .integer = 48 });
+    try rusage.put(a, "total_tokens", .{ .integer = 173 });
+    try rusage.put(a, "input_tokens_details", .{ .object = in_details });
+    var rresp: std.json.ObjectMap = .empty;
+    try rresp.put(a, "usage", .{ .object = rusage });
+    @import("agent_context.zig").recordUsageResponses(&agent, rresp, 400);
+    try std.testing.expectEqual(@as(u64, 50), agent.last_cache_read);
+}

--- a/src/help.zig
+++ b/src/help.zig
@@ -33,7 +33,7 @@ pub const sections = [_]Section{
     .{ .title = "working autonomously", .names = &.{ "/goal", "/loop", "/review", "/plan", "/todo", "/jobs", "/ultracode", "/strict", "/yolo", "/never" } },
     .{ .title = "talking to other graffs", .names = &.{ "/tell", "/peek" }, .blurb = peers_blurb },
     .{ .title = "your setup", .names = &.{ "/login", "/key", "/cost", "/usage", "/privacy", "/mcp", "/import-claude", "/skills", "/plugins", "/agents", "/hooks", "/tools", "/fleet" } },
-    .{ .title = "context & history", .names = &.{ "/compact", "/btw", "/doctor", "/debug", "/trace", "/trajectory" } },
+    .{ .title = "context & history", .names = &.{ "/compact", "/btw", "/doctor", "/debug", "/cache", "/trace", "/trajectory" } },
     .{ .title = "shell & images", .names = &.{ "/bash", "/image", "/images", "/paste" } },
     .{ .title = "look & feel", .names = &.{ "/theme", "/animation", "/title" } },
     .{ .title = "this list", .names = &.{"/help"} },

--- a/src/http_headers.zig
+++ b/src/http_headers.zig
@@ -53,7 +53,7 @@ pub fn promptCacheKey(io: Io, label: []const u8, agent: *const anyopaque, buf: [
 /// OpenAI's documented ~15 requests/minute cache-routing guidance during fanout.
 pub fn promptPrefixCacheKey(io: Io, label: []const u8, buf: []u8) []const u8 {
     const base = projectRootId(io);
-    if (std.mem.eql(u8, label, "main")) return std.fmt.bufPrint(buf, "{s}", .{base}) catch base;
+    if (std.mem.eql(u8, label, "main") or sharesParentCache(label)) return std.fmt.bufPrint(buf, "{s}", .{base}) catch base;
     const lane = std.hash.Wyhash.hash(0, label) & 3;
     return std.fmt.bufPrint(buf, "{s}-child-{d}", .{ base, lane }) catch base;
 }
@@ -105,9 +105,16 @@ pub fn projectRootId(io: Io) []const u8 {
     return project_id_buf[0..project_id_len];
 }
 
+/// Side-calls that replay the parent history (`/btw`) share the root
+/// partition. Concurrent workers stay isolated. grok-build's recap does the
+/// same: same `prompt_cache_key` as the parent so the prefix stays warm.
+pub fn sharesParentCache(label: []const u8) bool {
+    return std.mem.eql(u8, label, "btw");
+}
+
 pub fn projectCacheKey(io: Io, label: []const u8, agent: *const anyopaque, buf: []u8) []const u8 {
     const base = projectRootId(io);
-    if (std.mem.eql(u8, label, "main")) {
+    if (std.mem.eql(u8, label, "main") or sharesParentCache(label)) {
         if (buf.len >= base.len) {
             @memcpy(buf[0..base.len], base);
             return buf[0..base.len];
@@ -255,6 +262,9 @@ test "project and prefix cache keys preserve conversation and sharing boundaries
     const sub = projectCacheKey(std.testing.io, "sub", agent, &buf3);
     const sibling_sub = projectCacheKey(std.testing.io, "sub", sibling, &buf4);
     try std.testing.expect(!std.mem.eql(u8, sub, sibling_sub));
+
+    var btw_buf: [96]u8 = undefined;
+    try std.testing.expectEqualStrings(a, projectCacheKey(std.testing.io, "btw", sibling, &btw_buf));
 
     // OpenAI/Codex prefix affinity is stable for a workflow role, but spreads
     // different roles over four lanes to stay below the per-key traffic guide.

--- a/src/http_headers.zig
+++ b/src/http_headers.zig
@@ -146,7 +146,7 @@ pub fn providerHeaders(io: Io, provider: Provider, bearer: []const u8, buf: *[12
 }
 
 /// Same as `providerHeaders`, with an explicit conversation id for xAI.
-/// Null falls back to the process session id (one-off posts: title, compact).
+/// Null falls back to `projectRootId` (one-off posts: title, compact).
 pub fn providerHeadersWithConv(io: Io, provider: Provider, bearer: []const u8, buf: *[12]std.http.Header, conv_id: ?[]const u8) []const std.http.Header {
     var count: usize = 0;
     switch (provider.auth) {
@@ -185,7 +185,13 @@ pub fn providerHeadersWithConv(io: Io, provider: Provider, bearer: []const u8, b
         count += 1;
     }
     if (wantsGrokConvId(provider.id)) {
-        buf[count] = .{ .name = "x-grok-conv-id", .value = conv_id orelse projectRootId(io) };
+        const root_id = projectRootId(io);
+        buf[count] = .{ .name = "x-grok-conv-id", .value = conv_id orelse root_id };
+        count += 1;
+        // grok-build always sends session + conv. Session stays the durable
+        // project id so a child partition still routes onto the same server
+        // family; conv-id / prompt_cache_key isolate the prefix itself.
+        buf[count] = .{ .name = "x-grok-session-id", .value = root_id };
         count += 1;
     }
     return buf[0..count];
@@ -267,6 +273,7 @@ test "x-grok-conv-id with no explicit conv still uses the project root id" {
     var buf: [12]std.http.Header = undefined;
     const headers = providerHeadersWithConv(io, xai, "Bearer k", &buf, null);
     try std.testing.expectEqualStrings(projectRootId(io), headerValue(headers, "x-grok-conv-id") orelse return error.MissingGrokConvId);
+    try std.testing.expectEqualStrings(projectRootId(io), headerValue(headers, "x-grok-session-id") orelse return error.MissingGrokSessionId);
 }
 
 test "adoptSessionId validates length and never overwrites a minted id" {
@@ -302,17 +309,21 @@ test "xAI Chat Completions headers carry a stable per-conversation x-grok-conv-i
     var buf: [12]std.http.Header = undefined;
     const first = providerHeadersWithConv(io, xai, "Bearer k", &buf, root_id);
     try std.testing.expectEqualStrings(root_id, headerValue(first, "x-grok-conv-id") orelse return error.MissingGrokConvId);
+    try std.testing.expectEqualStrings(root_id, headerValue(first, "x-grok-session-id") orelse return error.MissingGrokSessionId);
     var buf2: [12]std.http.Header = undefined;
     const second = providerHeadersWithConv(io, xai, "Bearer k", &buf2, root_id);
     try std.testing.expectEqualStrings(root_id, headerValue(second, "x-grok-conv-id").?);
+    try std.testing.expectEqualStrings(root_id, headerValue(second, "x-grok-session-id").?);
     var buf3: [12]std.http.Header = undefined;
     const child_headers = providerHeadersWithConv(io, xai, "Bearer k", &buf3, child_id);
     try std.testing.expectEqualStrings(child_id, headerValue(child_headers, "x-grok-conv-id").?);
+    try std.testing.expectEqualStrings(root_id, headerValue(child_headers, "x-grok-session-id").?);
 
     const anth: Provider = .{ .id = "anthropic", .kind = .anthropic, .auth = .x_api_key, .url = "", .api_key = "k", .model = "claude", .context = 200_000 };
     var abuf: [12]std.http.Header = undefined;
     const ah = providerHeadersWithConv(io, anth, "", &abuf, root_id);
     try std.testing.expect(headerValue(ah, "x-grok-conv-id") == null);
+    try std.testing.expect(headerValue(ah, "x-grok-session-id") == null);
 }
 
 test "xai login tokens send X-XAI-Token-Auth; API keys do not" {

--- a/src/json_controls.zig
+++ b/src/json_controls.zig
@@ -24,7 +24,7 @@ const side_question = @import("side_question.zig");
 pub fn sideQuestion(root: *Agent, arena: Allocator, rtype: []const u8, text: []const u8) bool {
     if (!std.mem.eql(u8, rtype, "btw")) return false;
     if (side_question.ask(root, arena, text)) |answer| {
-        root.emit(.{ .type = "btw", .ok = true, .text = answer, .persisted = false });
+        root.emit(.{ .type = "btw", .ok = true, .text = answer.text, .persisted = false, .cache_read_tokens = answer.cache_read });
     } else {
         root.emit(.{ .type = "error", .message = "side question failed; the conversation is unchanged" });
     }

--- a/src/mainloop.zig
+++ b/src/mainloop.zig
@@ -216,7 +216,7 @@ pub fn run(ctx: *Ctx) !void {
                 const id = if (parsed.object.get("id")) |v| (if (v == .string) v.string else "") else "";
                 if (id.len == 0) {
                     @import("prompt_cache_hud.zig").noteBust(.persona);
-                try prompts.setSystemPrompts(ctx.root, ctx.sys_normal, ctx.arena); // #326: reset to the startup base, all four variants
+                    try prompts.setSystemPrompts(ctx.root, ctx.sys_normal, ctx.arena); // #326: reset to the startup base, all four variants
                     ctx.root.rebaseContextMeter();
                     ctx.root.emit(.{ .type = "agent", .ok = true, .id = id, .chars = ctx.root.sys_normal.len });
                     continue;

--- a/src/mainloop.zig
+++ b/src/mainloop.zig
@@ -285,7 +285,7 @@ pub fn run(ctx: *Ctx) !void {
             }
             if (std.mem.eql(u8, rtype, "review")) review_prompt = text;
             // #415: a side question is ANSWERED here and never becomes a turn —
-            // no tools, billed, and nothing added to the session or its transcript.
+            // billed, parent-prefix cached, nothing added to the session.
             if (json_controls.sideQuestion(ctx.root, ctx.arena, rtype, text)) continue;
             json_controls.applyToolKnobs(parsed.object);
             break :blk text;

--- a/src/mainloop.zig
+++ b/src/mainloop.zig
@@ -1,5 +1,4 @@
-//! Root interactive/JSON event loop. `main` owns setup and storage; `Ctx` holds
-//! borrowed pointers valid until `run` returns for final session cleanup.
+//! Root interactive/JSON event loop. `main` owns setup; `Ctx` is borrowed until `run` returns.
 
 const std = @import("std");
 const Io = std.Io;
@@ -26,7 +25,7 @@ const goal_state = @import("goal_state.zig");
 const goal_flow = @import("goal_flow.zig");
 const goal_pacing = @import("goal_pacing.zig");
 const eval_memory = @import("eval_memory.zig");
-const json_controls = @import("json_controls.zig"); // #415: the --json controls that never become a turn
+const json_controls = @import("json_controls.zig");
 const json_inbox = @import("json_inbox.zig");
 const mainloop_score = @import("mainloop_score.zig");
 const mainloop_trace = @import("mainloop_trace.zig");
@@ -73,7 +72,6 @@ pub fn run(ctx: *Ctx) !void {
     // Trajectory spine: each turn's parent is the previous; a changed prompt fingerprint marks a set_system_prompt edge.
     var prev_turn_id: u64 = 0;
     var prev_prompt_fp: [16]u8 = scoring.promptFingerprint(ctx.root.systemPrompt());
-
     // Armed only after a clean /loop turn and consumed by the next read (#226).
     const loop_iter_cap: u32 = 25; // hard per-/loop iteration bound (never-completing-model guard)
     var loop_iters_left: u32 = 0; // continuation turns still authorized this /loop run
@@ -217,7 +215,8 @@ pub fn run(ctx: *Ctx) !void {
             if (std.mem.eql(u8, rtype, "set_agent")) {
                 const id = if (parsed.object.get("id")) |v| (if (v == .string) v.string else "") else "";
                 if (id.len == 0) {
-                    try prompts.setSystemPrompts(ctx.root, ctx.sys_normal, ctx.arena); // #326: reset to the startup base, all four variants
+                    @import("prompt_cache_hud.zig").noteBust(.persona);
+                try prompts.setSystemPrompts(ctx.root, ctx.sys_normal, ctx.arena); // #326: reset to the startup base, all four variants
                     ctx.root.rebaseContextMeter();
                     ctx.root.emit(.{ .type = "agent", .ok = true, .id = id, .chars = ctx.root.sys_normal.len });
                     continue;
@@ -228,6 +227,7 @@ pub fn run(ctx: *Ctx) !void {
                     continue;
                 };
                 const persona_base = try std.fmt.allocPrint(ctx.arena, "{s}\n\n{s}", .{ ctx.sys_normal, prompt });
+                @import("prompt_cache_hud.zig").noteBust(.persona);
                 try prompts.setSystemPrompts(ctx.root, persona_base, ctx.arena); // #326: recomputes strict + ultra too
                 ctx.root.rebaseContextMeter();
                 ctx.root.emit(.{ .type = "agent", .ok = true, .id = id, .chars = ctx.root.sys_normal.len });
@@ -277,6 +277,7 @@ pub fn run(ctx: *Ctx) !void {
                     try std.fmt.allocPrint(ctx.arena, "{s}\n\n{s}", .{ ctx.root.sys_normal, text })
                 else
                     try ctx.arena.dupe(u8, text);
+                @import("prompt_cache_hud.zig").noteBust(.persona);
                 try prompts.setSystemPrompts(ctx.root, new_base, ctx.arena); // #326: recomputes strict + ultra too
                 ctx.root.rebaseContextMeter();
                 ctx.root.emit(.{ .type = "system_prompt", .ok = true, .append = append, .chars = ctx.root.sys_normal.len });

--- a/src/obs.zig
+++ b/src/obs.zig
@@ -333,6 +333,7 @@ pub fn renderHud(w: *Io.Writer) !void {
             try w.writeByte('\n');
         }
     }
+    try @import("prompt_cache_hud.zig").renderLine(w);
     try w.writeAll("  last events\n");
     var recs: [ring_cap]Record = undefined;
     const n = recent(&recs);
@@ -456,13 +457,14 @@ test "note: session and prompt never store paths or prompt text" {
     try std.testing.expectEqual(EventName.user_prompt, recs[1].name);
     try std.testing.expectEqualStrings("grok-4", recs[1].modelSlice());
     try std.testing.expectEqual(@as(u32, 7), recs[1].prompt_len);
-    var buf: [1024]u8 = undefined;
+    var buf: [2048]u8 = undefined;
     var w: Io.Writer = .fixed(&buf);
     try renderHud(&w);
     const text = w.buffered();
     try std.testing.expect(!contains(text, "/Users/secret"));
     try std.testing.expect(!contains(text, "traces/x"));
     try std.testing.expect(contains(text, "session_start"));
+    try std.testing.expect(contains(text, "cache"));
 }
 
 test "note: tool decision and result stay content-free" {
@@ -492,7 +494,7 @@ test "note: tool decision and result stay content-free" {
     try std.testing.expectEqual(@as(u64, 1), s.decisions_allow);
     try std.testing.expectEqual(@as(u64, 1), s.decisions_deny);
     try std.testing.expectEqual(@as(u64, 1), s.tool_calls);
-    var buf: [1024]u8 = undefined;
+    var buf: [2048]u8 = undefined;
     var w: Io.Writer = .fixed(&buf);
     try renderHud(&w);
     const text = w.buffered();

--- a/src/obs_cost_test.zig
+++ b/src/obs_cost_test.zig
@@ -66,6 +66,7 @@ test "usage/debug match the cost-tally renderer and add turn/decision extras" {
     try std.testing.expect(contains(usage, cost));
     try std.testing.expect(contains(debug, cost));
     try std.testing.expect(contains(debug, "turns"));
+    try std.testing.expect(contains(debug, "cache"));
     try std.testing.expect(contains(debug, "deny"));
     try std.testing.expect(contains(debug, "completed"));
     try std.testing.expect(!contains(usage, "chars sent"));

--- a/src/playbook_glue.zig
+++ b/src/playbook_glue.zig
@@ -65,6 +65,7 @@ pub fn noteConstraint(agent: *Agent, input: std.json.Value) ExecResult {
         // retrying or apologising for a ledger that is already correct.
         .is_error = !std.mem.eql(u8, r.reason, "already recorded (same normalized text)"),
     };
+    @import("prompt_cache_hud.zig").noteBust(.playbook);
     refreshRoot(agent, agent.arena);
     agent.say("  {s}⛔ constraint recorded ({s}){s} {s}\n", .{ style.yellow, r.id, style.reset, text }) catch {};
     return .{ .text = std.fmt.allocPrint(agent.arena, "constraint recorded as {s}. It is now in {s} and rides every subagent, workflow and pipeline brief from here on, in this session and in later ones — you do not need to restate it.", .{ r.id, playbook.path }) catch "constraint recorded", .is_error = false };
@@ -102,6 +103,7 @@ pub fn command(root: *Agent, arena: Allocator, line: []const u8, out: *Io.Writer
     if (std.mem.startsWith(u8, arg, "rm ") or std.mem.startsWith(u8, arg, "remove ")) {
         const id = std.mem.trim(u8, arg[if (arg[0] == 'r' and arg[1] == 'm') 3 else 7..], " \t");
         if (playbook.retire(root.io, arena, id)) {
+            @import("prompt_cache_hud.zig").noteBust(.playbook);
             refreshRoot(root, arena);
             try out.print("retired {s} — it no longer rides new briefs (the record stays in the log as a tombstone)\n", .{id});
         } else try out.print("no live playbook item with id '{s}' — /never lists them\n", .{id});
@@ -112,6 +114,7 @@ pub fn command(root: *Agent, arena: Allocator, line: []const u8, out: *Io.Writer
     const provenance = std.fmt.bufPrint(&prov_buf, "user:{d}", .{@import("util.zig").unixMs(root.io)}) catch "user";
     const r = playbook.add(root.io, arena, arg, .user, provenance);
     if (r.ok) {
+        @import("prompt_cache_hud.zig").noteBust(.playbook);
         refreshRoot(root, arena);
         try out.print("{s}⛔ recorded {s}{s} — this now rides every brief, in this session and later ones\n", .{ style.yellow, r.id, style.reset });
     } else try out.print("not recorded: {s}\n", .{r.reason});

--- a/src/prompt_cache_hud.zig
+++ b/src/prompt_cache_hud.zig
@@ -1,0 +1,309 @@
+//! Content-free prompt-cache posture: `/cache` and a one-line `/debug` row.
+//!
+//! Stores lengths, a prefix hash, and named bust reasons — never prompt text,
+//! paths, or tool bodies. Codex's rule is still the product rule: the old
+//! prompt must be an exact prefix of the new one. This module is how you see
+//! whether this session is still earning that.
+
+const std = @import("std");
+const Io = std.Io;
+
+const pricing = @import("pricing.zig");
+const mcp_schema_gate = @import("mcp_schema_gate.zig");
+
+pub const Bust = enum {
+    none,
+    start,
+    goal,
+    playbook,
+    compact,
+    transcript,
+    persona,
+    tools,
+    mcp,
+    mode,
+    other,
+};
+
+pub const Snap = struct {
+    prefix: u32 = 0,
+    prev: u32 = 0,
+    sys_bytes: u32 = 0,
+    tools_bytes: u32 = 0,
+    same: bool = true,
+    requests: u32 = 0,
+    busts: u32 = 0,
+    last_bust: Bust = .none,
+    last_read: u64 = 0,
+    last_write: u64 = 0,
+};
+
+var lock: std.atomic.Value(bool) = .init(false);
+var snap: Snap = .{};
+var pending: Bust = .none;
+var g_io: ?Io = null;
+
+fn acquire() void {
+    while (lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) std.atomic.spinLoopHint();
+}
+fn release() void {
+    lock.store(false, .release);
+}
+
+pub fn reset() void {
+    acquire();
+    defer release();
+    snap = .{};
+    pending = .none;
+    g_io = null;
+}
+
+pub fn snapshot() Snap {
+    acquire();
+    defer release();
+    return snap;
+}
+
+/// Hash of the bytes the provider prefixes. First 32 bits of SHA-256 — enough
+/// to see a change, not enough to recover the prompt.
+pub fn prefixHash(system: []const u8, tools: []const u8) u32 {
+    var digest: [32]u8 = undefined;
+    var h = std.crypto.hash.sha2.Sha256.init(.{});
+    h.update(system);
+    h.update("\x1e");
+    h.update(tools);
+    h.final(&digest);
+    return std.mem.readInt(u32, digest[0..4], .big);
+}
+
+/// Startup compose is not a bust. After the first request, a named reason
+/// waits for the next `noteRequest` and only counts if the hash actually moved.
+pub fn noteBust(reason: Bust) void {
+    acquire();
+    defer release();
+    if (snap.requests == 0) return;
+    pending = reason;
+}
+
+pub fn noteUsage(read: u64, write: u64) void {
+    acquire();
+    defer release();
+    snap.last_read = read;
+    snap.last_write = write;
+}
+
+pub fn noteRequest(io: Io, system: []const u8, tools: []const u8) void {
+    const hash = prefixHash(system, tools);
+    acquire();
+    defer release();
+    g_io = io;
+    const prev = snap.prefix;
+    const had = snap.requests > 0;
+    const changed = had and hash != prev;
+    if (changed) {
+        snap.busts += 1;
+        snap.last_bust = if (pending != .none) pending else .other;
+    } else if (!had) {
+        snap.last_bust = .start;
+    }
+    pending = .none;
+    snap.prev = prev;
+    snap.prefix = hash;
+    snap.sys_bytes = std.math.cast(u32, system.len) orelse std.math.maxInt(u32);
+    snap.tools_bytes = std.math.cast(u32, tools.len) orelse std.math.maxInt(u32);
+    snap.same = !changed;
+    snap.requests += 1;
+}
+
+pub fn bustLabel(b: Bust) []const u8 {
+    return switch (b) {
+        .none => "none",
+        .start => "start",
+        .goal => "goal",
+        .playbook => "playbook",
+        .compact => "compact",
+        .transcript => "transcript",
+        .persona => "persona",
+        .tools => "tools",
+        .mcp => "mcp",
+        .mode => "mode",
+        .other => "other",
+    };
+}
+
+fn kib(n: u32) u32 {
+    return n / 1024;
+}
+
+fn hitPct(cached: u64, billed_in: u64) u64 {
+    const den = billed_in +| cached;
+    if (den == 0) return 0;
+    return @min((cached *| 100) / den, 100);
+}
+
+/// One row for `/debug`. Content-free.
+pub fn renderLine(w: *Io.Writer) !void {
+    const s = snapshot();
+    if (s.requests == 0) {
+        try w.writeAll("  cache      (no API call yet — /cache shows the remaining max levers)\n");
+        return;
+    }
+    try w.print("  cache      {d}% hit · prefix {s} · {d} bust{s}", .{
+        sessionHitPct(),
+        if (s.same) "same" else "changed",
+        s.busts,
+        if (s.busts == 1) "" else "s",
+    });
+    if (s.busts > 0) try w.print(" ({s})", .{bustLabel(s.last_bust)});
+    try w.writeByte('\n');
+}
+
+/// The `/cache` HUD: current posture plus the remaining product levers.
+pub fn render(w: *Io.Writer) !void {
+    const s = snapshot();
+    try w.writeAll("prompt cache\n");
+    if (s.requests == 0) {
+        try w.writeAll("  prefix     (no request yet)\n");
+    } else {
+        try w.print("  prefix     {x:0>8}  (sys {d}kB · tools {d}kB)  {s}\n", .{
+            s.prefix,
+            kib(s.sys_bytes),
+            kib(s.tools_bytes),
+            if (s.same) "same" else "changed",
+        });
+        try w.print("  last       {d} read · {d} write\n", .{ s.last_read, s.last_write });
+        try w.print("  session    {d}% hit", .{sessionHitPct()});
+        if (g_io) |io| {
+            const c = pricing.g_cost.snap(io);
+            try w.print("  ({d} cached / {d} in) · {d} writes", .{
+                c.cache_tokens, c.in_tokens +| c.cache_tokens, c.cache_write_tokens,
+            });
+        }
+        try w.writeByte('\n');
+        try w.print("  busts      {d}  last: {s}\n", .{ s.busts, bustLabel(s.last_bust) });
+    }
+    try w.print("  catalog    {s}\n", .{if (mcp_schema_gate.g_stable_catalog) "stable (loads append tail only)" else "mutating (a load rewrites tools JSON)"});
+    try w.writeAll(
+        \\  remaining max
+        \\    GRAFF_STABLE_CATALOG=1  opt-in: keep tools JSON byte-identical after load
+        \\    /goal /never /strict    each prefix rewrite is one miss; compaction already pays one
+        \\    leave skill bodies      and file: paths out of the prefix (already the default)
+        \\
+    );
+}
+
+fn sessionHitPct() u64 {
+    const io = g_io orelse return 0;
+    const c = pricing.g_cost.snap(io);
+    return hitPct(c.cache_tokens, c.in_tokens);
+}
+
+fn contains(hay: []const u8, needle: []const u8) bool {
+    return std.mem.indexOf(u8, hay, needle) != null;
+}
+
+test "first prefix is start, not a bust" {
+    reset();
+    defer reset();
+    noteRequest(std.testing.io, "system", "[]");
+    const s = snapshot();
+    try std.testing.expectEqual(@as(u32, 1), s.requests);
+    try std.testing.expectEqual(@as(u32, 0), s.busts);
+    try std.testing.expectEqual(Bust.start, s.last_bust);
+    try std.testing.expect(s.same);
+}
+
+test "identical prefix stays same" {
+    reset();
+    defer reset();
+    noteRequest(std.testing.io, "system", "[]");
+    const first = snapshot().prefix;
+    noteRequest(std.testing.io, "system", "[]");
+    const s = snapshot();
+    try std.testing.expectEqual(first, s.prefix);
+    try std.testing.expectEqual(@as(u32, 0), s.busts);
+    try std.testing.expect(s.same);
+}
+
+test "changed prefix without a named reason is other" {
+    reset();
+    defer reset();
+    noteRequest(std.testing.io, "system", "[]");
+    noteRequest(std.testing.io, "system-b", "[]");
+    const s = snapshot();
+    try std.testing.expectEqual(@as(u32, 1), s.busts);
+    try std.testing.expectEqual(Bust.other, s.last_bust);
+    try std.testing.expect(!s.same);
+}
+
+test "named bust waits for a real hash change" {
+    reset();
+    defer reset();
+    noteRequest(std.testing.io, "system", "[]");
+    noteBust(.goal);
+    noteRequest(std.testing.io, "system", "[]");
+    try std.testing.expectEqual(@as(u32, 0), snapshot().busts);
+    noteBust(.playbook);
+    noteRequest(std.testing.io, "system-2", "[]");
+    const s = snapshot();
+    try std.testing.expectEqual(@as(u32, 1), s.busts);
+    try std.testing.expectEqual(Bust.playbook, s.last_bust);
+}
+
+test "startup noteBust is ignored" {
+    reset();
+    defer reset();
+    noteBust(.persona);
+    noteRequest(std.testing.io, "system", "[]");
+    try std.testing.expectEqual(@as(u32, 0), snapshot().busts);
+    try std.testing.expectEqual(Bust.start, snapshot().last_bust);
+}
+
+test "render stays content-free and names remaining levers" {
+    reset();
+    defer reset();
+    noteRequest(std.testing.io, "SECRET-PROMPT /Users/me/repo", "[{\"name\":\"bash\"}]");
+    noteUsage(6002, 0);
+    var buf: [2048]u8 = undefined;
+    var w: Io.Writer = .fixed(&buf);
+    try render(&w);
+    const text = w.buffered();
+    try std.testing.expect(contains(text, "prompt cache"));
+    try std.testing.expect(contains(text, "prefix"));
+    try std.testing.expect(contains(text, "GRAFF_STABLE_CATALOG"));
+    try std.testing.expect(contains(text, "/goal"));
+    try std.testing.expect(!contains(text, "SECRET-PROMPT"));
+    try std.testing.expect(!contains(text, "/Users/me"));
+    try std.testing.expect(!contains(text, "bash"));
+}
+
+test "renderLine is one content-free row" {
+    reset();
+    defer reset();
+    var empty_buf: [256]u8 = undefined;
+    var empty_w: Io.Writer = .fixed(&empty_buf);
+    try renderLine(&empty_w);
+    try std.testing.expect(contains(empty_w.buffered(), "no API call"));
+
+    noteRequest(std.testing.io, "system", "[]");
+    noteRequest(std.testing.io, "system-2", "[]");
+    var buf: [256]u8 = undefined;
+    var w: Io.Writer = .fixed(&buf);
+    try renderLine(&w);
+    const text = w.buffered();
+    try std.testing.expect(contains(text, "cache"));
+    try std.testing.expect(contains(text, "changed"));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, text, "\n"));
+}
+
+test "hitPct saturates and handles zero" {
+    try std.testing.expectEqual(@as(u64, 0), hitPct(0, 0));
+    try std.testing.expectEqual(@as(u64, 50), hitPct(50, 50));
+    try std.testing.expectEqual(@as(u64, 100), hitPct(200, 0));
+}
+
+test "bustLabel covers every tag" {
+    try std.testing.expectEqualStrings("goal", bustLabel(.goal));
+    try std.testing.expectEqualStrings("tools", bustLabel(.tools));
+    try std.testing.expectEqualStrings("start", bustLabel(.start));
+}

--- a/src/prompt_cache_hud.zig
+++ b/src/prompt_cache_hud.zig
@@ -216,6 +216,7 @@ pub fn render(w: *Io.Writer) !void {
         \\    leave skill bodies      and file: paths out of the prefix (already the default)
         \\    append-only messages    official xAI prefix; edit/remove/reorder is a miss
         \\    replay reasoning        Chat reasoning_content · Responses encrypted_content
+        \\    /btw                    parent tools + system + cache key; note is the user message
         \\
     );
 }

--- a/src/prompt_cache_hud.zig
+++ b/src/prompt_cache_hud.zig
@@ -205,9 +205,9 @@ pub fn render(w: *Io.Writer) !void {
     if (g_xai and g_aff_len > 0) {
         try w.print("  xAI        {s}  (automatic prefix cache)\n", .{if (g_responses) "responses" else "chat"});
         try w.print("  affinity   {s}\n", .{g_aff[0..g_aff_len]});
-        try w.writeAll("             x-grok-conv-id + prompt_cache_key, same value\n");
+        try w.writeAll("             x-grok-conv-id + x-grok-session-id + prompt_cache_key\n");
     } else {
-        try w.writeAll("  xAI        x-grok-conv-id + prompt_cache_key (same project id, automatic)\n");
+        try w.writeAll("  xAI        x-grok-conv-id + x-grok-session-id + prompt_cache_key\n");
     }
     try w.writeAll(
         \\  remaining max

--- a/src/prompt_cache_hud.zig
+++ b/src/prompt_cache_hud.zig
@@ -42,6 +42,10 @@ var lock: std.atomic.Value(bool) = .init(false);
 var snap: Snap = .{};
 var pending: Bust = .none;
 var g_io: ?Io = null;
+var g_aff: [64]u8 = undefined;
+var g_aff_len: usize = 0;
+var g_xai: bool = false;
+var g_responses: bool = false;
 
 fn acquire() void {
     while (lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) std.atomic.spinLoopHint();
@@ -56,6 +60,9 @@ pub fn reset() void {
     snap = .{};
     pending = .none;
     g_io = null;
+    g_aff_len = 0;
+    g_xai = false;
+    g_responses = false;
 }
 
 pub fn snapshot() Snap {
@@ -113,6 +120,18 @@ pub fn noteRequest(io: Io, system: []const u8, tools: []const u8) void {
     snap.tools_bytes = std.math.cast(u32, tools.len) orelse std.math.maxInt(u32);
     snap.same = !changed;
     snap.requests += 1;
+}
+
+/// Content-free xAI routing id (`x-grok-conv-id` / `prompt_cache_key`).
+/// Official docs: same value on Chat header and Responses body.
+pub fn noteAffinity(key: []const u8, xai: bool, responses: bool) void {
+    acquire();
+    defer release();
+    g_xai = xai;
+    g_responses = responses;
+    const n = @min(key.len, g_aff.len);
+    @memcpy(g_aff[0..n], key[0..n]);
+    g_aff_len = n;
 }
 
 pub fn bustLabel(b: Bust) []const u8 {
@@ -183,11 +202,20 @@ pub fn render(w: *Io.Writer) !void {
         try w.print("  busts      {d}  last: {s}\n", .{ s.busts, bustLabel(s.last_bust) });
     }
     try w.print("  catalog    {s}\n", .{if (mcp_schema_gate.g_stable_catalog) "stable (loads append tail only)" else "mutating (a load rewrites tools JSON)"});
+    if (g_xai and g_aff_len > 0) {
+        try w.print("  xAI        {s}  (automatic prefix cache)\n", .{if (g_responses) "responses" else "chat"});
+        try w.print("  affinity   {s}\n", .{g_aff[0..g_aff_len]});
+        try w.writeAll("             x-grok-conv-id + prompt_cache_key, same value\n");
+    } else {
+        try w.writeAll("  xAI        x-grok-conv-id + prompt_cache_key (same project id, automatic)\n");
+    }
     try w.writeAll(
         \\  remaining max
         \\    GRAFF_STABLE_CATALOG=1  opt-in: keep tools JSON byte-identical after load
         \\    /goal /never /strict    each prefix rewrite is one miss; compaction already pays one
         \\    leave skill bodies      and file: paths out of the prefix (already the default)
+        \\    append-only messages    official xAI prefix; edit/remove/reorder is a miss
+        \\    replay reasoning        Chat reasoning_content · Responses encrypted_content
         \\
     );
 }
@@ -272,9 +300,26 @@ test "render stays content-free and names remaining levers" {
     try std.testing.expect(contains(text, "prefix"));
     try std.testing.expect(contains(text, "GRAFF_STABLE_CATALOG"));
     try std.testing.expect(contains(text, "/goal"));
+    try std.testing.expect(contains(text, "x-grok-conv-id"));
+    try std.testing.expect(contains(text, "append-only"));
     try std.testing.expect(!contains(text, "SECRET-PROMPT"));
     try std.testing.expect(!contains(text, "/Users/me"));
     try std.testing.expect(!contains(text, "bash"));
+}
+
+test "render shows xAI affinity without prompt text" {
+    reset();
+    defer reset();
+    noteRequest(std.testing.io, "SECRET-PROMPT", "[]");
+    noteAffinity("b79ad29b-b3f9-463c-bca6-041d5058d366", true, true);
+    var buf: [2048]u8 = undefined;
+    var w: Io.Writer = .fixed(&buf);
+    try render(&w);
+    const text = w.buffered();
+    try std.testing.expect(contains(text, "responses"));
+    try std.testing.expect(contains(text, "b79ad29b-b3f9-463c-bca6-041d5058d366"));
+    try std.testing.expect(contains(text, "prompt_cache_key"));
+    try std.testing.expect(!contains(text, "SECRET-PROMPT"));
 }
 
 test "renderLine is one content-free row" {

--- a/src/prompts.zig
+++ b/src/prompts.zig
@@ -340,6 +340,7 @@ pub fn pinStandingGoal(agent: *Agent, arena: Allocator) void {
         }
     }
     if (agent.sys_base.len == 0) return;
+    @import("prompt_cache_hud.zig").noteBust(.goal);
     setSystemPrompts(agent, agent.sys_base, arena) catch {};
 }
 

--- a/src/repl_model_commands.zig
+++ b/src/repl_model_commands.zig
@@ -113,8 +113,8 @@ pub fn runCommand(self: *Model, line: []const u8) void {
         self.push(.info, "hooks run around the agent loop, not the chat repl") catch {};
     } else if (std.mem.eql(u8, cmd, "/loop")) {
         self.push(.info, "`/loop` schedules repeated runs in the main session, not the chat repl") catch {};
-    } else if (eqlAny(cmd, &.{ "/trace", "/trajectory" })) {
-        self.push(.info, "trace/trajectory logging is a main-session feature") catch {};
+    } else if (eqlAny(cmd, &.{ "/trace", "/trajectory", "/cache" })) {
+        self.push(.info, "trace/trajectory/cache logging is a main-session feature") catch {};
     } else if (eqlAny(cmd, &.{ "/save", "/resume", "/sessions", "/workspace", "/ws", "/plugins" })) {
         self.push(.info, "the chat repl is ephemeral — session save/resume/list/workspace/plugins lives in the main `graff` session") catch {};
     } else if (std.mem.eql(u8, cmd, "/images")) {

--- a/src/session_start.zig
+++ b/src/session_start.zig
@@ -345,6 +345,7 @@ pub fn initTelemetry(io: Io, gpa: Allocator, client: *std.http.Client, environ_m
             default_telemetry_endpoint;
     const telem_home = keys_cli.homeEnv(environ_map) orelse "";
     obs.reset();
+    @import("prompt_cache_hud.zig").reset();
     obs.attach(io);
     obs.export_endpoint = telem_endpoint;
     return .{

--- a/src/side_question.zig
+++ b/src/side_question.zig
@@ -1,5 +1,6 @@
 //! #415 — `/btw`: a throwaway side question, answered from the LIVE
-//! conversation with tools disabled, rendered once, and then dropped.
+//! conversation, rendered once, and then dropped. Tools stay on the wire
+//! so the parent prompt-cache prefix hits; they are not executed.
 //!
 //! THE POINT. "what did that error actually mean?" is a question ABOUT the work
 //! in progress, not a step of it. Asking it the ordinary way costs the session
@@ -25,11 +26,12 @@
 //! agent's messages live in an arena the root holds no pointer to, and its
 //! `sub = true` makes `record` refuse it outright at the first line.
 //!
-//! NO TOOLS, GENUINELY. `Agent.request(null)` omits the `tools` field from the
-//! body entirely rather than sending an empty array, for all three wire
-//! formats — the same trick compaction and the title task use. `text_only` is
-//! set too, so the agent stays tool-less if it is ever driven through
-//! `runTurn` instead.
+//! PARENT PREFIX, grok-build side-call shape. The request keeps the root
+//! system prompt, the root tools JSON, and the root `prompt_cache_key` so
+//! the provider's prefix cache stays warm. The side-question note is a new
+//! user message (append-only), not a system rewrite. `text_only` stays set
+//! so `runTurn` cannot execute a tool if the model ignores the note; `ask`
+//! is still a single `request`, so a tool call is never run.
 //!
 //! IT IS STILL BILLED. The request goes through `Agent.request` like any
 //! other, so recordUsage/recordCost bank it in `pricing.g_cost` — the tally the
@@ -57,11 +59,11 @@ pub const output_limit: u32 = 1024;
 /// Shown when `/btw` arrives with nothing to ask. Says what the command is for,
 /// because an empty one is nearly always a half-typed line.
 pub const usage_hint = "/btw <question> — ask one side question about this conversation; " ++
-    "it runs with no tools and is never added to the session";
+    "it rides the parent cache prefix and is never added to the session";
 
-/// Appended to the ROOT's own system prompt for this one call. The model keeps
-/// its identity and its project context — the question is about the work in
-/// front of it — and is told the two things that are only true here.
+/// Appended as a USER message (not a system rewrite) so the cached prefix
+/// stays byte-identical. The model is told the two things that are only true
+/// here; tools stay on the wire for the prefix and must not be used.
 pub const side_note =
     \\[side question: the user has asked something ALONGSIDE the conversation
     \\above, not as the next step of it. Answer it from what is already in this
@@ -99,7 +101,8 @@ pub fn questionFromLine(line: []const u8) ?[]const u8 {
 /// allocate out of the session's.
 pub fn build(self: *Agent, arena: Allocator, question: []const u8) !Agent {
     var messages = try agent_compact.cloneJsonArray(arena, self.messages);
-    try messages.append(try textMessage(arena, "user", question));
+    const asked = try std.fmt.allocPrint(arena, "{s}\n\n{s}", .{ side_note, question });
+    try messages.append(try textMessage(arena, "user", asked));
     return .{
         .gpa = self.gpa,
         .arena = arena,
@@ -108,8 +111,8 @@ pub fn build(self: *Agent, arena: Allocator, question: []const u8) !Agent {
         .provider = self.provider,
         .messages = messages,
         .sub = true, // never touches stdout, the root's state, or the transcript
-        .text_only = true, // and could not be handed tools even through runTurn
-        .label = "btw",
+        .text_only = true, // runTurn must not execute a tool if the model ignores the note
+        .label = "btw", // shares the root prompt_cache_key (http_headers.sharesParentCache)
         .out = null,
         .tracer = self.tracer,
         .run_budget = self.run_budget,
@@ -119,26 +122,38 @@ pub fn build(self: *Agent, arena: Allocator, question: []const u8) !Agent {
         .call_kind = .judge, // an auxiliary, bounded, non-recursive call
         .responses_output_limit = output_limit,
         .message_mutation_arena = arena,
-        .sys_override = try std.fmt.allocPrint(arena, "{s}\n\n{s}", .{ self.systemPrompt(), side_note }),
+        .sys_override = self.systemPrompt(), // exact parent prefix; note is the user message
+        .tools_anthropic = self.tools_anthropic,
+        .tools_openai = self.tools_openai,
+        .tools_responses = self.tools_responses,
     };
 }
 
-/// One tool-less request over a clone of the live history. The answer is duped
-/// into `out_arena` (the caller's turn arena, not the session's) and everything
-/// else — the clone, the reply tree, the side agent — dies with the scratch
-/// arena before this returns. Null on any failure: a side question that could
-/// not be answered must still leave the conversation exactly as it found it.
-pub fn ask(self: *Agent, out_arena: Allocator, question: []const u8) ?[]const u8 {
+pub const Reply = struct {
+    text: []const u8,
+    cache_read: u64,
+};
+
+/// One request over a clone of the live history, parent tools on the wire.
+/// The answer is duped into `out_arena` (the caller's turn arena, not the
+/// session's) and everything else dies with the scratch arena. Null on any
+/// failure: a side question that could not be answered must still leave the
+/// conversation exactly as it found it.
+pub fn ask(self: *Agent, out_arena: Allocator, question: []const u8) ?Reply {
     var arena_state = std.heap.ArenaAllocator.init(self.gpa);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
     var agent = build(self, arena, question) catch return null;
     defer agent.tools_used.deinit(self.gpa);
     defer agent.closeCodexWs(); // its own socket + response-id anchor, gpa-owned
-    const root = agent.request(null) catch return null;
+    const tools = self.toolsJson();
+    const root = agent.request(if (tools.len > 0) tools else null) catch return null;
     const text = std.mem.trim(u8, title.assistantText(self.provider.kind, root), " \t\r\n");
     if (text.len == 0) return null;
-    return out_arena.dupe(u8, text) catch null;
+    return .{
+        .text = out_arena.dupe(u8, text) catch return null,
+        .cache_read = agent.last_cache_read,
+    };
 }
 
 /// The `/btw` slash command. Returns false when `line` is not one, so it can sit
@@ -157,7 +172,9 @@ pub fn command(root: *Agent, arena: Allocator, line: []const u8, out: *Io.Writer
         try out.flush();
         return true;
     };
-    try out.print("{s}\n{s}(side question — not added to this session){s}\n", .{ answer, style.dim, style.reset });
+    try out.print("{s}\n{s}(side question — not added · {d} cached){s}\n", .{
+        answer.text, style.dim, answer.cache_read, style.reset,
+    });
     try out.flush();
     return true;
 }

--- a/src/side_question_tests.zig
+++ b/src/side_question_tests.zig
@@ -76,40 +76,67 @@ fn serialize(arena: Allocator, msgs: std.json.Array) ![]const u8 {
     return aw.writer.buffered();
 }
 
-test "/btw (#415): the side request carries the live context and the question, with NO tools" {
+test "/btw (#415): the side request is the parent prefix plus an appended user note" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    // Every wire format, because "no tools" is written three times in buildBody
-    // and a fourth caller getting one of them wrong is exactly how a `/btw`
-    // would quietly grow the ability to edit files.
+    // Every wire format: the parent tools JSON must ride the body so the
+    // prefix matches, and the side note must be a user message, not a system
+    // rewrite. runTurn still cannot execute a tool (`text_only`).
     for ([_]Provider.Kind{ .anthropic, .openai, .responses }) |kind| {
         var r = try root(arena, kind);
         var agent = try side_question.build(&r, arena, question);
         defer agent.tools_used.deinit(std.testing.allocator);
-        const body = try agent.buildBody(null, false, false, false);
+        const tools = r.toolsJson();
+        const parent_body = try r.buildBody(tools, false, false, false);
+        defer std.testing.allocator.free(parent_body);
+        const body = try agent.buildBody(tools, false, false, false);
         defer std.testing.allocator.free(body);
 
-        // The answer is produced FROM the existing context: the conversation so
-        // far is in the request, with the question appended after it.
         try std.testing.expect(std.mem.indexOf(u8, body, "undefined symbol _graff_main") != null);
         const asked = std.mem.indexOf(u8, body, "what did that linker error") orelse
             return error.TestUnexpectedResult;
         try std.testing.expect(asked > std.mem.indexOf(u8, body, "undefined symbol _graff_main").?);
 
-        // No toolset, and not an empty one either — the key is absent.
-        try std.testing.expect(std.mem.indexOf(u8, body, "\"tools\"") == null);
-        try std.testing.expect(std.mem.indexOf(u8, body, "\"bash\"") == null);
-        try std.testing.expect(std.mem.indexOf(u8, body, "tool_choice") == null);
-        try std.testing.expect(agent.text_only); // and runTurn could not add any
+        try std.testing.expect(std.mem.indexOf(u8, body, "\"tools\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, body, "\"bash\"") != null);
+        try std.testing.expect(agent.text_only);
 
-        // The root's own prompt, plus the note that says why this turn is odd.
         try std.testing.expect(std.mem.indexOf(u8, body, "ROOT-BASE") != null);
         try std.testing.expect(std.mem.indexOf(u8, body, "You have NO tools on this turn") != null);
-        // It is a subagent for every root-only path, the transcript included.
         try std.testing.expect(agent.sub);
+        try std.testing.expectEqualStrings("btw", agent.label);
     }
+}
+
+test "/btw shares the parent prompt_cache_key and does not rewrite instructions" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var r = try root(arena, .responses);
+    r.provider.id = "xai";
+    r.provider.model = "grok-4.6";
+    r.label = "main";
+    var agent = try side_question.build(&r, arena, question);
+    defer agent.tools_used.deinit(std.testing.allocator);
+    const tools = r.toolsJson();
+    const parent_body = try r.buildBody(tools, false, false, false);
+    defer std.testing.allocator.free(parent_body);
+    const body = try agent.buildBody(tools, false, false, false);
+    defer std.testing.allocator.free(body);
+
+    const needle = "\"prompt_cache_key\":\"";
+    const p_start = std.mem.indexOf(u8, parent_body, needle) orelse return error.MissingParentKey;
+    const b_start = std.mem.indexOf(u8, body, needle) orelse return error.MissingSideKey;
+    const p_from = p_start + needle.len;
+    const b_from = b_start + needle.len;
+    const p_end = std.mem.indexOfScalarPos(u8, parent_body, p_from, '"') orelse return error.MissingParentKey;
+    const b_end = std.mem.indexOfScalarPos(u8, body, b_from, '"') orelse return error.MissingSideKey;
+    try std.testing.expectEqualStrings(parent_body[p_from..p_end], body[b_from..b_end]);
+    try std.testing.expect(std.mem.indexOf(u8, parent_body, "\"instructions\":\"ROOT-BASE\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"instructions\":\"ROOT-BASE\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, parent_body, "You have NO tools on this turn") == null);
 }
 
 test "/btw (#415): root.messages is byte-identical before and after, and the clone is deep" {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The product already cache-maxes the prefix: sticky `prompt_cache_key`, names-only skill catalog pinned once, standing goal as one prefix line, Anthropic `cache_control`, GPT-5.6 explicit breakpoint (ADR 0009), per-agent partitions. `/cache` is the content-free HUD for that posture.

## `/btw` now rides the parent prefix (grok-build side-call)

`/btw` used to omit tools and rewrite the system prompt, which busted the warm conversation. It now matches [grok-build](https://github.com/xai-org/grok-build) recap:

- same system prompt bytes as the parent
- same tools JSON on the wire (`text_only` so they are not executed)
- same `prompt_cache_key` / `x-grok-conv-id` as the root
- side-question note appended as a **user** message (append-only)
- JSON `{type:btw}` reports `cache_read_tokens`; the REPL prints `(side question — not added · N cached)`

`GRAFF_STABLE_CATALOG` stays off (ADR 0010 on this branch).

## Live Grok 4.6 (Responses, SuperGrok OAuth)

```
turn  cache_read=128   input=3721  text='ping'
btw   cache_read=3712  text='ping'  persisted=False
```

**3,712 / 3,721 (99.8%)** of the prior prompt came back from cache. The aside did not persist.

Release landing: same commits on `cursor/prompt-cache-max-release-1a17` targeting `release/v0.0.267`, with the ADR numbered **0011** there because that branch already used 0010 for jobs.

Verified: `zig fmt`, 600-line ceiling, spec, **1459** unit tests, TUI suite, named invariants, SDK. `tuiguard` hover flake in this VM on an earlier push (paint path untouched); unit + tui-test are the gate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ac9d0ef-bfc6-4b2a-9dab-d63c9f9f1a17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ac9d0ef-bfc6-4b2a-9dab-d63c9f9f1a17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

