### PR TITLE
feat(chrome): last-turn cache hit % next to ctx on REPL and TUI

### DIFF
--- a/TUI/chrome.zig
+++ b/TUI/chrome.zig
@@ -68,11 +68,11 @@ pub fn promptBox(self: *const Model, a: std.mem.Allocator, width: usize) ![]cons
     // centred, so a meter ticking 9% → 10% used to widen the label by one and
     // slide every character of the footer half a cell sideways mid-turn — the
     // same class of jitter a two-column spinner frame causes (glyphs.zig).
-    var pct_buf: [16]u8 = undefined;
-    const pct: []const u8 = if (self.contextPercent()) |p|
-        (std.fmt.bufPrint(&pct_buf, " · {d: >3}%", .{p}) catch "")
-    else
-        "";
+    var pct_buf: [32]u8 = undefined;
+    const pct: []const u8 = if (self.contextPercent()) |p| blk: {
+        const cache = if (self.status) |st| st.cachePercent() else null;
+        break :blk (std.fmt.bufPrint(&pct_buf, " · {d: >3}% · {d: >3}%c", .{ p, cache orelse 0 }) catch "");
+    } else "";
     const label = try std.fmt.allocPrint(a, " {s} ({s}) · {s}{s} ", .{ model, @tagName(self.effort), self.modeSlug(), pct });
     try out.appendSlice(try footer(a, border, th.muted, label, inner));
     return out.items;
