### PR TITLE
fix(model): Codex gpt-5.6-sol first when searching "5.6 sol"

### DIFF
--- a/TUI/models.zig
+++ b/TUI/models.zig
@@ -13,7 +13,23 @@ pub const max_models = 256;
 /// reads the same window the renderer draws rather than a second copy of it.
 pub const visible_rows = 14;
 
+fn isSep(c: u8) bool {
+    return c == '-' or c == '_' or c == ' ' or c == '.' or c == '/';
+}
+
+/// Fold separators so "5.6 sol" and "gpt-5.6-sol" share a needle.
+fn foldSeps(dst: []u8, s: []const u8) []const u8 {
+    var n: usize = 0;
+    for (s) |c| {
+        if (isSep(c) or n >= dst.len) continue;
+        dst[n] = std.ascii.toLower(c);
+        n += 1;
+    }
+    return dst[0..n];
+}
+
 /// Case-insensitive substring, else fzf-style subsequence ("gpt56" -> gpt-5.6).
+/// Spaces/hyphens/dots are ignored so "5.6 sol" hits `gpt-5.6-sol`.
 pub fn modelMatch(name: []const u8, query: []const u8) bool {
     if (query.len == 0) return true;
     if (containsIgnoreCase(name, query)) return true;
@@ -21,7 +37,12 @@ pub fn modelMatch(name: []const u8, query: []const u8) bool {
     for (name) |c| {
         if (qi < query.len and std.ascii.toLower(c) == std.ascii.toLower(query[qi])) qi += 1;
     }
-    return qi == query.len;
+    if (qi == query.len) return true;
+    var nb: [128]u8 = undefined;
+    var qb: [128]u8 = undefined;
+    const n = foldSeps(&nb, name);
+    const q = foldSeps(&qb, query);
+    return q.len > 0 and containsIgnoreCase(n, q);
 }
 
 fn containsIgnoreCase(hay: []const u8, needle: []const u8) bool {
@@ -41,16 +62,57 @@ pub fn entryMatch(e: engine.ModelEntry, query: []const u8) bool {
     return modelMatch(e.name, query) or containsIgnoreCase(e.provider, query);
 }
 
-/// Keep the catalog rows matching `query`, in catalog order.
+const Ranked = struct { e: engine.ModelEntry, score: i32, idx: usize };
+
+fn rankedLess(_: void, a: Ranked, b: Ranked) bool {
+    if (a.score != b.score) return a.score > b.score;
+    return a.idx < b.idx;
+}
+
+fn nameScore(name: []const u8, query: []const u8) i32 {
+    if (query.len == 0) return 0;
+    var nb: [128]u8 = undefined;
+    var qb: [128]u8 = undefined;
+    const n = foldSeps(&nb, name);
+    const q = foldSeps(&qb, query);
+    const len_pen: i32 = @intCast(@min(name.len, 200));
+    if (q.len == 0) return -len_pen;
+    if (std.mem.eql(u8, n, q)) return 300_000 - len_pen;
+    if (std.mem.endsWith(u8, n, q)) return 200_000 - len_pen;
+    if (std.mem.indexOf(u8, n, q) != null) return 100_000 - len_pen;
+    return -len_pen;
+}
+
+/// Rank a keyed plan above a metered/reseller hit. "5.6 sol" with a Codex
+/// login should land on `gpt-5.6-sol` / codex, not openai or a gateway slug.
+fn entryScore(e: engine.ModelEntry, query: []const u8) i32 {
+    var s: i32 = nameScore(e.name, query);
+    if (e.has_key) s += 1_000_000;
+    s += switch (e.cost) {
+        .plan => 400_000,
+        .local => 300_000,
+        .credits => 200_000,
+        .api => 0,
+    };
+    return s;
+}
+
+/// Keep the catalog rows matching `query`. An empty query stays in catalog
+/// order (the map of what exists). A typed query ranks: keyed plan first,
+/// then tighter name match, then original order.
 pub fn filterModels(list: []const engine.ModelEntry, query: []const u8, out: []engine.ModelEntry) usize {
-    var n: usize = 0;
-    for (list) |e| {
+    var tmp: [max_models]Ranked = undefined;
+    var k: usize = 0;
+    for (list, 0..) |e, i| {
         if (e.name.len == 0) continue;
         if (!entryMatch(e, query)) continue;
-        if (n >= out.len) break;
-        out[n] = e;
-        n += 1;
+        if (k >= tmp.len) break;
+        tmp[k] = .{ .e = e, .score = if (query.len == 0) 0 else entryScore(e, query), .idx = i };
+        k += 1;
     }
+    if (query.len > 0) std.mem.sort(Ranked, tmp[0..k], {}, rankedLess);
+    const n = @min(k, out.len);
+    for (0..n) |i| out[i] = tmp[i].e;
     return n;
 }
 
@@ -154,6 +216,7 @@ fn tailId(name: []const u8) []const u8 {
 test "modelMatch: substring and subsequence" {
     try std.testing.expect(modelMatch("gpt-5.6", "gpt"));
     try std.testing.expect(modelMatch("gpt-5.6", "gpt56"));
+    try std.testing.expect(modelMatch("gpt-5.6-sol", "5.6 sol"));
     try std.testing.expect(modelMatch("accounts/fireworks/models/deepseek-v4-pro", "deepseek"));
     try std.testing.expect(!modelMatch("gpt-5.6", "claude"));
 }
@@ -180,8 +243,9 @@ test "the query searches the provider column too" {
     var buf: [8]engine.ModelEntry = undefined;
     const n = filterModels(&sample, "codex", &buf);
     try std.testing.expectEqual(@as(usize, 2), n);
-    try std.testing.expectEqualStrings("ccc", buf[0].name);
-    try std.testing.expectEqualStrings("gpt-5.6", buf[1].name);
+    // Keyed plan first; the keyless codex row still matches the provider column.
+    try std.testing.expectEqualStrings("gpt-5.6", buf[0].name);
+    try std.testing.expectEqualStrings("ccc", buf[1].name);
     try std.testing.expectEqual(@as(usize, 1), filterModels(&sample, "codegraff", &buf));
     try std.testing.expectEqual(@as(usize, 0), filterModels(&sample, "anthropic", &buf));
 }
@@ -275,6 +339,30 @@ test "the provider column lines up under ragged model names" {
         seen += 1;
     }
     try std.testing.expectEqual(@as(usize, 2), seen);
+}
+
+test "a 5.6 sol search ranks keyed Codex above openai and a gateway slug" {
+    const rows = [_]engine.ModelEntry{
+        .{ .name = "gpt-5.6", .provider = "openai", .has_key = true, .cost = .api },
+        .{ .name = "openai/gpt-5.6-sol", .provider = "vercel", .has_key = true, .cost = .api },
+        .{ .name = "gpt-5.6-sol", .provider = "codex", .has_key = true, .cost = .plan },
+        .{ .name = "gpt-5.6-sol", .provider = "codex", .cost = .plan },
+    };
+    var buf: [8]engine.ModelEntry = undefined;
+    const n = filterModels(&rows, "5.6 sol", &buf);
+    try std.testing.expectEqual(@as(usize, 3), n);
+    try std.testing.expectEqualStrings("gpt-5.6-sol", buf[0].name);
+    try std.testing.expectEqualStrings("codex", buf[0].provider);
+    try std.testing.expect(buf[0].has_key);
+    try std.testing.expectEqualStrings("openai/gpt-5.6-sol", buf[1].name);
+}
+
+test "an empty query keeps catalog order" {
+    var buf: [8]engine.ModelEntry = undefined;
+    const n = filterModels(&sample, "", &buf);
+    try std.testing.expectEqual(@as(usize, 5), n);
+    try std.testing.expectEqualStrings("aaa", buf[0].name);
+    try std.testing.expectEqualStrings("gpt-5.6", buf[4].name);
 }
 
 /// `line` with its SGR sequences removed, written into `buf`. The padding is

--- a/src/pickers.zig
+++ b/src/pickers.zig
@@ -42,11 +42,27 @@ fn fuzzySubseq(hay: []const u8, needle: []const u8) bool {
     return false;
 }
 
-/// Rank a fuzzy match for the pickers (higher = better, null = no match).
-/// Tiers: basename/whole-string prefix > substring (earlier and shorter is
-/// better) > bare subsequence — so "dem" puts demo.py above README.md, which
-/// only matches as a d…e…m subsequence.
+/// Rank a fuzzy match (higher = better). Prefix > substring > subsequence.
+/// Separators fold so "5.6 sol" matches `gpt-5.6-sol`.
 fn fuzzyScore(hay: []const u8, needle: []const u8) ?i32 {
+    if (needle.len == 0) return 0;
+    if (scoreFolded(hay, needle)) |s| return s;
+    var hb: [256]u8 = undefined;
+    var nb: [128]u8 = undefined;
+    return scoreFolded(foldSeps(&hb, hay), foldSeps(&nb, needle));
+}
+
+fn foldSeps(dst: []u8, s: []const u8) []const u8 {
+    var n: usize = 0;
+    for (s) |c| {
+        if (c == '-' or c == '_' or c == ' ' or c == '.' or c == '/' or n >= dst.len) continue;
+        dst[n] = std.ascii.toLower(c);
+        n += 1;
+    }
+    return dst[0..n];
+}
+
+fn scoreFolded(hay: []const u8, needle: []const u8) ?i32 {
     if (needle.len == 0) return 0;
     if (needle.len > hay.len) return null;
     const len_pen: i32 = @intCast(@min(hay.len, 200));
@@ -243,8 +259,13 @@ pub fn modelPicker(root: *Agent, keys: *Keys, arena: Allocator, out: *Io.Writer)
             scored.clearRetainingCapacity();
             for (model_table, 0..) |m, i| {
                 if ((keys.get(m.provider) != null) != want_keyed) continue;
-                if (pickScore(.{ .name = m.name, .desc = m.provider }, query.items)) |s|
-                    scored.append(arena, .{ .idx = i, .score = s }) catch {};
+                if (pickScore(.{ .name = m.name, .desc = m.provider }, query.items)) |s| {
+                    const plan: i32 = if (provider_mod.specFor(m.provider)) |spec|
+                        @as(i32, @intFromBool(spec.sub_login)) * 400_000
+                    else
+                        0;
+                    scored.append(arena, .{ .idx = i, .score = s + plan }) catch {};
+                }
             }
             std.mem.sort(Scored, scored.items, {}, scoredLess);
             for (scored.items) |s| filtered.append(arena, s.idx) catch {};
@@ -493,6 +514,7 @@ test "fuzzyScore ranks basename prefix above substring above subsequence" {
     // whole-string prefix counts even with directories in the hay
     try std.testing.expect(fuzzyScore("sdk/ts/harness.ts", "sdk").? >= 300_000 - 200);
     // no match at all → null; empty needle → 0
+    try std.testing.expect(fuzzyScore("gpt-5.6-sol", "5.6 sol").? > fuzzyScore("gpt-5.6", "5.6").?);
     try std.testing.expect(fuzzyScore("abc", "xyz") == null);
     try std.testing.expectEqual(@as(?i32, 0), fuzzyScore("abc", ""));
 }

--- a/src/pricing.zig
+++ b/src/pricing.zig
@@ -492,15 +492,25 @@ pub fn resolveModelName(keys: anytype, query: []const u8) ?[]const u8 {
     for (models()) |m| if (familyAliasEquals(m.provider, m.name, query)) return m.name;
     var qbuf: [128]u8 = undefined;
     const qnorm = normalizeModelAlias(&qbuf, query);
-    var fallback: ?[]const u8 = null;
+    var best_name: ?[]const u8 = null;
+    var best_score: i32 = std.math.minInt(i32);
     for (models()) |m| {
         var nbuf: [128]u8 = undefined;
         const nnorm = normalizeModelAlias(&nbuf, m.name);
         if (util.indexOfIgnoreCase(m.name, query) == null and std.mem.indexOf(u8, nnorm, qnorm) == null) continue;
-        if (keys.get(m.provider) != null) return m.name;
-        if (fallback == null) fallback = m.name;
+        const keyed = keys.get(m.provider) != null;
+        var s: i32 = if (keyed) 1_000_000 else 0;
+        // A ChatGPT/Codex login beats a metered or gateway slug for the same
+        // needle ("5.6 sol" → gpt-5.6-sol on codex, not openai/gpt-5.6-sol).
+        if (keyed and std.mem.eql(u8, m.provider, "codex")) s += 400_000;
+        if (std.mem.eql(u8, nnorm, qnorm)) s += 300_000 else if (std.mem.endsWith(u8, nnorm, qnorm)) s += 200_000 else s += 100_000;
+        s -= @intCast(@min(m.name.len, 200));
+        if (s > best_score) {
+            best_score = s;
+            best_name = m.name;
+        }
     }
-    return fallback;
+    return best_name;
 }
 
 /// Exact membership test against the active model table — used to ignore a

--- a/src/pricing_tests.zig
+++ b/src/pricing_tests.zig
@@ -53,6 +53,22 @@ test "resolveModelName (#377): family-prefixed spelling resolves to the provider
     try std.testing.expect(!pricing.familyAliasEquals("codex", "k3", "kimi-k3"));
 }
 
+test "resolveModelName: 5.6 sol prefers Codex gpt-5.6-sol over a gateway slug" {
+    const saved = pricing.active_model_table;
+    defer pricing.active_model_table = saved;
+    const rows = [_]pricing.ModelInfo{
+        .{ .provider = "codegraff", .name = "openai/gpt-5.6-sol", .context = 272_000 },
+        .{ .provider = "openai", .name = "gpt-5.6", .context = 1_050_000 },
+        .{ .provider = "codex", .name = "gpt-5.6-sol", .context = 272_000 },
+    };
+    pricing.active_model_table = &rows;
+    var keys: provider_mod.Keys = .{ .values = @splat(null) };
+    _ = keys.set("codex", "tok", .login);
+    _ = keys.set("openai", "sk", .environment);
+    _ = keys.set("codegraff", "cg", .login);
+    try std.testing.expectEqualStrings("gpt-5.6-sol", pricing.resolveModelName(keys, "5.6 sol").?);
+}
+
 test "usdFor: per-million math, cache writes, and negative clamping" {
     const p = pricing.priceFor("gpt-5.5").?; // $5 in / $30 out / $0.5 cache per 1M
     try std.testing.expectApproxEqAbs(@as(f64, 5.0), pricing.usdFor(p, 1_000_000, 0, 0), 1e-9);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

If you have a Codex login, searching **5.6 sol** should put `gpt-5.6-sol` on that plan at the top — not OpenAI’s `gpt-5.6` or a gateway slug.

- Spaces/hyphens/dots fold so `5.6 sol` matches `gpt-5.6-sol`.
- A typed query ranks **keyed plan** (Codex) above metered/reseller rows, then tighter name match.
- Empty `/model` stays catalog order (the map of what exists).
- `resolveModelName("5.6 sol")` prefers the Codex native name over `openai/gpt-5.6-sol`.

## Test plan

- [x] `zig build test` — 1532 pass, 1 skip
- [x] `zig build tui-test` — 422 pass
- [x] CI on this PR (zig / sdk / windows green)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00e21-907e-7738-b167-6d4c0294554f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00e21-907e-7738-b167-6d4c0294554f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

