### PR TITLE
fix(repl): PTY waiters look for ctx N% after ADR 0016

### DIFF
--- a/scripts/codex_ws_test.py
+++ b/scripts/codex_ws_test.py
@@ -21,11 +21,12 @@ _arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
 GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
 
 
-# The reported 1500-token usage is conservatively floored by graff's serialized
-# request estimate, so the displayed used count can move with the built-in tool
-# schema. Assert the meter shape and invariants rather than freezing either the
-# prefill estimate or the Codex catalog window.
-METER_RE = re.compile(r"(\d+)(k?)/(\d+)k ctx \((\d+)% · compact@(\d+)k\)")
+# ADR 0016/0018: the standing line is `ctx N%` (optional ` · cache N%`). Used,
+# window, and compact@ left that line. `/models health` still prints
+# `active: … · {d}k ctx · compact@{d}k` — that is how smoke scenarios learn the
+# runtime Codex window without freezing the catalog.
+CTX_RE = re.compile(r"ctx (\d+)%")
+ACTIVE_WINDOW_RE = re.compile(r"active: .+ · (\d+)k ctx · compact@(\d+)k")
 COMPACTING_RE = re.compile(r"compacting ~(\d+) tokens")
 
 MIDTURN_PROMPT = "exercise the server-side context meter"