@@ -360,7 +360,14 @@ test "the composer footer holds its columns as the context meter ticks" {
     defer arena.deinit();
     var col: ?usize = null;
     for ([_]u64{ 5, 9, 10, 99, 100 }) |pct| {
-        m.setStatus(.{ .model = "grok-4", .provider_id = "xai", .has_context = true, .tokens = pct, .window = 100 });
+        m.setStatus(.{
+            .model = "grok-4",
+            .provider_id = "xai",
+            .has_context = true,
+            .tokens = pct,
+            .window = 100,
+            .cache_read = pct / 2,
+        });
         const box = try promptBox(&m, arena.allocator(), 80);
         var it = std.mem.splitScalar(u8, box, '\n');
         var footer_row: []const u8 = "";
@@ -371,7 +378,29 @@ test "the composer footer holds its columns as the context meter ticks" {
         const start = theme_mod.visibleLen(footer_row[0..at]);
         if (col) |want| try std.testing.expectEqual(want, start) else col = start;
         try std.testing.expectEqual(@as(usize, 80), theme_mod.visibleLen(footer_row));
+        try std.testing.expect(std.mem.indexOf(u8, footer_row, "%c") != null);
     }
+}
+
+test "composer footer prints last-turn cache hit next to context share" {
+    engine.g_model_name = "grok-4";
+    defer engine.g_model_name = "";
+    var m: Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    m.setStatus(.{
+        .model = "grok-4",
+        .provider_id = "xai",
+        .has_context = true,
+        .tokens = 12_345,
+        .window = 200_000,
+        .cache_read = 2048,
+    });
+    const box = try promptBox(&m, arena.allocator(), 80);
+    try std.testing.expect(std.mem.indexOf(u8, box, "  6%") != null);
+    try std.testing.expect(std.mem.indexOf(u8, box, " 16%c") != null);
 }
 
 test "prompt box wraps a long draft onto several rows" {

--- a/TUI/events.zig
+++ b/TUI/events.zig
@@ -72,6 +72,13 @@ pub const Status = struct {
         if (!self.has_context or self.window == 0) return 0;
         return @min((self.tokens *| 100) / self.window, 100);
     }
+
+    /// Last-turn prompt-cache hit: cached tokens over the prompt that
+    /// produced them. Null until a turn has reported a context size.
+    pub fn cachePercent(self: Status) ?u64 {
+        if (!self.has_context or self.tokens == 0) return null;
+        return @min((self.cache_read *| 100) / self.tokens, 100);
+    }
 };
 
 pub const Event = union(enum) {

--- a/TUI/meters.zig
+++ b/TUI/meters.zig
@@ -28,10 +28,11 @@ pub fn contextInfo(self: *Model) void {
         self.pushFmt(.system, "context: {s} has not reported usage yet", .{st.model}) catch {};
         return;
     }
-    self.pushFmt(.system, "context: {d} / {d} tokens ({d}%) · compacts at {d} · {d} cached", .{
+    self.pushFmt(.system, "context: {d} / {d} tokens ({d}%) · cache {d}% · compacts at {d} · {d} cached", .{
         st.tokens,
         st.window,
         st.percent(),
+        st.cachePercent() orelse 0,
         st.compact_at,
         st.cache_read,
     }) catch {};
@@ -88,6 +89,7 @@ test "/context reports the engine's tokens, never a character count (#551)" {
     try testing.expect(std.mem.indexOf(u8, line, "12345") != null);
     try testing.expect(std.mem.indexOf(u8, line, "200000") != null);
     try testing.expect(std.mem.indexOf(u8, line, "6%") != null);
+    try testing.expect(std.mem.indexOf(u8, line, "cache 16%") != null);
     try testing.expect(std.mem.indexOf(u8, line, "160000") != null);
     try testing.expect(std.mem.indexOf(u8, line, "2048") != null);
     try testing.expect(std.mem.indexOf(u8, line, "chars") == null);

--- a/docs/adr/0018-standing-chrome-shows-last-turn-cache-hit.md
+++ b/docs/adr/0018-standing-chrome-shows-last-turn-cache-hit.md
@@ -1,0 +1,28 @@
+# 0018. Standing chrome shows last-turn cache hit
+
+Status: accepted 2026-08-21
+
+## Context
+
+`/cache` already has session hit rate (ADR 0011). The standing line only
+said `ctx N%` — window fill — so a 99% prompt-cache hit looked like
+nothing happened. `cache_read` was already on `.prompt_ready`; the TUI
+footer and the line-REPL meter just never printed the share.
+
+## Decision
+
+Last-turn hit rate (`cache_read / prompt tokens`) rides next to `ctx`
+on both frontends:
+
+- line REPL dim meter: `ctx 6% · cache 94%`
+- TUI composer footer: ` ·  12% ·  94%c` (fixed-width; the `c` is cache)
+
+Cache never appears without a context meter (no denominator). A measured
+turn with zero cached tokens still prints `cache 0%` — the fun is
+watching it jump. `/cache` stays the posture HUD.
+
+## Consequences
+
+A narrow pane may drop `cache` before `ctx` (same #209 right-to-left
+budget). Do not substitute session hit rate here; that number lives
+behind `/cache`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ record only when you need the evidence or the edge cases.
 | [0015](0015-ask-user-images-are-a-follow-up-user-message.md) | `ask_user` images ride a follow-up user message after the text tool result; Responses/OpenAI tool output stays text-only. |
 | [0016](0016-line-repl-is-a-working-block.md) | Line REPL chrome is a `WORKING` block plus a bare `›`; tool fan-out is a tree, never `✓ bash`. |
 | [0017](0017-model-election-ranks-signed-in-plans-first.md) | `/model` and `/models` on both frontends rank signed-in plan seats above credits and metered keys (`src/models_rank.zig`). |
+| [0018](0018-standing-chrome-shows-last-turn-cache-hit.md) | Last-turn cache hit % rides with `ctx` on the line-REPL meter and the TUI footer; `/cache` stays the posture HUD. |
 
 ## When to write one
 

--- a/src/agent_prompt_render.zig
+++ b/src/agent_prompt_render.zig
@@ -154,6 +154,17 @@ fn line(w: *Io.Writer, st: PromptStatus, cols: usize) !void {
         (std.fmt.bufPrint(&ctxbuf, "ctx {d}%", .{contextPercent(meter.tokens, meter.window)}) catch "")
     else
         "";
+    var cachebuf: [24]u8 = undefined;
+    // Last-turn hit rate: cached tokens over the prompt that produced them.
+    // Rides with ctx — a lone cache badge has no denominator. 0% after a
+    // measured turn is still a reading (the fun is watching it jump).
+    const cache: []const u8 = if (st.context) |meter|
+        (if (meter.tokens > 0)
+            (std.fmt.bufPrint(&cachebuf, "cache {d}%", .{contextPercent(st.cache_read, meter.tokens)}) catch "")
+        else
+            "")
+    else
+        "";
     var resumebuf: [24]u8 = undefined;
     const resume_hint: []const u8 = if (st.saved_sessions > 0)
         (std.fmt.bufPrint(&resumebuf, "/resume {d}", .{st.saved_sessions}) catch "")
@@ -174,6 +185,7 @@ fn line(w: *Io.Writer, st: PromptStatus, cols: usize) !void {
     const show_strict = st.strict and fitsSegment(&used, avail, 3 + "Strict".len);
     const show_ultra = st.ultracode and fitsSegment(&used, avail, 3 + "Ultracode".len);
     const show_ctx = ctx.len > 0 and fitsSegment(&used, avail, 3 + ctx.len);
+    const show_cache = show_ctx and cache.len > 0 and fitsSegment(&used, avail, 3 + cache.len);
     const show_cost = cost.len > 0 and fitsSegment(&used, avail, 3 + cost.len);
     const show_resume = resume_hint.len > 0 and fitsSegment(&used, avail, 3 + resume_hint.len);
     const show_image = st.standing.image and fitsSegment(&used, avail, 3 + "image".len);
@@ -188,6 +200,7 @@ fn line(w: *Io.Writer, st: PromptStatus, cols: usize) !void {
     if (show_strict) try w.print(" · Strict", .{});
     if (show_ultra) try w.print(" · Ultracode", .{});
     if (show_ctx) try w.print(" · {s}", .{ctx});
+    if (show_cache) try w.print(" · {s}", .{cache});
     if (show_cost) try w.print(" · {s}", .{cost});
     if (show_resume) try w.print(" · {s}", .{resume_hint});
     if (show_image) try w.print(" · image", .{});
@@ -294,7 +307,7 @@ test "batch 3: every status-line segment renders exactly as it did inline" {
         .ultracode = true,
     };
     try std.testing.expectEqualStrings(
-        "\ngpt-5.6 · Fast · High · Fallback · Plan · Strict · Ultracode · ctx 6% · $0.50\n› ",
+        "\ngpt-5.6 · Fast · High · Fallback · Plan · Strict · Ultracode · ctx 6% · cache 16% · $0.50\n› ",
         renderPlain(&aw, full),
     );
 
@@ -360,7 +373,7 @@ test "batch 3: a shrinking pane sheds segments in the #209 priority order" {
         .cost = .unpriced,
     };
     const cases = [_]struct { cols: usize, want: []const u8 }{
-        .{ .cols = 80, .want = "\ngpt-5.6 · High · ctx 6% · $?\n› " },
+        .{ .cols = 80, .want = "\ngpt-5.6 · High · ctx 6% · cache 16% · $?\n› " },
         .{ .cols = 28, .want = "\ngpt-5.6 · High · ctx 6%\n› " },
         .{ .cols = 18, .want = "\ngpt-5.6 · High\n› " },
     };
@@ -389,6 +402,27 @@ test "batch 3: the cache badge rides with the context meter, never alone" {
         .cache_read = 4096, // reported, but no context meter to ride with
     });
     try std.testing.expect(std.mem.indexOf(u8, out, "cached") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "cache ") == null);
+}
+
+test "a measured turn prints last-turn cache hit next to ctx" {
+    const saved = style.*;
+    style.* = .{};
+    defer style.* = saved;
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    // 2048 of 12345 input tokens ≈ 16%; the window share stays ctx 6%.
+    const out = renderPlain(&aw, .{
+        .model = "m",
+        .provider_id = "p",
+        .cwd = "/w",
+        .privacy_label = "Privacy:Local",
+        .privacy = .local,
+        .context = .{ .tokens = 12_345, .window = 200_000, .compact_at = 160_000 },
+        .cache_read = 2048,
+    });
+    try std.testing.expect(std.mem.indexOf(u8, out, "ctx 6%") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "cache 16%") != null);
 }
 
 test "WORKING block sits above a bare prompt and is skipped when empty" {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Yes — and it was already on the wire. `.prompt_ready` carries `cache_read`; the standing chrome just never printed the share.

After a turn that reports usage:

- **Line REPL** dim meter: `ctx 6% · cache 94%`
- **TUI** composer footer: ` ·  12% ·  94%c` (fixed-width so 9% → 10% does not slide the label)

That is last-turn hit rate (`cache_read / prompt tokens`), the number that jumps on turn 2. A measured miss still prints `cache 0%`. Cache never appears without a context meter (no denominator). A narrow pane may drop `cache` before `ctx`. `/cache` stays the posture HUD.

ADR 0018.

## Tests

- `zig build test`: 1551 pass / 1 skip
- `zig build tui-test`: 428 pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80b8b709-faa2-48f6-a175-66e96550bb1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80b8b709-faa2-48f6-a175-66e96550bb1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

