### PR TITLE
fix(imagegen): isolate Codex exec from the user's config.toml (#576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ current is part of cutting a release.
 - Cerebras Inference is a built-in OpenAI-chat provider (`CEREBRAS_API_KEY`,
   `graff key set cerebras …`, default `gpt-oss-120b`). Live `/v1/models`
   overlay; this is `api.cerebras.ai`, not the WSE CSL SDK.
+- imagegen's Codex engine uses a private features-only `config.toml` so
+  `codex exec` no longer dies with `input contains invalid characters at
+  line 1 column N` from the user's MCP/skills overlay (#576).
+- `/resume` restores the peer-channel byte cursor and parked inbox instead
+  of replaying the last 10 room lines (ADR 0014). Peer wakes are not a
+  human turn for title or meaningful-state.
+- Directory listing is `codedb list_dir` (in-process BFS, gitignore, 10k
+  cap), not a new always-on catalog tool (ADR 0013).
 - Custom subagent files can be Codex-shaped TOML: `name`, `description`,
   `developer_instructions`, plus `model` / `model_reasoning_effort` /
   `isolation` / `tier`. Loaded from `~/.codex/agents`, `~/.harness/agents`,

--- a/docs/releases/v0.0.268.md
+++ b/docs/releases/v0.0.268.md
@@ -50,13 +50,32 @@ next agent step sees it, and an idle TUI starts a turn. Combined with
 ADR 0010 (wait-for-exit already in 0.0.267), the model should not poll
 `bash_output` every 30s.
 
