### PR TITLE
fix(repl): PTY waiters look for the bare › prompt

### DIFF
--- a/scripts/codex_ws_test.py
+++ b/scripts/codex_ws_test.py
@@ -332,7 +332,7 @@ def run_scenario(
         unset_env=ambient,
         timeout=45.0,  # compaction legs stream 128 KiB of scripted reasoning; 20s flakes on loaded runners
     ) as session:
-        session.wait_for_literal("] ›")
+        session.wait_for_prompt()
         cursor = len(session.raw)
         session.send_line("ping")
         session.wait_for_literal(REPLY_TEXT, start=cursor)
@@ -356,7 +356,7 @@ def run_scenario(
         cursor = len(session.raw)
         session.send_line("/models health")
         session.wait_for_literal(f"Codex transport: {health}", start=cursor)
-        session.wait_for_literal("] ›", start=cursor)
+        session.wait_for_prompt(start=cursor)
         session.send_key("ctrl-d")
         result = session.read_until_exit(5.0)
         if result.timed_out or result.exit_code != 0:
@@ -687,7 +687,7 @@ def run_midturn_compaction_scenario(
         unset_env=ambient,
         timeout=45.0,  # compaction legs stream 128 KiB of scripted reasoning; 20s flakes on loaded runners
     ) as session:
-        session.wait_for_literal("] ›")
+        session.wait_for_prompt()
         cursor = len(session.raw)
         session.send_line(MIDTURN_PROMPT)
         session.wait_for_literal(MIDTURN_FINAL, start=cursor)
@@ -731,7 +731,7 @@ def run_transactional_compaction_scenario(
         unset_env=ambient,
         timeout=45.0,  # compaction legs stream 128 KiB of scripted reasoning; 20s flakes on loaded runners
     ) as session:
-        session.wait_for_literal("] ›")
+        session.wait_for_prompt()
         cursor = len(session.raw)
         session.send_line(TRANSACTIONAL_PROMPT)
         session.wait_for_literal(

--- a/scripts/eval/golden/README.md
+++ b/scripts/eval/golden/README.md
@@ -47,7 +47,7 @@ Each window is `raw[cursor:]`, with `cursor` taken just before sending input.
 The obvious way to write that is:
 
 ```python
-s.wait_for_literal("] ›")
+s.wait_for_prompt()
 cursor = len(s.raw)          # WRONG
 ```
 
@@ -65,7 +65,7 @@ looks exactly like a real difference until you diff the remainder.
 The fix, applied at every window here: **settle before opening a window.**
 
 ```python
-s.wait_for_literal("] ›")
+s.wait_for_prompt()
 s.pump_for(1.0)              # let the terminal go quiet
 cursor = len(s.raw)          # now the boundary is deterministic
 ```

--- a/scripts/eval/golden/run_golden.py
+++ b/scripts/eval/golden/run_golden.py
@@ -220,7 +220,7 @@ def scenario(graff: str, outdir: pathlib.Path, label: str, cols: int) -> None:
         rows=40,
         cols=cols,
     ) as s:
-        s.wait_for_literal("] ›")
+        s.wait_for_prompt()
         # Let readline's terminal setup (bracketed paste, the DSR cursor probe)
         # land BEFORE the first window opens. Without this those 12 bytes fall
         # on one side or the other of the cursor by luck. See README.

--- a/scripts/pty-debug.py
+++ b/scripts/pty-debug.py
@@ -37,7 +37,7 @@ Options:
   --cols N            terminal width (default: 120)
   --raw-out PATH      save exact PTY bytes, including ANSI/control sequences
   --text-out PATH     save the cleaned readable transcript
-  --no-ready          do not wait for the initial `] ›` prompt
+  --no-ready          do not wait for the initial `›` prompt
   --no-color          set NO_COLOR=1 and skip the interactive-prompt wait
   --quiet             print only failures and the final transcript
 
@@ -47,7 +47,7 @@ Ordered actions:
   --key NAME          enter/up/down/left/right/esc/tab/backspace/ctrl-c/ctrl-d
   --expect TEXT       wait for literal cleaned terminal text
   --expect-re REGEX   wait for a regular expression
-  --expect-prompt     wait for the next `] ›` prompt
+  --expect-prompt     wait for the next `›` prompt
   --sleep SECONDS     keep capturing output for a fixed interval
 """
 
@@ -191,7 +191,7 @@ def main() -> int:
     failed: Exception | None = None
     try:
         if config["ready"]:
-            cursor = session.wait_for_literal("] ›", start=cursor)
+            cursor = session.wait_for_prompt(start=cursor)
             note(quiet, "✓ initial REPL prompt")
         for action, value in actions:
             if action == "--cmd":
@@ -213,7 +213,7 @@ def main() -> int:
                 session.wait_for(re.compile(value), start=cursor)
                 note(quiet, f"✓ expect-re {value!r}")
             elif action == "--expect-prompt":
-                session.wait_for_literal("] ›", start=cursor)
+                session.wait_for_prompt(start=cursor)
                 note(quiet, "✓ next REPL prompt")
             elif action == "--sleep":
                 session.pump_for(float(value))

--- a/scripts/pty_harness.py
+++ b/scripts/pty_harness.py
@@ -138,6 +138,13 @@ class PtyResult:
         return terminal_text(self.raw)
 
 
+# Line REPL ready marker after ADR 0016: a bare `›` on its own line,
+# not `[model · …] ›`. A picker highlight is `› name`; the overlay
+# title is `Model ›` — neither is a line of only the glyph.
+PROMPT = "›"
+PROMPT_RE = re.compile(r"(?m)^›\s*$")
+
+
 class PtySession:
     """A real terminal session with incremental send/wait/capture operations."""
 
@@ -284,6 +291,9 @@ class PtySession:
         self, expected: str, *, start: int = 0, timeout: float | None = None
     ) -> int:
         return self.wait_for(re.compile(re.escape(expected)), start=start, timeout=timeout)
+
+    def wait_for_prompt(self, *, start: int = 0, timeout: float | None = None) -> int:
+        return self.wait_for(PROMPT_RE, start=start, timeout=timeout)
 
     def read_until_exit(self, timeout: float | None = None) -> PtyResult:
         deadline = time.monotonic() + (self.timeout if timeout is None else timeout)

--- a/scripts/test-codex-auth-recovery.py
+++ b/scripts/test-codex-auth-recovery.py
@@ -160,15 +160,15 @@ def main() -> None:
                 unset_env=ambient,
                 timeout=20.0,
             ) as session:
-                session.wait_for_literal("] ›")
+                session.wait_for_prompt()
                 cursor = len(session.raw)
                 session.send_line("say hello")
                 session.wait_for_literal(FINAL_REPLY, start=cursor)
-                session.wait_for_literal("] ›", start=cursor)
+                session.wait_for_prompt(start=cursor)
                 cursor = len(session.raw)
                 session.send_line("say hello again")
                 session.wait_for_literal(SECOND_REPLY, start=cursor)
-                session.wait_for_literal("] ›", start=cursor)
+                session.wait_for_prompt(start=cursor)
                 session.send_key("ctrl-d")
                 result = session.read_until_exit(5.0)
                 if result.timed_out or result.exit_code != 0:

--- a/scripts/test-learn-auto-init.py
+++ b/scripts/test-learn-auto-init.py
@@ -63,12 +63,12 @@ def run_session(tmp: str, port: int, prompts: int) -> str:
         unset_env=ambient,
         timeout=30.0,
     ) as session:
-        session.wait_for_literal("] ›")
+        session.wait_for_prompt()
         for _ in range(prompts):
             cursor = len(session.raw)
             session.send_line("do a little work")
             session.wait_for_literal(REPLY, start=cursor)
-            session.wait_for_literal("] ›", start=cursor)
+            session.wait_for_prompt(start=cursor)
         session.send_key("ctrl-d")
         # Bootstrapping materializes a kit and generates two suites, so the
         # exit path is slower than an ordinary session's (siblings use 5s).

--- a/scripts/test-model-preference.py
+++ b/scripts/test-model-preference.py
@@ -15,8 +15,6 @@ from pty_harness import PtySession
 
 _arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
 GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
-# Aggregate is the default learning ceiling; the badge reflects it.
-PRIVACY = "Privacy:Aggregate"
 PROVIDER_KEYS = (
     "ANTHROPIC_API_KEY",
     "DEEPSEEK_API_KEY",
@@ -110,11 +108,12 @@ def main() -> None:
 
         # An explicit picker/command selection is persisted.
         with launch(str(cwd), env, codex_home=str(codex_home)) as session:
-            session.wait_for_literal("] ›")
+            session.wait_for_prompt()
             cursor = len(session.raw)
             session.send_line("/model codex")
             session.wait_for_literal("switched to gpt-5.6-sol via codex", start=cursor)
-            session.wait_for_literal(f"[gpt-5.6-sol · Medium · codex · {PRIVACY} · cwd", start=cursor)
+            session.wait_for_literal("gpt-5.6-sol · Medium", start=cursor)
+            session.wait_for_prompt(start=cursor)
             clean_exit(session)
         preference = home / ".simple-harness-model"
         assert preference.read_text(encoding="utf-8") == "codex\ngpt-5.6-sol\n"
@@ -123,7 +122,8 @@ def main() -> None:
         # across providers until the workspace explicitly allowlists it.
         with launch(str(cwd), env, codex_home=None) as session:
             session.wait_for_literal("Cross-provider use is blocked")
-            session.wait_for_literal(f"[deepseek-v4-pro · Medium · codegraff · Fallback · {PRIVACY} · cwd")
+            session.wait_for_literal("deepseek-v4-pro · Medium · Fallback")
+            session.wait_for_prompt()
             cursor = len(session.raw)
             session.send_line("must not reach a provider")
             session.wait_for_literal("requires explicit consent", start=cursor)
@@ -136,12 +136,14 @@ def main() -> None:
         # With explicit consent persisted, the same fallback is ready for use.
         with launch(str(cwd), env, codex_home=None) as session:
             session.wait_for_literal("saved preference kept")
-            session.wait_for_literal(f"[deepseek-v4-pro · Medium · codegraff · Fallback · {PRIVACY} · cwd")
+            session.wait_for_literal("deepseek-v4-pro · Medium · Fallback")
+            session.wait_for_prompt()
             clean_exit(session)
 
         # Once credentials return, the preferred model is selected again.
         with launch(str(cwd), env, codex_home=str(codex_home)) as session:
-            session.wait_for_literal(f"[gpt-5.6-sol · Medium · codex · {PRIVACY} · cwd")
+            session.wait_for_literal("gpt-5.6-sol · Medium")
+            session.wait_for_prompt()
             clean_exit(session)
 
         # A removed rollout stays on the selected provider when that login is
@@ -158,7 +160,8 @@ def main() -> None:
         )
         with launch(str(cwd), env, codex_home=str(codex_home)) as session:
             session.wait_for_literal("saved preference kept")
-            session.wait_for_literal(f"[gpt-5.6-luna · Medium · codex · Fallback · {PRIVACY} · cwd")
+            session.wait_for_literal("gpt-5.6-luna · Medium · Fallback")
+            session.wait_for_prompt()
             clean_exit(session)
         assert preference.read_text(encoding="utf-8") == "codex\ngpt-5.6-sol\n"
 

--- a/scripts/test-pty-ask-user-paste.py
+++ b/scripts/test-pty-ask-user-paste.py
@@ -93,7 +93,7 @@ def main() -> None:
                 unset_env=ambient,
                 timeout=15.0,
             ) as session:
-                session.wait_for_literal("] ›")
+                session.wait_for_prompt()
                 session.send_line("ask me for details")
                 session.wait_for_literal("your answer ›")
 

--- a/scripts/test-pty-codex-ws-concurrent.py
+++ b/scripts/test-pty-codex-ws-concurrent.py
@@ -67,11 +67,11 @@ def main() -> None:
                     unset_env=ambient,
                     timeout=20.0,
                 ) as session:
-                    session.wait_for_literal("] ›")
+                    session.wait_for_prompt()
                     cursor = len(session.raw)
                     session.send_line(f"concurrent feature task {index}")
                     session.wait_for_literal(scenario.CONCURRENT_FINAL, start=cursor)
-                    session.wait_for_literal("] ›", start=cursor)
+                    session.wait_for_prompt(start=cursor)
                     session.send_key("ctrl-d")
                     result = session.read_until_exit(5.0)
                     if result.timed_out or result.exit_code != 0:

--- a/scripts/test-pty-goal-loop.py
+++ b/scripts/test-pty-goal-loop.py
@@ -121,7 +121,7 @@ def main() -> None:
                 unset_env=ambient,
                 timeout=10.0,
             ) as session:
-                session.wait_for_literal("] ›")
+                session.wait_for_prompt()
 
                 # 1. "/goal ship the thing" adopts a standing goal AND runs a turn
                 # immediately: the goal-set line prints, and the loop controller's
@@ -131,7 +131,7 @@ def main() -> None:
                 session.send_line("/goal ship the thing")
                 session.wait_for_literal("Goal set: ship the thing", start=cursor)
                 session.wait_for_literal("run stopped — idle", start=cursor, timeout=10.0)
-                session.wait_for_literal("] ›", start=cursor)
+                session.wait_for_prompt(start=cursor)
 
                 # 2. "/goal 30m ship the thing" prints the budget line (the arm
                 # announcement), and the recorded objective must NOT contain "30m" —
@@ -142,14 +142,14 @@ def main() -> None:
                 session.wait_for_literal("/loop budget: 30m", start=cursor)
                 session.wait_for_literal("Goal set: ship the thing", start=cursor)
                 session.wait_for_literal("run stopped — idle", start=cursor, timeout=10.0)
-                session.wait_for_literal("] ›", start=cursor)
+                session.wait_for_prompt(start=cursor)
 
                 # 4. "/goal status" stays a COMMAND: no turn runs.
                 before_status = len(mock.recorded_requests())
                 cursor = len(session.raw)
                 session.send_line("/goal status")
                 session.wait_for_literal("Status: active", start=cursor)
-                session.wait_for_literal("] ›", start=cursor)
+                session.wait_for_prompt(start=cursor)
                 if len(mock.recorded_requests()) != before_status:
                     raise AssertionError(
                         "/goal status ran a model turn; it must stay a lifecycle command"

--- a/scripts/test-pty-gutter.py
+++ b/scripts/test-pty-gutter.py
@@ -35,7 +35,7 @@ def main() -> None:
             unset_env=("CODEX_HOME", "NO_COLOR"),
             timeout=15.0,
         ) as session:
-            session.wait_for_literal("] ›")
+            session.wait_for_prompt()
 
             # A local slash command produces output without touching a backend.
             cursor = len(session.raw)

--- a/scripts/test-pty-images.py
+++ b/scripts/test-pty-images.py
@@ -117,7 +117,7 @@ def main() -> None:
                 unset_env=ambient,
                 timeout=20.0,
             ) as session:
-                session.wait_for_literal("] ›")
+                session.wait_for_prompt()
 
                 # Zero-image path: nothing in the conversation yet.
                 c0 = len(session.raw)

--- a/scripts/test-pty-obs.py
+++ b/scripts/test-pty-obs.py
@@ -29,7 +29,7 @@ def main() -> None:
             timeout=15.0,
             cols=240,
         ) as session:
-            session.wait_for_literal("] ›")
+            session.wait_for_prompt()
 
             cursor = len(session.raw)
             session.send_line("/debug")

--- a/scripts/test-pty-overflow.py
+++ b/scripts/test-pty-overflow.py
@@ -126,7 +126,7 @@ def _run(error_obj: dict, tmp: str, *, raw: dict | None = None, wait_for: str = 
             unset_env=ambient,
             timeout=20.0,
         ) as session:
-            session.wait_for_literal("] ›")
+            session.wait_for_prompt()
             cursor = len(session.raw)
             session.send_line("hello")
             session.wait_for_literal(wait_for, start=cursor)

--- a/scripts/test-pty-parallel-cancel.py
+++ b/scripts/test-pty-parallel-cancel.py
@@ -145,14 +145,14 @@ def main() -> None:
                 "GRAFF_SHUTDOWN_DEBUG": "1",
             }
             with PtySession(GRAFF, ["--model", "lmstudio", "--no-telemetry"], cwd=tmp, env=env, timeout=20) as session:
-                session.wait_for_literal("] ›")
+                session.wait_for_prompt()
                 session.send_line("/yolo")
                 session.wait_for_literal("yolo mode ON")
                 cursor = len(session.raw)
                 session.send_line("run both checks")
                 wait_for_pid_files(session, pid_paths)
                 session.send_key("esc")
-                session.wait_for(r"⊘ bash\s+⊘ bash", start=cursor)
+                session.wait_for(r"⊘ sleep[\s\S]+⊘ sleep", start=cursor)
                 session.wait_for_literal("interrupted (esc)", start=cursor)
                 assert_processes_gone(pid_paths)
                 session.send_key("ctrl-d")

--- a/scripts/test-pty-peer-channel.py
+++ b/scripts/test-pty-peer-channel.py
@@ -74,7 +74,7 @@ def main() -> None:
                 unset_env=("CODEX_HOME", "NO_COLOR"),
                 timeout=25.0,
             ) as session:
-                session.wait_for_literal("] ›")
+                session.wait_for_prompt()
 
                 live = os.path.join(home, ".graff", "live")
                 deadline = time.time() + 10

--- a/scripts/test-pty-repl.py
+++ b/scripts/test-pty-repl.py
@@ -40,7 +40,7 @@ def main() -> None:
             timeout=15.0,
             cols=240,
         ) as session:
-            session.wait_for_literal("] ›")
+            session.wait_for_prompt()
 
             def command(
                 line: str,
@@ -55,20 +55,19 @@ def main() -> None:
                 if color_bytes is not None and color_bytes not in bytes(session.raw[cursor:]):
                     raise AssertionError(f"missing colored badge {color_bytes!r} after {line}")
 
-            base = "deepseek-v4-pro · Extra high · codegraff"
-            privacy = "Privacy:Aggregate"  # the default learning ceiling
-            # Match through cwd but not the closing bracket: the live context
-            # meter is appended after cwd and changes as the session evolves.
+            # Dim meter above a bare › (ADR 0016): model · effort · badges.
+            # Provider, privacy, and cwd left the line; ctx/session may follow.
+            base = "deepseek-v4-pro · Extra high"
             command(
                 "/effort xhigh",
                 "reasoning effort: Extra high",
-                f"[{base} · {privacy} · cwd {tmp}",
-                ACCENT + b"Extra high" + RESET,
+                base,
+                None,  # effort sits on the dim meter line, not an accent badge
             )
             command(
                 "/model definitely-not-a-model",
                 "unknown model 'definitely-not-a-model'",
-                f"[{base} · {privacy} · cwd {tmp}",
+                base,
                 None,
             )
             cursor = len(session.raw)
@@ -76,7 +75,8 @@ def main() -> None:
             session.wait_for_literal("/models [health]", start=cursor)
             session.wait_for_literal("/fallback [allow|remove|off]", start=cursor)
             session.wait_for_literal("/login [codegraff|codex|kimi]", start=cursor)
-            session.wait_for_literal(f"[{base} · {privacy} · cwd {tmp}", start=cursor)
+            session.wait_for_literal(base, start=cursor)
+            session.wait_for_prompt(start=cursor)
             cursor = len(session.raw)
             session.send_line("/models health")
             session.wait_for_literal("active: deepseek-v4-pro via codegraff", start=cursor)
@@ -87,31 +87,32 @@ def main() -> None:
             )
             session.wait_for(r"✓\s+codegraff\s+environment", start=cursor)
             session.wait_for(r"·\s+codex\s+missing", start=cursor)
-            session.wait_for_literal(f"[{base} · {privacy} · cwd {tmp}", start=cursor)
+            session.wait_for_literal(base, start=cursor)
+            session.wait_for_prompt(start=cursor)
             if b"local-pty-test" in bytes(session.raw[cursor:]):
                 raise AssertionError("/models health exposed a credential value")
             command(
                 "/plan",
                 "plan mode on",
-                f"[{base} · Plan · {privacy} · cwd {tmp}",
-                b"\x1b[33mPlan\x1b[0m",
+                f"{base} · Plan",
+                None,
             )
             command(
                 "/strict",
                 "strict mode ON",
-                f"[{base} · Plan · Strict · {privacy} · cwd {tmp}",
-                b"\x1b[31mStrict\x1b[0m",
+                f"{base} · Plan · Strict",
+                None,
             )
             command(
                 "/ultracode on",
                 "ultracode mode: on",
-                f"[{base} · Plan · Strict · Ultracode · {privacy} · cwd {tmp}",
-                ACCENT + b"Ultracode" + RESET,
+                f"{base} · Plan · Strict · Ultracode",
+                None,
             )
             command(
                 "/yolo",
                 "yolo mode ON",
-                f"[{base} · Plan · Strict · Ultracode · {privacy} · cwd {tmp}",
+                f"{base} · Plan · Strict · Ultracode",
                 None,
             )
             if b"\x1b[31mYOLO\x1b[0m" in bytes(session.raw):
@@ -119,7 +120,7 @@ def main() -> None:
             cursor = len(session.raw)
             session.send_line("/key no-such-provider supersecret")
             session.wait_for_literal("unknown provider 'no-such-provider'", start=cursor)
-            session.wait_for_literal(f"cwd {tmp}", start=cursor)
+            session.wait_for_prompt(start=cursor)
             if b"supersecret" in bytes(session.raw[cursor:]):
                 raise AssertionError("/key secret was echoed to the terminal")
             session.send_key("ctrl-d")
@@ -146,7 +147,7 @@ def main() -> None:
             rows=12,
             cols=44,
         ) as session:
-            session.wait_for_literal("] ›")
+            session.wait_for_prompt()
             cursor = len(session.raw)
             session.send_line("/model")
             session.wait_for_literal("CTX/KEY", start=cursor)
@@ -157,7 +158,7 @@ def main() -> None:
             if ACCENT + b"\xe2\x80\xba deepseek-v4-pro" not in paint:
                 raise AssertionError("model picker did not initially select the active model")
             session.send_key("ctrl-c")
-            session.wait_for_literal("] ›", start=cursor)
+            session.wait_for_prompt(start=cursor)
 
             cursor = len(session.raw)
             session.send_line("/effort")
@@ -168,7 +169,7 @@ def main() -> None:
             if ACCENT + b"\xe2\x80\xba Extra high" not in paint:
                 raise AssertionError("reasoning picker did not initially select the current level")
             session.send_key("ctrl-c")
-            session.wait_for_literal("] ›", start=cursor)
+            session.wait_for_prompt(start=cursor)
             session.send_key("ctrl-d")
             result = session.read_until_exit(5.0)
             if result.timed_out or result.exit_code != 0:

--- a/scripts/test-run-budget.py
+++ b/scripts/test-run-budget.py
@@ -68,11 +68,11 @@ def main() -> None:
                 unset_env=ambient,
                 timeout=10.0,
             ) as session:
-                session.wait_for_literal("] ›")
+                session.wait_for_prompt()
                 cursor = len(session.raw)
                 session.send_line("answer even though AI titles are enabled")
                 session.wait_for_literal(ROOT_REPLY, start=cursor)
-                session.wait_for_literal("] ›", start=cursor)
+                session.wait_for_prompt(start=cursor)
                 session.send_key("ctrl-d")
                 result = session.read_until_exit(5.0)
                 if result.timed_out or result.exit_code != 0:

--- a/scripts/test-title-parallel.py
+++ b/scripts/test-title-parallel.py
@@ -126,12 +126,12 @@ def main() -> None:
                 unset_env=ambient,
                 timeout=10.0,
             ) as session:
-                session.wait_for_literal("] ›")
+                session.wait_for_prompt()
                 cursor = len(session.raw)
                 sent_at = time.monotonic()
                 session.send_line("make the title and answer overlap")
                 session.wait_for_literal(MAIN_REPLY, start=cursor)
-                session.wait_for_literal("] ›", start=cursor)
+                session.wait_for_prompt(start=cursor)
                 prompt_elapsed = time.monotonic() - sent_at
                 if prompt_elapsed >= TITLE_DELAY_SECONDS - 0.4:
                     raise AssertionError(

--- a/scripts/test-tool-preview.py
+++ b/scripts/test-tool-preview.py
@@ -115,11 +115,11 @@ def main() -> None:
                 unset_env=ambient,
                 timeout=10.0,
             ) as session:
-                session.wait_for_literal("] ›")
+                session.wait_for_prompt()
                 cursor = len(session.raw)
                 session.send_line("read the large file, then finish")
                 session.wait_for_literal(FINAL_REPLY, start=cursor)
-                session.wait_for_literal("] ›", start=cursor)
+                session.wait_for_prompt(start=cursor)
                 session.send_key("ctrl-d")
                 result = session.read_until_exit(5.0)
                 if result.timed_out or result.exit_code != 0:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Zig CI miss on #596 was leftover from ADR 0016: `test-learn-auto-init.py` (and the rest of the line-REPL PTY suite) still waited for `] ›`. The prompt is now a dim meter line plus a bare `›`.

`PtySession.wait_for_prompt()` matches a line that is only that glyph, so it does not fire on a picker highlight (`› name`) or `Model ›`. Status-line assertions in `test-pty-repl.py` and `test-model-preference.py` drop the old `[model · provider · Privacy · cwd` frame. Parallel cancel looks for `⊘ sleep`, not `⊘ bash`.

Locally: `test-learn-auto-init`, `test-pty-repl`, `test-model-preference`, `test-title-parallel`, `test-pty-parallel-cancel`, `test-pty-peer-channel` pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80b8b709-faa2-48f6-a175-66e96550bb1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80b8b709-faa2-48f6-a175-66e96550bb1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