@@ -336,18 +337,11 @@ def run_scenario(
         cursor = len(session.raw)
         session.send_line("ping")
         session.wait_for_literal(REPLY_TEXT, start=cursor)
-        session.wait_for(METER_RE, start=cursor)
-        meter = METER_RE.search(terminal_text(bytes(session.raw[cursor:])))
-        used = int(meter.group(1)) * (1000 if meter.group(2) == "k" else 1)
-        ctx_k, pct, compact_k = map(int, meter.group(3, 4, 5))
-        if used <= 0 or not 0 <= pct <= 100:
-            raise AssertionError(
-                f"{label}: invalid context meter values used={used} pct={pct}"
-            )
-        if ctx_k <= 0 or not 79 * ctx_k <= 100 * compact_k <= 81 * ctx_k:
-            raise AssertionError(
-                f"{label}: inconsistent meter context={ctx_k}k compact@={compact_k}k"
-            )
+        session.wait_for(CTX_RE, start=cursor)
+        standing = terminal_text(bytes(session.raw[cursor:]))
+        pct = int(CTX_RE.search(standing).group(1))
+        if not 0 <= pct <= 100:
+            raise AssertionError(f"{label}: invalid standing ctx percent {pct}")
         if mock.ws_turns != expect_ws or mock.sse_turns != expect_sse:
             raise AssertionError(
                 f"{label}: transport mismatch — ws_turns={mock.ws_turns} "
@@ -356,6 +350,15 @@ def run_scenario(
         cursor = len(session.raw)
         session.send_line("/models health")
         session.wait_for_literal(f"Codex transport: {health}", start=cursor)
+        session.wait_for(ACTIVE_WINDOW_RE, start=cursor)
+        health_text = terminal_text(bytes(session.raw[cursor:]))
+        window = ACTIVE_WINDOW_RE.search(health_text)
+        ctx_k, compact_k = map(int, window.group(1, 2))
+        if ctx_k <= 0 or not 79 * ctx_k <= 100 * compact_k <= 81 * ctx_k:
+            raise AssertionError(
+                f"{label}: inconsistent /models health context={ctx_k}k "
+                f"compact@={compact_k}k"
+            )
         session.wait_for_prompt(start=cursor)
         session.send_key("ctrl-d")
         result = session.read_until_exit(5.0)

--- a/scripts/test-pty-overflow.py
+++ b/scripts/test-pty-overflow.py
@@ -9,8 +9,8 @@ precise:
   A. error.code = context_length_exceeded with a message that matches none of the
      English substrings (Dutch). graff must still detect the overflow via the
      STRUCTURED code (#203/G2), pin the meter to the window, and stay responsive
-     rather than wedge (#201/#202). Observable: the prompt's ctx meter reads
-     "<W>k/<W>k ctx (100% ...)".
+     rather than wedge (#201/#202). Observable: the standing line pins at
+     `ctx 100%` (ADR 0016).
   B. error.code = rate_limit_exceeded with a non-overflow message. graff must NOT
      mistake it for an overflow: the meter must not pin. Proves detection is precise.
 
@@ -44,9 +44,9 @@ from pty_harness import PtySession, terminal_text
 _arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
 GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
 
-# "<used>k/<window>k ctx (<pct>% · compact@<X>k)" — the "·" is U+00B7.
-METER_RE = re.compile(r"(\d+)k/(\d+)k ctx \((\d+)% · compact@(\d+)k\)")
-PINNED_RE = re.compile(r"(\d+)k/(\d+)k ctx \(100% · compact@\d+k\)")
+# ADR 0016: standing chrome is `ctx N%`. Overflow pins at 100%.
+PINNED_RE = re.compile(r"ctx 100%")
+ACTIVE_WINDOW_RE = re.compile(r"active: .+ · (\d+)k ctx")
 
 # lmstudio/lmstudio is a CATALOGUED model (pricing.zig context_overlay), so its
 # window is fixed at 200k and GRAFF_CONTEXT deliberately cannot shrink it (#203).
@@ -131,13 +131,18 @@ def _run(error_obj: dict, tmp: str, *, raw: dict | None = None, wait_for: str = 
             session.send_line("hello")
             session.wait_for_literal(wait_for, start=cursor)
             session.pump_for(1.5)
-            rendered = terminal_text(bytes(session.raw[cursor:]))
 
             # Session must remain usable after the failed turn (no wedge): a local
-            # command still works and the REPL exits cleanly.
+            # command still works and the REPL exits cleanly. `/models health`
+            # is also how we read the catalog window now that the standing line
+            # is percent-only (ADR 0016).
             c2 = len(session.raw)
             session.send_line("/help")
             session.wait_for_literal("/models [health]", start=c2)
+            c3 = len(session.raw)
+            session.send_line("/models health")
+            session.wait_for(ACTIVE_WINDOW_RE, start=c3)
+            rendered = terminal_text(bytes(session.raw[cursor:]))
             session.send_key("ctrl-d")
             result = session.read_until_exit(5.0)
             if result.timed_out or result.exit_code != 0:
@@ -187,10 +192,7 @@ def main() -> None:
                 "A: meter did not pin to the window — the structured error.code "
                 f"(context_length_exceeded) was not detected as overflow (#203/G2):\n{rendered}"
             )
-        m = METER_RE.search(rendered)
-        if m.group(1) != m.group(2):
-            raise AssertionError(f"A: meter used != window despite pin: {m.group(0)!r}")
-        print(f"ok    overflow-by-code detected end to end; meter pinned to {m.group(2)}k (100%)")
+        print("ok    overflow-by-code detected end to end; standing line pinned at ctx 100%")
 
         # Scenario B: a non-overflow code + non-overflow message must NOT pin.
         rendered, _ = _run(
@@ -248,8 +250,12 @@ def main() -> None:
         pinned = PINNED_RE.search(rendered)
         if not pinned:
             raise AssertionError(f"D: silent overflow did not pin the meter to the window:\n{rendered}")
-        if pinned.group(2) != str(LMSTUDIO_WINDOW // 1000):
-            raise AssertionError(f"D: lmstudio's catalogued window moved; update LMSTUDIO_WINDOW ({pinned.group(0)!r})")
+        window = ACTIVE_WINDOW_RE.search(rendered)
+        if window is None or window.group(1) != str(LMSTUDIO_WINDOW // 1000):
+            raise AssertionError(
+                "D: lmstudio's catalogued window moved; update LMSTUDIO_WINDOW "
+                f"({None if window is None else window.group(0)!r})"
+            )
         print("ok    silent 200 (empty completion, usage at the window) classified as overflow (#414)")
 
         # Scenario E (#414): MiMo truncates an oversized input to fit the window,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The zig job on `release/v0.0.269` has been red since the line-chrome merge. `test-pty-codex-ws.py` still waited for the old standing meter:

```
2k/200k ctx (1% · compact@160k)
```

ADR 0016 made that line `ctx 2%` (and ADR 0018 may add ` · cache N%`). The smoke timed out looking for compact@.

This keeps the same invariants, just reads them from the surfaces that still print them:

- standing line: `ctx N%` (0–100)
- `/models health`: `active: … · {d}k ctx · compact@{d}k` — still the source for the runtime Codex window the mid-turn compaction fixtures size against

`test-pty-overflow.py` is the same leftover (not in the zig job). Pin is now `ctx 100%`; the catalogued window comes from `/models health`.

Base is `release/v0.0.269`. Not a 270 cut.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80b8b709-faa2-48f6-a175-66e96550bb1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80b8b709-faa2-48f6-a175-66e96550bb1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