+## Cerebras Inference
+
+`graff key set cerebras csk-…` (or `CEREBRAS_API_KEY`) adds the same
+OpenAI-chat seat Groq already has, at `https://api.cerebras.ai`. Default
+model is `gpt-oss-120b`; `gemma-4-31b` is the other offline catalog
+entry. This is Cerebras Inference, not the WSE CSL kernel SDK.
+
+## Session resume and peer speech
+
+`/resume` now restores the worktree/device room cursors and the parked
+`peer_message` inbox (ADR 0014). A new process no longer re-drains the
+last 10 JSONL lines into history. Peer wakes do not title or mint a
+session. `-p` one-shots still join at the tail.
+
+`codedb list_dir` is the directory listing (ADR 0013): in-process BFS,
+gitignore, 10k cap — not a new always-on catalog tool.
+
 ## Images in ask_user and compaction
 
 Pasted screenshots in an `ask_user` reply used to arrive as `[Image]`
 placeholders (#580). They now ride a follow-up user vision message after
 the text tool result (ADR 0015). Compaction and emergency trim stop
 before an unresolved current prompt so those blocks are not summarized
-to text (#581).
+to text (#581). imagegen's Codex engine writes a private features-only
+`config.toml` and only links `auth.json`, so `codex exec` no longer dies
+on the user's MCP/skills overlay (#576).
 
 ## Distribution
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -24,6 +24,7 @@ pub const changelog_text =
     \\0.0.268
     \\  • Cerebras Inference (CEREBRAS_API_KEY → gpt-oss-120b); not the WSE CSL SDK
     \\  • Codex-shaped .harness/agents/*.toml (and ~/.codex/agents) pin model/effort
+    \\  • imagegen Codex engine: private config so exec no longer rejects JSON (#576)
     \\  • Live bash chunks + idle job notify + raw terminal (do not poll)
     \\  • ask_user pastes reach the model as vision blocks; compact keeps the live prompt's images
     \\

--- a/src/imagegen.zig
+++ b/src/imagegen.zig
@@ -373,6 +373,7 @@ fn runCodex(gpa: Allocator, arena: Allocator, io: Io, prompt: []const u8, resolv
         .is_error = true,
     } };
     if (codex.tooOld(out.stdout) or codex.tooOld(out.stderr)) return .{ .fail = try errText(gpa, codex.too_old_text) };
+    if (codex.badJsonInput(out.stdout) or codex.badJsonInput(out.stderr)) return .{ .fail = try errText(gpa, codex.bad_json_text) };
     if (codex.saidUnavailable(out.stdout)) return .{ .fail = try errText(gpa, codex.unavailable_text) };
     if (!out.ranClean()) return .{ .fail = .{
         .text = try std.fmt.allocPrint(gpa, "codex exec failed (exit {?d}) — nothing was generated.\ntranscript tail:\n{s}", .{ out.exit_code, tails }),

--- a/src/imagegen_codex.zig
+++ b/src/imagegen_codex.zig
@@ -79,7 +79,21 @@ pub fn buildArgv(arena: Allocator, private_home: []const u8, prompt: []const u8)
 /// Credentials that make a private CODEX_HOME usable. Symlinked rather than
 /// copied where the OS allows it, so a token never lands as a second plaintext
 /// file in a temp dir; see `prepareHome` for the copy fallback.
-pub const linked_files = [_][]const u8{ "auth.json", "config.toml" };
+///
+/// `config.toml` is NOT linked (#576). The user's real config can be several
+/// KB of MCP/skills/session overlay; Codex 0.144+ then JSON-parses that
+/// overlay and dies with `input contains invalid characters at line 1 column
+/// N` at a fixed column even for a one-line prompt. A private home gets a
+/// tiny features-only config instead (written in `prepareHome`).
+pub const linked_files = [_][]const u8{"auth.json"};
+
+/// Private-home config: enable image_generation and nothing else. Model
+/// selection stays Codex's default for this CLI — same as not pinning `-m`.
+pub const private_config =
+    \\[features]
+    \\image_generation = true
+    \\
+;
 
 /// Build a private CODEX_HOME for ONE run.
 ///
@@ -104,6 +118,8 @@ pub const linked_files = [_][]const u8{ "auth.json", "config.toml" };
 /// idempotent, and losing one is far cheaper than cross-attributing an image.
 pub fn prepareHome(io: Io, arena: Allocator, private_home: []const u8, real_home: []const u8) !void {
     try Io.Dir.cwd().createDirPath(io, private_home);
+    const cfg = try std.fmt.allocPrint(arena, "{s}/config.toml", .{private_home});
+    Io.Dir.cwd().writeFile(io, .{ .sub_path = cfg, .data = private_config }) catch {};
     for (linked_files) |name| {
         const target = try std.fmt.allocPrint(arena, "{s}/{s}", .{ real_home, name });
         _ = Io.Dir.cwd().statFile(io, target, .{}) catch continue; // config.toml is optional
@@ -223,6 +239,16 @@ pub fn tooOld(text: []const u8) bool {
         std.mem.indexOf(u8, text, "requires a newer version of codex") != null;
 }
 
+/// #576: Codex 0.144+ serde-parses an exec overlay and rejects it at a
+/// fixed column (`input contains invalid characters at line 1 column 4224`)
+/// when the private home inherited the user's MCP/skills config. Detected
+/// so the tool result names the cause instead of dumping a raw transcript.
+pub fn badJsonInput(text: []const u8) bool {
+    return std.mem.indexOf(u8, text, "input contains invalid characters") != null;
+}
+
+pub const bad_json_text = "codex exec rejected its input JSON (\"input contains invalid characters\") — usually leftover MCP/skills overlay from the user's config.toml, not the image prompt. This run uses a private config that only enables image_generation. If you still see this, upgrade the Codex CLI or pass engine \"openai_api\". Nothing was generated.";
+
 pub const too_old_text = "the installed codex CLI is too old for the model your codex config selects, so the hosted image_gen tool was never offered. Upgrade it (bun install -g @openai/codex) and call imagegen again, or pass engine \"openai_api\" to use the OPENAI_API_KEY path instead. Nothing was generated.";
 
 /// The model told us outright that it had no image_gen tool. Worth its own
@@ -288,6 +314,7 @@ test "#352: a private CODEX_HOME links only credentials, so its save_root starts
     const real_home = try std.fmt.allocPrint(arena, "{s}/codex", .{base});
     try Io.Dir.cwd().createDirPath(io, try std.fmt.allocPrint(arena, "{s}/generated_images/other", .{real_home}));
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = try std.fmt.allocPrint(arena, "{s}/auth.json", .{real_home}), .data = "{\"tok\":1}" });
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = try std.fmt.allocPrint(arena, "{s}/config.toml", .{real_home}), .data = "[mcp_servers.evil]\ncommand = \"x\"\n" });
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = try std.fmt.allocPrint(arena, "{s}/generated_images/other/exec-theirs.png", .{real_home}), .data = "\x89PNG\r\n\x1a\n" ++ "theirs" });
 
     const private_home = try std.fmt.allocPrint(arena, "{s}/run-a/home", .{base});
@@ -296,8 +323,10 @@ test "#352: a private CODEX_HOME links only credentials, so its save_root starts
     // Credentials reachable through the link...
     const auth = try Io.Dir.cwd().readFileAlloc(io, try std.fmt.allocPrint(arena, "{s}/auth.json", .{private_home}), arena, .limited(64));
     try testing.expectEqualStrings("{\"tok\":1}", auth);
-    // ...and no config.toml link, because the source had none.
-    try testing.expect(Io.Dir.cwd().statFile(io, try std.fmt.allocPrint(arena, "{s}/config.toml", .{private_home}), .{}) == error.FileNotFound);
+    // Private config is written here (features only) — the user's config.toml
+    // is never linked, even when they have one (#576).
+    const cfg = try Io.Dir.cwd().readFileAlloc(io, try std.fmt.allocPrint(arena, "{s}/config.toml", .{private_home}), arena, .limited(256));
+    try testing.expectEqualStrings(private_config, cfg);
 
     // The private save_root is empty: a sibling's fresh artifact is invisible.
     const mine = try saveRoot(arena, private_home);
@@ -416,6 +445,9 @@ test "#352: a too-old CLI and a self-reported missing tool each get their own ac
     try testing.expect(saidUnavailable("IMAGE_GEN_UNAVAILABLE"));
     try testing.expect(!saidUnavailable("image generated fine"));
     try testing.expect(std.mem.indexOf(u8, unavailable_text, "codex features list") != null);
+    try testing.expect(badJsonInput("input contains invalid characters at line 1 column 4224"));
+    try testing.expect(!badJsonInput("some other 400"));
+    try testing.expect(std.mem.indexOf(u8, bad_json_text, "openai_api") != null);
     // The empty-handed success case names #352 so the failure is recognisable.
     try testing.expect(std.mem.indexOf(u8, no_artifact_text, "#352") != null);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #576.

The harness prompt tells Codex (and any other agent) to file harness bugs on **justrach/codegraff**, never on the repo they happen to be working in. Those filings are the “Codex issues on the main issues” list. This PR takes the one that is actually a Codex-engine failure.

## #576

`codex exec` was dying with:

```
input contains invalid characters at line 1 column 4224
```

Same column on a one-line prompt, so it was not the image text. The private `CODEX_HOME` was **symlinking the user's `config.toml`**, and 0.144+ serde-parses that overlay (MCP servers, skills, session). Column 4224 is a fixed offset into that blob.

**Change:** link only `auth.json`. Write a features-only `config.toml` (`image_generation = true`). If the serde error still appears, the tool result names it instead of dumping the transcript.

`zig build test -Dtest-filter="#352"` — 82 passed (includes the new detector + private-config assertions).

## Still open on the main tracker (not this PR)

Same filing path, different bugs:

| issue | what |
|---|---|
| #580 | `ask_user` image uploads become literal `[Image]` placeholders |
| #581 | compaction drops images from the unresolved current prompt |
| #577 | TUI history recall loses image attachments |

Say if you want those next.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00e21-907e-7738-b167-6d4c0294554f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00e21-907e-7738-b167-6d4c0294554f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

