### PR TITLE
release/v0.0.277 — MCP slim (L) + licensed surface, no tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,11 @@ current is part of cutting a release.
 - xAI Responses splices hosted `x_search` onto tools turns (ADR 0031).
   Not a catalog tool. `GRAFF_XAI_X_SEARCH=0` opts out. Same-prompt
   SuperGrok A/B vs scrape: 101s / 7 calls / 64k in → 37s / 1 call / 28k.
+- Small turns hide `rlm` / sPTC (ADR 0030). Showcase on `--rlm`, a ≥4
+  native batch, context ≥50% of `compactAt`, or an explicit load —
+  never MCP fan-out, never the prefix. Tools head stays cache-stable.
 - No `v0.0.277` git tag on this cut.
-- Test ratchet: unit suite 1672 (floor 1664).
+- Test ratchet: unit suite 1677 (floor 1664).
 
 ## v0.0.276 (2026-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,11 @@ current is part of cutting a release.
   (#624/#625).
 - Smolify / deepwiki / mobbin stay out of the default catalog unless opted
   in (`GRAFF_SMOLIFY`) (#628).
+- xAI Responses splices hosted `x_search` onto tools turns (ADR 0031).
+  Not a catalog tool. `GRAFF_XAI_X_SEARCH=0` opts out. Same-prompt
+  SuperGrok A/B vs scrape: 101s / 7 calls / 64k in → 37s / 1 call / 28k.
 - No `v0.0.277` git tag on this cut.
-- Test ratchet: unit suite 1664.
+- Test ratchet: unit suite 1672 (floor 1664).
 
 ## v0.0.276 (2026-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
-## v0.0.277 (2026-08-25)
+## v0.0.277 (2026-08-26)
 
 - MCP tools that `load_tool_schemas` has unfolded are `rlm` host functions
   (`each` / `len` / `project`). Return **shapes** (keys + broad types, never
@@ -37,7 +37,6 @@ current is part of cutting a release.
 - Small turns hide `rlm` / sPTC (ADR 0030). Showcase on `--rlm`, a ≥4
   native batch, context ≥50% of `compactAt`, or an explicit load —
   never MCP fan-out, never the prefix. Tools head stays cache-stable.
-- No `v0.0.277` git tag on this cut.
 - Test ratchet: unit suite 1677 (floor 1664).
 
 ## v0.0.276 (2026-08-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
+## v0.0.277 (2026-08-25)
+
+- MCP tools that `load_tool_schemas` has unfolded are `rlm` host functions
+  (`each` / `len` / `project`). Return **shapes** (keys + broad types, never
+  values) persist in `.graff/mcp-shapes.json` and splice onto the next load
+  **result**, never the catalog prefix (ADR 0029).
+- Fat MCP JSON arrays auto-slim after `remember()`: identity keys on
+  issue-like rows; comments fold to `{n, latest_author}`. Two stored shapes
+  add a `# muscle:` playbook on the load result.
+- Full-harness SuperGrok grok-4.6 (`graff-dev-nolean`): **L** (warm slim)
+  14.8s / 31k / 5 and **N** (cold slim) 20.8s / 30k / 5 dominate the
+  pre-slim H/I/J front. Lean catalog (R) is a different prefix and is not
+  on that front.
+- Default `-p` connects a workspace `.mcp.json` and folds schemas; it no
+  longer skips MCP. `--no-lean` is eager schemas, not the MCP on-switch.
+- Licensed codedb-pro: one read/search surface (hide native `read_file` /
+  `codedb`, omit companion writes, keep native edits) (#626/#627).
+- Long turns and transport retries pulse without a default 16-call cap
+  (#624/#625).
+- Smolify / deepwiki / mobbin stay out of the default catalog unless opted
+  in (`GRAFF_SMOLIFY`) (#628).
+- No `v0.0.277` git tag on this cut.
+- Test ratchet: unit suite 1664.
+
 ## v0.0.276 (2026-08-25)
 
 - `rlm` (Zhang/Khattab RLM + alexzhang13 spec-ptc, Zig — not Prime's

--- a/docs/adr/0002-xai-defaults-to-the-responses-wire.md
+++ b/docs/adr/0002-xai-defaults-to-the-responses-wire.md
@@ -38,6 +38,8 @@ back onto chat completions.
   full-resend over the held socket.
 - Revisit if xAI's wire diverges from OpenAI Responses semantics or the
   compact endpoint's blob replay pricing changes the cost picture.
+- Hosted `x_search` rides this wire by default (ADR
+  [0031](0031-xai-hosted-x-search.md)); chat completions cannot host it.
 
 Evidence: #502, #503, #505, the recall A/B kit (session scratchpad
 recall-ab/), ADR [0001](0001-structured-outputs-are-a-formatting-step.md)

--- a/docs/adr/0022-rlm-is-opt-in-speculative-ptc.md
+++ b/docs/adr/0022-rlm-is-opt-in-speculative-ptc.md
@@ -85,8 +85,8 @@ regression* without a catalog tax. Per-task swings are one-rep variance.
 - Semicolons (outside strings) are statements, so a one-line script still
   speculates. Host positional fields include `bash` / `webfetch`. `print(a, b)`
   joins binds. Do not splice `system_note` onto the always-on prefix
-  (ADR 0011 / 0030): small turns hide `rlm` until `--rlm` or a wide
-  native batch. sPTC stays wired for after unfold.
+  (ADR 0011 / 0030): small turns hide `rlm` until `--rlm`, a wide
+  native batch, or context ≥50% of compactAt. sPTC stays wired for after unfold.
 - Scatter-gather tasks live in the `rlm` eval suite (`graff-evals/run.py
   --suite rlm`). Default `--suite all` runs core + rlm + swe. Measured
   2026-08-25 on grok-4.6 (one rep): both **4/4**, native **86.8s / 53564

--- a/docs/adr/0022-rlm-is-opt-in-speculative-ptc.md
+++ b/docs/adr/0022-rlm-is-opt-in-speculative-ptc.md
@@ -84,8 +84,9 @@ regression* without a catalog tax. Per-task swings are one-rep variance.
   only). Launch flags `--rlm` / `--old` are in the `--schema` flags list.
 - Semicolons (outside strings) are statements, so a one-line script still
   speculates. Host positional fields include `bash` / `webfetch`. `print(a, b)`
-  joins binds. A short system note is spliced only while the flag is on so
-  the folded spec is discoverable without paying its schema.
+  joins binds. Do not splice `system_note` onto the always-on prefix
+  (ADR 0011 / 0030): small turns hide `rlm` until `--rlm` or a wide
+  native batch. sPTC stays wired for after unfold.
 - Scatter-gather tasks live in the `rlm` eval suite (`graff-evals/run.py
   --suite rlm`). Default `--suite all` runs core + rlm + swe. Measured
   2026-08-25 on grok-4.6 (one rep): both **4/4**, native **86.8s / 53564

--- a/docs/adr/0024-three-harness-compare-prompt-subagent-rss.md
+++ b/docs/adr/0024-three-harness-compare-prompt-subagent-rss.md
@@ -52,9 +52,9 @@ compare only.
 
 **Prompt hell-optimize (this revision):**
 
-- `rlm_spec.system_note` stays on the root prefix only (children use
-  `sub_system_prompt` — they never see `rlm(code)`). Shorten the note
-  without dropping persist / sidecar / print.
+- `rlm_spec.system_note` is not on the always-on prefix (ADR 0030).
+  Children already use `sub_system_prompt` and never see `rlm(code)`.
+  Keep the note short (persist / sidecar / print) for `--rlm` / load.
 - Child brief: do not broaden, do not narrate tool calls (grok + kimi).
 - Do not reshuffle messages. Keep `reasoning_content` replay (already
   pinned; grok's official top Chat cache-miss cause).

--- a/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
+++ b/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
@@ -120,7 +120,7 @@ A point is on the front if nothing else is ≤ on every axis and < on one.
 
 | id | wall | in | calls | why it stays |
 |---|---:|---:|---:|---|
-| **H** | **28.0s** | 112k | **7** | fastest / fewest calls (no-hint structured) |
+| **R** | **16.3s** | **14k** | **4** | default `-p` (lean fold + slim); dominates H |
 | **I** | 31.1s | 107k | 7 | same path, slightly fewer tokens |
 | **D-r1** | 41.1s | 107k | 10 | rlm+each, one lucky rep |
 | **J-live** | 47.3s | **84k** | 9 | `each` + `len`/`project`; first script printed ids only |
@@ -155,3 +155,12 @@ tool. Consent is unchanged. `--no-lean` is the eager-schema opt-out, not
 the MCP on-switch.
 
 Prove with variant **R**: `graff-dev` (no `--no-lean`) + `linear-nohint`.
+
+Live SuperGrok grok-4.6, ReleaseSafe, one rep (`9ec5884`):
+
+| var | harness | pass | wall | RSS | in | out | calls |
+|---|---|---:|---:|---:|---:|---:|---:|
+| **R** default `-p` | graff-dev (lean+yolo) | ✓ | **16.3s** | 9.5M | **14113** | 928 | **4** |
+| H (prior, `--no-lean`) | graff-dev-nolean | ✓ | 28.0s | 10.6M | 112073 | 1607 | 7 |
+
+R dominates H on wall, tokens, and calls. The `--no-lean` MCP one-shot was the expensive path: full catalog + fat results. Default `-p` + fold + slim is the box.

--- a/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
+++ b/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
@@ -109,6 +109,8 @@ signal. H/I 7-call structured is the stable cheap path today.
 - A later `len`/`for` would cut C/D/F/G retries; do not grow a general
   language without that measurement.
 - Prompting "prefer one rlm script" is not free. Default no-hint.
+- Small MCP/coding turns do not advertise `rlm` or sPTC (ADR 0030).
+  Do not showcase on first slim or an MCP comment fan-out.
 
 ## Pareto front (wall / tok_in / calls)
 

--- a/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
+++ b/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
@@ -143,3 +143,15 @@ called `rlm`). The learnt part is therefore applied in Zig: after
 When two MCP shapes are stored, `annotate` adds a one-line `# muscle:`
 playbook on the load **result** (never the catalog prefix). No new
 `GRAFF_` knob. Live L–Q sweep: `eval-mcp-shapes.py --only L,M,N,O,P,Q`.
+
+## Out of the box (default `-p`)
+
+Lean used to **skip MCP connect** and **hide** `load_tool_schemas` even
+when a workspace `.mcp.json` was present. That forced `--no-lean` for
+every MCP one-shot (ADR 0024 leftover). Default `-p` implies lean +
+yolo: now it **connects** and **folds** (names + one-liners, full
+schemas a load away). Empty `-p` (no deferred MCP) still hides the meta
+tool. Consent is unchanged. `--no-lean` is the eager-schema opt-out, not
+the MCP on-switch.
+
+Prove with variant **R**: `graff-dev` (no `--no-lean`) + `linear-nohint`.

--- a/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
+++ b/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
@@ -1,0 +1,81 @@
+# 0029. MCP-inside-rlm host calls + persist return shapes (not V8)
+
+Status: accepted 2026-08-25
+
+## Context
+
+[Blacksmith code mode](https://www.blacksmith.sh/blog/code-smith-code-mode)
+(2026-08-24) hid the MCP catalog, ran one sandbox script, and persisted
+return **shapes** (field names + broad types, never values) so the next
+search did not guess. Cold code mode lost on wall because the model
+lacked shapes and retried.
+
+Graff already has the coding-loop half as default `rlm` (ADR 0022). ADR
+0023 rejected V8 Code Mode. An rlm-only catalog already failed (122
+calls, ADR 0024). This record is the Linear-shaped measurement of
+**MCP-inside-rlm** + muscle memory, on a fixture stdio server
+(`scripts/linear_fixture_mcp.py`: 8 fat issues, fat comments per id).
+No live Linear.
+
+## Decision
+
+- After `load_tool_schemas` unfolds a tool, an `rlm` script may call that
+  MCP name via `exec_mod` (`src/rlm_mcp.zig`). Unloaded names are
+  refused. Deferral can only subtract. `GRAFF_RLM_MCP=0` restores
+  today's structured-only gap. Lean/consent unchanged (`--no-lean` is
+  still required to see MCP).
+- Infer a small return schema after an MCP result; persist
+  `.graff/mcp-shapes.json`; splice onto the next `load_tool_schemas`
+  **result**. Never the always-on prefix (ADR 0011).
+- `each(arr, tool, field)` maps a JSON array. Not a general language.
+- Do not hide bash/edit/read_file. Do not add IPython/V8/QuickJS. Do
+  not make `rlm` the only catalog tool.
+
+## Live A/B (2026-08-25)
+
+SuperGrok OAuth, grok-4.6, one rep, ReleaseSafe. `[usage]` is `$0.0000 ·
+N subscription call(s), flat-rate`. Same prompt for A–D (8 issues +
+comments + counts + latest authors). `tok_in` is ordinary+cache_read+
+cache_write as graff reports it.
+
+Rerun: `zig build -Doptimize=ReleaseSafe && python3 scripts/eval-mcp-shapes.py`
+
+| var | harness | pass | wall | RSS | in | cached | out | calls | rlm retries |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| A `--old` structured MCP | graff-dev-old-nolean | ✓ | 36.7s | 10.6M | 167692 | 128000 | 2033 | 10 | none |
+| B rlm, MCP structured-only | graff-dev-rlm-struct | ✓ | 43.3s | 10.8M | 179822 | 109312 | 2358 | 11 | 2 (host off, then `import`) |
+| C rlm+MCP host, cold | graff-dev-nolean | ✓ | 56.7s | 10.6M | 147948 | 130048 | 3313 | 13 | 3 (`import` / `for` / `len`) |
+| D rlm+MCP host, warm shapes | graff-dev-nolean + pre-seeded `.graff/mcp-shapes.json` | ✓ | 41.1s | 10.7M | **107213** | 83840 | 2253 | 10 | 1 (`len`) |
+| E1 sidecar summarize | graff-dev-nolean / linear-sidecar | ✓ | 37.5s | 10.7M | 168164 | 120704 | 1998 | 11 | none (structured MCP on root) |
+| E2 two sibling children | graff-dev-nolean / linear-split | ✓ | 75.5s | 12.3M | 149156 | 77824 | 5490 | 18 | children have no MCP; more expensive |
+
+**B is the old gap, not papered over.** The model wrote
+`each(issues, mcp__linear__list_comments, "id")` and was refused
+(`GRAFF_RLM_MCP=0`), then fell back to 1+8 structured MCP.
+
+**C each() worked** on the first script (host calls + map). Cold lost
+on **wall** (+20s vs A) because `print(issues)` / `print(comments)`
+dumped the fat payloads and the model retried Python `for`/`len`.
+Token-in still beat A (−12%).
+
+**D muscle memory was a real token win vs `--old`:** −36% input
+(167k→107k), same 10 calls, −4s vs cold C. Wall still +4s vs A this
+rep — the model still printed a fat bind. Shapes appeared on the
+`load_tool_schemas` result (`return_shapes`), not on the catalog
+prefix. No wrong MCP field names this rep; retries were missing
+language (`len`/`for`), not `issue_id` vs `id`.
+
+**E1** kept MCP on the root (ADR 0023) and matched A's wall; no token
+win. **E2** passed but is the expensive split (18 calls / 75s).
+
+Verdict: ship MCP-inside-rlm + shape cache. Do not copy Blacksmith's
+V8 sandbox. SuperGrok $ is a wash; the 60k input cut on D is the
+metered-key spend win.
+
+## Consequences
+
+- `--no-lean` remains the MCP one-shot. Lean still hides
+  `load_tool_schemas`.
+- `each()` is the only new control-flow helper. A later `len`/`for`
+  would cut C/D retries; do not grow a general language without another
+  measured A/B.

--- a/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
+++ b/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
@@ -120,19 +120,20 @@ A point is on the front if nothing else is ≤ on every axis and < on one.
 
 | id | wall | in | calls | why it stays |
 |---|---:|---:|---:|---|
-| **R** | **16.3s** | **14k** | **4** | default `-p` (lean fold + slim); dominates H |
+| **H** | **28.0s** | 112k | **7** | fastest / fewest calls (no-hint structured, `--no-lean`) |
 | **I** | 31.1s | 107k | 7 | same path, slightly fewer tokens |
 | **D-r1** | 41.1s | 107k | 10 | rlm+each, one lucky rep |
 | **J-live** | 47.3s | **84k** | 9 | `each` + `len`/`project`; first script printed ids only |
 
 Everything else is dominated (including `--old`, sidecar, split,
-quiet-print, K-live, and H-live's 70s variance rep).
+quiet-print, K-live, and H-live's 70s variance rep). **R is not on
+this front:** it ran the lean catalog (`graff-dev`), a different
+harness. The MCP bench is `--no-lean` only (`graff-dev-nolean`).
 
 J used rlm for real (`issues = list_issues(); comments = each(...);
 print(len, project)`). It is the **token vertex**. H is the **wall
 vertex**. There is still no point that wins both. Warm shapes (K) did
-not help J. Do not ship rlm-as-default for this MCP task; keep
-len/project so the token vertex is reachable.
+not help J. Keep len/project so the token vertex is reachable.
 
 ## Learnt slim (the muscle, not another hint)
 
@@ -154,13 +155,7 @@ schemas a load away). Empty `-p` (no deferred MCP) still hides the meta
 tool. Consent is unchanged. `--no-lean` is the eager-schema opt-out, not
 the MCP on-switch.
 
-Prove with variant **R**: `graff-dev` (no `--no-lean`) + `linear-nohint`.
-
-Live SuperGrok grok-4.6, ReleaseSafe, one rep (`9ec5884`):
-
-| var | harness | pass | wall | RSS | in | out | calls |
-|---|---|---:|---:|---:|---:|---:|---:|
-| **R** default `-p` | graff-dev (lean+yolo) | ✓ | **16.3s** | 9.5M | **14113** | 928 | **4** |
-| H (prior, `--no-lean`) | graff-dev-nolean | ✓ | 28.0s | 10.6M | 112073 | 1607 | 7 |
-
-R dominates H on wall, tokens, and calls. The `--no-lean` MCP one-shot was the expensive path: full catalog + fat results. Default `-p` + fold + slim is the box.
+Variant **R** (`graff-dev`, implied `--lean`) did pass at 16.3s / 14k / 4
+calls. That is a **different catalog** (lean keep-list). It is not an
+A/B against H/J. The bench stays `graff-dev-nolean`. Learnt slim on
+that harness is N/L/P.

--- a/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
+++ b/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
@@ -109,3 +109,27 @@ signal. H/I 7-call structured is the stable cheap path today.
 - A later `len`/`for` would cut C/D/F/G retries; do not grow a general
   language without that measurement.
 - Prompting "prefer one rlm script" is not free. Default no-hint.
+
+## Pareto front (wall / tok_in / calls)
+
+Minimize all three among passing SuperGrok grok-4.6 runs. `len(x)` /
+`project(x, field)` landed in `src/rlm_reduce.zig` so a script can print
+a slim summary. Rerun: `python3 scripts/eval-mcp-pareto.py`
+
+A point is on the front if nothing else is ≤ on every axis and < on one.
+
+| id | wall | in | calls | why it stays |
+|---|---:|---:|---:|---|
+| **H** | **28.0s** | 112k | **7** | fastest / fewest calls (no-hint structured) |
+| **I** | 31.1s | 107k | 7 | same path, slightly fewer tokens |
+| **D-r1** | 41.1s | 107k | 10 | rlm+each, one lucky rep |
+| **J-live** | 47.3s | **84k** | 9 | `each` + `len`/`project`; first script printed ids only |
+
+Everything else is dominated (including `--old`, sidecar, split,
+quiet-print, K-live, and H-live's 70s variance rep).
+
+J used rlm for real (`issues = list_issues(); comments = each(...);
+print(len, project)`). It is the **token vertex**. H is the **wall
+vertex**. There is still no point that wins both. Warm shapes (K) did
+not help J. Do not ship rlm-as-default for this MCP task; keep
+len/project so the token vertex is reachable.

--- a/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
+++ b/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
@@ -120,20 +120,21 @@ A point is on the front if nothing else is ≤ on every axis and < on one.
 
 | id | wall | in | calls | why it stays |
 |---|---:|---:|---:|---|
-| **H** | **28.0s** | 112k | **7** | fastest / fewest calls (no-hint structured, `--no-lean`) |
-| **I** | 31.1s | 107k | 7 | same path, slightly fewer tokens |
-| **D-r1** | 41.1s | 107k | 10 | rlm+each, one lucky rep |
-| **J-live** | 47.3s | **84k** | 9 | `each` + `len`/`project`; first script printed ids only |
+| **L** | **14.8s** | 31k | **5** | slim + warm playbook, no hint, **`--no-lean`** |
+| **N** | 20.8s | **30k** | 5 | slim mid-run, no hint, cold, **`--no-lean`** |
 
-Everything else is dominated (including `--old`, sidecar, split,
-quiet-print, K-live, and H-live's 70s variance rep). **R is not on
-this front:** it ran the lean catalog (`graff-dev`), a different
-harness. The MCP bench is `--no-lean` only (`graff-dev-nolean`).
+Both dominate the pre-slim front (H 28s/112k/7, I 31s/107k/7, J 47s/84k/9).
+P (48s/66k/9, reduce recipe + slim) is dominated by L/N. **R is not on
+this front:** lean catalog (`graff-dev`), a different prefix. The MCP
+bench is `--no-lean` only.
 
-J used rlm for real (`issues = list_issues(); comments = each(...);
-print(len, project)`). It is the **token vertex**. H is the **wall
-vertex**. There is still no point that wins both. Warm shapes (K) did
-not help J. Keep len/project so the token vertex is reachable.
+Live SuperGrok grok-4.6, ReleaseSafe, `graff-dev-nolean` (`c4901bd` binary):
+
+| var | vs | wall | in | calls |
+|---|---|---:|---:|---:|
+| **L** warm + slim | I 31s/107k/7 | **14.8s** | **31348** | **5** |
+| **N** cold + slim | H 28s/112k/7 | **20.8s** | **30314** | **5** |
+| **P** reduce + slim | J 47s/84k/9 | 48.1s | 66260 | 9 |
 
 ## Learnt slim (the muscle, not another hint)
 
@@ -158,4 +159,4 @@ the MCP on-switch.
 Variant **R** (`graff-dev`, implied `--lean`) did pass at 16.3s / 14k / 4
 calls. That is a **different catalog** (lean keep-list). It is not an
 A/B against H/J. The bench stays `graff-dev-nolean`. Learnt slim on
-that harness is N/L/P.
+that harness is N/L/P (measured: L 14.8s/31k/5, N 20.8s/30k/5).

--- a/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
+++ b/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
@@ -68,14 +68,44 @@ language (`len`/`for`), not `issue_id` vs `id`.
 **E1** kept MCP on the root (ADR 0023) and matched A's wall; no token
 win. **E2** passed but is the expensive split (18 calls / 75s).
 
-Verdict: ship MCP-inside-rlm + shape cache. Do not copy Blacksmith's
-V8 sandbox. SuperGrok $ is a wash; the 60k input cut on D is the
-metered-key spend win.
+Verdict (rep 1): MCP-inside-rlm + shape cache can cut tokens. Do not
+copy Blacksmith's V8 sandbox. SuperGrok $ is a wash; the 60k input cut
+on D is the metered-key spend win **when the model stays in `each()`**.
+
+## Follow-up A/B (2026-08-25, same day)
+
+Second live rep of A/D plus four new prompts. SuperGrok grok-4.6,
+ReleaseSafe, one rep each. `python3 scripts/eval-mcp-shapes.py --only A,D,F,G,H,I`
+
+| var | prompt | pass | wall | RSS | in | cached | out | calls | what it did |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| A-r2 | `--old` + each() hint (ignored) | ✓ | 36.4s | 10.4M | 145497 | 96896 | 2075 | 9 | structured 1+8 again; wall stable |
+| D-r2 | rlm+MCP, warm, each() hint | ✓ | 60.5s | 10.8M | 158769 | 122752 | 3101 | 11 | rlm then `report_issues = []`; **D token win did not hold** |
+| F | each() hint + never print() fat arrays | ✓ | 220s | 10.8M | 462379 | 426880 | 9944 | 29 | `def`/`for`/`len`/`import`; grepped graff src |
+| G | F + warm shapes | ✓ | 156s | 10.9M | 279981 | 166528 | 7947 | 21 | same dialect hole, slightly less lost |
+| H | **no each() recipe**, cold | ✓ | **28.0s** | 10.6M | 112073 | 85248 | 1607 | **7** | never used rlm; parallel structured MCP |
+| I | no each() recipe, warm shapes | ✓ | 31.1s | 10.5M | **107284** | 81536 | 1865 | **7** | same as H; shapes on the load result unused |
+
+**The `each()` hint is a footgun on grok-4.6.** It pushes the model into
+a dialect that cannot map/filter without `print()`ing the fat bind
+(C/D) or inventing Python (F/G). Telling it not to print made it
+*worse* — mapping without print needs `for`/`len` we do not have.
+
+**No-hint (H/I) beat `--old` on wall and tokens** by doing the classic
+loop well: one `load_tool_schemas`, then `list_issues` + 8
+`list_comments` in one batch. That is not code mode. Muscle memory did
+not change the path (I still never called `rlm`).
+
+D-r1 107k / 41s vs D-r2 159k / 61s: one-rep token wins are not a ship
+signal. H/I 7-call structured is the stable cheap path today.
 
 ## Consequences
 
 - `--no-lean` remains the MCP one-shot. Lean still hides
   `load_tool_schemas`.
-- `each()` is the only new control-flow helper. A later `len`/`for`
-  would cut C/D retries; do not grow a general language without another
-  measured A/B.
+- Keep MCP-inside-rlm + shape splice (the host path is real). Do not
+  advertise `each()` on this task until a `len`/project helper exists
+  and beats H in a new A/B.
+- A later `len`/`for` would cut C/D/F/G retries; do not grow a general
+  language without that measurement.
+- Prompting "prefer one rlm script" is not free. Default no-hint.

--- a/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
+++ b/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
@@ -133,3 +133,13 @@ print(len, project)`). It is the **token vertex**. H is the **wall
 vertex**. There is still no point that wins both. Warm shapes (K) did
 not help J. Do not ship rlm-as-default for this MCP task; keep
 len/project so the token vertex is reachable.
+
+## Learnt slim (the muscle, not another hint)
+
+Shapes on the load result did not change grok-4.6's path (I still never
+called `rlm`). The learnt part is therefore applied in Zig: after
+`remember()` of the fat payload, `takeSlim` / `print()` drop
+`description`/`body` and fold comment arrays to `{n, latest_author}`.
+When two MCP shapes are stored, `annotate` adds a one-line `# muscle:`
+playbook on the load **result** (never the catalog prefix). No new
+`GRAFF_` knob. Live L–Q sweep: `eval-mcp-shapes.py --only L,M,N,O,P,Q`.

--- a/docs/adr/0030-rlm-late-showcase.md
+++ b/docs/adr/0030-rlm-late-showcase.md
@@ -1,0 +1,47 @@
+# 0030. Hide `rlm` on small turns; showcase later (sPTC rides unfold)
+
+Status: accepted 2026-08-25
+
+## Context
+
+L and N (Linear MCP, `--no-lean`, no `each()` hint) are the cheap path:
+structured `load_tool_schemas` → list + comments → `report.json`. They
+never call `rlm`. Advertising the spec on every turn still costs:
+
+- `--no-lean` spliced `rlm_spec.system_note` onto the always-on prefix
+  (~360 bytes, every request) and listed `rlm` among Folded-native tools;
+- `--lean` / `-p` unfolded the full schema onto the catalog (ADR 0024:
+  one-shots were doing N structured calls instead of one script).
+
+sPTC (`src/spec_ptc.zig` + `rlm.feedLive`) is not a catalog tool. It
+only runs when an `rlm` script streams. Listing `rlm` is what invites
+speculation — and on grok-4.6, an `each()` hint is a footgun (ADR 0029).
+Showcasing because MCP slims would push Linear back into that dialect.
+
+## Decision
+
+Fold `rlm` whenever it is available, including `--lean`. Omit it from
+the Folded-native listing and from `composeBase` / lean notes until a
+showcase. Do not splice `system_note` onto the prefix (ADR 0011).
+
+Showcase (listing + `markLoaded`, so the next catalog can carry the
+schema and sPTC is live) when:
+
+- `--rlm` / `setFromCli(true)` — immediate;
+- a structured batch of **≥4 native** host tools (`read_file`, `codedb`,
+  `bash`, `webfetch`) — the scatter-gather that sPTC overlaps;
+- explicit `load_tool_schemas tools=["rlm"]` (already `markLoaded`).
+
+Do **not** showcase on MCP-only fan-out, first slim, or fat-payload
+size. `/new` and `/clear` hide a session-discovered showcase; `--rlm`
+sticks for the process.
+
+## Consequences
+
+- L/N keep the structured MCP path: no `rlm` name, no system note, no
+  sPTC invitation. Token win is prefix + listing, not another hint.
+- Scatter-gather one-shots pay one wide native batch, then see `rlm`
+  and can stream-speculate. `--rlm` skips the wait.
+- Auto-load on a confident `rlm` call still works (`gateExec`).
+- Revisit if a measured coding one-shot regresses to N serial reads
+  because the model never emits a 4-wide batch and never sees `rlm`.

--- a/docs/adr/0030-rlm-late-showcase.md
+++ b/docs/adr/0030-rlm-late-showcase.md
@@ -18,23 +18,41 @@ only runs when an `rlm` script streams. Listing `rlm` is what invites
 speculation — and on grok-4.6, an `each()` hint is a footgun (ADR 0029).
 Showcasing because MCP slims would push Linear back into that dialect.
 
+Zhang / Li / Khattab (MGH, 2026) argue the other half: RLM's job is
+length generalization — expanding the decomposition space so the root
+can chunk near-infinite context — not replacing structured tools on
+short in-distribution turns. Their 32k/1-needle RL curriculum is how a
+small model *learns* that decomposition; it is not a production
+token-floor. A naive "fat first payload" trigger is the MCP-slim case
+already rejected. The signal that matches the paper is the existing
+session meter (`effectiveContextTokens` / `compactAt`): the root is
+actually seeing OOD-length context.
+
 ## Decision
 
 Fold `rlm` whenever it is available, including `--lean`. Omit it from
 the Folded-native listing and from `composeBase` / lean notes until a
-showcase. Do not splice `system_note` onto the prefix (ADR 0011).
+showcase. Do not splice `system_note` onto the prefix (ADR 0011). Do
+not put `rlm` in the `load_tool_schemas` listing: that rewrites the
+tools **head**. Discovery is `markLoaded` so the next catalog carries
+the schema on the **tail**.
 
-Showcase (listing + `markLoaded`, so the next catalog can carry the
-schema and sPTC is live) when:
+Showcase when:
 
 - `--rlm` / `setFromCli(true)` — immediate;
 - a structured batch of **≥4 native** host tools (`read_file`, `codedb`,
   `bash`, `webfetch`) — the scatter-gather that sPTC overlaps;
+- `effectiveContextTokens() ≥ 50%` of `provider.compactAt()` — the
+  existing overflow meter, not a second counter;
 - explicit `load_tool_schemas tools=["rlm"]` (already `markLoaded`).
+
+`GRAFF_RLM_CONTEXT` overrides the size gate: unset = 50% of compactAt;
+`0`/`off` disables; `1`–`100` or `50%` is a percent; `32k` / `32768`
+is an absolute floor (Zhang's curriculum, opt-in).
 
 Do **not** showcase on MCP-only fan-out, first slim, or fat-payload
 size. `/new` and `/clear` hide a session-discovered showcase; `--rlm`
-sticks for the process.
+sticks for the process. `--old` resets discovery.
 
 ## Consequences
 
@@ -42,6 +60,10 @@ sticks for the process.
   sPTC invitation. Token win is prefix + listing, not another hint.
 - Scatter-gather one-shots pay one wide native batch, then see `rlm`
   and can stream-speculate. `--rlm` skips the wait.
+- A long session (or a huge user paste) that crosses half of compactAt
+  gets the RLM decomposition space without a prefix essay. Tools-head
+  bytes stay identical; only the tail grows.
 - Auto-load on a confident `rlm` call still works (`gateExec`).
 - Revisit if a measured coding one-shot regresses to N serial reads
-  because the model never emits a 4-wide batch and never sees `rlm`.
+  because the model never emits a 4-wide batch, never crosses 50% of
+  compactAt, and never sees `rlm`.

--- a/docs/adr/0031-xai-hosted-x-search.md
+++ b/docs/adr/0031-xai-hosted-x-search.md
@@ -1,0 +1,46 @@
+# 0031. xAI Responses hosts `x_search`; it is not a catalog tool
+
+Status: accepted 2026-08-25
+
+## Context
+
+xAI's Responses API accepts a server-side tool `{"type":"x_search"}`
+(keyword / semantic / user / thread search on X). A live SuperGrok
+probe on grok-4.6 (2026-08-25) returned HTTP 200 with
+`num_server_side_tools_used: 1` and an output item
+`{"type":"custom_tool_call","name":"x_keyword_search","status":"completed"}`
+plus `url_citation` annotations on the final message.
+
+Graff's catalog is function tools only. Adding `x_search` as an
+always-on root spec would grow the 64-cell kernel, invite local
+dispatch of a name the host already executed, and put an essay on the
+prefix (ADR 0011 / 0013). Chat completions (`GRAFF_XAI_WIRE=chat`)
+have no hosted-tool slot.
+
+## Decision
+
+On provider `xai` + Responses, when the request already carries a
+`tools` array, splice `{"type":"x_search"}` if it is not already
+present. Tools-off turns stay tools-off. Codex, chat-completions, and
+non-xAI Responses never receive the splice.
+
+Do not add `x_search` (or `x_keyword_search`) to `effectiveRootSpecs`.
+Do not put search docs on the always-on prefix. Treat
+`x_search_call` / `custom_tool_call` names `x_search`,
+`x_keyword_search`, `x_semantic_search`, `x_user_search`,
+`x_thread_fetch` as already done — append the item to history, never
+`runTools`.
+
+`GRAFF_XAI_X_SEARCH=0|off|false|no` disables the splice. Default is on
+because the registered grok-4.6 Responses path already executes it.
+
+## Consequences
+
+- A coding turn can ask grok-4.6 about X without a graff-executed
+  webfetch. The model still has bash / edit / `read_file`.
+- Prompt-cache bytes grow by one hosted object on every tools turn for
+  xAI Responses. Revisit if that noise shows up on a coding eval.
+- Citation placeholder text from the live probe was messy; v1 leaves
+  annotations on the message rather than pretty-printing them.
+- Sibling ADR 0030 (late RLM showcase) is on another branch; this
+  number stays 0031 so the two records do not collide on merge.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,7 +39,7 @@ record only when you need the evidence or the edge cases.
 | [0026](0026-foreground-bash-auto-backgrounds.md) | Root foreground `bash` auto-backgrounds after 120s (or `timeout` ms); it is not killed. Subagents still kill at 120s (#93). |
 | [0027](0027-kimi-identity-is-graff.md) | Kimi Coding User-Agent is `graff/<version>`, not a spoofed `kimi-code-cli` token. X-Msh device fields follow kimi-code's shapes. |
 | [0028](0028-codex-session-id-is-the-cache-key.md) | Codex HTTP/WS `session_id` is the `prompt_cache_key` (openai/codex ModelClient default), not a per-process random UUID. |
-| [0029](0029-mcp-inside-rlm-and-return-shapes.md) | Loaded MCP tools are rlm host functions; persist return shapes on the load result, never the prefix; fat MCP results auto-slim from learnt keys. |
+| [0029](0029-mcp-inside-rlm-and-return-shapes.md) | Loaded MCP tools are rlm host functions; persist return shapes on the load result, never the prefix; fat MCP results auto-slim; default `-p` connects `.mcp.json` (folded, not skipped). |
 
 ## When to write one
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,7 @@ record only when you need the evidence or the edge cases.
 | [0027](0027-kimi-identity-is-graff.md) | Kimi Coding User-Agent is `graff/<version>`, not a spoofed `kimi-code-cli` token. X-Msh device fields follow kimi-code's shapes. |
 | [0028](0028-codex-session-id-is-the-cache-key.md) | Codex HTTP/WS `session_id` is the `prompt_cache_key` (openai/codex ModelClient default), not a per-process random UUID. |
 | [0029](0029-mcp-inside-rlm-and-return-shapes.md) | Loaded MCP tools are rlm host functions; persist return shapes on the load result, never the prefix; fat MCP results auto-slim; default `-p` connects `.mcp.json` (folded, not skipped). |
+| [0030](0030-rlm-late-showcase.md) | Small turns hide `rlm` (and sPTC). Showcase on `--rlm`, a ≥4 native batch, context ≥50% of compactAt, or an explicit load — never on MCP fan-out or the prefix. |
 | [0031](0031-xai-hosted-x-search.md) | xAI Responses splices hosted `x_search` onto tools turns. It is not a catalog function; `GRAFF_XAI_X_SEARCH=0` opts out. |
 
 ## When to write one

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,7 +39,7 @@ record only when you need the evidence or the edge cases.
 | [0026](0026-foreground-bash-auto-backgrounds.md) | Root foreground `bash` auto-backgrounds after 120s (or `timeout` ms); it is not killed. Subagents still kill at 120s (#93). |
 | [0027](0027-kimi-identity-is-graff.md) | Kimi Coding User-Agent is `graff/<version>`, not a spoofed `kimi-code-cli` token. X-Msh device fields follow kimi-code's shapes. |
 | [0028](0028-codex-session-id-is-the-cache-key.md) | Codex HTTP/WS `session_id` is the `prompt_cache_key` (openai/codex ModelClient default), not a per-process random UUID. |
-| [0029](0029-mcp-inside-rlm-and-return-shapes.md) | Loaded MCP tools are rlm host functions; persist return shapes on the load result, never the prefix. Measured vs `--old`. |
+| [0029](0029-mcp-inside-rlm-and-return-shapes.md) | Loaded MCP tools are rlm host functions; persist return shapes on the load result, never the prefix; fat MCP results auto-slim from learnt keys. |
 
 ## When to write one
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,7 @@ record only when you need the evidence or the edge cases.
 | [0026](0026-foreground-bash-auto-backgrounds.md) | Root foreground `bash` auto-backgrounds after 120s (or `timeout` ms); it is not killed. Subagents still kill at 120s (#93). |
 | [0027](0027-kimi-identity-is-graff.md) | Kimi Coding User-Agent is `graff/<version>`, not a spoofed `kimi-code-cli` token. X-Msh device fields follow kimi-code's shapes. |
 | [0028](0028-codex-session-id-is-the-cache-key.md) | Codex HTTP/WS `session_id` is the `prompt_cache_key` (openai/codex ModelClient default), not a per-process random UUID. |
+| [0029](0029-mcp-inside-rlm-and-return-shapes.md) | Loaded MCP tools are rlm host functions; persist return shapes on the load result, never the prefix. Measured vs `--old`. |
 
 ## When to write one
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,7 @@ record only when you need the evidence or the edge cases.
 | [0027](0027-kimi-identity-is-graff.md) | Kimi Coding User-Agent is `graff/<version>`, not a spoofed `kimi-code-cli` token. X-Msh device fields follow kimi-code's shapes. |
 | [0028](0028-codex-session-id-is-the-cache-key.md) | Codex HTTP/WS `session_id` is the `prompt_cache_key` (openai/codex ModelClient default), not a per-process random UUID. |
 | [0029](0029-mcp-inside-rlm-and-return-shapes.md) | Loaded MCP tools are rlm host functions; persist return shapes on the load result, never the prefix; fat MCP results auto-slim; default `-p` connects `.mcp.json` (folded, not skipped). |
+| [0031](0031-xai-hosted-x-search.md) | xAI Responses splices hosted `x_search` onto tools turns. It is not a catalog function; `GRAFF_XAI_X_SEARCH=0` opts out. |
 
 ## When to write one
 

--- a/docs/releases/v0.0.277.md
+++ b/docs/releases/v0.0.277.md
@@ -34,3 +34,23 @@ L is N after muscle memory has been written. Both dominate H/I/J. Lean
 default `-p` (variant R) is a different catalog and is not on this front.
 
 See ADR 0029.
+
+## Hosted x_search (xAI Responses)
+
+grok-4.6 already runs `{"type":"x_search"}` server-side. This cut splices
+that hosted tool onto xAI Responses **tools** turns (ADR 0031). It is not
+a catalog function and not on the prefix. Chat completions and Codex
+never get it. `GRAFF_XAI_X_SEARCH=0` opts out.
+
+Same SuperGrok prompt (“what are people saying about xAI on X?”):
+
+| | scrape (`GRAFF_XAI_X_SEARCH=0`) | hosted `x_search` |
+|---|---:|---:|
+| wall | 101s | **37s** |
+| calls | 7 | **1** |
+| input tokens | 64k | **28k** |
+
+RLM is **not** flipped on by context size. Lean `-p` already advertises
+`rlm` on the catalog; REPL folds it behind `load_tool_schemas`. A load
+appends the schema to the tools **tail** (ADR 0011), so the cached prefix
+stays. sPTC only runs after an `rlm` script streams.

--- a/docs/releases/v0.0.277.md
+++ b/docs/releases/v0.0.277.md
@@ -1,0 +1,36 @@
+# v0.0.277 (2026-08-25)
+
+MCP-inside-rlm + learnt slim on the full harness, plus the licensed
+one-read-surface / turn pulse / Smolify opt-in already on
+`release/v0.0.277` (`d422ee8`). **No git tag** on this cut.
+
+## What was already on the branch
+
+`d422ee8` is +499/−42 across 21 files — not a large drop:
+
+- Licensed codedb-pro hides native `read_file`/`codedb` and companion
+  write tools; native `edit_file`/`write_file` stay (`src/tool_surface.zig`).
+- Long turns and transport retries pulse; no default 16-call cap.
+- Smolify/deepwiki/mobbin are opt-in (`GRAFF_SMOLIFY`).
+
+## What this cut adds (L works)
+
+Loaded MCP names are `rlm` host functions. After each MCP result, graff
+infers a value-free return shape, persists `.graff/mcp-shapes.json`, and
+**slims** the bytes the model sees (identity keys; comments →
+`n` + `latest_author`). A later run in the same repo is **L**: shapes
+already on disk, `# muscle:` on the load result.
+
+Measured SuperGrok grok-4.6, ReleaseSafe, **`--no-lean`**
+(`graff-dev-nolean`):
+
+| | wall | in | calls |
+|---|---:|---:|---:|
+| **L** warm + slim | **14.8s** | 31k | 5 |
+| **N** cold + slim | 20.8s | **30k** | 5 |
+| H (pre-slim, same harness) | 28.0s | 112k | 7 |
+
+L is N after muscle memory has been written. Both dominate H/I/J. Lean
+default `-p` (variant R) is a different catalog and is not on this front.
+
+See ADR 0029.

--- a/docs/releases/v0.0.277.md
+++ b/docs/releases/v0.0.277.md
@@ -50,7 +50,19 @@ Same SuperGrok prompt (“what are people saying about xAI on X?”):
 | calls | 7 | **1** |
 | input tokens | 64k | **28k** |
 
-RLM is **not** flipped on by context size. Lean `-p` already advertises
-`rlm` on the catalog; REPL folds it behind `load_tool_schemas`. A load
-appends the schema to the tools **tail** (ADR 0011), so the cached prefix
-stays. sPTC only runs after an `rlm` script streams.
+## Late + context showcase (ADR 0030)
+
+Small turns hide `rlm` (and sPTC). Showcase (`markLoaded`, schema on the
+tools **tail**) when:
+
+- `--rlm`;
+- a ≥4 native batch (`read_file` / `codedb` / `bash` / `webfetch`);
+- `effectiveContextTokens() ≥ 50%` of `provider.compactAt()`;
+- explicit `load_tool_schemas tools=["rlm"]`.
+
+MCP-only fan-out and first slim do **not** showcase. `/new` / `/clear`
+hide a session-discovered showcase; `--rlm` sticks. `GRAFF_RLM_CONTEXT`
+overrides the size gate (`0` off; `32k` is Zhang's curriculum floor).
+
+The hide is the token win on short work. Showcase itself costs ~200
+input tokens (schema on the tail) until the model actually scripts.

--- a/docs/releases/v0.0.277.md
+++ b/docs/releases/v0.0.277.md
@@ -1,8 +1,8 @@
-# v0.0.277 (2026-08-25)
+# v0.0.277 (2026-08-26)
 
 MCP-inside-rlm + learnt slim on the full harness, plus the licensed
 one-read-surface / turn pulse / Smolify opt-in already on
-`release/v0.0.277` (`d422ee8`). **No git tag** on this cut.
+`release/v0.0.277` (`d422ee8`).
 
 ## What was already on the branch
 

--- a/graff-evals/README.md
+++ b/graff-evals/README.md
@@ -20,7 +20,7 @@ harness under test spends model calls.
 | `core` | sequential single-file work (instruction, debug, git, schema, …) |
 | `rlm` | scatter-gather / multi-file reads (where default rlm can overlap) |
 | `swe` | DeepSWE-shaped multi-file bugfixes, distilled from [deepswe.datacurve.ai/run](https://deepswe.datacurve.ai/run) (no Harbor/Docker) |
-| `mcp` | Linear-shaped fixture MCP (Blacksmith code-mode + muscle memory). Use `--no-lean` harnesses. Variants include warm shapes, quiet `print()`, and no-`each()` prompts. |
+| `mcp` | Linear-shaped fixture MCP (Blacksmith code-mode + muscle memory). Use `--no-lean` harnesses. Variants include warm shapes, quiet `print()`, no-`each()` prompts, and learnt slim (L–Q). |
 
 ```sh
 ./run.py --suite swe --harness graff-dev-old,graff-dev --model grok-4.6 -j 12

--- a/graff-evals/README.md
+++ b/graff-evals/README.md
@@ -20,7 +20,7 @@ harness under test spends model calls.
 | `core` | sequential single-file work (instruction, debug, git, schema, …) |
 | `rlm` | scatter-gather / multi-file reads (where default rlm can overlap) |
 | `swe` | DeepSWE-shaped multi-file bugfixes, distilled from [deepswe.datacurve.ai/run](https://deepswe.datacurve.ai/run) (no Harbor/Docker) |
-| `mcp` | Linear-shaped fixture MCP (Blacksmith code-mode + muscle memory). Use `--no-lean` harnesses. |
+| `mcp` | Linear-shaped fixture MCP (Blacksmith code-mode + muscle memory). Use `--no-lean` harnesses. Variants include warm shapes, quiet `print()`, and no-`each()` prompts. |
 
 ```sh
 ./run.py --suite swe --harness graff-dev-old,graff-dev --model grok-4.6 -j 12

--- a/graff-evals/README.md
+++ b/graff-evals/README.md
@@ -20,7 +20,7 @@ harness under test spends model calls.
 | `core` | sequential single-file work (instruction, debug, git, schema, …) |
 | `rlm` | scatter-gather / multi-file reads (where default rlm can overlap) |
 | `swe` | DeepSWE-shaped multi-file bugfixes, distilled from [deepswe.datacurve.ai/run](https://deepswe.datacurve.ai/run) (no Harbor/Docker) |
-| `mcp` | Linear-shaped fixture MCP (Blacksmith code-mode + muscle memory). Use `--no-lean` harnesses. Variants include warm shapes, quiet `print()`, no-`each()` prompts, and learnt slim (L–Q). |
+| `mcp` | Linear-shaped fixture MCP (Blacksmith code-mode + muscle memory). Always `--no-lean` (`graff-dev-nolean`): lean is a different catalog and is not on the front. |
 
 ```sh
 ./run.py --suite swe --harness graff-dev-old,graff-dev --model grok-4.6 -j 12

--- a/graff-evals/README.md
+++ b/graff-evals/README.md
@@ -13,13 +13,14 @@ harness under test spends model calls.
 
 ## Suites
 
-`--suite` selects which tasks run (`all` is the default):
+`--suite` selects which tasks run (`all` is core+rlm+swe; `mcp` is opt-in):
 
 | suite | what it measures |
 |---|---|
 | `core` | sequential single-file work (instruction, debug, git, schema, …) |
 | `rlm` | scatter-gather / multi-file reads (where default rlm can overlap) |
 | `swe` | DeepSWE-shaped multi-file bugfixes, distilled from [deepswe.datacurve.ai/run](https://deepswe.datacurve.ai/run) (no Harbor/Docker) |
+| `mcp` | Linear-shaped fixture MCP (Blacksmith code-mode + muscle memory). Use `--no-lean` harnesses. |
 
 ```sh
 ./run.py --suite swe --harness graff-dev-old,graff-dev --model grok-4.6 -j 12

--- a/graff-evals/harnesses.json
+++ b/graff-evals/harnesses.json
@@ -42,7 +42,7 @@
     "schema_args": ["--output-schema", "{schema}"],
     "env": {"GRAFF_POST_DEADLINE_SECS": "90"},
     "default_model": "grok-4.6",
-    "note": "default rlm + MCP visible (need --no-lean for load_tool_schemas); MCP host functions on"
+    "note": "full harness for the MCP bench: --no-lean (complete catalog). Lean is a different prefix and is not comparable."
   },
   "graff-dev-rlm-struct": {
     "cmd": ["{repo}/zig-out/bin/graff", "-p", "{prompt}", "--model", "{model}", "--yolo", "--no-lean"],

--- a/graff-evals/harnesses.json
+++ b/graff-evals/harnesses.json
@@ -34,6 +34,36 @@
     "default_model": "grok-4.6",
     "note": "explicit --rlm (same as graff-dev after RLM became the default)"
   },
+  "graff-dev-nolean": {
+    "cmd": ["{repo}/zig-out/bin/graff", "-p", "{prompt}", "--model", "{model}", "--yolo", "--no-lean"],
+    "answer": "stdout",
+    "usage": "graff-stderr",
+    "capabilities": ["output-schema"],
+    "schema_args": ["--output-schema", "{schema}"],
+    "env": {"GRAFF_POST_DEADLINE_SECS": "90"},
+    "default_model": "grok-4.6",
+    "note": "default rlm + MCP visible (need --no-lean for load_tool_schemas); MCP host functions on"
+  },
+  "graff-dev-rlm-struct": {
+    "cmd": ["{repo}/zig-out/bin/graff", "-p", "{prompt}", "--model", "{model}", "--yolo", "--no-lean"],
+    "answer": "stdout",
+    "usage": "graff-stderr",
+    "capabilities": ["output-schema"],
+    "schema_args": ["--output-schema", "{schema}"],
+    "env": {"GRAFF_POST_DEADLINE_SECS": "90", "GRAFF_RLM_MCP": "0"},
+    "default_model": "grok-4.6",
+    "note": "default rlm but MCP stays structured-only (today's gap / variant B)"
+  },
+  "graff-dev-old-nolean": {
+    "cmd": ["{repo}/zig-out/bin/graff", "-p", "{prompt}", "--model", "{model}", "--yolo", "--old", "--no-lean"],
+    "answer": "stdout",
+    "usage": "graff-stderr",
+    "capabilities": ["output-schema"],
+    "schema_args": ["--output-schema", "{schema}"],
+    "env": {"GRAFF_POST_DEADLINE_SECS": "90"},
+    "default_model": "grok-4.6",
+    "note": "--old structured MCP only + --no-lean so load_tool_schemas is visible"
+  },
   "graff-dev-old": {
     "cmd": ["{repo}/zig-out/bin/graff", "-p", "{prompt}", "--model", "{model}", "--yolo", "--old"],
     "answer": "stdout",

--- a/graff-evals/hidden/check_linear_report.py
+++ b/graff-evals/hidden/check_linear_report.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Held-out check for the Linear-shaped MCP bench. The agent never sees this."""
+import json
+import os
+import sys
+
+EXPECTED = {
+    "ISS-1": ("Login timeout on session resume", 2, "bev"),
+    "ISS-2": ("Checkout tax rounding", 3, "eli"),
+    "ISS-3": ("Search index lag", 1, "fay"),
+    "ISS-4": ("Webhook retries drop 429s", 4, "jay"),
+    "ISS-5": ("Avatar upload EXIF leak", 2, "lee"),
+    "ISS-6": ("Board filter forgets assignee", 3, "oak"),
+    "ISS-7": ("CSV export truncates UTF-8", 1, "pip"),
+    "ISS-8": ("Nightly digest duplicates", 4, "tess"),
+}
+
+path = "report.json"
+if not os.path.exists(path):
+    sys.exit("report.json missing")
+data = json.load(open(path))
+assert data.get("issue_count") == 8, data.get("issue_count")
+issues = data.get("issues") or []
+assert len(issues) == 8, len(issues)
+got = {i["id"]: i for i in issues}
+for iid, (title, n, author) in EXPECTED.items():
+    row = got[iid]
+    assert row["title"] == title, (iid, row.get("title"), title)
+    assert int(row["comment_count"]) == n, (iid, row.get("comment_count"), n)
+    assert row["latest_author"] == author, (iid, row.get("latest_author"), author)
+print("linear-report-ok")

--- a/graff-evals/run.py
+++ b/graff-evals/run.py
@@ -10,6 +10,7 @@ outcome, and writes JSONL results plus a summary table.
   ./run.py --harness graff --model grok-4.6              # full suite (core + rlm + swe)
   ./run.py --suite rlm --harness graff-dev-old,graff-dev # scatter-gather A/B
   ./run.py --suite swe --harness graff-dev-old,graff-dev -j 12  # DeepSWE-shaped A/B, parallel
+  ./run.py --suite mcp --harness graff-dev-old-nolean,graff-dev-rlm-struct,graff-dev-nolean
   ./run.py --harness grok --task fix-fib --reps 3        # one task, 3 reps
   ./run.py --interactive                                 # pick + watch live
 """
@@ -350,7 +351,7 @@ def main():
     ap.add_argument("--harness", default="graff", help="comma-separated harness names (see harnesses.json)")
     ap.add_argument("--model", default=None, help="model id (default: per-harness default_model)")
     ap.add_argument("--task", action="append", help="task id filter (repeatable)")
-    ap.add_argument("--suite", default="all", help="core, rlm, swe, comma-mix, or all (default all)")
+    ap.add_argument("--suite", default="all", help="core, rlm, swe, mcp, comma-mix, or all (core+rlm+swe; mcp is opt-in)")
     ap.add_argument("--reps", type=int, default=1)
     ap.add_argument("--jobs", "-j", type=int, default=1,
                     help="parallel task×harness runs (default 1; each has its own sandbox)")
@@ -367,12 +368,15 @@ def main():
     stamp = time.strftime("%Y%m%d-%H%M%S")
     out_path = os.path.join(RESULTS_DIR, f"run-{stamp}.jsonl")
     suites = {s.strip() for s in args.suite.split(",") if s.strip()}
+    if "all" in suites:
+        suites.update({"core", "rlm", "swe"})
+        suites.discard("all")
     picked = {}
     for tid, t in tasks.items():
         if args.task and tid not in args.task:
             continue
         suite = t.get("suite", "core")
-        if "all" not in suites and suite not in suites:
+        if suite not in suites:
             continue
         picked[tid] = t
     work = []

--- a/graff-evals/tasks/24-linear-issues.json
+++ b/graff-evals/tasks/24-linear-issues.json
@@ -1,0 +1,12 @@
+{
+  "id": "linear-issues",
+  "suite": "mcp",
+  "category": "mcp-shapes",
+  "prompt": "This workspace has a Linear-shaped MCP server named linear (stdio, deferred). Load its schemas, then fetch all 8 issues and every issue's comments. Write report.json as {\"issue_count\": N, \"issues\": [{\"id\", \"title\", \"comment_count\", \"latest_author\"}, ...]} in ISS-1..ISS-8 order. latest_author is the author.name of the newest comment (last in that issue's list). Do not invent ids or authors. If rlm is available, prefer one script after load_tool_schemas: issues = list_issues(); comments = each(issues, list_comments, \"id\").",
+  "files": {
+    ".mcp.json": "{\"mcpServers\":{\"linear\":{\"command\":\"python3\",\"args\":[\"linear_fixture_mcp.py\"]}}}\n"
+  },
+  "setup": ["python3 -c \"import pathlib,shutil; p=pathlib.Path('.').resolve(); root=next(x for x in p.parents if (x/'scripts'/'linear_fixture_mcp.py').exists()); shutil.copy(root/'scripts'/'linear_fixture_mcp.py','.')\""],
+  "check": "python3 \"$TASK_ROOT/hidden/check_linear_report.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/25-linear-warm.json
+++ b/graff-evals/tasks/25-linear-warm.json
@@ -1,0 +1,13 @@
+{
+  "id": "linear-warm",
+  "suite": "mcp",
+  "category": "mcp-shapes",
+  "prompt": "This workspace has a Linear-shaped MCP server named linear (stdio, deferred). Load its schemas, then fetch all 8 issues and every issue's comments. Write report.json as {\"issue_count\": N, \"issues\": [{\"id\", \"title\", \"comment_count\", \"latest_author\"}, ...]} in ISS-1..ISS-8 order. latest_author is the author.name of the newest comment (last in that issue's list). Do not invent ids or authors. If rlm is available, prefer one script after load_tool_schemas: issues = list_issues(); comments = each(issues, list_comments, \"id\").",
+  "files": {
+    ".mcp.json": "{\"mcpServers\":{\"linear\":{\"command\":\"python3\",\"args\":[\"linear_fixture_mcp.py\"]}}}\n",
+    ".graff/mcp-shapes.json": "{\"mcp__linear__list_issues\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"keys\":{\"id\":\"string\",\"identifier\":\"string\",\"title\":\"string\",\"description\":\"string\",\"team\":\"object\",\"labels\":\"array\",\"cycle\":\"object\",\"project\":\"object\",\"state\":\"object\",\"estimate\":\"number\",\"priority\":\"number\",\"url\":\"string\",\"createdAt\":\"string\",\"updatedAt\":\"string\",\"dueDate\":\"null\",\"parentId\":\"null\",\"subscriberIds\":\"array\",\"assignee\":\"object\",\"sla\":\"object\",\"customFields\":\"object\",\"attachments\":\"array\",\"metadata\":\"object\"}}},\"mcp__linear__list_comments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"keys\":{\"id\":\"string\",\"issueId\":\"string\",\"body\":\"string\",\"author\":\"object\",\"createdAt\":\"string\",\"updatedAt\":\"string\",\"url\":\"string\",\"edited\":\"bool\",\"parentId\":\"null\",\"reactions\":\"array\",\"metadata\":\"object\"}}}}\n"
+  },
+  "setup": ["python3 -c \"import pathlib,shutil; p=pathlib.Path('.').resolve(); root=next(x for x in p.parents if (x/'scripts'/'linear_fixture_mcp.py').exists()); shutil.copy(root/'scripts'/'linear_fixture_mcp.py','.')\""],
+  "check": "python3 \"$TASK_ROOT/hidden/check_linear_report.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/26-linear-sidecar.json
+++ b/graff-evals/tasks/26-linear-sidecar.json
@@ -1,0 +1,12 @@
+{
+  "id": "linear-sidecar",
+  "suite": "mcp",
+  "category": "mcp-shapes",
+  "prompt": "This workspace has a Linear-shaped MCP server named linear (stdio, deferred). Fetch all 8 issues and every issue's comments, then write report.json as {\"issue_count\": N, \"issues\": [{\"id\", \"title\", \"comment_count\", \"latest_author\"}, ...]} in ISS-1..ISS-8 order. latest_author is the author.name of the newest comment (last in that issue's list). Keep the MCP fetch on the root (critical path). You may spawn one sidecar subagent only to draft a one-line summary of the report after the data is on disk — do not hand list_issues/list_comments to a child.",
+  "files": {
+    ".mcp.json": "{\"mcpServers\":{\"linear\":{\"command\":\"python3\",\"args\":[\"linear_fixture_mcp.py\"]}}}\n"
+  },
+  "setup": ["python3 -c \"import pathlib,shutil; p=pathlib.Path('.').resolve(); root=next(x for x in p.parents if (x/'scripts'/'linear_fixture_mcp.py').exists()); shutil.copy(root/'scripts'/'linear_fixture_mcp.py','.')\""],
+  "check": "python3 \"$TASK_ROOT/hidden/check_linear_report.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/27-linear-split.json
+++ b/graff-evals/tasks/27-linear-split.json
@@ -1,0 +1,12 @@
+{
+  "id": "linear-split",
+  "suite": "mcp",
+  "category": "mcp-shapes",
+  "prompt": "This workspace has a Linear-shaped MCP server named linear (stdio, deferred). Write report.json as {\"issue_count\": N, \"issues\": [{\"id\", \"title\", \"comment_count\", \"latest_author\"}, ...]} in ISS-1..ISS-8 order. latest_author is the author.name of the newest comment (last in that issue's list). Split the 8 issues across two sibling subagents (ISS-1..4 and ISS-5..8). Each child should fetch comments for its half and return counts + latest authors. Root writes report.json.",
+  "files": {
+    ".mcp.json": "{\"mcpServers\":{\"linear\":{\"command\":\"python3\",\"args\":[\"linear_fixture_mcp.py\"]}}}\n"
+  },
+  "setup": ["python3 -c \"import pathlib,shutil; p=pathlib.Path('.').resolve(); root=next(x for x in p.parents if (x/'scripts'/'linear_fixture_mcp.py').exists()); shutil.copy(root/'scripts'/'linear_fixture_mcp.py','.')\""],
+  "check": "python3 \"$TASK_ROOT/hidden/check_linear_report.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/28-linear-quiet.json
+++ b/graff-evals/tasks/28-linear-quiet.json
@@ -1,0 +1,12 @@
+{
+  "id": "linear-quiet",
+  "suite": "mcp",
+  "category": "mcp-shapes",
+  "prompt": "This workspace has a Linear-shaped MCP server named linear (stdio, deferred). Load its schemas, then fetch all 8 issues and every issue's comments. Write report.json as {\"issue_count\": N, \"issues\": [{\"id\", \"title\", \"comment_count\", \"latest_author\"}, ...]} in ISS-1..ISS-8 order. latest_author is the author.name of the newest comment (last in that issue's list). Do not invent ids or authors. If rlm is available, prefer one script after load_tool_schemas: issues = list_issues(); comments = each(issues, list_comments, \"id\"). Never print() raw issue or comment arrays — those payloads are huge. Write report.json. If you print, print only the mapped counts.",
+  "files": {
+    ".mcp.json": "{\"mcpServers\":{\"linear\":{\"command\":\"python3\",\"args\":[\"linear_fixture_mcp.py\"]}}}\n"
+  },
+  "setup": ["python3 -c \"import pathlib,shutil; p=pathlib.Path('.').resolve(); root=next(x for x in p.parents if (x/'scripts'/'linear_fixture_mcp.py').exists()); shutil.copy(root/'scripts'/'linear_fixture_mcp.py','.')\""],
+  "check": "python3 \"$TASK_ROOT/hidden/check_linear_report.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/29-linear-quiet-warm.json
+++ b/graff-evals/tasks/29-linear-quiet-warm.json
@@ -1,0 +1,13 @@
+{
+  "id": "linear-quiet-warm",
+  "suite": "mcp",
+  "category": "mcp-shapes",
+  "prompt": "This workspace has a Linear-shaped MCP server named linear (stdio, deferred). Load its schemas, then fetch all 8 issues and every issue's comments. Write report.json as {\"issue_count\": N, \"issues\": [{\"id\", \"title\", \"comment_count\", \"latest_author\"}, ...]} in ISS-1..ISS-8 order. latest_author is the author.name of the newest comment (last in that issue's list). Do not invent ids or authors. If rlm is available, prefer one script after load_tool_schemas: issues = list_issues(); comments = each(issues, list_comments, \"id\"). Never print() raw issue or comment arrays — those payloads are huge. Write report.json. If you print, print only the mapped counts.",
+  "files": {
+    ".mcp.json": "{\"mcpServers\":{\"linear\":{\"command\":\"python3\",\"args\":[\"linear_fixture_mcp.py\"]}}}\n",
+    ".graff/mcp-shapes.json": "{\"mcp__linear__list_issues\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"keys\":{\"id\":\"string\",\"identifier\":\"string\",\"title\":\"string\",\"description\":\"string\",\"team\":\"object\",\"labels\":\"array\",\"cycle\":\"object\",\"project\":\"object\",\"state\":\"object\",\"estimate\":\"number\",\"priority\":\"number\",\"url\":\"string\",\"createdAt\":\"string\",\"updatedAt\":\"string\",\"dueDate\":\"null\",\"parentId\":\"null\",\"subscriberIds\":\"array\",\"assignee\":\"object\",\"sla\":\"object\",\"customFields\":\"object\",\"attachments\":\"array\",\"metadata\":\"object\"}}},\"mcp__linear__list_comments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"keys\":{\"id\":\"string\",\"issueId\":\"string\",\"body\":\"string\",\"author\":\"object\",\"createdAt\":\"string\",\"updatedAt\":\"string\",\"url\":\"string\",\"edited\":\"bool\",\"parentId\":\"null\",\"reactions\":\"array\",\"metadata\":\"object\"}}}}\n"
+  },
+  "setup": ["python3 -c \"import pathlib,shutil; p=pathlib.Path('.').resolve(); root=next(x for x in p.parents if (x/'scripts'/'linear_fixture_mcp.py').exists()); shutil.copy(root/'scripts'/'linear_fixture_mcp.py','.')\""],
+  "check": "python3 \"$TASK_ROOT/hidden/check_linear_report.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/30-linear-nohint.json
+++ b/graff-evals/tasks/30-linear-nohint.json
@@ -1,0 +1,12 @@
+{
+  "id": "linear-nohint",
+  "suite": "mcp",
+  "category": "mcp-shapes",
+  "prompt": "This workspace has a Linear-shaped MCP server named linear (stdio, deferred). Load its schemas, then fetch all 8 issues and every issue's comments. Write report.json as {\"issue_count\": N, \"issues\": [{\"id\", \"title\", \"comment_count\", \"latest_author\"}, ...]} in ISS-1..ISS-8 order. latest_author is the author.name of the newest comment (last in that issue's list). Do not invent ids or authors.",
+  "files": {
+    ".mcp.json": "{\"mcpServers\":{\"linear\":{\"command\":\"python3\",\"args\":[\"linear_fixture_mcp.py\"]}}}\n"
+  },
+  "setup": ["python3 -c \"import pathlib,shutil; p=pathlib.Path('.').resolve(); root=next(x for x in p.parents if (x/'scripts'/'linear_fixture_mcp.py').exists()); shutil.copy(root/'scripts'/'linear_fixture_mcp.py','.')\""],
+  "check": "python3 \"$TASK_ROOT/hidden/check_linear_report.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/31-linear-nohint-warm.json
+++ b/graff-evals/tasks/31-linear-nohint-warm.json
@@ -1,0 +1,13 @@
+{
+  "id": "linear-nohint-warm",
+  "suite": "mcp",
+  "category": "mcp-shapes",
+  "prompt": "This workspace has a Linear-shaped MCP server named linear (stdio, deferred). Load its schemas, then fetch all 8 issues and every issue's comments. Write report.json as {\"issue_count\": N, \"issues\": [{\"id\", \"title\", \"comment_count\", \"latest_author\"}, ...]} in ISS-1..ISS-8 order. latest_author is the author.name of the newest comment (last in that issue's list). Do not invent ids or authors.",
+  "files": {
+    ".mcp.json": "{\"mcpServers\":{\"linear\":{\"command\":\"python3\",\"args\":[\"linear_fixture_mcp.py\"]}}}\n",
+    ".graff/mcp-shapes.json": "{\"mcp__linear__list_issues\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"keys\":{\"id\":\"string\",\"identifier\":\"string\",\"title\":\"string\",\"description\":\"string\",\"team\":\"object\",\"labels\":\"array\",\"cycle\":\"object\",\"project\":\"object\",\"state\":\"object\",\"estimate\":\"number\",\"priority\":\"number\",\"url\":\"string\",\"createdAt\":\"string\",\"updatedAt\":\"string\",\"dueDate\":\"null\",\"parentId\":\"null\",\"subscriberIds\":\"array\",\"assignee\":\"object\",\"sla\":\"object\",\"customFields\":\"object\",\"attachments\":\"array\",\"metadata\":\"object\"}}},\"mcp__linear__list_comments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"keys\":{\"id\":\"string\",\"issueId\":\"string\",\"body\":\"string\",\"author\":\"object\",\"createdAt\":\"string\",\"updatedAt\":\"string\",\"url\":\"string\",\"edited\":\"bool\",\"parentId\":\"null\",\"reactions\":\"array\",\"metadata\":\"object\"}}}}\n"
+  },
+  "setup": ["python3 -c \"import pathlib,shutil; p=pathlib.Path('.').resolve(); root=next(x for x in p.parents if (x/'scripts'/'linear_fixture_mcp.py').exists()); shutil.copy(root/'scripts'/'linear_fixture_mcp.py','.')\""],
+  "check": "python3 \"$TASK_ROOT/hidden/check_linear_report.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/32-linear-reduce.json
+++ b/graff-evals/tasks/32-linear-reduce.json
@@ -1,0 +1,12 @@
+{
+  "id": "linear-reduce",
+  "suite": "mcp",
+  "category": "mcp-shapes",
+  "prompt": "This workspace has a Linear-shaped MCP server named linear (stdio, deferred). Load its schemas, then fetch all 8 issues and every issue's comments. Write report.json as {\"issue_count\": N, \"issues\": [{\"id\", \"title\", \"comment_count\", \"latest_author\"}, ...]} in ISS-1..ISS-8 order. latest_author is the author.name of the newest comment (last in that issue's list). Do not invent ids or authors. If rlm is available, after load_tool_schemas prefer: issues = list_issues(); comments = each(issues, list_comments, \"id\"); ids = project(issues, \"id\"); print(len(issues), len(comments), ids). Never print() raw issue or comment arrays. Then write report.json.",
+  "files": {
+    ".mcp.json": "{\"mcpServers\":{\"linear\":{\"command\":\"python3\",\"args\":[\"linear_fixture_mcp.py\"]}}}\n"
+  },
+  "setup": ["python3 -c \"import pathlib,shutil; p=pathlib.Path('.').resolve(); root=next(x for x in p.parents if (x/'scripts'/'linear_fixture_mcp.py').exists()); shutil.copy(root/'scripts'/'linear_fixture_mcp.py','.')\""],
+  "check": "python3 \"$TASK_ROOT/hidden/check_linear_report.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/33-linear-reduce-warm.json
+++ b/graff-evals/tasks/33-linear-reduce-warm.json
@@ -1,0 +1,13 @@
+{
+  "id": "linear-reduce-warm",
+  "suite": "mcp",
+  "category": "mcp-shapes",
+  "prompt": "This workspace has a Linear-shaped MCP server named linear (stdio, deferred). Load its schemas, then fetch all 8 issues and every issue's comments. Write report.json as {\"issue_count\": N, \"issues\": [{\"id\", \"title\", \"comment_count\", \"latest_author\"}, ...]} in ISS-1..ISS-8 order. latest_author is the author.name of the newest comment (last in that issue's list). Do not invent ids or authors. If rlm is available, after load_tool_schemas prefer: issues = list_issues(); comments = each(issues, list_comments, \"id\"); ids = project(issues, \"id\"); print(len(issues), len(comments), ids). Never print() raw issue or comment arrays. Then write report.json.",
+  "files": {
+    ".mcp.json": "{\"mcpServers\":{\"linear\":{\"command\":\"python3\",\"args\":[\"linear_fixture_mcp.py\"]}}}\n",
+    ".graff/mcp-shapes.json": "{\"mcp__linear__list_issues\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"keys\":{\"id\":\"string\",\"identifier\":\"string\",\"title\":\"string\",\"description\":\"string\",\"team\":\"object\",\"labels\":\"array\",\"cycle\":\"object\",\"project\":\"object\",\"state\":\"object\",\"estimate\":\"number\",\"priority\":\"number\",\"url\":\"string\",\"createdAt\":\"string\",\"updatedAt\":\"string\",\"dueDate\":\"null\",\"parentId\":\"null\",\"subscriberIds\":\"array\",\"assignee\":\"object\",\"sla\":\"object\",\"customFields\":\"object\",\"attachments\":\"array\",\"metadata\":\"object\"}}},\"mcp__linear__list_comments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"keys\":{\"id\":\"string\",\"issueId\":\"string\",\"body\":\"string\",\"author\":\"object\",\"createdAt\":\"string\",\"updatedAt\":\"string\",\"url\":\"string\",\"edited\":\"bool\",\"parentId\":\"null\",\"reactions\":\"array\",\"metadata\":\"object\"}}}}\n"
+  },
+  "setup": ["python3 -c \"import pathlib,shutil; p=pathlib.Path('.').resolve(); root=next(x for x in p.parents if (x/'scripts'/'linear_fixture_mcp.py').exists()); shutil.copy(root/'scripts'/'linear_fixture_mcp.py','.')\""],
+  "check": "python3 \"$TASK_ROOT/hidden/check_linear_report.py\"",
+  "timeout_s": 240
+}

--- a/scripts/eval-mcp-pareto.py
+++ b/scripts/eval-mcp-pareto.py
@@ -91,7 +91,7 @@ def live_row(variant: str) -> dict | None:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--history", action="store_true", help="do not drive a provider")
-    ap.add_argument("--only", default="A,H,J,K", help="live variant ids")
+    ap.add_argument("--only", default="L,M,N,O,P,Q", help="live variant ids")
     args = ap.parse_args()
 
     points = [dict(p) for p in HISTORY]

--- a/scripts/eval-mcp-pareto.py
+++ b/scripts/eval-mcp-pareto.py
@@ -37,6 +37,10 @@ HISTORY = [
     {"id": "G", "wall": 155.6, "tok_in": 279981, "calls": 21, "ok": True, "note": "quiet + warm"},
     {"id": "H", "wall": 28.0, "tok_in": 112073, "calls": 7, "ok": True, "note": "no each() recipe"},
     {"id": "I", "wall": 31.1, "tok_in": 107284, "calls": 7, "ok": True, "note": "no recipe + warm"},
+    {"id": "A-live", "wall": 36.13, "tok_in": 133403, "calls": 8, "ok": True, "note": "--old (pareto session)"},
+    {"id": "H-live", "wall": 70.1, "tok_in": 178473, "calls": 14, "ok": True, "note": "no recipe (pareto session; variance)"},
+    {"id": "J-live", "wall": 47.31, "tok_in": 84041, "calls": 9, "ok": True, "note": "len/project recipe, cold"},
+    {"id": "K-live", "wall": 75.46, "tok_in": 113688, "calls": 11, "ok": True, "note": "len/project recipe, warm"},
 ]
 
 

--- a/scripts/eval-mcp-pareto.py
+++ b/scripts/eval-mcp-pareto.py
@@ -41,7 +41,7 @@ HISTORY = [
     {"id": "H-live", "wall": 70.1, "tok_in": 178473, "calls": 14, "ok": True, "note": "no recipe (pareto session; variance)"},
     {"id": "J-live", "wall": 47.31, "tok_in": 84041, "calls": 9, "ok": True, "note": "len/project recipe, cold"},
     {"id": "K-live", "wall": 75.46, "tok_in": 113688, "calls": 11, "ok": True, "note": "len/project recipe, warm"},
-    {"id": "R", "wall": 16.32, "tok_in": 14113, "calls": 4, "ok": True, "note": "default -p lean+yolo, no hint"},
+    # R (16.3s / 14k / 4) used graff-dev lean catalog — excluded from this front.
 ]
 
 
@@ -92,7 +92,7 @@ def live_row(variant: str) -> dict | None:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--history", action="store_true", help="do not drive a provider")
-    ap.add_argument("--only", default="L,M,N,O,P,Q", help="live variant ids")
+    ap.add_argument("--only", default="N,L,P", help="live variant ids (full --no-lean harness)")
     args = ap.parse_args()
 
     points = [dict(p) for p in HISTORY]

--- a/scripts/eval-mcp-pareto.py
+++ b/scripts/eval-mcp-pareto.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Pareto front for the Linear MCP bench.
+
+Minimize wall_s, tok_in, tok_calls among passing runs. A point is on the
+front if nothing else is ≤ on all three and < on at least one.
+
+  zig build -Doptimize=ReleaseSafe
+  python3 scripts/eval-mcp-pareto.py            # live A,H,J,K + history
+  python3 scripts/eval-mcp-pareto.py --history  # print front from seeded + json only
+
+Seeded history is ADR 0029's SuperGrok grok-4.6 reps (2026-08-25).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+EVALS = REPO / "graff-evals"
+SHAPES = REPO / "scripts" / "eval-mcp-shapes.py"
+
+# wall, tok_in, calls — lower is better. pass required.
+HISTORY = [
+    {"id": "A-r1", "wall": 36.7, "tok_in": 167692, "calls": 10, "ok": True, "note": "--old structured"},
+    {"id": "A-r2", "wall": 36.4, "tok_in": 145497, "calls": 9, "ok": True, "note": "--old structured"},
+    {"id": "B", "wall": 43.3, "tok_in": 179822, "calls": 11, "ok": True, "note": "rlm, MCP structured-only"},
+    {"id": "C", "wall": 56.7, "tok_in": 147948, "calls": 13, "ok": True, "note": "rlm+MCP cold + each()"},
+    {"id": "D-r1", "wall": 41.1, "tok_in": 107213, "calls": 10, "ok": True, "note": "rlm+MCP warm + each()"},
+    {"id": "D-r2", "wall": 60.5, "tok_in": 158769, "calls": 11, "ok": True, "note": "rlm+MCP warm + each()"},
+    {"id": "E1", "wall": 37.5, "tok_in": 168164, "calls": 11, "ok": True, "note": "sidecar"},
+    {"id": "E2", "wall": 75.5, "tok_in": 149156, "calls": 18, "ok": True, "note": "two siblings"},
+    {"id": "F", "wall": 220.1, "tok_in": 462379, "calls": 29, "ok": True, "note": "each() + quiet print"},
+    {"id": "G", "wall": 155.6, "tok_in": 279981, "calls": 21, "ok": True, "note": "quiet + warm"},
+    {"id": "H", "wall": 28.0, "tok_in": 112073, "calls": 7, "ok": True, "note": "no each() recipe"},
+    {"id": "I", "wall": 31.1, "tok_in": 107284, "calls": 7, "ok": True, "note": "no recipe + warm"},
+]
+
+
+def dominates(a: dict, b: dict) -> bool:
+    """a dominates b: ≤ on every objective and < on one."""
+    aw, at, ac = a["wall"], a["tok_in"], a["calls"]
+    bw, bt, bc = b["wall"], b["tok_in"], b["calls"]
+    le = aw <= bw and at <= bt and ac <= bc
+    lt = aw < bw or at < bt or ac < bc
+    return le and lt
+
+
+def frontier(points: list[dict]) -> list[dict]:
+    ok = [p for p in points if p.get("ok")]
+    front = []
+    for p in ok:
+        if any(dominates(q, p) for q in ok if q is not p):
+            continue
+        front.append(p)
+    return sorted(front, key=lambda p: (p["wall"], p["tok_in"], p["calls"]))
+
+
+def live_row(variant: str) -> dict | None:
+    proc = subprocess.run(
+        [sys.executable, str(SHAPES), "--only", variant, "--model", "grok-4.6"],
+        cwd=REPO,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    path = EVALS / "results" / "mcp-shapes-summary.json"
+    if not path.exists():
+        return None
+    rows = json.loads(path.read_text())
+    if not rows:
+        return None
+    r = rows[0]
+    return {
+        "id": f"{variant}-live",
+        "wall": float(r.get("wall_s") or 0),
+        "tok_in": int(r.get("tok_in") or 0),
+        "calls": int(r.get("tok_calls") or 0),
+        "ok": bool(r.get("outcome_ok")),
+        "note": r.get("label") or variant,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--history", action="store_true", help="do not drive a provider")
+    ap.add_argument("--only", default="A,H,J,K", help="live variant ids")
+    args = ap.parse_args()
+
+    points = [dict(p) for p in HISTORY]
+    if not args.history:
+        oauth = Path.home() / ".xai/credentials/graff-oauth.json"
+        if not oauth.exists():
+            print("no SuperGrok OAuth — use --history", file=sys.stderr)
+            return 2
+        for vid in [x.strip().upper() for x in args.only.split(",") if x.strip()]:
+            print(f"== live {vid} ==", flush=True)
+            row = live_row(vid)
+            if row:
+                points.append(row)
+                print(json.dumps(row), flush=True)
+
+    front = frontier(points)
+    front_ids = {p["id"] for p in front}
+    print("\nall points (pass only); * = Pareto front on wall / tok_in / calls\n")
+    print(f"{'id':<10} {'front':<5} {'wall':>7} {'in':>8} {'calls':>5}  note")
+    for p in sorted(points, key=lambda x: (not x.get("ok"), x["wall"], x["tok_in"])):
+        if not p.get("ok"):
+            continue
+        mark = "*" if p["id"] in front_ids else " "
+        print(f"{p['id']:<10} {mark:<5} {p['wall']:7.1f} {p['tok_in']:8} {p['calls']:5}  {p['note']}")
+    print("\nfrontier:")
+    for p in front:
+        print(f"  {p['id']}: {p['wall']:.1f}s / {p['tok_in']} in / {p['calls']} calls — {p['note']}")
+    out = EVALS / "results" / "mcp-pareto.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps({"points": points, "frontier": front}, indent=2) + "\n")
+    print(f"\nwrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval-mcp-pareto.py
+++ b/scripts/eval-mcp-pareto.py
@@ -41,6 +41,9 @@ HISTORY = [
     {"id": "H-live", "wall": 70.1, "tok_in": 178473, "calls": 14, "ok": True, "note": "no recipe (pareto session; variance)"},
     {"id": "J-live", "wall": 47.31, "tok_in": 84041, "calls": 9, "ok": True, "note": "len/project recipe, cold"},
     {"id": "K-live", "wall": 75.46, "tok_in": 113688, "calls": 11, "ok": True, "note": "len/project recipe, warm"},
+    {"id": "L", "wall": 14.75, "tok_in": 31348, "calls": 5, "ok": True, "note": "slim+playbook, nohint, warm, --no-lean"},
+    {"id": "N", "wall": 20.84, "tok_in": 30314, "calls": 5, "ok": True, "note": "slim mid-run, nohint, cold, --no-lean"},
+    {"id": "P", "wall": 48.07, "tok_in": 66260, "calls": 9, "ok": True, "note": "slim+reduce recipe, cold, --no-lean"},
     # R (16.3s / 14k / 4) used graff-dev lean catalog — excluded from this front.
 ]
 

--- a/scripts/eval-mcp-pareto.py
+++ b/scripts/eval-mcp-pareto.py
@@ -41,6 +41,7 @@ HISTORY = [
     {"id": "H-live", "wall": 70.1, "tok_in": 178473, "calls": 14, "ok": True, "note": "no recipe (pareto session; variance)"},
     {"id": "J-live", "wall": 47.31, "tok_in": 84041, "calls": 9, "ok": True, "note": "len/project recipe, cold"},
     {"id": "K-live", "wall": 75.46, "tok_in": 113688, "calls": 11, "ok": True, "note": "len/project recipe, warm"},
+    {"id": "R", "wall": 16.32, "tok_in": 14113, "calls": 4, "ok": True, "note": "default -p lean+yolo, no hint"},
 ]
 
 

--- a/scripts/eval-mcp-shapes.py
+++ b/scripts/eval-mcp-shapes.py
@@ -136,6 +136,12 @@ VARIANTS = [
         "task": "linear-reduce-warm",
         "label": "learnt slim + len/project recipe, warm",
     },
+    {
+        "id": "R",
+        "harness": "graff-dev",
+        "task": "linear-nohint",
+        "label": "out of the box: default -p (lean + yolo), no each() hint",
+    },
 ]
 
 

--- a/scripts/eval-mcp-shapes.py
+++ b/scripts/eval-mcp-shapes.py
@@ -100,6 +100,42 @@ VARIANTS = [
         "task": "linear-reduce-warm",
         "label": "rlm+MCP host, warm, len/project recipe",
     },
+    {
+        "id": "L",
+        "harness": "graff-dev-nolean",
+        "task": "linear-nohint-warm",
+        "label": "learnt slim + playbook, no each() hint, warm",
+    },
+    {
+        "id": "M",
+        "harness": "graff-dev-nolean",
+        "task": "linear-warm",
+        "label": "learnt slim + each() hint, warm",
+    },
+    {
+        "id": "N",
+        "harness": "graff-dev-nolean",
+        "task": "linear-nohint",
+        "label": "learnt slim mid-run, no each() hint, cold",
+    },
+    {
+        "id": "O",
+        "harness": "graff-dev-nolean",
+        "task": "linear-quiet",
+        "label": "learnt slim, quiet print, cold",
+    },
+    {
+        "id": "P",
+        "harness": "graff-dev-nolean",
+        "task": "linear-reduce",
+        "label": "learnt slim + len/project recipe, cold",
+    },
+    {
+        "id": "Q",
+        "harness": "graff-dev-nolean",
+        "task": "linear-reduce-warm",
+        "label": "learnt slim + len/project recipe, warm",
+    },
 ]
 
 

--- a/scripts/eval-mcp-shapes.py
+++ b/scripts/eval-mcp-shapes.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Run the Blacksmith-shaped MCP A/B (variants A–E) and print the table.
+
+  zig build -Doptimize=ReleaseSafe
+  python3 scripts/eval-mcp-shapes.py
+  python3 scripts/eval-mcp-shapes.py --mock   # scripted model, no provider
+
+Records pass/fail, wall, RSS, tokens, API calls, and whether the model
+retried or guessed wrong MCP fields (from .graff/traces).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+EVALS = REPO / "graff-evals"
+WRONG = re.compile(
+    r"unknown|missing required|needs id|unsupported statement|not loaded|GRAFF_RLM_MCP|bad args|issue_id|issueId",
+    re.I,
+)
+
+
+VARIANTS = [
+    {
+        "id": "A",
+        "harness": "graff-dev-old-nolean",
+        "task": "linear-issues",
+        "label": "--old structured MCP only",
+    },
+    {
+        "id": "B",
+        "harness": "graff-dev-rlm-struct",
+        "task": "linear-issues",
+        "label": "default rlm, MCP structured-only",
+    },
+    {
+        "id": "C",
+        "harness": "graff-dev-nolean",
+        "task": "linear-issues",
+        "label": "rlm + MCP host, cold",
+    },
+    {
+        "id": "D",
+        "harness": "graff-dev-nolean",
+        "task": "linear-warm",
+        "label": "rlm + MCP host, warm shapes",
+    },
+    {
+        "id": "E1",
+        "harness": "graff-dev-nolean",
+        "task": "linear-sidecar",
+        "label": "C + sidecar summarize subagent",
+    },
+    {
+        "id": "E2",
+        "harness": "graff-dev-nolean",
+        "task": "linear-split",
+        "label": "two sibling subagents split 8 issues",
+    },
+]
+
+
+def parse_traces(sandbox: Path) -> dict:
+    retried = False
+    wrong = False
+    mcp_calls = 0
+    rlm_calls = 0
+    for path in sandbox.glob(".graff/traces/*.jsonl"):
+        for line in path.read_text().splitlines():
+            if not line.startswith("{"):
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            name = ev.get("name") or ev.get("tool") or ""
+            text = str(ev.get("text") or ev.get("output") or "")
+            if name.startswith("mcp__") or name in {"list_issues", "list_comments"}:
+                mcp_calls += 1
+            if name == "rlm":
+                rlm_calls += 1
+            if ev.get("is_error") or ev.get("error"):
+                if WRONG.search(text) or WRONG.search(name):
+                    wrong = True
+                    retried = True
+            if "load_tool_schemas first" in text or "not loaded" in text:
+                retried = True
+                wrong = True
+    return {"retried": retried, "wrong_fields": wrong, "mcp_calls": mcp_calls, "rlm_calls": rlm_calls}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mock", action="store_true", help="skip live provider (print harness plan only)")
+    ap.add_argument("--model", default="grok-4.6")
+    args = ap.parse_args()
+
+    if args.mock:
+        print("mock: not driving a provider. Unit tests cover dispatch/shapes; live A/B needs SuperGrok.")
+        for v in VARIANTS:
+            print(f"  {v['id']}  {v['harness']}  {v['task']}  {v['label']}")
+        return 0
+
+    oauth = Path.home() / ".xai/credentials/graff-oauth.json"
+    if not oauth.exists():
+        print("no SuperGrok OAuth at ~/.xai/credentials/graff-oauth.json — pass --mock or sign in", file=sys.stderr)
+        return 2
+
+    rows = []
+    for v in VARIANTS:
+        cmd = [
+            sys.executable,
+            str(EVALS / "run.py"),
+            "--suite",
+            "mcp",
+            "--task",
+            v["task"],
+            "--harness",
+            v["harness"],
+            "--model",
+            args.model,
+            "--reps",
+            "1",
+        ]
+        print(f"== {v['id']} {v['label']} ==", flush=True)
+        subprocess.run(cmd, cwd=EVALS, check=False)
+        # newest result line for this harness/task
+        results = sorted((EVALS / "results").glob("run-*.jsonl"))
+        rec = None
+        if results:
+            for line in reversed(results[-1].read_text().splitlines()):
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if r.get("harness") == v["harness"] and r.get("task") == v["task"]:
+                    rec = r
+                    break
+        sandbox = EVALS / ".sandboxes" / f"{v['harness']}-{v['task']}-r1"
+        extra = parse_traces(sandbox) if sandbox.exists() else {}
+        row = {"variant": v["id"], "label": v["label"], **(rec or {}), **extra}
+        rows.append(row)
+        print(json.dumps({k: row.get(k) for k in (
+            "variant", "outcome_ok", "wall_s", "rss_peak_kb", "tok_in", "tok_out",
+            "tok_calls", "retried", "wrong_fields")}, default=str), flush=True)
+
+    out = EVALS / "results" / "mcp-shapes-summary.json"
+    out.write_text(json.dumps(rows, indent=2) + "\n")
+    print(f"\nsummary → {out}")
+    print(f"{'var':<4} {'pass':<5} {'wall':>7} {'RSS':>8} {'in':>8} {'out':>6} {'calls':>5} {'retry':<6} {'wrong':<6}  label")
+    for row in rows:
+        ok = "✓" if row.get("outcome_ok") else "✗"
+        print(
+            f"{row['variant']:<4} {ok:<5} {row.get('wall_s') or 0:7.1f} "
+            f"{(row.get('rss_peak_kb') or 0) / 1024:7.1f}M "
+            f"{row.get('tok_in') or 0:8} {row.get('tok_out') or 0:6} "
+            f"{row.get('tok_calls') or 0:5} "
+            f"{'yes' if row.get('retried') else 'no':<6} "
+            f"{'yes' if row.get('wrong_fields') else 'no':<6}  {row['label']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval-mcp-shapes.py
+++ b/scripts/eval-mcp-shapes.py
@@ -64,6 +64,30 @@ VARIANTS = [
         "task": "linear-split",
         "label": "two sibling subagents split 8 issues",
     },
+    {
+        "id": "F",
+        "harness": "graff-dev-nolean",
+        "task": "linear-quiet",
+        "label": "rlm+MCP host, cold, no fat print()",
+    },
+    {
+        "id": "G",
+        "harness": "graff-dev-nolean",
+        "task": "linear-quiet-warm",
+        "label": "rlm+MCP host, warm, no fat print()",
+    },
+    {
+        "id": "H",
+        "harness": "graff-dev-nolean",
+        "task": "linear-nohint",
+        "label": "rlm+MCP host, cold, no each() recipe",
+    },
+    {
+        "id": "I",
+        "harness": "graff-dev-nolean",
+        "task": "linear-nohint-warm",
+        "label": "rlm+MCP host, warm, no each() recipe",
+    },
 ]
 
 
@@ -100,11 +124,15 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--mock", action="store_true", help="skip live provider (print harness plan only)")
     ap.add_argument("--model", default="grok-4.6")
+    ap.add_argument("--only", default="", help="comma-separated variant ids (A,D,F,...)")
     args = ap.parse_args()
+
+    wanted = {x.strip().upper() for x in args.only.split(",") if x.strip()}
+    variants = [v for v in VARIANTS if not wanted or v["id"] in wanted]
 
     if args.mock:
         print("mock: not driving a provider. Unit tests cover dispatch/shapes; live A/B needs SuperGrok.")
-        for v in VARIANTS:
+        for v in variants:
             print(f"  {v['id']}  {v['harness']}  {v['task']}  {v['label']}")
         return 0
 
@@ -114,7 +142,7 @@ def main() -> int:
         return 2
 
     rows = []
-    for v in VARIANTS:
+    for v in variants:
         cmd = [
             sys.executable,
             str(EVALS / "run.py"),

--- a/scripts/eval-mcp-shapes.py
+++ b/scripts/eval-mcp-shapes.py
@@ -140,7 +140,7 @@ VARIANTS = [
         "id": "R",
         "harness": "graff-dev",
         "task": "linear-nohint",
-        "label": "out of the box: default -p (lean + yolo), no each() hint",
+        "label": "lean catalog (NOT the MCP bench; different prefix than H/J)",
     },
 ]
 

--- a/scripts/eval-mcp-shapes.py
+++ b/scripts/eval-mcp-shapes.py
@@ -88,6 +88,18 @@ VARIANTS = [
         "task": "linear-nohint-warm",
         "label": "rlm+MCP host, warm, no each() recipe",
     },
+    {
+        "id": "J",
+        "harness": "graff-dev-nolean",
+        "task": "linear-reduce",
+        "label": "rlm+MCP host, cold, len/project recipe",
+    },
+    {
+        "id": "K",
+        "harness": "graff-dev-nolean",
+        "task": "linear-reduce-warm",
+        "label": "rlm+MCP host, warm, len/project recipe",
+    },
 ]
 
 

--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -15,7 +15,7 @@
     "src/repl.zig",
     "TUI/root.zig"
   ],
-  "test_count_baseline": 1600,
+  "test_count_baseline": 1664,
   "test_count_slack": 25,
   "required_invariants": [
     {

--- a/scripts/linear_fixture_mcp.py
+++ b/scripts/linear_fixture_mcp.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Stdio MCP fixture shaped like Blacksmith's Linear task.
+
+list_issues returns 8 fat issue objects. list_comments returns a fat comment
+list per issue id. The point is payload size + return-shape guessing, not
+Linear OAuth. JSON-RPC, one object per line, on stdin/stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+PAD = "x" * 400
+
+
+def issue(n: int) -> dict:
+    return {
+        "id": f"ISS-{n}",
+        "identifier": f"ENG-{100 + n}",
+        "title": (
+            "Login timeout on session resume",
+            "Checkout tax rounding",
+            "Search index lag",
+            "Webhook retries drop 429s",
+            "Avatar upload EXIF leak",
+            "Board filter forgets assignee",
+            "CSV export truncates UTF-8",
+            "Nightly digest duplicates",
+        )[n - 1],
+        "description": f"Long description for issue {n}. {PAD}",
+        "team": {"id": "team-eng", "name": "Engineering", "key": "ENG", "pad": PAD},
+        "labels": [{"id": f"lab-{i}", "name": f"label-{i}", "color": "#059669", "pad": PAD[:80]} for i in range(6)],
+        "cycle": {"id": "cyc-9", "name": "Cycle 9", "startsAt": "2026-08-01", "endsAt": "2026-08-14", "pad": PAD},
+        "project": {"id": "proj-1", "name": "Platform", "state": "started", "pad": PAD},
+        "state": {"id": "st-open", "name": "In Progress", "type": "started", "pad": PAD},
+        "estimate": n + 2,
+        "priority": (n % 4) + 1,
+        "url": f"https://linear.app/fixture/issue/ENG-{100 + n}",
+        "createdAt": f"2026-08-0{n}T10:00:00Z",
+        "updatedAt": f"2026-08-1{n}T12:00:00Z",
+        "dueDate": None,
+        "parentId": None,
+        "subscriberIds": [f"user-{i}" for i in range(12)],
+        "assignee": {"id": f"user-{n}", "name": f"Dev {n}", "email": f"dev{n}@example.test", "pad": PAD},
+        "sla": {"breached": False, "status": "ok", "pad": PAD},
+        "customFields": {f"cf_{i}": f"value-{i}-{PAD[:40]}" for i in range(8)},
+        "attachments": [{"id": f"att-{n}-{i}", "url": f"https://files.example/{n}/{i}", "pad": PAD} for i in range(3)],
+        "metadata": {"workspaceId": "ws-1", "pad": PAD},
+    }
+
+
+AUTHORS = {
+    1: ["ada", "bev"],
+    2: ["cam", "deb", "eli"],
+    3: ["fay"],
+    4: ["gus", "hal", "ivy", "jay"],
+    5: ["kim", "lee"],
+    6: ["mo", "nia", "oak"],
+    7: ["pip"],
+    8: ["quin", "raj", "sky", "tess"],
+}
+
+
+def comments(issue_id: str) -> list[dict]:
+    n = int(issue_id.split("-")[1])
+    out = []
+    for i, author in enumerate(AUTHORS[n], start=1):
+        out.append({
+            "id": f"C-{n}-{i}",
+            "issueId": issue_id,
+            "body": f"Comment {i} on {issue_id} by {author}. {PAD}",
+            "author": {"id": f"u-{author}", "name": author, "email": f"{author}@example.test", "pad": PAD},
+            "createdAt": f"2026-08-{10 + i:02d}T0{i}:00:00Z",
+            "updatedAt": f"2026-08-{10 + i:02d}T1{i}:00:00Z",
+            "url": f"https://linear.app/fixture/comment/C-{n}-{i}",
+            "edited": False,
+            "parentId": None,
+            "reactions": [{"emoji": "👍", "count": i, "pad": PAD[:60]} for _ in range(4)],
+            "metadata": {"pad": PAD},
+        })
+    return out
+
+
+TOOLS = [
+    {
+        "name": "list_issues",
+        "description": "List issues in the fixture workspace. Returns fat issue objects (many unused fields).",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "list_comments",
+        "description": "List comments for one issue. Pass id (ISS-N). Returns a fat comment list.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"id": {"type": "string", "description": "Issue id, e.g. ISS-1"}},
+            "required": ["id"],
+        },
+    },
+]
+
+
+def send(obj: dict) -> None:
+    sys.stdout.write(json.dumps(obj, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+def result(mid, payload) -> None:
+    send({"jsonrpc": "2.0", "id": mid, "result": payload})
+
+
+def handle(msg: dict) -> None:
+    method = msg.get("method")
+    mid = msg.get("id")
+    if method == "initialize":
+        result(mid, {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "linear-fixture", "version": "1"},
+        })
+        return
+    if method == "notifications/initialized":
+        return
+    if method == "server/discover":
+        send({"jsonrpc": "2.0", "id": mid, "error": {"code": -32601, "message": "Method not found"}})
+        return
+    if method == "tools/list":
+        result(mid, {"tools": TOOLS})
+        return
+    if method == "tools/call":
+        params = msg.get("params") or {}
+        name = params.get("name")
+        args = params.get("arguments") or {}
+        if name == "list_issues":
+            result(mid, {"content": [{"type": "text", "text": json.dumps([issue(i) for i in range(1, 9)])}]})
+            return
+        if name == "list_comments":
+            iid = args.get("id") or args.get("issueId") or args.get("issue_id")
+            if not iid:
+                send({"jsonrpc": "2.0", "id": mid, "error": {"code": -32602, "message": "list_comments needs id"}})
+                return
+            result(mid, {"content": [{"type": "text", "text": json.dumps(comments(str(iid)))}]})
+            return
+        send({"jsonrpc": "2.0", "id": mid, "error": {"code": -32601, "message": f"unknown tool {name}"}})
+        return
+
+
+def main() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        handle(json.loads(line))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-smolify-boundary.py
+++ b/scripts/test-smolify-boundary.py
@@ -128,8 +128,8 @@ def run(graff: Path) -> None:
                     "codex",
                     "--yolo",
                     "--no-telemetry",
-                    # -p implies --lean, which skips MCP (ADR 0024). This
-                    # test is the MCP advertisement/secret-egress boundary.
+                    # --no-lean so this test sees the full MCP advertisement
+                    # surface (secret-egress boundary), not the lean fold.
                     "--no-lean",
                     "-p",
                     "try the hosted docs query, then report",

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -123,6 +123,7 @@ pub const Agent = struct {
     agent_cwd: ?[]const u8 = null, // subagent-only (#276 P0-1): absolute path of this agent's isolated git worktree, threaded through ToolCtx per tool call instead of a process-wide chdir — parallel siblings each keep their own
     tools_used: trace.ToolSink = .{}, // external tool calls this agent made (per turn for the root)
     tool_calls_this_turn: u64 = 0,
+    model_calls_this_turn: u64 = 0,
     handle_note_shown: bool = false, // #541: the handle-protocol lesson rides this agent's FIRST handle, once
     seen_tool_keys: std.ArrayList([]const u8) = .empty, // root-only per-turn dedupe keys
     md_buf: std.ArrayList(u8) = .empty, // current incomplete streamed line (markdown rendering)
@@ -264,33 +265,12 @@ pub const Agent = struct {
         return true;
     }
 
-    /// #330/#352: a child's catalog is a comptime constant, so both gates just
-    /// pick the pre-built twin rather than rebuilding one per subagent —
-    /// schema.subToolsJson owns that choice. Root catalogs are filtered where
-    /// they are assembled (schema.effectiveRootSpecs).
     pub fn toolsJson(self: *const Agent) []const u8 {
-        if (self.sub) return schema.subToolsJson(self.provider.kind, no_local_tools.enabled);
-        return switch (self.provider.kind) {
-            .anthropic => self.tools_anthropic,
-            .openai => self.tools_openai,
-            .responses => self.tools_responses,
-        };
+        return @import("agent_catalog.zig").toolsJson(self);
     }
 
-    /// Root catalogs include meta + MCP tools and are much larger than the
-    /// subagent constants. Materialize only a wire format the session actually
-    /// uses; provider switching calls this before updating the context meter.
     pub fn ensureRootTools(self: *Agent, kind: Provider.Kind) !void {
-        if (self.sub) return;
-        const slot = switch (kind) {
-            .anthropic => &self.tools_anthropic,
-            .openai => &self.tools_openai,
-            .responses => &self.tools_responses,
-        };
-        if (slot.*.len != 0) return;
-        const specs = try schema.effectiveRootSpecs(self.arena);
-        const connected: []const mcp.Tool = if (self.registry) |registry| registry.tools else &.{};
-        slot.* = try schema.renderRootTools(self.arena, kind, specs, connected);
+        return @import("agent_catalog.zig").ensureRootTools(self, kind);
     }
 
     /// A live MCP registry change invalidates provider-specific catalogs. The
@@ -343,9 +323,8 @@ pub const Agent = struct {
         self.completed = null;
         if (!self.sub and !root_turn_prepared.swap(false, .acq_rel)) esc_cancel.store(false, .release);
         while (true) {
-            // Esc during a tool join (set by escWatchTask) lands here: the
-            // root consumes the flag and aborts before the next request;
-            // subagents see it too and bail without consuming.
+            if (try @import("turn_chrome.zig").beforeRequest(self)) |paused| return paused;
+            // Esc during a tool join lands here; root consumes, subagents bail.
             if (esc_cancel.load(.acquire)) {
                 if (!self.sub) esc_cancel.store(false, .release);
                 return error.Interrupted;

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -362,6 +362,15 @@ pub const Agent = struct {
                 self.autocompact(recovery_meter);
                 self.closeCodexWs();
             }
+            // ADR 0030: showcase rlm once the existing compact meter is
+            // actually large. Schema rides the tail; head bytes stay put.
+            if (!self.sub) {
+                const fold = @import("native_fold.zig");
+                if (fold.noticeContext(self.effectiveContextTokens(), self.provider.compactAt())) {
+                    self.invalidateRootTools();
+                    try self.ensureRootTools(self.provider.kind);
+                }
+            }
             const hist_len = self.messages.items.len;
             const root = try self.request(if (self.text_only) null else self.toolsJson());
             const done = switch (self.provider.kind) {

--- a/src/agent_catalog.zig
+++ b/src/agent_catalog.zig
@@ -1,0 +1,44 @@
+//! Root/worker tool-catalog materialization. Split out of agent.zig (600-line ceiling).
+
+const main_mod = @import("main.zig");
+const schema = @import("schema.zig");
+const no_local_tools = @import("no_local_tools.zig");
+const surface = @import("tool_surface.zig");
+const mcp = @import("mcp.zig");
+const Provider = @import("provider.zig").Provider;
+const Agent = @import("agent.zig").Agent;
+
+pub fn toolsJson(self: *const Agent) []const u8 {
+    if (self.sub) {
+        if (main_mod.g_codedbpro_licensed) return slot(self);
+        return schema.subToolsJson(self.provider.kind, no_local_tools.enabled);
+    }
+    return slot(self);
+}
+
+fn slot(self: *const Agent) []const u8 {
+    return switch (self.provider.kind) {
+        .anthropic => self.tools_anthropic,
+        .openai => self.tools_openai,
+        .responses => self.tools_responses,
+    };
+}
+
+pub fn ensureRootTools(self: *Agent, kind: Provider.Kind) !void {
+    if (self.sub and !main_mod.g_codedbpro_licensed) return;
+    const dest = switch (kind) {
+        .anthropic => &self.tools_anthropic,
+        .openai => &self.tools_openai,
+        .responses => &self.tools_responses,
+    };
+    if (dest.*.len != 0) return;
+    const specs = if (self.sub)
+        try surface.filterSpecs(@TypeOf(schema.base_specs[0]), self.arena, schema.base_specs[0..])
+    else
+        try schema.effectiveRootSpecs(self.arena);
+    const connected: []const mcp.Tool = if (self.registry) |registry|
+        (if (self.sub) try surface.filterWorkerMcp(self.arena, registry.tools) else registry.tools)
+    else
+        &.{};
+    dest.* = try schema.renderRootTools(self.arena, kind, specs, connected);
+}

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -366,6 +366,7 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
                             // just-closed keep-alive almost always re-fail
                             // (#86). 250ms·2ⁿ, capped at 4s over 6 tries; Esc cancels.
                             const delay_ms = RetryPlan.delayMs(throttled, attempt);
+                            @import("turn_chrome.zig").emitRetryNotice(self.io, @errorName(err), attempt + 1, max_attempts);
                             if (showRecoveredTransportRetry(self.call_kind))
                                 try self.say("[network error: {t} — retrying in {d}ms ({d}/{d})]\n", .{ err, delay_ms, attempt + 1, max_attempts });
                             // Same trace breadcrumb the 429/5xx branch leaves: a

--- a/src/agent_request_body_responses.zig
+++ b/src/agent_request_body_responses.zig
@@ -10,6 +10,7 @@ const serde = @import("serde.zig");
 const http_headers = @import("http_headers.zig");
 const codex_chain = @import("codex_chain.zig");
 const server_compact = @import("agent_server_compact.zig");
+const xai_hosted = @import("xai_hosted.zig");
 
 pub fn write(self: *Agent, s: *std.json.Stringify, tools: ?[]const u8, force_tool: bool) !void {
     // Responses API (codex / ChatGPT, xAI, and native Codegraff aliases).
@@ -57,8 +58,12 @@ pub fn write(self: *Agent, s: *std.json.Stringify, tools: ?[]const u8, force_too
     for (self.messages.items[from..]) |m| try s.write(m);
     try s.endArray();
     if (tools) |t| {
+        const payload = if (xai_hosted.active(self.provider.id, self.provider.kind))
+            xai_hosted.splice(self.scratchAlloc(), t) catch t
+        else
+            t;
         try s.objectField("tools");
-        try serde.writeOpenAITools(s, self.scratchAlloc(), t); // #261 follow-up
+        try serde.writeOpenAITools(s, self.scratchAlloc(), payload); // #261 follow-up
         try s.objectField("tool_choice");
         try s.write(if (force_tool) "required" else "auto");
         try s.objectField("parallel_tool_calls");
@@ -331,6 +336,37 @@ test "xai Responses body is bearer-clean: no codex-isms, xAI-legal fields only (
     try std.testing.expect(std.mem.indexOf(u8, body, "prompt_cache_options") == null);
     try std.testing.expect(std.mem.indexOf(u8, body, "context_management") == null);
     try std.testing.expect(std.mem.indexOf(u8, body, "previous_response_id") == null);
+}
+
+test "xAI Responses splices hosted x_search onto a tools turn; Codex and chat do not" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    const tools = "[{\"type\":\"function\",\"function\":{\"name\":\"bash\",\"description\":\"\",\"parameters\":{\"type\":\"object\"}}}]";
+    const saved = xai_hosted.enabled;
+    defer xai_hosted.enabled = saved;
+    xai_hosted.enabled = true;
+
+    var xai = try testAgentFor(a, "xai", .responses, "grok-4.6");
+    const body = try xai.buildBody(tools, false, true, true);
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"type\":\"x_search\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"name\":\"bash\"") != null);
+
+    var codex = try testAgentFor(a, "codex", .responses, "gpt-5.6-sol");
+    const cb = try codex.buildBody(tools, false, true, true);
+    defer std.testing.allocator.free(cb);
+    try std.testing.expect(std.mem.indexOf(u8, cb, "x_search") == null);
+
+    var chat = try testAgentFor(a, "xai", .openai, "grok-4.6");
+    const chat_body = try chat.buildBody(tools, false, true, true);
+    defer std.testing.allocator.free(chat_body);
+    try std.testing.expect(std.mem.indexOf(u8, chat_body, "x_search") == null);
+
+    xai_hosted.enabled = false;
+    const off = try xai.buildBody(tools, false, true, true);
+    defer std.testing.allocator.free(off);
+    try std.testing.expect(std.mem.indexOf(u8, off, "x_search") == null);
 }
 
 test "--output-schema rides text.format on Responses and response_format on chat (#502)" {

--- a/src/agent_steps.zig
+++ b/src/agent_steps.zig
@@ -99,6 +99,7 @@ pub fn stepResponses(self: *Agent, response: std.json.ObjectMap) !?[]const u8 {
             };
         } else if (std.mem.eql(u8, itype, "function_call")) {
             const name = if (item.object.get("name")) |n| (if (n == .string) n.string else continue) else continue;
+            if (@import("xai_hosted.zig").isServerSideCall(itype, name)) continue;
             const call_id = if (item.object.get("call_id")) |c| (if (c == .string) c.string else continue) else continue;
             const args = if (item.object.get("arguments")) |a| (if (a == .string) a.string else "") else "";
             const input: Value = if (args.len == 0)

--- a/src/agent_tools.zig
+++ b/src/agent_tools.zig
@@ -120,7 +120,7 @@ pub fn runTools(self: *Agent, calls: []const ToolCall) ![]ExecResult {
             .provider = self.provider,
             .subagent_provider = self.subagent_provider,
             .subagent_cross_provider = self.subagent_cross_provider,
-            .registry = if (self.sub) null else self.registry,
+            .registry = self.registry, // workers get licensed codedb-pro reads too (#627)
             .from_sub = self.sub,
             .has_eval = self.eval_cmd != null,
             .approvals = self.approvals,

--- a/src/agent_tools.zig
+++ b/src/agent_tools.zig
@@ -67,6 +67,12 @@ const rawNonblockStdin = Agent.rawNonblockStdin;
 /// Bash calls must clear the permission gate before dispatch. Results
 /// are returned in call order, arena-owned.
 pub fn runTools(self: *Agent, calls: []const ToolCall) ![]ExecResult {
+    if (!self.sub and calls.len >= 4) {
+        var names: [32][]const u8 = undefined;
+        const n = @min(calls.len, names.len);
+        for (calls[0..n], 0..) |c, i| names[i] = c.name;
+        if (native_fold.noticeWideNative(names[0..n])) self.invalidateRootTools();
+    }
     const results = try self.arena.alloc(ExecResult, calls.len);
     const eval_index = eval_control.evalCallIndex(calls);
     const blocks_completion = eval_control.batchBlocksCompletion(calls);

--- a/src/args.zig
+++ b/src/args.zig
@@ -34,7 +34,7 @@ pub const Flags = struct {
     yolo_flag: bool = false,
     safe_flag: bool = false, // --safe: one-shot WITHOUT the implied --yolo (approval-gated, the old -p default)
     no_lean_flag: bool = false, // --no-lean: one-shot WITHOUT the implied --lean (full tool surface + eager MCP, the old -p default)
-    lean_flag: bool = false, // --lean: skip connecting MCP servers entirely (GRAFF_LEAN=1) — a smaller per-turn prefix for one-shot/CI runs
+    lean_flag: bool = false, // --lean: slim catalog + MCP schemas folded behind load_tool_schemas (GRAFF_LEAN=1); does not skip connect
     no_telemetry_flag: bool = false,
     learning_privacy_flag: ?learning_privacy.Mode = null,
     schema_flag: bool = false,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -25,6 +25,7 @@ pub const changelog_text =
     \\  • MCP-inside-rlm + learnt slim: fat MCP results drop to id/title; comments fold to n+latest_author (ADR 0029)
     \\  • L (warm slim, --no-lean) 14.8s/31k/5 vs H 28s/112k/7 on SuperGrok grok-4.6; no v0.0.277 tag
     \\  • xAI Responses hosts x_search on grok-4.6 tools turns (ADR 0031); GRAFF_XAI_X_SEARCH=0 opts out
+    \\  • rlm stays hidden on small turns; showcase at --rlm, a 4-wide native batch, or 50% of compactAt (ADR 0030)
     \\  • licensed codedb-pro is one read/search surface; Smolify is opt-in; turns pulse without a 16-call cap
     \\
     \\0.0.276

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -256,8 +256,8 @@ pub const usage_text =
     \\  --yolo           skip all permission prompts for the session
     \\  --rlm            advertise the rlm REPL (default; persistent binds, subagent(), llm_query, mid-stream spec-ptc; GRAFF_RLM=1)
     \\  --old, --no-rlm  restore the pre-rlm structured-only catalog (GRAFF_OLD=1 or GRAFF_RLM=0)
-    \\  --lean           slim tool surface (8 core tools) + MCP deferred behind load_tool_schemas — the DEFAULT for -p one-shots (GRAFF_LEAN=1)
-    \\  --no-lean        opt a one-shot out of the implied --lean: full tool surface + eager MCP, the pre-default -p behavior
+    \\  --lean           slim tool surface (8 core tools) + MCP schemas folded behind load_tool_schemas — the DEFAULT for -p one-shots (GRAFF_LEAN=1). `.mcp.json` still connects.
+    \\  --no-lean        opt a one-shot out of the implied --lean: full tool surface + eager MCP schemas, the pre-default -p behavior
     \\  --no-local-tools embedder mode: hard-disable the built-in bash/bash_output/bash_kill/read_file/edit_file/write_file/codedb tools for the whole process (subagents included), so graff can run outside the sandbox and get its coding tools from an MCP server instead; webfetch, orchestration and MCP tools still work (GRAFF_NO_LOCAL_TOOLS=1)
     \\  -p, --print      one-shot print mode (answer on stdout, progress on stderr)
     \\  --timing         show per-tool wall-clock on result lines

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -21,6 +21,11 @@ const harness_version = root.harness_version;
 pub const changelog_text =
     \\What's new
     \\──────────
+    \\0.0.277
+    \\  • MCP-inside-rlm + learnt slim: fat MCP results drop to id/title; comments fold to n+latest_author (ADR 0029)
+    \\  • L (warm slim, --no-lean) 14.8s/31k/5 vs H 28s/112k/7 on SuperGrok grok-4.6; no v0.0.277 tag
+    \\  • licensed codedb-pro is one read/search surface; Smolify is opt-in; turns pulse without a 16-call cap
+    \\
     \\0.0.276
     \\  • rlm (RLM + mid-stream spec-ptc) is the default loop; --old / --no-rlm restores structured-only
     \\  • prompt-cache max: stable catalog is the default (loads no longer rewrite tools JSON); children share prefix lanes

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -23,7 +23,7 @@ pub const changelog_text =
     \\──────────
     \\0.0.277
     \\  • MCP-inside-rlm + learnt slim: fat MCP results drop to id/title; comments fold to n+latest_author (ADR 0029)
-    \\  • L (warm slim, --no-lean) 14.8s/31k/5 vs H 28s/112k/7 on SuperGrok grok-4.6; no v0.0.277 tag
+    \\  • L (warm slim, --no-lean) 14.8s/31k/5 vs H 28s/112k/7 on SuperGrok grok-4.6
     \\  • xAI Responses hosts x_search on grok-4.6 tools turns (ADR 0031); GRAFF_XAI_X_SEARCH=0 opts out
     \\  • rlm stays hidden on small turns; showcase at --rlm, a 4-wide native batch, or 50% of compactAt (ADR 0030)
     \\  • licensed codedb-pro is one read/search surface; Smolify is opt-in; turns pulse without a 16-call cap

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -24,6 +24,7 @@ pub const changelog_text =
     \\0.0.277
     \\  • MCP-inside-rlm + learnt slim: fat MCP results drop to id/title; comments fold to n+latest_author (ADR 0029)
     \\  • L (warm slim, --no-lean) 14.8s/31k/5 vs H 28s/112k/7 on SuperGrok grok-4.6; no v0.0.277 tag
+    \\  • xAI Responses hosts x_search on grok-4.6 tools turns (ADR 0031); GRAFF_XAI_X_SEARCH=0 opts out
     \\  • licensed codedb-pro is one read/search surface; Smolify is opt-in; turns pulse without a 16-call cap
     \\
     \\0.0.276

--- a/src/codedbpro_report.zig
+++ b/src/codedbpro_report.zig
@@ -156,7 +156,7 @@ fn leadingSearchCommand(cmd: []const u8) bool {
     const trimmed = std.mem.trimStart(u8, cmd, " \t");
     const end = std.mem.indexOfAny(u8, trimmed, " \t") orelse trimmed.len;
     const first = trimmed[0..end];
-    return std.mem.eql(u8, first, "grep") or std.mem.eql(u8, first, "rg") or std.mem.eql(u8, first, "find");
+    return @import("tool_surface.zig").isSearchBash(first);
 }
 
 /// Whether the licensed-pro enforcement applies to this call right now.
@@ -465,9 +465,9 @@ test "nativeRefusal: licensed pro tools block the natives they replaced" {
     try std.testing.expect(nativeRefusal(ctx, namedCall("codedb")) != null);
     try std.testing.expect(nativeRefusal(ctx, bashCall(a, "find . -name '*.zig'")) != null);
     try std.testing.expect(nativeRefusal(ctx, bashCall(a, "rg TODO src")) != null);
-    // Untouched: edits stay native, non-search bash stays open, a piped grep
-    // filters command output rather than searching the tree.
-    try std.testing.expect(nativeRefusal(ctx, namedCall("edit_file")) == null);
+    try std.testing.expect(nativeRefusal(ctx, bashCall(a, "cat src/main.zig")) != null);
+    try std.testing.expect(nativeRefusal(ctx, bashCall(a, "head src/main.zig")) != null);
+    try std.testing.expect(nativeRefusal(ctx, namedCall("edit_file")) == null); // edits stay native
     try std.testing.expect(nativeRefusal(ctx, bashCall(a, "git status")) == null);
     try std.testing.expect(nativeRefusal(ctx, bashCall(a, "curl -s x | grep err")) == null);
 }

--- a/src/commands_session.zig
+++ b/src/commands_session.zig
@@ -79,6 +79,7 @@ pub fn resetConversationSteering(root: *Agent) void {
     // attempt_completion ended their steering - #318 through the /clear door.
     if (root.goal_flag) |g| root.goal = goal_flow.standingGoalFromFlag(g, null, root.todos.items, 0);
     @import("rlm_spec.zig").resetBindsSession(root.io);
+    @import("native_fold.zig").resetSession();
 }
 
 /// Try to handle a session/environment slash command. Returns false (line

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -211,7 +211,11 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
             return failure(gpa, err);
         };
         if (r.is_error) codedbpro_report.onFailure(ctx, call.name, r.text);
-        if (!r.is_error) @import("mcp_shapes.zig").remember(ctx, call.name, r.text);
+        if (!r.is_error) {
+            const shapes = @import("mcp_shapes.zig");
+            shapes.remember(ctx, call.name, r.text);
+            return .{ .text = shapes.takeSlim(gpa, r.text), .is_error = false };
+        }
         return .{ .text = r.text, .is_error = r.is_error };
     }
 

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -453,6 +453,7 @@ test { // main.zig is at the 600-line cap; exec.zig is these modules' importer, 
     _ = @import("rlm_spec.zig");
     _ = @import("rlm_query.zig");
     _ = @import("rlm_mcp.zig");
+    _ = @import("rlm_reduce.zig");
     _ = @import("rlm_tests.zig");
     _ = @import("mcp_shapes.zig");
     _ = @import("spec_ptc.zig");

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -9,6 +9,7 @@ const Allocator = std.mem.Allocator;
 const main_mod = @import("main.zig");
 const util = @import("util.zig");
 const codedbpro_report = @import("codedbpro_report.zig"); // licensed-companion failure → redacted issue filer
+const tool_surface = @import("tool_surface.zig"); // companion-write gate + licensed hide
 const codedbpro_paths = @import("codedbpro_paths.zig"); // session-cwd paths for the resident companion daemon
 const tool_balance = @import("tool_balance.zig"); // session-wide tool-class tally (/tools)
 const ToolCall = tools.ToolCall;
@@ -120,7 +121,7 @@ pub fn execTool(ctx: ToolCtx, call: ToolCall) ToolOutput {
     // #255: reserved before any gate/dispatch runs so tool_started/
     // tool_finished bracket the whole call, including a gate denial below.
     const call_id: u64 = if (ctx.tracer) |tr| tr.toolStarted(call.name, call.input) else 0;
-    if (noLocalToolsGate(ctx, call) orelse codedbGuard(ctx, call) orelse companionRoute(ctx, call) orelse hookGate(ctx, call) orelse codedbpro_report.licensedGate(ctx, call) orelse native_fold.gateExec(ctx.gpa, call.name, ctx.from_sub)) |blocked| {
+    if (noLocalToolsGate(ctx, call) orelse codedbGuard(ctx, call) orelse companionRoute(ctx, call) orelse hookGate(ctx, call) orelse codedbpro_report.licensedGate(ctx, call) orelse tool_surface.gate(ctx, call) orelse native_fold.gateExec(ctx.gpa, call.name, ctx.from_sub)) |blocked| {
         var out = blocked;
         out.ms = t0.untilNow(ctx.io, .awake).toMilliseconds();
         if (ctx.tracer) |tr| {

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -462,4 +462,5 @@ test { // main.zig is at the 600-line cap; exec.zig is these modules' importer, 
     _ = @import("rlm_tests.zig");
     _ = @import("mcp_shapes.zig");
     _ = @import("spec_ptc.zig");
+    _ = @import("xai_hosted.zig");
 }

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -211,6 +211,7 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
             return failure(gpa, err);
         };
         if (r.is_error) codedbpro_report.onFailure(ctx, call.name, r.text);
+        if (!r.is_error) @import("mcp_shapes.zig").remember(ctx, call.name, r.text);
         return .{ .text = r.text, .is_error = r.is_error };
     }
 
@@ -451,5 +452,8 @@ test { // main.zig is at the 600-line cap; exec.zig is these modules' importer, 
     _ = @import("rlm.zig");
     _ = @import("rlm_spec.zig");
     _ = @import("rlm_query.zig");
+    _ = @import("rlm_mcp.zig");
+    _ = @import("rlm_tests.zig");
+    _ = @import("mcp_shapes.zig");
     _ = @import("spec_ptc.zig");
 }

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -460,6 +460,7 @@ test { // main.zig is at the 600-line cap; exec.zig is these modules' importer, 
     _ = @import("rlm_mcp.zig");
     _ = @import("rlm_reduce.zig");
     _ = @import("rlm_tests.zig");
+    _ = @import("native_fold_rlm.zig");
     _ = @import("mcp_shapes.zig");
     _ = @import("spec_ptc.zig");
     _ = @import("xai_hosted.zig");

--- a/src/mainloop.zig
+++ b/src/mainloop.zig
@@ -401,6 +401,7 @@ pub fn run(ctx: *Ctx) !void {
         } else 0;
         ctx.root.tools_used.clear(ctx.io); // per-turn tool log for the turn's node
         ctx.root.tool_calls_this_turn = 0;
+        ctx.root.model_calls_this_turn = 0;
         goal_state.beginTurn(ctx.root, !is_loop_continuation); // per-turn gate flags (the ARMED double-check is NOT one, #318) + the new-ask retirement of a finished checklist (#394)
         ctx.root.seen_tool_keys.clearRetainingCapacity();
         if (main_mod.json_mode) ctx.root.emit(.{ .type = "started", .provider = ctx.root.provider.id, .model = ctx.root.provider.model });

--- a/src/mcp_boot.zig
+++ b/src/mcp_boot.zig
@@ -103,6 +103,7 @@ pub fn init(gpa: Allocator, io: Io, config_path: []const u8, global_path: ?[]con
     var it = merged.servers.iterator();
     while (it.next()) |entry| {
         if (std.mem.eql(u8, entry.key_ptr.*, "smolify")) continue;
+        if (@import("tool_surface.zig").skipOptionalServer(entry.key_ptr.*, environ_map)) continue;
         if (entry.value_ptr.* != .object) continue;
         try entries.append(a, .{ .name = try a.dupe(u8, entry.key_ptr.*), .cfg = entry.value_ptr.*.object });
     }

--- a/src/mcp_schema_gate.zig
+++ b/src/mcp_schema_gate.zig
@@ -508,9 +508,7 @@ pub fn descWithListing(arena: Allocator, all: []const mcp.Tool) ![]const u8 {
     if (native_fold.anyFolded() and !@import("no_local_tools.zig").lean) {
         for (native_fold.folded) |name| {
             if (!native_fold.isFolded(name)) continue;
-            // rlm never rides the meta desc: listing it on showcase would
-            // rewrite the tools head (ADR 0011 / 0030). Discovery is the tail.
-            if (std.mem.eql(u8, name, "rlm")) continue;
+            if (std.mem.eql(u8, name, "rlm")) continue; // tail-only; listing rewrites the head
             if (!g_stable_catalog and native_fold.isLoaded(name)) continue;
             if (tool_surface.hideBuiltin(name)) continue;
             try natives.append(arena, name);

--- a/src/mcp_schema_gate.zig
+++ b/src/mcp_schema_gate.zig
@@ -295,9 +295,9 @@ pub fn hiddenSpec(name: []const u8, all: []const mcp.Tool) bool {
         std.mem.eql(u8, name, "mcp_search_tools") or
         std.mem.eql(u8, name, "mcp_select_tool");
     if (!progressive) return false;
-    // -p: even a deferred home MCP kept the 1.4kB meta tool on every
-    // turn. One-shots that need MCP pass --no-lean (ADR 0024).
-    if (@import("no_local_tools.zig").lean) return true;
+    // Lean used to hide this even when MCP was connected, which made
+    // default `-p` unable to unfold `.mcp.json`. Show it whenever
+    // something is deferred; hide it when the listing would be empty.
     return !anyDeferred(all);
 }
 

--- a/src/mcp_schema_gate.zig
+++ b/src/mcp_schema_gate.zig
@@ -508,7 +508,9 @@ pub fn descWithListing(arena: Allocator, all: []const mcp.Tool) ![]const u8 {
     if (native_fold.anyFolded() and !@import("no_local_tools.zig").lean) {
         for (native_fold.folded) |name| {
             if (!native_fold.isFolded(name)) continue;
-            if (std.mem.eql(u8, name, "rlm") and !native_fold.listed()) continue;
+            // rlm never rides the meta desc: listing it on showcase would
+            // rewrite the tools head (ADR 0011 / 0030). Discovery is the tail.
+            if (std.mem.eql(u8, name, "rlm")) continue;
             if (!g_stable_catalog and native_fold.isLoaded(name)) continue;
             if (tool_surface.hideBuiltin(name)) continue;
             try natives.append(arena, name);

--- a/src/mcp_schema_gate.zig
+++ b/src/mcp_schema_gate.zig
@@ -45,6 +45,8 @@ const mcp = @import("mcp.zig");
 const mcp_config = @import("mcp_config.zig");
 const tools_mod = @import("tools.zig");
 const util = @import("util.zig");
+const tool_surface = @import("tool_surface.zig");
+pub const omitMcp = tool_surface.omitMcp;
 
 const ExecResult = tools_mod.ExecResult;
 
@@ -317,6 +319,7 @@ pub fn shortDesc(desc: []const u8) []const u8 {
 /// direction — same rule as the native fold's markIfFolded). The catalog's
 /// zero-stub listing is unchanged; the call itself was already provider-legal.
 pub fn autoLoad(arena: Allocator, all: []const mcp.Tool, qualified: []const u8) void {
+    if (omitMcp(qualified)) return;
     if (!blocked(all, qualified)) return;
     for (all) |t| {
         if (std.mem.eql(u8, t.qualified_name, qualified)) {
@@ -411,6 +414,7 @@ pub fn loadInto(arena: Allocator, all: []const mcp.Tool, input: Value) !Loaded {
         // Named twice in one call (`server` plus its own name, say), or loaded
         // by an earlier call: neither is an error, both are the cache working.
         if (std.mem.indexOfScalar(usize, wanted.items[0..k], i) != null) continue;
+        if (omitMcp(all[i].qualified_name)) continue;
         const first_time = !isLoaded(all[i].qualified_name);
         try aw.writer.print("{s}\n", .{try enable(arena, all[i])});
         emitted += 1;
@@ -505,6 +509,7 @@ pub fn descWithListing(arena: Allocator, all: []const mcp.Tool) ![]const u8 {
         for (native_fold.folded) |name| {
             if (!native_fold.isFolded(name)) continue; // rlm stays off the default listing
             if (!g_stable_catalog and native_fold.isLoaded(name)) continue;
+            if (tool_surface.hideBuiltin(name)) continue;
             try natives.append(arena, name);
         }
     }
@@ -514,6 +519,7 @@ pub fn descWithListing(arena: Allocator, all: []const mcp.Tool) ![]const u8 {
     const deferredRule: *const fn ([]const mcp.Tool, mcp.Tool) bool = if (g_stable_catalog) &policyDeferred else &isDeferred;
     var servers: std.ArrayList([]const u8) = .empty;
     for (all) |t| {
+        if (omitMcp(t.qualified_name)) continue;
         if (!deferredRule(all, t)) continue;
         const sv = serverOf(t.qualified_name);
         const seen = for (servers.items) |s| {
@@ -533,6 +539,7 @@ pub fn descWithListing(arena: Allocator, all: []const mcp.Tool) ![]const u8 {
         try aw.writer.print(" {s} (", .{sv});
         var first = true;
         for (all) |t| {
+            if (omitMcp(t.qualified_name)) continue;
             if (!deferredRule(all, t)) continue;
             if (!std.mem.eql(u8, serverOf(t.qualified_name), sv)) continue;
             if (!first) try aw.writer.writeAll(", ");

--- a/src/mcp_schema_gate.zig
+++ b/src/mcp_schema_gate.zig
@@ -507,7 +507,8 @@ pub fn descWithListing(arena: Allocator, all: []const mcp.Tool) ![]const u8 {
     var natives: std.ArrayList([]const u8) = .empty;
     if (native_fold.anyFolded() and !@import("no_local_tools.zig").lean) {
         for (native_fold.folded) |name| {
-            if (!native_fold.isFolded(name)) continue; // rlm stays off the default listing
+            if (!native_fold.isFolded(name)) continue;
+            if (std.mem.eql(u8, name, "rlm") and !native_fold.listed()) continue;
             if (!g_stable_catalog and native_fold.isLoaded(name)) continue;
             if (tool_surface.hideBuiltin(name)) continue;
             try natives.append(arena, name);

--- a/src/mcp_schema_gate_tests.zig
+++ b/src/mcp_schema_gate_tests.zig
@@ -357,9 +357,9 @@ test "an eager tool is never blocked, and the load tool is advertised only when 
     try testing.expect(!gate.blocked(fat, "mcp__fat__ghost"));
 }
 
-test "lean hides load_tool_schemas even when MCP is deferred" {
-    // Home Smolify still counts as deferred and used to keep the 1.4kB
-    // meta tool on every -p turn. --no-lean is the MCP one-shot.
+test "lean shows load_tool_schemas only when MCP is actually deferred" {
+    // Empty -p stays cheap (no meta tool). A connected `.mcp.json` must
+    // still unfold on the default lean one-shot (ADR 0029).
     const schema = @import("schema.zig");
     const no_local = @import("no_local_tools.zig");
     withDefaults();
@@ -374,12 +374,12 @@ test "lean hides load_tool_schemas even when MCP is deferred" {
     try testing.expect(gate.hiddenSpec(gate.tool_name, &.{}));
     const specs = try schema.effectiveRootSpecs(arena);
     const empty = try schema.renderRootTools(arena, .openai, specs, &.{});
-    try testing.expect(std.mem.indexOf(u8, empty, gate.tool_name) == null);
+    try testing.expect(std.mem.indexOf(u8, empty, "\"name\":\"load_tool_schemas\"") == null);
 
     const fat = try fixture(arena, "fat", 8, 2000);
-    try testing.expect(gate.hiddenSpec(gate.tool_name, fat));
+    try testing.expect(!gate.hiddenSpec(gate.tool_name, fat));
     const with_mcp = try schema.renderRootTools(arena, .openai, specs, fat);
-    try testing.expect(std.mem.indexOf(u8, with_mcp, gate.tool_name) == null);
+    try testing.expect(std.mem.indexOf(u8, with_mcp, "\"name\":\"load_tool_schemas\"") != null);
 }
 
 test "tool_desc stays JSON-escape-free (it is spliced into a raw schema string)" {

--- a/src/mcp_select.zig
+++ b/src/mcp_select.zig
@@ -97,10 +97,17 @@ pub fn handleSelect(agent: anytype, input: Value) tools_mod.ExecResult {
     return mcp_schema_gate.handleLoad(agent, selectInput(agent.arena, input));
 }
 
+fn withShapes(agent: anytype, r: tools_mod.ExecResult) tools_mod.ExecResult {
+    if (r.is_error) return r;
+    const cwd = agent.agent_cwd;
+    const text = @import("mcp_shapes.zig").annotate(agent.gpa, agent.arena, agent.io, cwd, r.text) catch r.text;
+    return .{ .text = text, .is_error = r.is_error };
+}
+
 pub fn dispatch(agent: anytype, call: tools_mod.ToolCall) tools_mod.ExecResult {
-    if (std.mem.eql(u8, call.name, search_name)) return handleSearch(agent, call.input);
-    if (std.mem.eql(u8, call.name, select_name)) return handleSelect(agent, call.input);
-    return mcp_schema_gate.handleLoad(agent, call.input);
+    if (std.mem.eql(u8, call.name, search_name)) return withShapes(agent, handleSearch(agent, call.input));
+    if (std.mem.eql(u8, call.name, select_name)) return withShapes(agent, handleSelect(agent, call.input));
+    return withShapes(agent, mcp_schema_gate.handleLoad(agent, call.input));
 }
 
 test "search lists matches and does not enable them" {

--- a/src/mcp_shapes.zig
+++ b/src/mcp_shapes.zig
@@ -280,6 +280,141 @@ fn closeBase(io: Io, opened: Opened, _: ?[]const u8) void {
     }
 }
 
+/// Fat enough that dumping the bind is the token problem C/D/F hit.
+pub const slim_min_bytes: usize = 800;
+
+const identity_keys = [_][]const u8{ "id", "identifier", "title", "name" };
+
+/// Learnt projection: identity keys on issue-like rows; comments fold to
+/// `{n, latest_author}`. Values of `description`/`body` never survive.
+/// Returns null when the payload is small, not a JSON array of objects, or
+/// has nothing to cut. Caller owns a non-null result.
+pub fn slim(alloc: Allocator, payload: []const u8) ?[]u8 {
+    if (payload.len < slim_min_bytes) return null;
+    const trimmed = std.mem.trim(u8, payload, " \t\r\n");
+    const parsed = std.json.parseFromSlice(Value, alloc, trimmed, .{}) catch return null;
+    defer parsed.deinit();
+    const items = arrayItems(parsed.value) orelse return null;
+    if (items.len == 0 or items[0] != .object) return null;
+    if (looksLikeComments(items[0].object)) return slimComments(alloc, items);
+    return slimIdentity(alloc, items);
+}
+
+/// Remember the fat payload, then replace it with the learnt cut when one
+/// exists. `text` is owned by `gpa`.
+pub fn takeSlim(gpa: Allocator, text: []u8) []u8 {
+    const cut = slim(gpa, text) orelse return text;
+    gpa.free(text);
+    return cut;
+}
+
+fn arrayItems(v: Value) ?[]const Value {
+    if (v == .array) return v.array.items;
+    if (v != .object) return null;
+    var it = v.object.iterator();
+    while (it.next()) |e| {
+        if (e.value_ptr.* == .array) return e.value_ptr.array.items;
+    }
+    return null;
+}
+
+fn looksLikeComments(obj: std.json.ObjectMap) bool {
+    return obj.get("body") != null and obj.get("author") != null;
+}
+
+fn slimComments(alloc: Allocator, items: []const Value) ?[]u8 {
+    var latest_i: usize = items.len - 1;
+    var latest_at: []const u8 = "";
+    for (items, 0..) |item, i| {
+        if (item != .object) continue;
+        const at = if (item.object.get("createdAt")) |c| (if (c == .string) c.string else "") else "";
+        if (at.len == 0) continue;
+        if (latest_at.len == 0 or std.mem.order(u8, at, latest_at) == .gt) {
+            latest_at = at;
+            latest_i = i;
+        }
+    }
+    const name = authorName(items[latest_i]);
+    var aw: Io.Writer.Allocating = .init(alloc);
+    var s: std.json.Stringify = .{ .writer = &aw.writer };
+    s.beginObject() catch {
+        aw.deinit();
+        return null;
+    };
+    s.objectField("n") catch {
+        aw.deinit();
+        return null;
+    };
+    s.write(items.len) catch {
+        aw.deinit();
+        return null;
+    };
+    s.objectField("latest_author") catch {
+        aw.deinit();
+        return null;
+    };
+    s.write(name orelse "") catch {
+        aw.deinit();
+        return null;
+    };
+    s.endObject() catch {
+        aw.deinit();
+        return null;
+    };
+    return aw.toOwnedSlice() catch null;
+}
+
+fn authorName(item: Value) ?[]const u8 {
+    if (item != .object) return null;
+    const author = item.object.get("author") orelse return null;
+    if (author == .string) return author.string;
+    if (author != .object) return null;
+    const n = author.object.get("name") orelse return null;
+    return if (n == .string) n.string else null;
+}
+
+fn slimIdentity(alloc: Allocator, items: []const Value) ?[]u8 {
+    if (!hasIdentity(items[0].object)) return null;
+    var aw: Io.Writer.Allocating = .init(alloc);
+    var s: std.json.Stringify = .{ .writer = &aw.writer };
+    s.beginArray() catch {
+        aw.deinit();
+        return null;
+    };
+    for (items) |item| {
+        if (item != .object) continue;
+        s.beginObject() catch {
+            aw.deinit();
+            return null;
+        };
+        for (identity_keys) |k| {
+            const v = item.object.get(k) orelse continue;
+            s.objectField(k) catch {
+                aw.deinit();
+                return null;
+            };
+            s.write(v) catch {
+                aw.deinit();
+                return null;
+            };
+        }
+        s.endObject() catch {
+            aw.deinit();
+            return null;
+        };
+    }
+    s.endArray() catch {
+        aw.deinit();
+        return null;
+    };
+    return aw.toOwnedSlice() catch null;
+}
+
+fn hasIdentity(obj: std.json.ObjectMap) bool {
+    for (identity_keys) |k| if (obj.get(k) != null) return true;
+    return false;
+}
+
 /// Splice stored shapes onto a load_tool_schemas / search RESULT. Never call
 /// this from catalog render (ADR 0011 prefix must stay byte-stable).
 pub fn annotate(gpa: Allocator, arena: Allocator, io: Io, cwd: ?[]const u8, text: []const u8) ![]const u8 {
@@ -293,6 +428,11 @@ pub fn annotate(gpa: Allocator, arena: Allocator, io: Io, cwd: ?[]const u8, text
     var it = store.map.iterator();
     while (it.next()) |e| {
         try aw.writer.print("  {s}: {s}\n", .{ e.key_ptr.*, e.value_ptr.* });
+    }
+    if (store.map.count() >= 2) {
+        try aw.writer.writeAll(
+            "# muscle: fat MCP print() auto-slims (id/title; comments → n+latest_author). issues=list_issues(); comments=each(issues,\"list_comments\",\"id\"); print(len(issues), project(issues,\"id\"), project(comments,\"latest_author\"))\n",
+        );
     }
     return aw.toOwnedSlice();
 }
@@ -354,5 +494,67 @@ test "remember merges keys; annotate splices shapes; prefix text is untouched" {
     const annotated = try annotate(gpa, arena_state.allocator(), io, dir, "1 tool schema(s) below\nmcp__linear__list_issues");
     try std.testing.expect(std.mem.indexOf(u8, annotated, "return_shapes") != null);
     try std.testing.expect(std.mem.indexOf(u8, annotated, "mcp__linear__list_issues") != null);
+    try std.testing.expect(std.mem.indexOf(u8, annotated, "muscle:") == null);
     try std.testing.expect(std.mem.indexOf(u8, @import("mcp_schema_gate.zig").tool_desc, "return_shapes") == null);
+    try std.testing.expect(std.mem.indexOf(u8, @import("rlm.zig").tool_desc, "muscle:") == null);
+}
+
+test "slim drops description/body; comments fold to n and latest_author" {
+    const gpa = std.testing.allocator;
+    try std.testing.expect(slim(gpa, "[{\"id\":1}]") == null);
+    const pad: [400]u8 = @splat('x');
+    const pad_s: []const u8 = &pad;
+    const issues = try std.fmt.allocPrint(gpa, "[{{\"id\":\"ISS-1\",\"identifier\":\"ENG-101\",\"title\":\"Login\",\"description\":\"{s}\",\"body\":\"KEEP-OUT\"}},{{\"id\":\"ISS-2\",\"identifier\":\"ENG-102\",\"title\":\"Tax\",\"description\":\"{s}\"}}]", .{ pad_s, pad_s });
+    defer gpa.free(issues);
+    const cut = slim(gpa, issues) orelse return error.ExpectedSlim;
+    defer gpa.free(cut);
+    try std.testing.expect(std.mem.indexOf(u8, cut, "ISS-1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cut, "ENG-101") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cut, "Login") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cut, "description") == null);
+    try std.testing.expect(std.mem.indexOf(u8, cut, "KEEP-OUT") == null);
+    try std.testing.expect(std.mem.indexOf(u8, cut, pad_s) == null);
+
+    const comments = try std.fmt.allocPrint(gpa, "[{{\"body\":\"old {s}\",\"author\":{{\"name\":\"ada\"}},\"createdAt\":\"2026-08-11T01:00:00Z\"}},{{\"body\":\"new {s}\",\"author\":{{\"name\":\"bev\"}},\"createdAt\":\"2026-08-12T02:00:00Z\"}}]", .{ pad_s, pad_s });
+    defer gpa.free(comments);
+    const folded = slim(gpa, comments) orelse return error.ExpectedCommentSlim;
+    defer gpa.free(folded);
+    try std.testing.expect(std.mem.indexOf(u8, folded, "\"n\":2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, folded, "bev") != null);
+    try std.testing.expect(std.mem.indexOf(u8, folded, "ada") == null);
+    try std.testing.expect(std.mem.indexOf(u8, folded, "old ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, folded, pad_s) == null);
+}
+
+test "annotate writes a muscle playbook once two MCP shapes are stored" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &path_buf);
+    const dir = path_buf[0..n];
+    reset(gpa, io);
+    defer reset(gpa, io);
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const ctx: ToolCtx = .{
+        .gpa = gpa,
+        .io = io,
+        .client = &dummy_client,
+        .provider = undefined,
+        .registry = null,
+        .from_sub = false,
+        .approvals = null,
+        .tracer = null,
+        .agent_cwd = dir,
+    };
+    remember(ctx, "mcp__linear__list_issues", "[{\"id\":\"A\"}]");
+    remember(ctx, "mcp__linear__list_comments", "[{\"body\":\"b\",\"author\":\"ada\"}]");
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const annotated = try annotate(gpa, arena_state.allocator(), io, dir, "2 tool schema(s)");
+    try std.testing.expect(std.mem.indexOf(u8, annotated, "muscle:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, annotated, "each(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, @import("mcp_schema_gate.zig").tool_desc, "muscle:") == null);
 }

--- a/src/mcp_shapes.zig
+++ b/src/mcp_shapes.zig
@@ -1,0 +1,358 @@
+//! Muscle memory for tool return shapes (Blacksmith): persist field names +
+//! broad types, never values. Shown on the next load_tool_schemas RESULT, not
+//! on the always-on catalog prefix (ADR 0011).
+
+const std = @import("std");
+const Io = std.Io;
+const Value = std.json.Value;
+const Allocator = std.mem.Allocator;
+
+const tools = @import("tools.zig");
+const ToolCtx = tools.ToolCtx;
+
+pub const file_name = "mcp-shapes.json";
+pub const rel_path = ".graff/mcp-shapes.json";
+
+const Store = struct {
+    mu: Io.Mutex = .init,
+    map: std.StringHashMapUnmanaged([]const u8) = .empty,
+    gpa: ?Allocator = null,
+};
+
+var store: Store = .{};
+
+pub fn reset(gpa: Allocator, io: Io) void {
+    store.mu.lockUncancelable(io);
+    defer store.mu.unlock(io);
+    clearUnlocked(gpa);
+}
+
+fn clearUnlocked(gpa: Allocator) void {
+    var it = store.map.iterator();
+    while (it.next()) |e| {
+        gpa.free(e.key_ptr.*);
+        gpa.free(e.value_ptr.*);
+    }
+    store.map.deinit(gpa);
+    store.map = .empty;
+    store.gpa = null;
+}
+
+/// Infer a value-free schema from a tool result. Best-effort JSON; anything
+/// else is just `{"type":"string"}` so we never persist payload bytes.
+pub fn infer(arena: Allocator, text: []const u8) ![]const u8 {
+    const trimmed = std.mem.trim(u8, text, " \t\r\n");
+    if (trimmed.len == 0) return try arena.dupe(u8, "{\"type\":\"string\"}");
+    const parsed = std.json.parseFromSlice(Value, arena, trimmed, .{}) catch
+        return try arena.dupe(u8, "{\"type\":\"string\"}");
+    var aw: Io.Writer.Allocating = .init(arena);
+    var s: std.json.Stringify = .{ .writer = &aw.writer };
+    try writeShape(arena, &s, parsed.value, 0);
+    return aw.toOwnedSlice();
+}
+
+fn typeName(v: Value) []const u8 {
+    return switch (v) {
+        .null => "null",
+        .bool => "bool",
+        .integer, .float, .number_string => "number",
+        .string => "string",
+        .array => "array",
+        .object => "object",
+    };
+}
+
+fn writeShape(arena: Allocator, s: *std.json.Stringify, v: Value, depth: u8) anyerror!void {
+    try s.beginObject();
+    try s.objectField("type");
+    try s.write(typeName(v));
+    if (depth >= 3) {
+        try s.endObject();
+        return;
+    }
+    switch (v) {
+        .object => |obj| {
+            try s.objectField("keys");
+            try s.beginObject();
+            var it = obj.iterator();
+            while (it.next()) |e| {
+                try s.objectField(e.key_ptr.*);
+                try writeKeyType(arena, s, e.value_ptr.*, depth + 1);
+            }
+            try s.endObject();
+        },
+        .array => |arr| {
+            try s.objectField("items");
+            if (arr.items.len == 0) {
+                try s.write("any");
+            } else {
+                try writeMergedItems(arena, s, arr.items, depth + 1);
+            }
+        },
+        else => {},
+    }
+    try s.endObject();
+}
+
+fn writeKeyType(arena: Allocator, s: *std.json.Stringify, v: Value, depth: u8) anyerror!void {
+    if ((v == .object or v == .array) and depth < 3) return writeShape(arena, s, v, depth);
+    try s.write(typeName(v));
+}
+
+fn writeMergedItems(arena: Allocator, s: *std.json.Stringify, items: []const Value, depth: u8) anyerror!void {
+    const cap = @min(items.len, 4);
+    if (items[0] != .object) return writeShape(arena, s, items[0], depth);
+    var keys: std.StringHashMapUnmanaged([]const u8) = .empty;
+    var i: usize = 0;
+    while (i < cap) : (i += 1) {
+        if (items[i] != .object) continue;
+        var it = items[i].object.iterator();
+        while (it.next()) |e| {
+            const t = typeName(e.value_ptr.*);
+            if (keys.get(e.key_ptr.*)) |old| {
+                if (!std.mem.eql(u8, old, t) and !std.mem.eql(u8, old, "any"))
+                    try keys.put(arena, e.key_ptr.*, "any");
+            } else {
+                try keys.put(arena, e.key_ptr.*, t);
+            }
+        }
+    }
+    try s.beginObject();
+    try s.objectField("type");
+    try s.write("object");
+    try s.objectField("keys");
+    try s.beginObject();
+    var it = keys.iterator();
+    while (it.next()) |e| {
+        try s.objectField(e.key_ptr.*);
+        try s.write(e.value_ptr.*);
+    }
+    try s.endObject();
+    try s.endObject();
+}
+
+fn mergeShapes(arena: Allocator, old_s: []const u8, new_s: []const u8) ![]const u8 {
+    const old_p = std.json.parseFromSlice(Value, arena, old_s, .{}) catch return new_s;
+    const new_p = std.json.parseFromSlice(Value, arena, new_s, .{}) catch return old_s;
+    const old_keys = keysOf(old_p.value);
+    const new_keys = keysOf(new_p.value);
+    if (old_keys == null or new_keys == null) return new_s;
+    var merged: std.json.ObjectMap = .empty;
+    var it = old_keys.?.iterator();
+    while (it.next()) |e| try merged.put(arena, e.key_ptr.*, e.value_ptr.*);
+    var it2 = new_keys.?.iterator();
+    while (it2.next()) |e| {
+        if (merged.get(e.key_ptr.*)) |old_t| {
+            if (old_t == .string and e.value_ptr.* == .string and
+                !std.mem.eql(u8, old_t.string, e.value_ptr.string))
+                try merged.put(arena, e.key_ptr.*, .{ .string = "any" });
+        } else try merged.put(arena, e.key_ptr.*, e.value_ptr.*);
+    }
+    const typ = if (old_p.value == .object) old_p.value.object.get("type") else null;
+    var out: std.json.ObjectMap = .empty;
+    try out.put(arena, "type", typ orelse .{ .string = "object" });
+    if (old_p.value == .object) if (old_p.value.object.get("items")) |_| {
+        var items: std.json.ObjectMap = .empty;
+        try items.put(arena, "type", .{ .string = "object" });
+        try items.put(arena, "keys", .{ .object = merged });
+        try out.put(arena, "items", .{ .object = items });
+        var aw: Io.Writer.Allocating = .init(arena);
+        var s: std.json.Stringify = .{ .writer = &aw.writer };
+        try s.write(Value{ .object = out });
+        return aw.toOwnedSlice();
+    };
+    try out.put(arena, "keys", .{ .object = merged });
+    var aw: Io.Writer.Allocating = .init(arena);
+    var s: std.json.Stringify = .{ .writer = &aw.writer };
+    try s.write(Value{ .object = out });
+    return aw.toOwnedSlice();
+}
+
+fn keysOf(v: Value) ?std.json.ObjectMap {
+    if (v != .object) return null;
+    if (v.object.get("keys")) |k| if (k == .object) return k.object;
+    if (v.object.get("items")) |items| {
+        if (items == .object) if (items.object.get("keys")) |k| if (k == .object) return k.object;
+    }
+    return null;
+}
+
+pub fn remember(ctx: ToolCtx, name: []const u8, text: []const u8) void {
+    if (name.len == 0 or text.len == 0) return;
+    var arena_state = std.heap.ArenaAllocator.init(ctx.gpa);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const shape = infer(arena, text) catch return;
+    store.mu.lockUncancelable(ctx.io);
+    defer store.mu.unlock(ctx.io);
+    loadUnlocked(ctx.gpa, ctx.io, ctx.agent_cwd);
+    putUnlocked(ctx.gpa, arena, name, shape);
+    persistUnlocked(ctx.gpa, ctx.io, ctx.agent_cwd);
+}
+
+fn putUnlocked(gpa: Allocator, arena: Allocator, name: []const u8, shape: []const u8) void {
+    const merged = if (store.map.get(name)) |old|
+        mergeShapes(arena, old, shape) catch shape
+    else
+        shape;
+    const owned_shape = gpa.dupe(u8, merged) catch return;
+    if (store.map.getPtr(name)) |slot| {
+        gpa.free(slot.*);
+        slot.* = owned_shape;
+        return;
+    }
+    const owned_name = gpa.dupe(u8, name) catch {
+        gpa.free(owned_shape);
+        return;
+    };
+    store.map.put(gpa, owned_name, owned_shape) catch {
+        gpa.free(owned_name);
+        gpa.free(owned_shape);
+        return;
+    };
+    store.gpa = gpa;
+}
+
+fn loadUnlocked(gpa: Allocator, io: Io, cwd: ?[]const u8) void {
+    if (store.map.count() > 0) return;
+    const opened = openBase(io, cwd) orelse return;
+    defer closeBase(io, opened, cwd);
+    const raw = opened.dir.readFileAlloc(io, rel_path, gpa, .limited(64 * 1024)) catch return;
+    defer gpa.free(raw);
+    const parsed = std.json.parseFromSlice(Value, gpa, raw, .{}) catch return;
+    defer parsed.deinit();
+    if (parsed.value != .object) return;
+    var it = parsed.value.object.iterator();
+    while (it.next()) |e| {
+        if (e.value_ptr.* != .object and e.value_ptr.* != .string) continue;
+        var aw: Io.Writer.Allocating = .init(gpa);
+        var s: std.json.Stringify = .{ .writer = &aw.writer };
+        s.write(e.value_ptr.*) catch {
+            aw.deinit();
+            continue;
+        };
+        const shape = aw.toOwnedSlice() catch continue;
+        const name = gpa.dupe(u8, e.key_ptr.*) catch {
+            gpa.free(shape);
+            continue;
+        };
+        store.map.put(gpa, name, shape) catch {
+            gpa.free(name);
+            gpa.free(shape);
+        };
+    }
+    store.gpa = gpa;
+}
+
+fn persistUnlocked(gpa: Allocator, io: Io, cwd: ?[]const u8) void {
+    const opened = openBase(io, cwd) orelse return;
+    defer closeBase(io, opened, cwd);
+    opened.dir.createDir(io, ".graff", .default_dir) catch {};
+    var aw: Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    var s: std.json.Stringify = .{ .writer = &aw.writer };
+    s.beginObject() catch return;
+    var it = store.map.iterator();
+    while (it.next()) |e| {
+        s.objectField(e.key_ptr.*) catch return;
+        const parsed = std.json.parseFromSlice(Value, gpa, e.value_ptr.*, .{}) catch continue;
+        defer parsed.deinit();
+        s.write(parsed.value) catch return;
+    }
+    s.endObject() catch return;
+    opened.dir.writeFile(io, .{ .sub_path = rel_path, .data = aw.writer.buffered() }) catch {};
+}
+
+const Opened = struct { dir: Io.Dir, owned: bool };
+
+fn openBase(io: Io, cwd: ?[]const u8) ?Opened {
+    if (cwd) |p| {
+        const d = Io.Dir.cwd().openDir(io, p, .{}) catch return null;
+        return .{ .dir = d, .owned = true };
+    }
+    return .{ .dir = Io.Dir.cwd(), .owned = false };
+}
+
+fn closeBase(io: Io, opened: Opened, _: ?[]const u8) void {
+    if (opened.owned) {
+        var d = opened.dir;
+        d.close(io);
+    }
+}
+
+/// Splice stored shapes onto a load_tool_schemas / search RESULT. Never call
+/// this from catalog render (ADR 0011 prefix must stay byte-stable).
+pub fn annotate(gpa: Allocator, arena: Allocator, io: Io, cwd: ?[]const u8, text: []const u8) ![]const u8 {
+    store.mu.lockUncancelable(io);
+    defer store.mu.unlock(io);
+    loadUnlocked(gpa, io, cwd);
+    if (store.map.count() == 0) return text;
+    var aw: Io.Writer.Allocating = .init(arena);
+    try aw.writer.writeAll(text);
+    try aw.writer.writeAll("\nreturn_shapes (field names + broad types, never values):\n");
+    var it = store.map.iterator();
+    while (it.next()) |e| {
+        try aw.writer.print("  {s}: {s}\n", .{ e.key_ptr.*, e.value_ptr.* });
+    }
+    return aw.toOwnedSlice();
+}
+
+pub fn lookup(io: Io, name: []const u8) ?[]const u8 {
+    store.mu.lockUncancelable(io);
+    defer store.mu.unlock(io);
+    return store.map.get(name);
+}
+
+test "infer strips values and keeps keys plus broad types" {
+    const gpa = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    const shape = try infer(a,
+        \\[{"id":"ISS-1","title":"Login","n":3,"ok":true,"meta":{"x":1},"tags":["a"]}]
+    );
+    try std.testing.expect(std.mem.indexOf(u8, shape, "ISS-1") == null);
+    try std.testing.expect(std.mem.indexOf(u8, shape, "Login") == null);
+    try std.testing.expect(std.mem.indexOf(u8, shape, "\"id\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, shape, "string") != null);
+    try std.testing.expect(std.mem.indexOf(u8, shape, "number") != null);
+    try std.testing.expect(std.mem.indexOf(u8, shape, "bool") != null);
+}
+
+test "remember merges keys; annotate splices shapes; prefix text is untouched" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &path_buf);
+    const dir = path_buf[0..n];
+    reset(gpa, io);
+    defer reset(gpa, io);
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const ctx: ToolCtx = .{
+        .gpa = gpa,
+        .io = io,
+        .client = &dummy_client,
+        .provider = undefined,
+        .registry = null,
+        .from_sub = false,
+        .approvals = null,
+        .tracer = null,
+        .agent_cwd = dir,
+    };
+    remember(ctx, "mcp__linear__list_issues", "[{\"id\":\"A\",\"title\":\"t\"}]");
+    remember(ctx, "mcp__linear__list_issues", "[{\"id\":\"B\",\"state\":\"open\"}]");
+    const hit = lookup(io, "mcp__linear__list_issues") orelse return error.MissingShape;
+    try std.testing.expect(std.mem.indexOf(u8, hit, "\"id\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, hit, "\"title\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, hit, "\"state\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, hit, "\"A\"") == null);
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const annotated = try annotate(gpa, arena_state.allocator(), io, dir, "1 tool schema(s) below\nmcp__linear__list_issues");
+    try std.testing.expect(std.mem.indexOf(u8, annotated, "return_shapes") != null);
+    try std.testing.expect(std.mem.indexOf(u8, annotated, "mcp__linear__list_issues") != null);
+    try std.testing.expect(std.mem.indexOf(u8, @import("mcp_schema_gate.zig").tool_desc, "return_shapes") == null);
+}

--- a/src/native_fold.zig
+++ b/src/native_fold.zig
@@ -55,8 +55,9 @@ pub const folded = [_][]const u8{
     "agent_output",
     "skill",
     "webfetch",
-    // ADR 0022: isFolded is false under --old so the structured-only
-    // load_tool_schemas listing stays byte-stable.
+    // ADR 0022 / 0030: isFolded is false under --old so the structured-only
+    // load_tool_schemas listing stays byte-stable. The name stays hidden
+    // until listed() — small turns do not advertise rlm or sPTC.
     "rlm",
 };
 
@@ -64,16 +65,81 @@ pub const folded = [_][]const u8{
 /// `rlm` joins the stack while available (default); `--old` drops it so the
 /// structured-only catalog and the meta-tool listing stay unchanged.
 pub fn isFolded(name: []const u8) bool {
-    // --lean / -p: rlm is the default loop (ADR 0022), not a late power
-    // tool. Folding it behind load_tool_schemas on a 5–10 turn one-shot
-    // made the model do N structured calls instead of one script (ADR 0024
-    // leftover token tax vs grok-build).
-    if (std.mem.eql(u8, name, "rlm"))
-        return @import("rlm_spec.zig").available and !@import("no_local_tools.zig").lean;
+    if (std.mem.eql(u8, name, "rlm")) return @import("rlm_spec.zig").available;
     for (folded) |tool| {
         if (std.mem.eql(u8, name, tool)) return true;
     }
     return false;
+}
+
+/// Session-discovered rlm (a wide native batch). `--rlm` sets `g_cli_forced`
+/// so /new does not hide it again. Never set this because MCP slims.
+var g_showcased: bool = false;
+var g_cli_forced: bool = false;
+
+/// Folded-native listing and catalog discovery: hidden on small turns.
+pub fn listed() bool {
+    return g_showcased or isLoaded("rlm");
+}
+
+pub fn showcaseRlm() void {
+    if (!@import("rlm_spec.zig").available) return;
+    g_showcased = true;
+}
+
+/// `--rlm` / `setFromCli(true)`: schema on the first catalog, sPTC live.
+pub fn showcaseFromCli() void {
+    if (!@import("rlm_spec.zig").available) return;
+    g_showcased = true;
+    g_cli_forced = true;
+    markLoaded("rlm");
+}
+
+/// `/new` and `/clear`: hide a session-discovered showcase. `--rlm` sticks.
+pub fn resetSession() void {
+    if (g_cli_forced) return;
+    g_showcased = false;
+    unmark("rlm");
+}
+
+/// Test + `--old` path: drop CLI-forced showcase too.
+pub fn resetRlmDiscovery() void {
+    g_cli_forced = false;
+    g_showcased = false;
+    unmark("rlm");
+}
+
+fn unmark(name: []const u8) void {
+    var i: usize = 0;
+    while (i < g_loaded_len) : (i += 1) {
+        if (std.mem.eql(u8, g_loaded[i], name)) {
+            if (i + 1 < g_loaded_len) g_loaded[i] = g_loaded[g_loaded_len - 1];
+            g_loaded_len -= 1;
+            return;
+        }
+    }
+}
+
+/// Host tools sPTC can overlap. MCP fan-out (Linear comments) must not
+/// showcase — that re-invites the each() footgun (ADR 0029).
+const wide_native = [_][]const u8{ "read_file", "codedb", "bash", "webfetch" };
+
+/// True when this batch newly showcased rlm (caller rebuilds the catalog).
+pub fn noticeWideNative(names: []const []const u8) bool {
+    if (listed() or !@import("rlm_spec.zig").available) return false;
+    var n: usize = 0;
+    for (names) |name| {
+        for (wide_native) |w| {
+            if (std.mem.eql(u8, name, w)) {
+                n += 1;
+                break;
+            }
+        }
+    }
+    if (n < 4) return false;
+    showcaseRlm();
+    markLoaded("rlm");
+    return true;
 }
 
 /// Whether the fold is live at all — hiddenSpec consults this so
@@ -374,115 +440,4 @@ test "explicit native loads rebuild the active provider catalog (#492)" {
     try std.testing.expect(isLoaded("workflow"));
     try std.testing.expectEqual(@as(usize, 1), agent.invalidations);
     try std.testing.expectEqual(@as(usize, 1), agent.rebuilds);
-}
-
-test "rlm joins the fold only while available (off under --old)" {
-    const rlm_spec = @import("rlm_spec.zig");
-    const saved_avail = rlm_spec.available;
-    const saved_enabled = enabled;
-    const saved_loaded = g_loaded;
-    const saved_loaded_len = g_loaded_len;
-    defer {
-        rlm_spec.available = saved_avail;
-        enabled = saved_enabled;
-        g_loaded = saved_loaded;
-        g_loaded_len = saved_loaded_len;
-    }
-    enabled = true;
-    g_loaded_len = 0;
-    rlm_spec.available = false;
-    try std.testing.expect(!isFolded("rlm"));
-    try std.testing.expect(!blocked("rlm"));
-
-    rlm_spec.available = true;
-    try std.testing.expect(isFolded("rlm"));
-    try std.testing.expect(blocked("rlm"));
-    markLoaded("rlm");
-    try std.testing.expect(isLoaded("rlm"));
-    try std.testing.expect(!blocked("rlm"));
-}
-
-test "folded rlm is a listing name, not a catalog schema; off stays off the listing" {
-    const schema_mod = @import("schema.zig");
-    const rlm = @import("rlm.zig");
-    const rlm_spec = @import("rlm_spec.zig");
-    const saved_avail = rlm.available;
-    const saved_spec = rlm_spec.available;
-    const saved_enabled = enabled;
-    const saved_loaded = g_loaded;
-    const saved_loaded_len = g_loaded_len;
-    defer {
-        rlm.available = saved_avail;
-        rlm_spec.available = saved_spec;
-        rlm.sync();
-        enabled = saved_enabled;
-        g_loaded = saved_loaded;
-        g_loaded_len = saved_loaded_len;
-    }
-    enabled = true;
-    g_loaded_len = 0;
-
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-    const meta = [_]schema_mod.ToolSpec{.{
-        .name = mcp_schema_gate.tool_name,
-        .desc = mcp_schema_gate.tool_desc,
-        .schema = mcp_schema_gate.tool_schema,
-    }};
-    const with_rlm = [_]schema_mod.ToolSpec{
-        meta[0],
-        .{ .name = rlm.tool_name, .desc = rlm.tool_desc, .schema = rlm.tool_schema },
-    };
-
-    rlm.available = false;
-    rlm.sync();
-    const off = try schema_mod.renderRootTools(arena, .openai, &meta, &.{});
-    try std.testing.expect(std.mem.indexOf(u8, off, "rlm") == null);
-
-    rlm.available = true;
-    rlm.sync();
-    const on = try schema_mod.renderRootTools(arena, .openai, &with_rlm, &.{});
-    try std.testing.expect(std.mem.indexOf(u8, on, "rlm") != null); // listing
-    try std.testing.expect(std.mem.indexOf(u8, on, "llm_query") == null); // full desc/schema stay folded
-    try std.testing.expect(std.mem.indexOf(u8, on, rlm.tool_schema) == null);
-}
-
-test "lean unfolds rlm into the catalog (one-shot loop, not a listing stub)" {
-    const schema_mod = @import("schema.zig");
-    const rlm = @import("rlm.zig");
-    const rlm_spec = @import("rlm_spec.zig");
-    const no_local = @import("no_local_tools.zig");
-    const saved_avail = rlm.available;
-    const saved_spec = rlm_spec.available;
-    const saved_enabled = enabled;
-    const saved_lean = no_local.lean;
-    const saved_loaded = g_loaded;
-    const saved_loaded_len = g_loaded_len;
-    defer {
-        rlm.available = saved_avail;
-        rlm_spec.available = saved_spec;
-        rlm.sync();
-        enabled = saved_enabled;
-        no_local.lean = saved_lean;
-        g_loaded = saved_loaded;
-        g_loaded_len = saved_loaded_len;
-    }
-    enabled = true;
-    g_loaded_len = 0;
-    no_local.lean = true;
-    rlm.available = true;
-    rlm.sync();
-    try std.testing.expect(!isFolded("rlm"));
-    try std.testing.expect(!catalogSkips("rlm"));
-
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-    const specs = [_]schema_mod.ToolSpec{
-        .{ .name = rlm.tool_name, .desc = rlm.tool_desc, .schema = rlm.tool_schema },
-    };
-    const json = try schema_mod.renderRootTools(arena, .openai, &specs, &.{});
-    try std.testing.expect(std.mem.indexOf(u8, json, "llm_query") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, rlm.tool_schema) != null);
 }

--- a/src/native_fold.zig
+++ b/src/native_fold.zig
@@ -72,10 +72,79 @@ pub fn isFolded(name: []const u8) bool {
     return false;
 }
 
-/// Session-discovered rlm (a wide native batch). `--rlm` sets `g_cli_forced`
-/// so /new does not hide it again. Never set this because MCP slims.
+/// Session-discovered rlm (wide native batch or context threshold). `--rlm`
+/// sets `g_cli_forced` so /new does not hide it again. Never set this
+/// because MCP slims or a fat first payload.
 var g_showcased: bool = false;
 var g_cli_forced: bool = false;
+
+/// GRAFF_RLM_CONTEXT. Unset = 50% of `compactAt`. `0`/`off` disables.
+/// `1`–`100` or `50%` is a percent of compactAt; `32k` / `32768` is an
+/// absolute token floor. Zhang's 32k is an RL curriculum, not the default.
+pub var g_context_off: bool = false;
+pub var g_context_pct: ?u8 = null;
+pub var g_context_tokens: ?u64 = null;
+
+pub fn resetContextKnob() void {
+    g_context_off = false;
+    g_context_pct = null;
+    g_context_tokens = null;
+}
+
+pub fn applyContextEnv(v: []const u8) void {
+    const t = std.mem.trim(u8, v, " \t");
+    if (t.len == 0) return;
+    if (std.mem.eql(u8, t, "0") or std.ascii.eqlIgnoreCase(t, "off") or
+        std.ascii.eqlIgnoreCase(t, "false") or std.ascii.eqlIgnoreCase(t, "no"))
+    {
+        g_context_off = true;
+        g_context_pct = null;
+        g_context_tokens = null;
+        return;
+    }
+    g_context_off = false;
+    if (std.mem.endsWith(u8, t, "%")) {
+        if (std.fmt.parseInt(u8, std.mem.trim(u8, t[0 .. t.len - 1], " \t"), 10)) |n| {
+            if (n > 0) g_context_pct = @min(n, 100);
+            g_context_tokens = null;
+        } else |_| {}
+        return;
+    }
+    var num = t;
+    var mul: u64 = 1;
+    if (t.len > 1 and (t[t.len - 1] == 'k' or t[t.len - 1] == 'K')) {
+        num = t[0 .. t.len - 1];
+        mul = 1000;
+    }
+    const n = std.fmt.parseInt(u64, std.mem.trim(u8, num, " \t"), 10) catch return;
+    if (n == 0) return;
+    if (mul == 1 and n <= 100) {
+        g_context_pct = @intCast(n);
+        g_context_tokens = null;
+    } else {
+        g_context_tokens = n * mul;
+        g_context_pct = null;
+    }
+}
+
+/// Named threshold on the existing compact meter. `null` = disabled.
+pub fn contextThreshold(compact_at: u64) ?u64 {
+    if (g_context_off) return null;
+    if (g_context_tokens) |abs| return abs;
+    if (compact_at == 0) return null;
+    const pct: u64 = g_context_pct orelse 50;
+    return compact_at * pct / 100;
+}
+
+/// True when this sample newly showcased rlm (caller rebuilds the catalog).
+pub fn noticeContext(tokens: u64, compact_at: u64) bool {
+    if (listed() or !@import("rlm_spec.zig").available) return false;
+    const threshold = contextThreshold(compact_at) orelse return false;
+    if (tokens < threshold) return false;
+    showcaseRlm();
+    markLoaded("rlm");
+    return true;
+}
 
 /// Folded-native listing and catalog discovery: hidden on small turns.
 pub fn listed() bool {

--- a/src/native_fold_rlm.zig
+++ b/src/native_fold_rlm.zig
@@ -12,6 +12,7 @@ const no_local = @import("no_local_tools.zig");
 fn isolate() void {
     fold.enabled = true;
     fold.resetRlmDiscovery();
+    fold.resetContextKnob();
 }
 
 test "rlm joins the fold only while available (off under --old)" {
@@ -76,10 +77,16 @@ test "folded rlm stays off the listing until showcase; off stays off" {
 
     fold.showcaseRlm();
     try std.testing.expect(fold.listed());
+    // Name stays off the meta listing (that would rewrite the tools head).
+    const still = try schema_mod.renderRootTools(arena, .openai, &with_rlm, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, still, "rlm") == null);
+    try std.testing.expect(std.mem.indexOf(u8, still, "llm_query") == null);
+
+    fold.markLoaded("rlm");
     const shown = try schema_mod.renderRootTools(arena, .openai, &with_rlm, &.{});
     try std.testing.expect(std.mem.indexOf(u8, shown, "rlm") != null);
-    try std.testing.expect(std.mem.indexOf(u8, shown, "llm_query") == null);
-    try std.testing.expect(std.mem.indexOf(u8, shown, rlm.tool_schema) == null);
+    try std.testing.expect(std.mem.indexOf(u8, shown, "llm_query") != null);
+    try std.testing.expect(std.mem.indexOf(u8, shown, rlm.tool_schema) != null);
 }
 
 test "lean keeps rlm folded until showcase; --rlm puts the schema on" {
@@ -152,4 +159,106 @@ test "wide native batch showcases rlm; MCP fan-out does not" {
     fold.showcaseFromCli();
     fold.resetSession();
     try std.testing.expect(fold.listed());
+}
+
+test "context below 50% of compactAt does not showcase; crossing it does" {
+    const saved_spec = rlm_spec.available;
+    defer {
+        rlm_spec.available = saved_spec;
+        fold.resetRlmDiscovery();
+        fold.resetContextKnob();
+    }
+    isolate();
+    rlm_spec.available = true;
+
+    // Default: 50% of compactAt. compactAt=8000 → threshold 4000.
+    try std.testing.expectEqual(@as(?u64, 4000), fold.contextThreshold(8000));
+    try std.testing.expect(!fold.noticeContext(0, 8000));
+    try std.testing.expect(!fold.noticeContext(3999, 8000));
+    try std.testing.expect(!fold.listed());
+
+    try std.testing.expect(fold.noticeContext(4000, 8000));
+    try std.testing.expect(fold.listed());
+    try std.testing.expect(fold.isLoaded("rlm"));
+    try std.testing.expect(!fold.noticeContext(8000, 8000)); // already showcased
+
+    fold.resetSession();
+    try std.testing.expect(!fold.listed());
+    try std.testing.expect(!fold.isLoaded("rlm"));
+
+    fold.g_context_off = true;
+    try std.testing.expect(!fold.noticeContext(8000, 8000));
+    try std.testing.expect(!fold.listed());
+}
+
+test "lean first turn and MCP fan-out stay below the context trigger" {
+    const saved_spec = rlm_spec.available;
+    const saved_lean = no_local.lean;
+    defer {
+        rlm_spec.available = saved_spec;
+        no_local.lean = saved_lean;
+        fold.resetRlmDiscovery();
+        fold.resetContextKnob();
+    }
+    isolate();
+    rlm_spec.available = true;
+    no_local.lean = true;
+
+    // A small -p prompt is nowhere near 50% of a real compactAt.
+    try std.testing.expect(!fold.noticeContext(800, 160_000));
+    try std.testing.expect(!fold.listed());
+    try std.testing.expect(!fold.noticeWideNative(&.{
+        "mcp__linear__list_comments",
+        "mcp__linear__list_comments",
+        "mcp__linear__list_comments",
+        "mcp__linear__list_comments",
+    }));
+    try std.testing.expect(!fold.listed());
+}
+
+test "showcasing rlm keeps the tools head bytes; schema rides the tail" {
+    const saved_avail = rlm.available;
+    const saved_spec = rlm_spec.available;
+    const saved_stable = mcp_schema_gate.g_stable_catalog;
+    defer {
+        rlm.available = saved_avail;
+        rlm_spec.available = saved_spec;
+        rlm.sync();
+        mcp_schema_gate.g_stable_catalog = saved_stable;
+        fold.resetRlmDiscovery();
+        fold.resetContextKnob();
+    }
+    isolate();
+    mcp_schema_gate.g_stable_catalog = true;
+    rlm.available = true;
+    rlm.sync();
+
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const specs = [_]schema_mod.ToolSpec{
+        .{
+            .name = mcp_schema_gate.tool_name,
+            .desc = mcp_schema_gate.tool_desc,
+            .schema = mcp_schema_gate.tool_schema,
+        },
+        .{ .name = "bash", .desc = "run a command", .schema = "{\"type\":\"object\"}" },
+        .{ .name = rlm.tool_name, .desc = rlm.tool_desc, .schema = rlm.tool_schema },
+    };
+
+    const before = try schema_mod.renderRootTools(arena, .openai, &specs, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, before, "rlm") == null);
+    try std.testing.expect(std.mem.indexOf(u8, before, rlm.tool_schema) == null);
+
+    try std.testing.expect(fold.noticeContext(50_000, 80_000));
+    const after = try schema_mod.renderRootTools(arena, .openai, &specs, &.{});
+    try std.testing.expect(before.len >= 1 and before[before.len - 1] == ']');
+    try std.testing.expect(std.mem.startsWith(u8, after, before[0 .. before.len - 1]));
+    try std.testing.expect(after.len > before.len);
+    try std.testing.expect(after[before.len - 1] == ',');
+    try std.testing.expect(std.mem.indexOf(u8, after[before.len - 1 ..], rlm.tool_schema) != null);
+    try std.testing.expect(std.mem.indexOf(u8, after[before.len - 1 ..], "llm_query") != null);
+
+    fold.resetSession();
+    try std.testing.expect(!fold.listed());
 }

--- a/src/native_fold_rlm.zig
+++ b/src/native_fold_rlm.zig
@@ -116,7 +116,7 @@ test "lean keeps rlm folded until showcase; --rlm puts the schema on" {
     fold.showcaseFromCli();
     try std.testing.expect(fold.listed());
     try std.testing.expect(fold.isLoaded("rlm"));
-    try std.testing.expect(!fold.catalogSkips("rlm"));
+    // Stable catalog still skips the mid-array slot; the schema rides the tail.
     const shown = try schema_mod.renderRootTools(arena, .openai, &specs, &.{});
     try std.testing.expect(std.mem.indexOf(u8, shown, "llm_query") != null);
     try std.testing.expect(std.mem.indexOf(u8, shown, rlm.tool_schema) != null);

--- a/src/native_fold_rlm.zig
+++ b/src/native_fold_rlm.zig
@@ -1,0 +1,155 @@
+//! Late-showcase tests for folded `rlm` (ADR 0030). Split out of
+//! native_fold.zig so that file stays under the 600-line ceiling.
+
+const std = @import("std");
+const fold = @import("native_fold.zig");
+const schema_mod = @import("schema.zig");
+const rlm = @import("rlm.zig");
+const rlm_spec = @import("rlm_spec.zig");
+const mcp_schema_gate = @import("mcp_schema_gate.zig");
+const no_local = @import("no_local_tools.zig");
+
+fn isolate() void {
+    fold.enabled = true;
+    fold.resetRlmDiscovery();
+}
+
+test "rlm joins the fold only while available (off under --old)" {
+    const saved_avail = rlm_spec.available;
+    const saved_enabled = fold.enabled;
+    defer {
+        rlm_spec.available = saved_avail;
+        fold.enabled = saved_enabled;
+        fold.resetRlmDiscovery();
+    }
+    isolate();
+    rlm_spec.available = false;
+    try std.testing.expect(!fold.isFolded("rlm"));
+    try std.testing.expect(!fold.blocked("rlm"));
+
+    rlm_spec.available = true;
+    try std.testing.expect(fold.isFolded("rlm"));
+    try std.testing.expect(fold.blocked("rlm"));
+    fold.markLoaded("rlm");
+    try std.testing.expect(fold.isLoaded("rlm"));
+    try std.testing.expect(!fold.blocked("rlm"));
+}
+
+test "folded rlm stays off the listing until showcase; off stays off" {
+    const saved_avail = rlm.available;
+    const saved_spec = rlm_spec.available;
+    const saved_enabled = fold.enabled;
+    defer {
+        rlm.available = saved_avail;
+        rlm_spec.available = saved_spec;
+        rlm.sync();
+        fold.enabled = saved_enabled;
+        fold.resetRlmDiscovery();
+    }
+    isolate();
+
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const meta = [_]schema_mod.ToolSpec{.{
+        .name = mcp_schema_gate.tool_name,
+        .desc = mcp_schema_gate.tool_desc,
+        .schema = mcp_schema_gate.tool_schema,
+    }};
+    const with_rlm = [_]schema_mod.ToolSpec{
+        meta[0],
+        .{ .name = rlm.tool_name, .desc = rlm.tool_desc, .schema = rlm.tool_schema },
+    };
+
+    rlm.available = false;
+    rlm.sync();
+    const off = try schema_mod.renderRootTools(arena, .openai, &meta, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, off, "rlm") == null);
+
+    rlm.available = true;
+    rlm.sync();
+    try std.testing.expect(fold.isFolded("rlm"));
+    try std.testing.expect(!fold.listed());
+    const hidden = try schema_mod.renderRootTools(arena, .openai, &with_rlm, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, hidden, "rlm") == null);
+    try std.testing.expect(std.mem.indexOf(u8, hidden, "llm_query") == null);
+
+    fold.showcaseRlm();
+    try std.testing.expect(fold.listed());
+    const shown = try schema_mod.renderRootTools(arena, .openai, &with_rlm, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, shown, "rlm") != null);
+    try std.testing.expect(std.mem.indexOf(u8, shown, "llm_query") == null);
+    try std.testing.expect(std.mem.indexOf(u8, shown, rlm.tool_schema) == null);
+}
+
+test "lean keeps rlm folded until showcase; --rlm puts the schema on" {
+    const saved_avail = rlm.available;
+    const saved_spec = rlm_spec.available;
+    const saved_enabled = fold.enabled;
+    const saved_lean = no_local.lean;
+    defer {
+        rlm.available = saved_avail;
+        rlm_spec.available = saved_spec;
+        rlm.sync();
+        fold.enabled = saved_enabled;
+        no_local.lean = saved_lean;
+        fold.resetRlmDiscovery();
+    }
+    isolate();
+    no_local.lean = true;
+    rlm.available = true;
+    rlm.sync();
+    try std.testing.expect(fold.isFolded("rlm"));
+    try std.testing.expect(fold.catalogSkips("rlm"));
+    try std.testing.expect(!fold.listed());
+
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const specs = [_]schema_mod.ToolSpec{
+        .{ .name = rlm.tool_name, .desc = rlm.tool_desc, .schema = rlm.tool_schema },
+    };
+    const hidden = try schema_mod.renderRootTools(arena, .openai, &specs, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, hidden, "llm_query") == null);
+    try std.testing.expect(std.mem.indexOf(u8, hidden, rlm.tool_schema) == null);
+
+    fold.showcaseFromCli();
+    try std.testing.expect(fold.listed());
+    try std.testing.expect(fold.isLoaded("rlm"));
+    try std.testing.expect(!fold.catalogSkips("rlm"));
+    const shown = try schema_mod.renderRootTools(arena, .openai, &specs, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, shown, "llm_query") != null);
+    try std.testing.expect(std.mem.indexOf(u8, shown, rlm.tool_schema) != null);
+}
+
+test "wide native batch showcases rlm; MCP fan-out does not" {
+    const saved_spec = rlm_spec.available;
+    defer {
+        rlm_spec.available = saved_spec;
+        fold.resetRlmDiscovery();
+    }
+    isolate();
+    rlm_spec.available = true;
+
+    try std.testing.expect(!fold.noticeWideNative(&.{ "read_file", "codedb", "bash" }));
+    try std.testing.expect(!fold.listed());
+    try std.testing.expect(!fold.noticeWideNative(&.{
+        "mcp__linear__list_comments",
+        "mcp__linear__list_comments",
+        "mcp__linear__list_comments",
+        "mcp__linear__list_comments",
+    }));
+    try std.testing.expect(!fold.listed());
+
+    try std.testing.expect(fold.noticeWideNative(&.{ "read_file", "codedb", "bash", "webfetch" }));
+    try std.testing.expect(fold.listed());
+    try std.testing.expect(fold.isLoaded("rlm"));
+
+    fold.resetSession();
+    try std.testing.expect(!fold.listed());
+    try std.testing.expect(!fold.isLoaded("rlm"));
+
+    fold.showcaseFromCli();
+    fold.resetSession();
+    try std.testing.expect(fold.listed());
+}

--- a/src/no_local_tools.zig
+++ b/src/no_local_tools.zig
@@ -379,7 +379,7 @@ test "lean prompt diet: no fan-out / trace / issue-filing; short local-tools not
     try std.testing.expect(std.mem.indexOf(u8, out, "Parallelize") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "ONE response") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "not covered by /rewind") == null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "rlm") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "rlm") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "SPEC.md") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "discard work") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "Fix root causes") == null);
@@ -398,6 +398,6 @@ test "lean catalog drops overflow pager and empty load_tool_schemas" {
     const json = try schema.renderRootTools(arena, .openai, specs, &.{});
     try std.testing.expect(std.mem.indexOf(u8, json, "read_tool_result") == null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"load_tool_schemas\"") == null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"rlm\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"rlm\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"read_file\"") != null);
 }

--- a/src/no_local_tools.zig
+++ b/src/no_local_tools.zig
@@ -66,7 +66,7 @@ pub fn blocks(name: []const u8) bool {
 }
 
 /// --lean / GRAFF_LEAN=1 tool surface — the token-cost counterpart of the MCP
-/// skip (session_start.leanSkipsMcp reads the same flag/env). A one-shot
+/// fold (session_start.leanMode reads the same flag/env). A one-shot
 /// coding task keeps the file/shell tools plus attempt_completion; every
 /// other schema is prefix re-sent on EVERY model turn. Unlike #330 this
 /// is NOT a security boundary: an unadvertised tool is simply unknown.
@@ -77,7 +77,8 @@ pub var lean: bool = false;
 /// calls / 4/6. Dropping catalog `read_file` (085320) made it worse
 /// (63 calls) — the model retried rlm/bash cat when print(read_file)
 /// was a no-op. `load_tool_schemas` stays so MCP can unfold; it is
-/// hidden on lean. Overflow paging (`read_tool_result`) is interactive.
+/// hidden only when nothing is deferred. Overflow paging
+/// (`read_tool_result`) is interactive.
 pub const lean_tools = [_][]const u8{
     "bash",
     "read_file",
@@ -396,7 +397,7 @@ test "lean catalog drops overflow pager and empty load_tool_schemas" {
     const specs = try schema.effectiveRootSpecs(arena);
     const json = try schema.renderRootTools(arena, .openai, specs, &.{});
     try std.testing.expect(std.mem.indexOf(u8, json, "read_tool_result") == null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "load_tool_schemas") == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"load_tool_schemas\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"rlm\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"read_file\"") != null);
 }

--- a/src/prompt_text.zig
+++ b/src/prompt_text.zig
@@ -262,9 +262,8 @@ pub const lean_local_tools_note =
     \\
     \\read_file before editing; prefer edit_file for existing files and
     \\write_file only for new files. Navigate with codedb (context, around,
-    \\callpath, list_dir, status) or one rlm script of those functions.
-    \\print(read_file("path")) returns the file — do not read it again.
-    \\Independent reads belong in ONE response or one rlm script, not a chain of turns.
+    \\callpath, list_dir, status).
+    \\Independent reads belong in ONE response, not a chain of turns.
     \\A passing verify command and attempt_completion belong in ONE response.
 ;
 
@@ -280,7 +279,7 @@ pub const lean_parallel_note =
 
 pub const lean_intro_note =
     \\You are a coding agent. Use the cataloged tools; never invent one.
-    \\Independent reads belong in ONE response (or one rlm script), not one per turn.
+    \\Independent reads belong in ONE response, not one per turn.
     \\A passing test and attempt_completion belong in ONE response.
 ;
 

--- a/src/prompts.zig
+++ b/src/prompts.zig
@@ -37,6 +37,7 @@ const playbook = @import("playbook.zig"); // #381: the user-constraint block com
 const compact_note = @import("compact_note.zig"); // #391: the pre-compaction note-to-self, composed the same way and for the same reason
 const no_local_tools = @import("no_local_tools.zig"); // #330's subtractive gate — one half of every capability answer below
 const tool_gates = @import("tool_gates.zig"); // #352's additive gate — the other half
+const tool_surface = @import("tool_surface.zig");
 const session_index = @import("session_index.zig"); // #410: where the durable transcript lives
 
 /// The prompt text itself lives next door; this file owns when each part
@@ -130,7 +131,7 @@ pub const Caps = struct {
 /// can remove a built-in, and nothing else — the same pair `exec.zig` refuses
 /// a hallucinated call with, so the prompt can never disagree with dispatch.
 pub fn toolAdvertised(name: []const u8) bool {
-    return !no_local_tools.blocks(name) and !tool_gates.blocks(name);
+    return !no_local_tools.blocks(name) and !tool_gates.blocks(name) and !tool_surface.hideBuiltin(name);
 }
 
 /// The live gates. Every flag and env knob feeding them is settled before
@@ -139,7 +140,7 @@ pub fn detectCaps() Caps {
     // The lean halves agree: a tool the catalog filtered out (no_local_tools)
     // is also not a capability the prompt may instruct about.
     return .{
-        .local_tools = toolAdvertised("read_file") and toolAdvertised("bash"),
+        .local_tools = toolAdvertised("edit_file") and toolAdvertised("bash"),
         .subagents = toolAdvertised("subagent") and !no_local_tools.lean, // lean: no fan-out essay
         .todos = toolAdvertised("todo_write") and !no_local_tools.lean,
         .constraints = toolAdvertised("note_constraint") and !no_local_tools.lean,

--- a/src/rlm.zig
+++ b/src/rlm.zig
@@ -163,9 +163,7 @@ fn runHost(ctx: ToolCtx, call: spec_ptc.Call) ToolOutput {
         return .{ .text = ctx.gpa.dupe(u8, "rlm: bad args") catch &.{}, .is_error = true };
     };
     defer parsed.deinit();
-    const out = exec_mod.execTool(ctx, .{ .id = "rlm", .name = ready.name, .input = parsed.value });
-    if (!out.is_error and rlm_mcp.looksMcp(ready.name)) mcp_shapes.remember(ctx, ready.name, out.text);
-    return out;
+    return exec_mod.execTool(ctx, .{ .id = "rlm", .name = ready.name, .input = parsed.value });
 }
 
 fn runSleep(ctx: ToolCtx, args_json: []const u8) ToolOutput {
@@ -242,18 +240,23 @@ fn renderPrint(ctx: ToolCtx, arena: Allocator, inner: []const u8, binds: []const
 fn renderPrintPart(ctx: ToolCtx, arena: Allocator, inner: []const u8, binds: []const Binding, claimed: *std.StringHashMap(ToolOutput)) ![]const u8 {
     const t = std.mem.trim(u8, inner, " \t");
     if (t.len >= 2 and (t[0] == '"' or t[0] == '\'') and t[t.len - 1] == t[0]) return t[1 .. t.len - 1];
-    if (rlm_reduce.evalExpr(arena, t, binds)) |text| return text else |_| {}
+    if (rlm_reduce.evalExpr(arena, t, binds)) |text| return maybeSlim(arena, text) else |_| {}
     var i = binds.len;
     while (i > 0) {
         i -= 1;
-        if (std.mem.eql(u8, binds[i].name, t)) return binds[i].text;
+        if (std.mem.eql(u8, binds[i].name, t)) return maybeSlim(arena, binds[i].text);
     }
     if (try spec_ptc.extractCall(arena, t)) |c| {
         const key = try c.key(arena);
-        if (claimed.get(key)) |hit| return try arena.dupe(u8, hit.text);
+        if (claimed.get(key)) |hit| return maybeSlim(arena, hit.text);
         const out = runHost(ctx, c);
         defer ctx.gpa.free(out.text);
+        if (mcp_shapes.slim(arena, out.text)) |s| return s;
         return try arena.dupe(u8, out.text);
     }
     return try arena.dupe(u8, t);
+}
+
+fn maybeSlim(arena: Allocator, payload: []const u8) []const u8 {
+    return mcp_shapes.slim(arena, payload) orelse payload;
 }

--- a/src/rlm.zig
+++ b/src/rlm.zig
@@ -20,15 +20,16 @@ const exec_mod = @import("exec.zig");
 const rlm_query = @import("rlm_query.zig");
 const rlm_spec = @import("rlm_spec.zig");
 const rlm_mcp = @import("rlm_mcp.zig");
+const rlm_reduce = @import("rlm_reduce.zig");
 const mcp_shapes = @import("mcp_shapes.zig");
 
 pub const tool_name = "rlm";
-pub const tool_desc = "Programmatic tool calling (RLM + sPTC). Functions ARE this session's tools. Literal read_file/codedb/bash/webfetch/sleep_ms/llm_query/subagent start as the script streams. Binds persist. subagent(\"task\") is sidecar-only (keep the critical-path next step local). Loaded MCP names are host functions after load_tool_schemas; each(arr, tool, field) maps a JSON array. print() is the answer. Prefer one rlm over N tool calls.";
+pub const tool_desc = "Programmatic tool calling (RLM + sPTC). Functions ARE this session's tools. Literal read_file/codedb/bash/webfetch/sleep_ms/llm_query/subagent start as the script streams. Binds persist. subagent(\"task\") is sidecar-only (keep the critical-path next step local). Loaded MCP names are host functions after load_tool_schemas; each(arr, tool, field) maps a JSON array; len(x)/project(x, field) slim it. print() is the answer. Prefer one rlm over N tool calls.";
 /// --lean catalog desc: same contract, no REPL essay. maybeAppend is after
 /// compactLeanSpecs, so this is the one-shot wire text.
 pub const lean_tool_desc = "Batch independent read_file/codedb/bash here. print(read_file(\"p\")) returns the file — do not catalog-read it again. Then edit_file/write_file/bash as catalog tools. Literal calls start as it streams. Binds persist.";
 pub const tool_schema =
-    \\{"type": "object", "properties": {"code": {"type": "string", "description": "Python-like script: name = read_file(\"path\") / codedb(\"command\") / bash(\"cmd\") / sleep_ms(ms) / llm_query(\"prompt\") / subagent(\"task\") / loaded mcp__server__tool(); each(arr, tool, field) maps a JSON array; print(...) is the result. Assignments persist across rlm calls."}}, "required": ["code"]}
+    \\{"type": "object", "properties": {"code": {"type": "string", "description": "Python-like script: name = read_file(\"path\") / codedb(\"command\") / bash(\"cmd\") / sleep_ms(ms) / llm_query(\"prompt\") / subagent(\"task\") / loaded mcp__server__tool(); each(arr, tool, field) maps a JSON array; len(x) and project(x, field) slim it; print(...) is the result. Assignments persist across rlm calls."}}, "required": ["code"]}
 ;
 
 /// Process-global: on by default. `--old` / `--no-rlm` turn it off; `--rlm`
@@ -146,8 +147,8 @@ fn speculate(ctx: ToolCtx, arena: Allocator, calls: []const spec_ptc.Call, claim
 fn runHost(ctx: ToolCtx, call: spec_ptc.Call) ToolOutput {
     if (std.mem.eql(u8, call.name, "sleep_ms")) return runSleep(ctx, call.args_json);
     if (std.mem.eql(u8, call.name, "llm_query")) return rlm_query.run(ctx, call.args_json);
-    if (std.mem.eql(u8, call.name, "each")) {
-        return .{ .text = ctx.gpa.dupe(u8, "rlm: each() needs binds, not speculation") catch &.{}, .is_error = true };
+    if (std.mem.eql(u8, call.name, "each") or std.mem.eql(u8, call.name, "len") or std.mem.eql(u8, call.name, "project")) {
+        return .{ .text = ctx.gpa.dupe(u8, "rlm: each/len/project need binds, not speculation") catch &.{}, .is_error = true };
     }
     var arena_state = std.heap.ArenaAllocator.init(ctx.gpa);
     defer arena_state.deinit();
@@ -188,6 +189,11 @@ fn evalStmt(
     bind_out: *std.ArrayList(Binding),
 ) !?[]u8 {
     switch (try rlm_mcp.evalEach(ctx, arena, stmt, binds, bind_out, runHost)) {
+        .miss => {},
+        .ok => return null,
+        .fail => |e| return e,
+    }
+    switch (try rlm_reduce.evalStmt(arena, ctx.gpa, stmt, binds, bind_out)) {
         .miss => {},
         .ok => return null,
         .fail => |e| return e,
@@ -236,6 +242,7 @@ fn renderPrint(ctx: ToolCtx, arena: Allocator, inner: []const u8, binds: []const
 fn renderPrintPart(ctx: ToolCtx, arena: Allocator, inner: []const u8, binds: []const Binding, claimed: *std.StringHashMap(ToolOutput)) ![]const u8 {
     const t = std.mem.trim(u8, inner, " \t");
     if (t.len >= 2 and (t[0] == '"' or t[0] == '\'') and t[t.len - 1] == t[0]) return t[1 .. t.len - 1];
+    if (rlm_reduce.evalExpr(arena, t, binds)) |text| return text else |_| {}
     var i = binds.len;
     while (i > 0) {
         i -= 1;

--- a/src/rlm.zig
+++ b/src/rlm.zig
@@ -65,9 +65,9 @@ pub fn feedLive(ctx: ToolCtx, delta: []const u8) void {
 }
 
 /// Append `rlm` after the lean/no-local filters so a later showcase can
-/// put the spec on the catalog. Folded and unlisted until `--rlm`, a
-/// wide native batch, or an explicit load (ADR 0030). No-op when `--old`
-/// or embedder mode stripped host tools.
+/// put the spec on the catalog tail. Folded and unlisted until `--rlm`,
+/// a wide native batch, context ≥50% of compactAt, or an explicit load
+/// (ADR 0030). No-op when `--old` or embedder mode stripped host tools.
 pub fn maybeAppend(comptime Spec: type, arena: Allocator, specs: []const Spec) ![]const Spec {
     sync();
     if (!available or no_local_tools.enabled) return specs;

--- a/src/rlm.zig
+++ b/src/rlm.zig
@@ -27,7 +27,7 @@ pub const tool_name = "rlm";
 pub const tool_desc = "Programmatic tool calling (RLM + sPTC). Functions ARE this session's tools. Literal read_file/codedb/bash/webfetch/sleep_ms/llm_query/subagent start as the script streams. Binds persist. subagent(\"task\") is sidecar-only (keep the critical-path next step local). Loaded MCP names are host functions after load_tool_schemas; each(arr, tool, field) maps a JSON array; len(x)/project(x, field) slim it. print() is the answer. Prefer one rlm over N tool calls.";
 /// --lean catalog desc: same contract, no REPL essay. maybeAppend is after
 /// compactLeanSpecs, so this is the one-shot wire text.
-pub const lean_tool_desc = "Batch independent read_file/codedb/bash here. print(read_file(\"p\")) returns the file — do not catalog-read it again. Then edit_file/write_file/bash as catalog tools. Literal calls start as it streams. Binds persist.";
+pub const lean_tool_desc = "Batch independent read_file/codedb/bash here. print(read_file(\"p\")) returns the file — do not catalog-read it again. Then edit_file/write_file/bash as catalog tools. Literal calls start as it streams. Binds persist. Loaded MCP names are host functions after load_tool_schemas.";
 pub const tool_schema =
     \\{"type": "object", "properties": {"code": {"type": "string", "description": "Python-like script: name = read_file(\"path\") / codedb(\"command\") / bash(\"cmd\") / sleep_ms(ms) / llm_query(\"prompt\") / subagent(\"task\") / loaded mcp__server__tool(); each(arr, tool, field) maps a JSON array; len(x) and project(x, field) slim it; print(...) is the result. Assignments persist across rlm calls."}}, "required": ["code"]}
 ;

--- a/src/rlm.zig
+++ b/src/rlm.zig
@@ -50,6 +50,7 @@ pub fn setFromCli(on: bool) void {
     available = on;
     cli_set = true;
     sync();
+    if (on) @import("native_fold.zig").showcaseFromCli() else @import("native_fold.zig").resetRlmDiscovery();
 }
 
 pub fn resetLive(gpa: Allocator, io: Io) void {
@@ -63,10 +64,10 @@ pub fn feedLive(ctx: ToolCtx, delta: []const u8) void {
     rlm_spec.feedLive(ctx, delta);
 }
 
-/// Append `rlm` after the lean/no-local filters so the default `-p` still
-/// sees it. The spec is folded behind `load_tool_schemas` (native_fold)
-/// until the model loads or calls it — the prefix stays the lean catalog
-/// plus a name. No-op when `--old` or embedder mode stripped host tools.
+/// Append `rlm` after the lean/no-local filters so a later showcase can
+/// put the spec on the catalog. Folded and unlisted until `--rlm`, a
+/// wide native batch, or an explicit load (ADR 0030). No-op when `--old`
+/// or embedder mode stripped host tools.
 pub fn maybeAppend(comptime Spec: type, arena: Allocator, specs: []const Spec) ![]const Spec {
     sync();
     if (!available or no_local_tools.enabled) return specs;

--- a/src/rlm.zig
+++ b/src/rlm.zig
@@ -3,8 +3,8 @@
 //! On unless `--old` / `--no-rlm` / `GRAFF_OLD=1` / `GRAFF_RLM=0`. `--rlm`
 //! and `GRAFF_RLM=1` force it back on. Host functions: `read_file`, `codedb`
 //! (real graff tools), `sleep_ms` (overlap proof), `llm_query` (RLM tools-off
-//! sub-LM), `print` (answer). Closed literal calls launch as the `code`
-//! argument streams (spec-ptc) and again at exec for anything the stream missed.
+//! sub-LM), `print` (answer), plus loaded MCP names (ADR 0029). Closed literal
+//! calls launch as the `code` argument streams (spec-ptc) and again at exec.
 
 const std = @import("std");
 const Io = std.Io;
@@ -19,14 +19,16 @@ const no_local_tools = @import("no_local_tools.zig");
 const exec_mod = @import("exec.zig");
 const rlm_query = @import("rlm_query.zig");
 const rlm_spec = @import("rlm_spec.zig");
+const rlm_mcp = @import("rlm_mcp.zig");
+const mcp_shapes = @import("mcp_shapes.zig");
 
 pub const tool_name = "rlm";
-pub const tool_desc = "Programmatic tool calling (RLM + sPTC). Script whose functions ARE this session's tools. Independent literal read_file/codedb/bash/webfetch/sleep_ms/llm_query/subagent calls start as the script streams. Binds persist across rlm calls. subagent(\"task\") is sidecar-only (keep the critical-path next step local; sync in v1; run_in_background=true returns an id). print() is the answer. Example: a = read_file(\"src/main.zig\"); b = codedb(\"status\"); print(a, b). No imports, no control flow. Prefer one rlm over N tool calls.";
+pub const tool_desc = "Programmatic tool calling (RLM + sPTC). Functions ARE this session's tools. Literal read_file/codedb/bash/webfetch/sleep_ms/llm_query/subagent start as the script streams. Binds persist. subagent(\"task\") is sidecar-only (keep the critical-path next step local). Loaded MCP names are host functions after load_tool_schemas; each(arr, tool, field) maps a JSON array. print() is the answer. Prefer one rlm over N tool calls.";
 /// --lean catalog desc: same contract, no REPL essay. maybeAppend is after
 /// compactLeanSpecs, so this is the one-shot wire text.
 pub const lean_tool_desc = "Batch independent read_file/codedb/bash here. print(read_file(\"p\")) returns the file — do not catalog-read it again. Then edit_file/write_file/bash as catalog tools. Literal calls start as it streams. Binds persist.";
 pub const tool_schema =
-    \\{"type": "object", "properties": {"code": {"type": "string", "description": "Python-like script: name = read_file(\"path\") / codedb(\"command\") / bash(\"cmd\") / sleep_ms(ms) / llm_query(\"prompt\") / subagent(\"task\"); print(...) is the result. Assignments persist across rlm calls. Semicolons or newlines separate statements."}}, "required": ["code"]}
+    \\{"type": "object", "properties": {"code": {"type": "string", "description": "Python-like script: name = read_file(\"path\") / codedb(\"command\") / bash(\"cmd\") / sleep_ms(ms) / llm_query(\"prompt\") / subagent(\"task\") / loaded mcp__server__tool(); each(arr, tool, field) maps a JSON array; print(...) is the result. Assignments persist across rlm calls."}}, "required": ["code"]}
 ;
 
 /// Process-global: on by default. `--old` / `--no-rlm` turn it off; `--rlm`
@@ -144,11 +146,25 @@ fn speculate(ctx: ToolCtx, arena: Allocator, calls: []const spec_ptc.Call, claim
 fn runHost(ctx: ToolCtx, call: spec_ptc.Call) ToolOutput {
     if (std.mem.eql(u8, call.name, "sleep_ms")) return runSleep(ctx, call.args_json);
     if (std.mem.eql(u8, call.name, "llm_query")) return rlm_query.run(ctx, call.args_json);
-    var parsed = std.json.parseFromSlice(Value, ctx.gpa, call.args_json, .{}) catch {
+    if (std.mem.eql(u8, call.name, "each")) {
+        return .{ .text = ctx.gpa.dupe(u8, "rlm: each() needs binds, not speculation") catch &.{}, .is_error = true };
+    }
+    var arena_state = std.heap.ArenaAllocator.init(ctx.gpa);
+    defer arena_state.deinit();
+    const ready = if (rlm_mcp.looksMcp(call.name) or rlm_mcp.resolve(ctx, call.name) != null)
+        switch (rlm_mcp.prepare(ctx, arena_state.allocator(), call)) {
+            .refuse => |r| return r,
+            .run => |c| c,
+        }
+    else
+        call;
+    var parsed = std.json.parseFromSlice(Value, ctx.gpa, ready.args_json, .{}) catch {
         return .{ .text = ctx.gpa.dupe(u8, "rlm: bad args") catch &.{}, .is_error = true };
     };
     defer parsed.deinit();
-    return exec_mod.execTool(ctx, .{ .id = "rlm", .name = call.name, .input = parsed.value });
+    const out = exec_mod.execTool(ctx, .{ .id = "rlm", .name = ready.name, .input = parsed.value });
+    if (!out.is_error and rlm_mcp.looksMcp(ready.name)) mcp_shapes.remember(ctx, ready.name, out.text);
+    return out;
 }
 
 fn runSleep(ctx: ToolCtx, args_json: []const u8) ToolOutput {
@@ -171,6 +187,11 @@ fn evalStmt(
     printed: *std.ArrayList(u8),
     bind_out: *std.ArrayList(Binding),
 ) !?[]u8 {
+    switch (try rlm_mcp.evalEach(ctx, arena, stmt, binds, bind_out, runHost)) {
+        .miss => {},
+        .ok => return null,
+        .fail => |e| return e,
+    }
     const call = try spec_ptc.extractCall(arena, stmt);
     if (call) |c| {
         const key = try c.key(arena);
@@ -228,367 +249,4 @@ fn renderPrintPart(ctx: ToolCtx, arena: Allocator, inner: []const u8, binds: []c
         return try arena.dupe(u8, out.text);
     }
     return try arena.dupe(u8, t);
-}
-
-fn testCtx(gpa: Allocator, io: Io, client: *std.http.Client) ToolCtx {
-    return .{
-        .gpa = gpa,
-        .io = io,
-        .client = client,
-        .provider = undefined,
-        .registry = null,
-        .from_sub = false,
-        .approvals = null,
-        .tracer = null,
-    };
-}
-
-test "maybeAppend is a no-op when --old, and refuses to double-append" {
-    const gpa = std.testing.allocator;
-    var arena_state = std.heap.ArenaAllocator.init(gpa);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-    const Spec = struct { name: []const u8, desc: []const u8 = "", schema: []const u8 = "{}" };
-    const base = [_]Spec{.{ .name = "read_file" }};
-    const saved = available;
-    const saved_local = no_local_tools.enabled;
-    defer {
-        available = saved;
-        no_local_tools.enabled = saved_local;
-    }
-    available = false;
-    no_local_tools.enabled = false;
-    try std.testing.expectEqual(@as(usize, 1), (try maybeAppend(Spec, arena, &base)).len);
-    available = true;
-    const one = try maybeAppend(Spec, arena, &base);
-    try std.testing.expectEqual(@as(usize, 2), one.len);
-    try std.testing.expectEqualStrings(tool_name, one[1].name);
-    const two = try maybeAppend(Spec, arena, one);
-    try std.testing.expectEqual(@as(usize, 2), two.len);
-    available = true;
-    no_local_tools.enabled = true;
-    try std.testing.expectEqual(@as(usize, 1), (try maybeAppend(Spec, arena, &base)).len);
-}
-
-test "runScript speculates three sleeps so wall time is ~one sleep, not three" {
-    const gpa = std.testing.allocator;
-    const io = std.testing.io;
-    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
-    defer dummy_client.deinit();
-    const saved = available;
-    defer {
-        available = saved;
-        resetLive(gpa, io);
-    }
-    available = true;
-    const ctx = testCtx(gpa, io, &dummy_client);
-    const t0: Io.Timestamp = .now(io, .awake);
-    const out = try runScript(ctx, "a = sleep_ms(40)\nb = sleep_ms(41)\nc = sleep_ms(42)\nprint(a)");
-    defer gpa.free(out.text);
-    const dt = t0.untilNow(io, .awake).toMilliseconds();
-    try std.testing.expect(!out.is_error);
-    try std.testing.expectEqualStrings("slept 40ms", out.text);
-    // Sequential would be ~120ms. Parallel speculation should land well under 100.
-    try std.testing.expect(dt < 100);
-}
-
-test "runScript reads a fixture via speculated read_file and prints it" {
-    const gpa = std.testing.allocator;
-    const io = std.testing.io;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    try tmp.dir.writeFile(io, .{ .sub_path = "note.txt", .data = "hello-rlm\n" });
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const n = try tmp.dir.realPath(io, &path_buf);
-    const dir = path_buf[0..n];
-    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
-    defer dummy_client.deinit();
-    const saved = available;
-    defer {
-        available = saved;
-        resetLive(gpa, io);
-    }
-    available = true;
-    var ctx = testCtx(gpa, io, &dummy_client);
-    ctx.agent_cwd = dir;
-    const out = try runScript(ctx, "x = read_file(\"note.txt\")\nprint(x)");
-    defer gpa.free(out.text);
-    try std.testing.expect(!out.is_error);
-    try std.testing.expect(std.mem.indexOf(u8, out.text, "hello-rlm") != null);
-    const nested = try runScript(ctx, "print(read_file(\"note.txt\"))");
-    defer gpa.free(nested.text);
-    try std.testing.expect(!nested.is_error);
-    try std.testing.expect(std.mem.indexOf(u8, nested.text, "hello-rlm") != null);
-}
-
-test "runScript splits a semicolon one-liner and prints both binds" {
-    const gpa = std.testing.allocator;
-    const io = std.testing.io;
-    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
-    defer dummy_client.deinit();
-    const saved = available;
-    defer {
-        available = saved;
-        resetLive(gpa, io);
-    }
-    available = true;
-    const ctx = testCtx(gpa, io, &dummy_client);
-    const t0: Io.Timestamp = .now(io, .awake);
-    const out = try runScript(ctx, "a = sleep_ms(40); b = sleep_ms(41); print(a, b)");
-    defer gpa.free(out.text);
-    const dt = t0.untilNow(io, .awake).toMilliseconds();
-    try std.testing.expect(!out.is_error);
-    try std.testing.expectEqualStrings("slept 40ms\nslept 41ms", out.text);
-    try std.testing.expect(dt < 90);
-}
-
-test "feedLive launches sleeps before runScript, so claim is a hit not a re-run" {
-    const gpa = std.testing.allocator;
-    const io = std.testing.io;
-    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
-    defer dummy_client.deinit();
-    const saved = available;
-    defer {
-        available = saved;
-        resetLive(gpa, io);
-    }
-    available = true;
-    const ctx = testCtx(gpa, io, &dummy_client);
-    const t0: Io.Timestamp = .now(io, .awake);
-    feedLive(ctx, "a = sleep_ms(40)\n");
-    feedLive(ctx, "b = sleep_ms(41)\n");
-    feedLive(ctx, "c = sleep_ms(42)\n");
-    const out = try runScript(ctx, "a = sleep_ms(40)\nb = sleep_ms(41)\nc = sleep_ms(42)\nprint(a)");
-    defer gpa.free(out.text);
-    const dt = t0.untilNow(io, .awake).toMilliseconds();
-    try std.testing.expect(!out.is_error);
-    try std.testing.expectEqualStrings("slept 40ms", out.text);
-    try std.testing.expect(dt < 100);
-}
-
-test "feedLive splits a semicolon line before runScript claims" {
-    const gpa = std.testing.allocator;
-    const io = std.testing.io;
-    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
-    defer dummy_client.deinit();
-    const saved = available;
-    defer {
-        available = saved;
-        resetLive(gpa, io);
-    }
-    available = true;
-    const ctx = testCtx(gpa, io, &dummy_client);
-    const t0: Io.Timestamp = .now(io, .awake);
-    feedLive(ctx, "a = sleep_ms(40); b = sleep_ms(41)\n");
-    const out = try runScript(ctx, "a = sleep_ms(40); b = sleep_ms(41); print(a, b)");
-    defer gpa.free(out.text);
-    const dt = t0.untilNow(io, .awake).toMilliseconds();
-    try std.testing.expect(!out.is_error);
-    try std.testing.expectEqualStrings("slept 40ms\nslept 41ms", out.text);
-    try std.testing.expect(dt < 90);
-}
-
-test "runScript reuses last-script binds; resetLive drops them" {
-    const gpa = std.testing.allocator;
-    const io = std.testing.io;
-    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
-    defer dummy_client.deinit();
-    const saved = available;
-    defer {
-        available = saved;
-        resetLive(gpa, io);
-    }
-    available = true;
-    const ctx = testCtx(gpa, io, &dummy_client);
-    const first = try runScript(ctx, "prev = sleep_ms(1)");
-    defer gpa.free(first.text);
-    try std.testing.expect(!first.is_error);
-    const reuse = try runScript(ctx, "print(prev)");
-    defer gpa.free(reuse.text);
-    try std.testing.expect(!reuse.is_error);
-    try std.testing.expectEqualStrings("slept 1ms", reuse.text);
-    const overwrite = try runScript(ctx, "prev = sleep_ms(2); print(prev)");
-    defer gpa.free(overwrite.text);
-    try std.testing.expectEqualStrings("slept 2ms", overwrite.text);
-    const kept = try runScript(ctx, "print(prev)");
-    defer gpa.free(kept.text);
-    try std.testing.expectEqualStrings("slept 2ms", kept.text);
-    resetLive(gpa, io);
-    const gone = try runScript(ctx, "print(prev)");
-    defer gpa.free(gone.text);
-    try std.testing.expectEqualStrings("prev", gone.text);
-}
-
-test "runScript last assignment wins when a name is rebound in one script" {
-    const gpa = std.testing.allocator;
-    const io = std.testing.io;
-    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
-    defer dummy_client.deinit();
-    const saved = available;
-    defer {
-        available = saved;
-        resetLive(gpa, io);
-    }
-    available = true;
-    const ctx = testCtx(gpa, io, &dummy_client);
-    const out = try runScript(ctx, "a = sleep_ms(1); a = sleep_ms(2); print(a)");
-    defer gpa.free(out.text);
-    try std.testing.expect(!out.is_error);
-    try std.testing.expectEqualStrings("slept 2ms", out.text);
-}
-
-fn catalogHas(specs: anytype, name: []const u8) bool {
-    for (specs) |s| if (std.mem.eql(u8, s.name, name)) return true;
-    return false;
-}
-
-test "maybeAppend keeps subagent and workflow; rlm is never the only catalog tool" {
-    const gpa = std.testing.allocator;
-    var arena_state = std.heap.ArenaAllocator.init(gpa);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-    const Spec = struct { name: []const u8, desc: []const u8 = "", schema: []const u8 = "{}" };
-    const base = [_]Spec{
-        .{ .name = "read_file" },
-        .{ .name = "subagent" },
-        .{ .name = "workflow" },
-    };
-    const saved = available;
-    const saved_local = no_local_tools.enabled;
-    defer {
-        available = saved;
-        no_local_tools.enabled = saved_local;
-        sync();
-    }
-    available = true;
-    no_local_tools.enabled = false;
-    const on = try maybeAppend(Spec, arena, &base);
-    try std.testing.expectEqual(@as(usize, 4), on.len);
-    try std.testing.expect(catalogHas(on, "subagent"));
-    try std.testing.expect(catalogHas(on, "workflow"));
-    try std.testing.expect(catalogHas(on, tool_name));
-    try std.testing.expect(on.len > 1);
-
-    available = false;
-    const off = try maybeAppend(Spec, arena, &base);
-    try std.testing.expectEqual(@as(usize, 3), off.len);
-    try std.testing.expect(catalogHas(off, "subagent"));
-    try std.testing.expect(!catalogHas(off, tool_name));
-}
-
-test "effectiveRootSpecs: default rlm keeps subagent; --old and --lean do not drop it" {
-    const schema = @import("schema.zig");
-    const root = @import("main.zig");
-    const learn_store = @import("learn_store.zig");
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-    const saved = available;
-    const saved_lean = no_local_tools.lean;
-    const saved_local = no_local_tools.enabled;
-    const saved_clock = root.g_clock_sleep;
-    const saved_learn = learn_store.active_agent_loaded;
-    defer {
-        available = saved;
-        no_local_tools.lean = saved_lean;
-        no_local_tools.enabled = saved_local;
-        root.g_clock_sleep = saved_clock;
-        learn_store.active_agent_loaded = saved_learn;
-        sync();
-    }
-    no_local_tools.enabled = false;
-    root.g_clock_sleep = false;
-    learn_store.active_agent_loaded = true;
-
-    available = true;
-    no_local_tools.lean = false;
-    sync();
-    const def = try schema.effectiveRootSpecs(arena);
-    try std.testing.expect(catalogHas(def, "subagent"));
-    try std.testing.expect(catalogHas(def, "workflow"));
-    try std.testing.expect(catalogHas(def, tool_name));
-    try std.testing.expect(def.len > 2);
-
-    available = false;
-    sync();
-    const old = try schema.effectiveRootSpecs(arena);
-    try std.testing.expect(catalogHas(old, "subagent"));
-    try std.testing.expect(catalogHas(old, "workflow"));
-    try std.testing.expect(!catalogHas(old, tool_name));
-
-    available = true;
-    no_local_tools.lean = true;
-    sync();
-    const lean_on = try schema.effectiveRootSpecs(arena);
-    try std.testing.expect(catalogHas(lean_on, "subagent"));
-    try std.testing.expect(catalogHas(lean_on, tool_name));
-    try std.testing.expect(!catalogHas(lean_on, "workflow"));
-    try std.testing.expect(catalogHas(lean_on, "bash"));
-    try std.testing.expect(no_local_tools.leanKeeps("subagent"));
-    try std.testing.expect(!no_local_tools.leanKeeps(tool_name));
-}
-
-test "runScript empty subagent() reaches execSubagent; persist binds do not break that" {
-    const gpa = std.testing.allocator;
-    const io = std.testing.io;
-    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
-    defer dummy_client.deinit();
-    const saved = available;
-    defer {
-        available = saved;
-        resetLive(gpa, io);
-    }
-    available = true;
-    const ctx = testCtx(gpa, io, &dummy_client);
-    const first = try runScript(ctx, "prev = sleep_ms(1)");
-    defer gpa.free(first.text);
-    try std.testing.expect(!first.is_error);
-    const miss = try runScript(ctx, "h = subagent()");
-    defer gpa.free(miss.text);
-    try std.testing.expect(miss.is_error);
-    try std.testing.expect(std.mem.indexOf(u8, miss.text, "missing required") != null);
-    try std.testing.expect(std.mem.indexOf(u8, miss.text, "prompt") != null);
-    const reuse = try runScript(ctx, "print(prev)");
-    defer gpa.free(reuse.text);
-    try std.testing.expect(!reuse.is_error);
-    try std.testing.expectEqualStrings("slept 1ms", reuse.text);
-}
-
-test "feedLive launches two independent subagent() calls before runScript claims" {
-    const gpa = std.testing.allocator;
-    const io = std.testing.io;
-    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
-    defer dummy_client.deinit();
-    const saved = available;
-    defer {
-        available = saved;
-        resetLive(gpa, io);
-    }
-    available = true;
-    const ctx = testCtx(gpa, io, &dummy_client);
-    feedLive(ctx, "a = subagent()\n");
-    feedLive(ctx, "b = subagent(\"\")\n");
-    var claimed = std.StringHashMap(ToolOutput).init(gpa);
-    defer {
-        var it = claimed.iterator();
-        while (it.next()) |e| gpa.free(e.value_ptr.text);
-        claimed.deinit();
-    }
-    var arena_state = std.heap.ArenaAllocator.init(gpa);
-    defer arena_state.deinit();
-    rlm_spec.takeLive(ctx, &claimed, arena_state.allocator());
-    try std.testing.expectEqual(@as(usize, 2), claimed.count());
-    var it = claimed.iterator();
-    while (it.next()) |e| {
-        try std.testing.expect(e.value_ptr.is_error);
-        try std.testing.expect(std.mem.indexOf(u8, e.value_ptr.text, "prompt") != null);
-    }
-}
-
-test "rlm prompt: subagent() is advertised as sidecar-only, not a critical-path handoff" {
-    try std.testing.expect(std.mem.indexOf(u8, tool_desc, "sidecar-only") != null);
-    try std.testing.expect(std.mem.indexOf(u8, tool_desc, "critical-path") != null);
-    try std.testing.expect(std.mem.indexOf(u8, rlm_spec.system_note, "sidecar-only") != null);
-    try std.testing.expect(std.mem.indexOf(u8, rlm_spec.system_note, "critical-path") != null);
-    try std.testing.expect(tool_desc.len < 600);
 }

--- a/src/rlm_mcp.zig
+++ b/src/rlm_mcp.zig
@@ -1,0 +1,338 @@
+//! MCP-inside-rlm: after `load_tool_schemas` unfolds a tool, an rlm script
+//! may call that name as a host function (same exec_mod path). Unloaded
+//! names are refused. Deferral can only subtract. GRAFF_RLM_MCP=0 restores
+//! today's structured-only gap. Does not import schema.zig.
+
+const std = @import("std");
+const Value = std.json.Value;
+const Allocator = std.mem.Allocator;
+
+const spec_ptc = @import("spec_ptc.zig");
+const tools = @import("tools.zig");
+const ToolCtx = tools.ToolCtx;
+const ToolOutput = tools.ToolOutput;
+const mcp = @import("mcp.zig");
+const mcp_schema_gate = @import("mcp_schema_gate.zig");
+const rlm_spec = @import("rlm_spec.zig");
+
+/// Test / env seam. `applyEnvKnobs` sets this from GRAFF_RLM_MCP.
+pub var host_enabled: bool = true;
+
+pub const Prep = union(enum) {
+    run: spec_ptc.Call,
+    refuse: ToolOutput,
+};
+
+pub fn looksMcp(name: []const u8) bool {
+    return mcp.Registry.isMcp(name);
+}
+
+pub fn resolve(ctx: ToolCtx, name: []const u8) ?[]const u8 {
+    if (mcp.Registry.isMcp(name)) return name;
+    const reg = ctx.registry orelse return null;
+    var hit: ?[]const u8 = null;
+    for (reg.tools) |t| {
+        if (!std.mem.eql(u8, shortName(t.qualified_name), name)) continue;
+        if (hit != null) return null; // ambiguous
+        hit = t.qualified_name;
+    }
+    return hit;
+}
+
+fn shortName(qualified: []const u8) []const u8 {
+    if (!std.mem.startsWith(u8, qualified, "mcp__")) return qualified;
+    const rest = qualified["mcp__".len..];
+    const sep = std.mem.indexOf(u8, rest, "__") orelse return qualified;
+    return rest[sep + 2 ..];
+}
+
+pub fn prepare(ctx: ToolCtx, arena: Allocator, call: spec_ptc.Call) Prep {
+    if (!host_enabled) {
+        return .{ .refuse = fail(ctx, "rlm: MCP host functions are off (GRAFF_RLM_MCP=0) — use structured MCP calls or drop the env") };
+    }
+    const qualified = resolve(ctx, call.name) orelse {
+        if (looksMcp(call.name))
+            return .{ .refuse = fail(ctx, "rlm: unknown MCP tool") };
+        return .{ .run = call };
+    };
+    const reg = ctx.registry orelse {
+        return .{ .refuse = fail(ctx, "MCP not available in this context") };
+    };
+    if (mcp_schema_gate.blocked(reg.tools, qualified)) {
+        return .{ .refuse = fail(ctx, "rlm: MCP tool schema is not loaded — call load_tool_schemas first (deferral only; consent is unchanged)") };
+    }
+    const args = remapArgs(arena, reg, qualified, call.args_json) catch call.args_json;
+    return .{ .run = .{ .name = qualified, .args_json = args } };
+}
+
+fn fail(ctx: ToolCtx, msg: []const u8) ToolOutput {
+    return .{ .text = ctx.gpa.dupe(u8, msg) catch &.{}, .is_error = true };
+}
+
+fn remapArgs(arena: Allocator, reg: *mcp.Registry, qualified: []const u8, args_json: []const u8) ![]const u8 {
+    var parsed = std.json.parseFromSlice(Value, arena, args_json, .{}) catch return args_json;
+    if (parsed.value != .object) return args_json;
+    if (parsed.value.object.get("arg") == null) return args_json;
+    if (parsed.value.object.count() != 1) return args_json;
+    const field = firstField(reg, qualified) orelse return args_json;
+    const val = parsed.value.object.get("arg").?;
+    var obj: std.json.ObjectMap = .empty;
+    try obj.put(arena, field, val);
+    var aw: std.Io.Writer.Allocating = .init(arena);
+    var s: std.json.Stringify = .{ .writer = &aw.writer };
+    try s.write(Value{ .object = obj });
+    return aw.toOwnedSlice();
+}
+
+fn firstField(reg: *mcp.Registry, qualified: []const u8) ?[]const u8 {
+    const tool = for (reg.tools) |t| {
+        if (std.mem.eql(u8, t.qualified_name, qualified)) break t;
+    } else return null;
+    if (tool.input_schema != .object) return null;
+    if (tool.input_schema.object.get("required")) |req| {
+        if (req == .array and req.array.items.len > 0 and req.array.items[0] == .string)
+            return req.array.items[0].string;
+    }
+    if (tool.input_schema.object.get("properties")) |props| {
+        if (props == .object) {
+            var it = props.object.iterator();
+            if (it.next()) |e| return e.key_ptr.*;
+        }
+    }
+    return null;
+}
+
+pub const StmtHit = union(enum) { miss, ok, fail: []u8 };
+
+/// `each(arr, tool, field)` — map a JSON array through one host tool.
+/// Smallest control flow that makes `for issue in list_issues(): list_comments(id)` honest.
+pub fn evalEach(
+    ctx: ToolCtx,
+    arena: Allocator,
+    stmt: []const u8,
+    binds: []const rlm_spec.Binding,
+    bind_out: *std.ArrayList(rlm_spec.Binding),
+    run: *const fn (ToolCtx, spec_ptc.Call) ToolOutput,
+) !StmtHit {
+    const parsed = parseEach(arena, stmt) orelse return .miss;
+    const arr_text = resolveBind(binds, parsed.arr) orelse parsed.arr;
+    const tool = stripQuotes(parsed.tool);
+    const field = stripQuotes(parsed.field);
+    const items = jsonArray(arena, arr_text) catch {
+        return .{ .fail = try std.fmt.allocPrint(ctx.gpa, "rlm: each() needs a JSON array (got {s})", .{arr_text}) };
+    };
+    var out: std.ArrayList(u8) = .empty;
+    try out.append(arena, '[');
+    for (items, 0..) |item, i| {
+        if (i > 0) try out.append(arena, ',');
+        const val = fieldValue(arena, item, field) catch {
+            return .{ .fail = try std.fmt.allocPrint(ctx.gpa, "rlm: each() item missing field {s}", .{field}) };
+        };
+        const args = try std.fmt.allocPrint(arena, "{{\"arg\":{s}}}", .{val});
+        const call: spec_ptc.Call = .{ .name = tool, .args_json = args };
+        const ready = switch (prepare(ctx, arena, call)) {
+            .refuse => |r| return .{ .fail = r.text },
+            .run => |c| c,
+        };
+        const got = run(ctx, ready);
+        defer ctx.gpa.free(got.text);
+        if (got.is_error) return .{ .fail = try ctx.gpa.dupe(u8, got.text) };
+        const piece = jsonOrString(arena, got.text);
+        try out.appendSlice(arena, piece);
+    }
+    try out.append(arena, ']');
+    const text = try out.toOwnedSlice(arena);
+    if (parsed.assign) |nm| try bind_out.append(arena, .{ .name = try arena.dupe(u8, nm), .text = try arena.dupe(u8, text) });
+    return .ok;
+}
+
+const Each = struct { assign: ?[]const u8, arr: []const u8, tool: []const u8, field: []const u8 };
+
+fn parseEach(arena: Allocator, stmt: []const u8) ?Each {
+    const trimmed = std.mem.trim(u8, stmt, " \t");
+    var rest = trimmed;
+    var assign: ?[]const u8 = null;
+    const paren = std.mem.indexOfScalar(u8, trimmed, '(') orelse return null;
+    if (std.mem.indexOfScalar(u8, trimmed[0..paren], '=')) |eq| {
+        const lhs = std.mem.trim(u8, trimmed[0..eq], " \t");
+        if (lhs.len == 0) return null;
+        assign = lhs;
+        rest = std.mem.trim(u8, trimmed[eq + 1 ..], " \t");
+    }
+    if (!std.mem.startsWith(u8, rest, "each(") or rest[rest.len - 1] != ')') return null;
+    const inner = rest["each(".len .. rest.len - 1];
+    const parts = spec_ptc.splitTopLevel(arena, inner, ',') catch return null;
+    if (parts.len != 3) return null;
+    return .{ .assign = assign, .arr = parts[0], .tool = parts[1], .field = parts[2] };
+}
+
+fn resolveBind(binds: []const rlm_spec.Binding, name: []const u8) ?[]const u8 {
+    const t = std.mem.trim(u8, name, " \t");
+    var i = binds.len;
+    while (i > 0) {
+        i -= 1;
+        if (std.mem.eql(u8, binds[i].name, t)) return binds[i].text;
+    }
+    return null;
+}
+
+fn stripQuotes(s: []const u8) []const u8 {
+    const t = std.mem.trim(u8, s, " \t");
+    if (t.len >= 2 and (t[0] == '"' or t[0] == '\'') and t[t.len - 1] == t[0]) return t[1 .. t.len - 1];
+    return t;
+}
+
+fn jsonArray(arena: Allocator, text: []const u8) ![]const Value {
+    const trimmed = std.mem.trim(u8, text, " \t\r\n");
+    const parsed = try std.json.parseFromSlice(Value, arena, trimmed, .{});
+    if (parsed.value == .array) return parsed.value.array.items;
+    if (parsed.value == .object) {
+        var it = parsed.value.object.iterator();
+        while (it.next()) |e| {
+            if (e.value_ptr.* == .array) return e.value_ptr.array.items;
+        }
+    }
+    return error.NotArray;
+}
+
+fn fieldValue(arena: Allocator, item: Value, field: []const u8) ![]const u8 {
+    if (item != .object) return error.NotObject;
+    const v = item.object.get(field) orelse return error.Missing;
+    var aw: std.Io.Writer.Allocating = .init(arena);
+    var s: std.json.Stringify = .{ .writer = &aw.writer };
+    try s.write(v);
+    return aw.toOwnedSlice();
+}
+
+fn jsonOrString(arena: Allocator, text: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, text, " \t\r\n");
+    if (std.json.parseFromSlice(Value, arena, trimmed, .{})) |_| {
+        return trimmed;
+    } else |_| {
+        var aw: std.Io.Writer.Allocating = .init(arena);
+        var s: std.json.Stringify = .{ .writer = &aw.writer };
+        s.write(trimmed) catch return trimmed;
+        return aw.toOwnedSlice() catch trimmed;
+    }
+}
+
+test "unloaded MCP name is refused; loaded name is prepared for exec" {
+    const gpa = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const io = std.testing.io;
+    mcp_schema_gate.reset();
+    defer mcp_schema_gate.reset();
+    mcp_schema_gate.g_policy = .{ .enabled = true, .budget = 0, .eager = &.{} };
+    const all = try @import("mcp_schema_gate_tests.zig").fixture(arena, "fat", 2, 200);
+    var registry = mcp.Registry.empty(gpa, io);
+    defer registry.deinit();
+    registry.tools = all;
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const ctx: ToolCtx = .{
+        .gpa = gpa,
+        .io = io,
+        .client = &dummy_client,
+        .provider = undefined,
+        .registry = &registry,
+        .from_sub = false,
+        .approvals = null,
+        .tracer = null,
+    };
+    const saved = host_enabled;
+    defer host_enabled = saved;
+    host_enabled = true;
+    const call: spec_ptc.Call = .{ .name = "mcp__fat__t0", .args_json = "{}" };
+    switch (prepare(ctx, arena, call)) {
+        .refuse => |r| {
+            defer gpa.free(r.text);
+            try std.testing.expect(r.is_error);
+            try std.testing.expect(std.mem.indexOf(u8, r.text, "load_tool_schemas") != null);
+        },
+        .run => return error.ShouldRefuseUnloaded,
+    }
+    const req = try std.json.parseFromSliceLeaky(Value, arena, "{\"tools\":[\"mcp__fat__t0\"]}", .{ .allocate = .alloc_always });
+    _ = try mcp_schema_gate.loadInto(arena, all, req);
+    try std.testing.expect(mcp_schema_gate.isLoaded("mcp__fat__t0"));
+    switch (prepare(ctx, arena, call)) {
+        .run => |c| try std.testing.expectEqualStrings("mcp__fat__t0", c.name),
+        .refuse => return error.ShouldDispatchLoaded,
+    }
+    host_enabled = false;
+    switch (prepare(ctx, arena, call)) {
+        .refuse => |r| {
+            defer gpa.free(r.text);
+            try std.testing.expect(std.mem.indexOf(u8, r.text, "GRAFF_RLM_MCP") != null);
+        },
+        .run => return error.ShouldRefuseWhenOff,
+    }
+}
+
+test "short name resolves when unique and loaded; consent/deferral still block" {
+    const gpa = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const io = std.testing.io;
+    mcp_schema_gate.reset();
+    defer mcp_schema_gate.reset();
+    mcp_schema_gate.g_policy = .{ .enabled = true, .budget = 0, .eager = &.{} };
+    const all = try @import("mcp_schema_gate_tests.zig").fixture(arena, "fat", 1, 200);
+    var registry = mcp.Registry.empty(gpa, io);
+    defer registry.deinit();
+    registry.tools = all;
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const ctx: ToolCtx = .{
+        .gpa = gpa,
+        .io = io,
+        .client = &dummy_client,
+        .provider = undefined,
+        .registry = &registry,
+        .from_sub = false,
+        .approvals = null,
+        .tracer = null,
+    };
+    try std.testing.expectEqualStrings("mcp__fat__t0", resolve(ctx, "t0").?);
+    try std.testing.expect(mcp_schema_gate.blocked(all, "mcp__fat__t0"));
+    const req = try std.json.parseFromSliceLeaky(Value, arena, "{\"tools\":[\"mcp__fat__t0\"]}", .{ .allocate = .alloc_always });
+    _ = try mcp_schema_gate.loadInto(arena, all, req);
+    try std.testing.expect(!mcp_schema_gate.blocked(all, "mcp__fat__t0"));
+}
+
+test "each() maps a JSON array through a host function" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const ctx: ToolCtx = .{
+        .gpa = gpa,
+        .io = io,
+        .client = &dummy_client,
+        .provider = undefined,
+        .registry = null,
+        .from_sub = false,
+        .approvals = null,
+        .tracer = null,
+    };
+    const binds = [_]rlm_spec.Binding{.{ .name = "issues", .text = "[{\"id\":\"A\"},{\"id\":\"B\"}]" }};
+    var bind_out: std.ArrayList(rlm_spec.Binding) = .empty;
+    const run = struct {
+        fn go(_: ToolCtx, call: spec_ptc.Call) ToolOutput {
+            const g = std.testing.allocator;
+            if (std.mem.indexOf(u8, call.args_json, "A") != null)
+                return .{ .text = g.dupe(u8, "{\"n\":1}") catch &.{} };
+            return .{ .text = g.dupe(u8, "{\"n\":2}") catch &.{} };
+        }
+    }.go;
+    const hit = try evalEach(ctx, arena, "out = each(issues, \"echo\", \"id\")", &binds, &bind_out, run);
+    try std.testing.expect(hit == .ok);
+    try std.testing.expectEqual(@as(usize, 1), bind_out.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, bind_out.items[0].text, "\"n\":1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, bind_out.items[0].text, "\"n\":2") != null);
+}

--- a/src/rlm_mcp.zig
+++ b/src/rlm_mcp.zig
@@ -270,6 +270,10 @@ test "unloaded MCP name is refused; loaded name is prepared for exec" {
     }
 }
 
+test "MCP-inside-rlm host functions are on by default" {
+    try std.testing.expect(host_enabled);
+}
+
 test "short name resolves when unique and loaded; consent/deferral still block" {
     const gpa = std.testing.allocator;
     var arena_state = std.heap.ArenaAllocator.init(gpa);

--- a/src/rlm_reduce.zig
+++ b/src/rlm_reduce.zig
@@ -1,0 +1,134 @@
+//! Slim rlm reducers: `len(x)` and `project(x, field)`.
+//!
+//! ADR 0029: `each()` without a way to print a small summary made grok-4.6
+//! dump fat MCP binds or invent `for`/`len`. These two stay data helpers,
+//! not a general language.
+
+const std = @import("std");
+const Value = std.json.Value;
+const Allocator = std.mem.Allocator;
+
+const spec_ptc = @import("spec_ptc.zig");
+const rlm_spec = @import("rlm_spec.zig");
+const rlm_mcp = @import("rlm_mcp.zig");
+
+pub const StmtHit = rlm_mcp.StmtHit;
+
+pub fn evalStmt(
+    arena: Allocator,
+    gpa: Allocator,
+    stmt: []const u8,
+    binds: []const rlm_spec.Binding,
+    bind_out: *std.ArrayList(rlm_spec.Binding),
+) !StmtHit {
+    const trimmed = std.mem.trim(u8, stmt, " \t");
+    var rest = trimmed;
+    var assign: ?[]const u8 = null;
+    if (std.mem.indexOfScalar(u8, trimmed, '=')) |eq| {
+        const lhs = std.mem.trim(u8, trimmed[0..eq], " \t");
+        const rhs = std.mem.trim(u8, trimmed[eq + 1 ..], " \t");
+        if (lhs.len > 0 and (std.mem.startsWith(u8, rhs, "len(") or std.mem.startsWith(u8, rhs, "project("))) {
+            assign = lhs;
+            rest = rhs;
+        }
+    }
+    const text = evalExpr(arena, rest, binds) catch |err| switch (err) {
+        error.Miss => return .miss,
+        else => return .{ .fail = try std.fmt.allocPrint(gpa, "rlm: {s} failed", .{rest}) },
+    };
+    if (assign) |nm| try bind_out.append(arena, .{
+        .name = try arena.dupe(u8, nm),
+        .text = try arena.dupe(u8, text),
+    });
+    return .ok;
+}
+
+/// Resolve `len(x)` / `project(x, "field")` for `print(...)`.
+pub fn evalExpr(arena: Allocator, expr: []const u8, binds: []const rlm_spec.Binding) ![]const u8 {
+    const t = std.mem.trim(u8, expr, " \t");
+    if (std.mem.startsWith(u8, t, "len(") and t[t.len - 1] == ')') {
+        const inner = std.mem.trim(u8, t["len(".len .. t.len - 1], " \t");
+        const raw = bindText(binds, inner) orelse inner;
+        const items = try jsonArray(arena, raw);
+        return try std.fmt.allocPrint(arena, "{d}", .{items.len});
+    }
+    if (std.mem.startsWith(u8, t, "project(") and t[t.len - 1] == ')') {
+        const inner = t["project(".len .. t.len - 1];
+        const parts = try spec_ptc.splitTopLevel(arena, inner, ',');
+        if (parts.len != 2) return error.Miss;
+        const raw = bindText(binds, parts[0]) orelse std.mem.trim(u8, parts[0], " \t");
+        const field = stripQuotes(parts[1]);
+        const items = try jsonArray(arena, raw);
+        var out: std.ArrayList(u8) = .empty;
+        try out.append(arena, '[');
+        for (items, 0..) |item, i| {
+            if (i > 0) try out.append(arena, ',');
+            try out.appendSlice(arena, try fieldValue(arena, item, field));
+        }
+        try out.append(arena, ']');
+        return out.toOwnedSlice(arena);
+    }
+    return error.Miss;
+}
+
+fn bindText(binds: []const rlm_spec.Binding, name: []const u8) ?[]const u8 {
+    const t = std.mem.trim(u8, name, " \t");
+    var i = binds.len;
+    while (i > 0) {
+        i -= 1;
+        if (std.mem.eql(u8, binds[i].name, t)) return binds[i].text;
+    }
+    return null;
+}
+
+fn stripQuotes(s: []const u8) []const u8 {
+    const t = std.mem.trim(u8, s, " \t");
+    if (t.len >= 2 and (t[0] == '"' or t[0] == '\'') and t[t.len - 1] == t[0]) return t[1 .. t.len - 1];
+    return t;
+}
+
+fn jsonArray(arena: Allocator, text: []const u8) ![]const Value {
+    const trimmed = std.mem.trim(u8, text, " \t\r\n");
+    const parsed = std.json.parseFromSlice(Value, arena, trimmed, .{}) catch return error.Miss;
+    if (parsed.value == .array) return parsed.value.array.items;
+    if (parsed.value == .object) {
+        var it = parsed.value.object.iterator();
+        while (it.next()) |e| {
+            if (e.value_ptr.* == .array) return e.value_ptr.array.items;
+        }
+    }
+    return error.Miss;
+}
+
+fn fieldValue(arena: Allocator, item: Value, field: []const u8) ![]const u8 {
+    if (item != .object) return error.Miss;
+    const v = item.object.get(field) orelse return error.Miss;
+    var aw: std.Io.Writer.Allocating = .init(arena);
+    var s: std.json.Stringify = .{ .writer = &aw.writer };
+    try s.write(v);
+    return aw.toOwnedSlice();
+}
+
+test "len() counts a JSON array bind" {
+    const gpa = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const binds = [_]rlm_spec.Binding{.{ .name = "issues", .text = "[{\"id\":1},{\"id\":2},{\"id\":3}]" }};
+    var bind_out: std.ArrayList(rlm_spec.Binding) = .empty;
+    const hit = try evalStmt(arena, gpa, "n = len(issues)", &binds, &bind_out);
+    try std.testing.expect(hit == .ok);
+    try std.testing.expectEqualStrings("3", bind_out.items[0].text);
+}
+
+test "project() extracts one field; print(len()) resolves" {
+    const gpa = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const binds = [_]rlm_spec.Binding{.{ .name = "issues", .text = "[{\"id\":\"ISS-1\",\"title\":\"a\"},{\"id\":\"ISS-2\",\"title\":\"b\"}]" }};
+    const ids = try evalExpr(arena, "project(issues, \"id\")", &binds);
+    try std.testing.expectEqualStrings("[\"ISS-1\",\"ISS-2\"]", ids);
+    const n = try evalExpr(arena, "len(issues)", &binds);
+    try std.testing.expectEqualStrings("2", n);
+}

--- a/src/rlm_spec.zig
+++ b/src/rlm_spec.zig
@@ -22,7 +22,7 @@ pub var run_host: ?*const fn (ToolCtx, spec_ptc.Call) ToolOutput = null;
 /// `subagent("task")` is Prime-style recursion via graff's existing subagent
 /// tool. v1 is synchronous; speculate() still overlaps independent calls.
 /// Keyword `run_in_background=true` returns an agent id (a handle).
-pub const system_note = "\n\nrlm(code): script of this session's tools. Independent literal read_file/codedb/bash/llm_query/subagent calls start as it streams. Binds persist until /new or /clear. subagent(\"task\") is sidecar-only — keep the critical-path next step local. Prefer one rlm over N tool calls. print(...) is the answer.";
+pub const system_note = "\n\nrlm(code): session tools as a script. Literal read_file/codedb/bash/llm_query/subagent start as it streams. Binds persist until /new or /clear. subagent(\"task\") is sidecar-only — keep the critical-path next step local. Loaded MCP names are host functions; each(arr, tool, field) maps a JSON array. print(...) is the answer.";
 
 /// One REPL assignment. `runScript` seeds these from the process-local store
 /// so a later `rlm` call can `print(prev)` without re-reading. Owned by the

--- a/src/rlm_spec.zig
+++ b/src/rlm_spec.zig
@@ -22,7 +22,7 @@ pub var run_host: ?*const fn (ToolCtx, spec_ptc.Call) ToolOutput = null;
 /// `subagent("task")` is Prime-style recursion via graff's existing subagent
 /// tool. v1 is synchronous; speculate() still overlaps independent calls.
 /// Keyword `run_in_background=true` returns an agent id (a handle).
-pub const system_note = "\n\nrlm(code): session tools as a script. Literal read_file/codedb/bash/llm_query/subagent start as it streams. Binds persist until /new or /clear. subagent(\"task\") is sidecar-only — keep the critical-path next step local. Loaded MCP names are host functions; each(arr, tool, field) maps a JSON array; len(x)/project(x, field) slim it. print(...) is the answer.";
+pub const system_note = "\n\nrlm(code): session tools as a script. Literal read_file/codedb/bash/llm_query/subagent start as it streams. Binds persist until /new or /clear. subagent(\"task\") is sidecar-only; keep the critical-path next step local. Loaded MCP names are host functions; each() maps a JSON array; len/project slim it. print(...) is the answer.";
 
 /// One REPL assignment. `runScript` seeds these from the process-local store
 /// so a later `rlm` call can `print(prev)` without re-reading. Owned by the

--- a/src/rlm_spec.zig
+++ b/src/rlm_spec.zig
@@ -22,7 +22,7 @@ pub var run_host: ?*const fn (ToolCtx, spec_ptc.Call) ToolOutput = null;
 /// `subagent("task")` is Prime-style recursion via graff's existing subagent
 /// tool. v1 is synchronous; speculate() still overlaps independent calls.
 /// Keyword `run_in_background=true` returns an agent id (a handle).
-pub const system_note = "\n\nrlm(code): session tools as a script. Literal read_file/codedb/bash/llm_query/subagent start as it streams. Binds persist until /new or /clear. subagent(\"task\") is sidecar-only — keep the critical-path next step local. Loaded MCP names are host functions; each(arr, tool, field) maps a JSON array. print(...) is the answer.";
+pub const system_note = "\n\nrlm(code): session tools as a script. Literal read_file/codedb/bash/llm_query/subagent start as it streams. Binds persist until /new or /clear. subagent(\"task\") is sidecar-only — keep the critical-path next step local. Loaded MCP names are host functions; each(arr, tool, field) maps a JSON array; len(x)/project(x, field) slim it. print(...) is the answer.";
 
 /// One REPL assignment. `runScript` seeds these from the process-local store
 /// so a later `rlm` call can `print(prev)` without re-reading. Owned by the

--- a/src/rlm_tests.zig
+++ b/src/rlm_tests.zig
@@ -1,0 +1,394 @@
+//! Tests split out of rlm.zig so the REPL stays under the 600-line cap.
+
+const std = @import("std");
+const Io = std.Io;
+
+const rlm = @import("rlm.zig");
+const rlm_spec = @import("rlm_spec.zig");
+const no_local_tools = @import("no_local_tools.zig");
+const tools = @import("tools.zig");
+const ToolCtx = tools.ToolCtx;
+const ToolOutput = tools.ToolOutput;
+
+fn testCtx(gpa: std.mem.Allocator, io: Io, client: *std.http.Client) ToolCtx {
+    return .{
+        .gpa = gpa,
+        .io = io,
+        .client = client,
+        .provider = undefined,
+        .registry = null,
+        .from_sub = false,
+        .approvals = null,
+        .tracer = null,
+    };
+}
+
+test "maybeAppend is a no-op when --old, and refuses to double-append" {
+    const gpa = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const Spec = struct { name: []const u8, desc: []const u8 = "", schema: []const u8 = "{}" };
+    const base = [_]Spec{.{ .name = "read_file" }};
+    const saved = rlm.available;
+    const saved_local = no_local_tools.enabled;
+    defer {
+        rlm.available = saved;
+        no_local_tools.enabled = saved_local;
+    }
+    rlm.available = false;
+    no_local_tools.enabled = false;
+    try std.testing.expectEqual(@as(usize, 1), (try rlm.maybeAppend(Spec, arena, &base)).len);
+    rlm.available = true;
+    const one = try rlm.maybeAppend(Spec, arena, &base);
+    try std.testing.expectEqual(@as(usize, 2), one.len);
+    try std.testing.expectEqualStrings(rlm.tool_name, one[1].name);
+    const two = try rlm.maybeAppend(Spec, arena, one);
+    try std.testing.expectEqual(@as(usize, 2), two.len);
+    rlm.available = true;
+    no_local_tools.enabled = true;
+    try std.testing.expectEqual(@as(usize, 1), (try rlm.maybeAppend(Spec, arena, &base)).len);
+}
+
+test "runScript speculates three sleeps so wall time is ~one sleep, not three" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const saved = rlm.available;
+    defer {
+        rlm.available = saved;
+        rlm.resetLive(gpa, io);
+    }
+    rlm.available = true;
+    const ctx = testCtx(gpa, io, &dummy_client);
+    const t0: Io.Timestamp = .now(io, .awake);
+    const out = try rlm.runScript(ctx, "a = sleep_ms(40)\nb = sleep_ms(41)\nc = sleep_ms(42)\nprint(a)");
+    defer gpa.free(out.text);
+    const dt = t0.untilNow(io, .awake).toMilliseconds();
+    try std.testing.expect(!out.is_error);
+    try std.testing.expectEqualStrings("slept 40ms", out.text);
+    try std.testing.expect(dt < 100);
+}
+
+test "runScript reads a fixture via speculated read_file and prints it" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "note.txt", .data = "hello-rlm\n" });
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &path_buf);
+    const dir = path_buf[0..n];
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const saved = rlm.available;
+    defer {
+        rlm.available = saved;
+        rlm.resetLive(gpa, io);
+    }
+    rlm.available = true;
+    var ctx = testCtx(gpa, io, &dummy_client);
+    ctx.agent_cwd = dir;
+    const out = try rlm.runScript(ctx, "x = read_file(\"note.txt\")\nprint(x)");
+    defer gpa.free(out.text);
+    try std.testing.expect(!out.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, out.text, "hello-rlm") != null);
+    const nested = try rlm.runScript(ctx, "print(read_file(\"note.txt\"))");
+    defer gpa.free(nested.text);
+    try std.testing.expect(!nested.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, nested.text, "hello-rlm") != null);
+}
+
+test "runScript splits a semicolon one-liner and prints both binds" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const saved = rlm.available;
+    defer {
+        rlm.available = saved;
+        rlm.resetLive(gpa, io);
+    }
+    rlm.available = true;
+    const ctx = testCtx(gpa, io, &dummy_client);
+    const t0: Io.Timestamp = .now(io, .awake);
+    const out = try rlm.runScript(ctx, "a = sleep_ms(40); b = sleep_ms(41); print(a, b)");
+    defer gpa.free(out.text);
+    const dt = t0.untilNow(io, .awake).toMilliseconds();
+    try std.testing.expect(!out.is_error);
+    try std.testing.expectEqualStrings("slept 40ms\nslept 41ms", out.text);
+    try std.testing.expect(dt < 90);
+}
+
+test "feedLive launches sleeps before runScript, so claim is a hit not a re-run" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const saved = rlm.available;
+    defer {
+        rlm.available = saved;
+        rlm.resetLive(gpa, io);
+    }
+    rlm.available = true;
+    const ctx = testCtx(gpa, io, &dummy_client);
+    const t0: Io.Timestamp = .now(io, .awake);
+    rlm.feedLive(ctx, "a = sleep_ms(40)\n");
+    rlm.feedLive(ctx, "b = sleep_ms(41)\n");
+    rlm.feedLive(ctx, "c = sleep_ms(42)\n");
+    const out = try rlm.runScript(ctx, "a = sleep_ms(40)\nb = sleep_ms(41)\nc = sleep_ms(42)\nprint(a)");
+    defer gpa.free(out.text);
+    const dt = t0.untilNow(io, .awake).toMilliseconds();
+    try std.testing.expect(!out.is_error);
+    try std.testing.expectEqualStrings("slept 40ms", out.text);
+    try std.testing.expect(dt < 100);
+}
+
+test "feedLive splits a semicolon line before runScript claims" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const saved = rlm.available;
+    defer {
+        rlm.available = saved;
+        rlm.resetLive(gpa, io);
+    }
+    rlm.available = true;
+    const ctx = testCtx(gpa, io, &dummy_client);
+    const t0: Io.Timestamp = .now(io, .awake);
+    rlm.feedLive(ctx, "a = sleep_ms(40); b = sleep_ms(41)\n");
+    const out = try rlm.runScript(ctx, "a = sleep_ms(40); b = sleep_ms(41); print(a, b)");
+    defer gpa.free(out.text);
+    const dt = t0.untilNow(io, .awake).toMilliseconds();
+    try std.testing.expect(!out.is_error);
+    try std.testing.expectEqualStrings("slept 40ms\nslept 41ms", out.text);
+    try std.testing.expect(dt < 90);
+}
+
+test "runScript reuses last-script binds; resetLive drops them" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const saved = rlm.available;
+    defer {
+        rlm.available = saved;
+        rlm.resetLive(gpa, io);
+    }
+    rlm.available = true;
+    const ctx = testCtx(gpa, io, &dummy_client);
+    const first = try rlm.runScript(ctx, "prev = sleep_ms(1)");
+    defer gpa.free(first.text);
+    try std.testing.expect(!first.is_error);
+    const reuse = try rlm.runScript(ctx, "print(prev)");
+    defer gpa.free(reuse.text);
+    try std.testing.expect(!reuse.is_error);
+    try std.testing.expectEqualStrings("slept 1ms", reuse.text);
+    const overwrite = try rlm.runScript(ctx, "prev = sleep_ms(2); print(prev)");
+    defer gpa.free(overwrite.text);
+    try std.testing.expectEqualStrings("slept 2ms", overwrite.text);
+    const kept = try rlm.runScript(ctx, "print(prev)");
+    defer gpa.free(kept.text);
+    try std.testing.expectEqualStrings("slept 2ms", kept.text);
+    rlm.resetLive(gpa, io);
+    const gone = try rlm.runScript(ctx, "print(prev)");
+    defer gpa.free(gone.text);
+    try std.testing.expectEqualStrings("prev", gone.text);
+}
+
+test "runScript last assignment wins when a name is rebound in one script" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const saved = rlm.available;
+    defer {
+        rlm.available = saved;
+        rlm.resetLive(gpa, io);
+    }
+    rlm.available = true;
+    const ctx = testCtx(gpa, io, &dummy_client);
+    const out = try rlm.runScript(ctx, "a = sleep_ms(1); a = sleep_ms(2); print(a)");
+    defer gpa.free(out.text);
+    try std.testing.expect(!out.is_error);
+    try std.testing.expectEqualStrings("slept 2ms", out.text);
+}
+
+fn catalogHas(specs: anytype, name: []const u8) bool {
+    for (specs) |s| if (std.mem.eql(u8, s.name, name)) return true;
+    return false;
+}
+
+test "maybeAppend keeps subagent and workflow; rlm is never the only catalog tool" {
+    const gpa = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const Spec = struct { name: []const u8, desc: []const u8 = "", schema: []const u8 = "{}" };
+    const base = [_]Spec{
+        .{ .name = "read_file" },
+        .{ .name = "subagent" },
+        .{ .name = "workflow" },
+    };
+    const saved = rlm.available;
+    const saved_local = no_local_tools.enabled;
+    defer {
+        rlm.available = saved;
+        no_local_tools.enabled = saved_local;
+        rlm.sync();
+    }
+    rlm.available = true;
+    no_local_tools.enabled = false;
+    const on = try rlm.maybeAppend(Spec, arena, &base);
+    try std.testing.expectEqual(@as(usize, 4), on.len);
+    try std.testing.expect(catalogHas(on, "subagent"));
+    try std.testing.expect(catalogHas(on, "workflow"));
+    try std.testing.expect(catalogHas(on, rlm.tool_name));
+    try std.testing.expect(on.len > 1);
+
+    rlm.available = false;
+    const off = try rlm.maybeAppend(Spec, arena, &base);
+    try std.testing.expectEqual(@as(usize, 3), off.len);
+    try std.testing.expect(catalogHas(off, "subagent"));
+    try std.testing.expect(!catalogHas(off, rlm.tool_name));
+}
+
+test "effectiveRootSpecs: default rlm keeps subagent; --old and --lean do not drop it" {
+    const schema = @import("schema.zig");
+    const root = @import("main.zig");
+    const learn_store = @import("learn_store.zig");
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const saved = rlm.available;
+    const saved_lean = no_local_tools.lean;
+    const saved_local = no_local_tools.enabled;
+    const saved_clock = root.g_clock_sleep;
+    const saved_learn = learn_store.active_agent_loaded;
+    defer {
+        rlm.available = saved;
+        no_local_tools.lean = saved_lean;
+        no_local_tools.enabled = saved_local;
+        root.g_clock_sleep = saved_clock;
+        learn_store.active_agent_loaded = saved_learn;
+        rlm.sync();
+    }
+    no_local_tools.enabled = false;
+    root.g_clock_sleep = false;
+    learn_store.active_agent_loaded = true;
+
+    rlm.available = true;
+    no_local_tools.lean = false;
+    rlm.sync();
+    const def = try schema.effectiveRootSpecs(arena);
+    try std.testing.expect(catalogHas(def, "subagent"));
+    try std.testing.expect(catalogHas(def, "workflow"));
+    try std.testing.expect(catalogHas(def, rlm.tool_name));
+    try std.testing.expect(def.len > 2);
+
+    rlm.available = false;
+    rlm.sync();
+    const old = try schema.effectiveRootSpecs(arena);
+    try std.testing.expect(catalogHas(old, "subagent"));
+    try std.testing.expect(catalogHas(old, "workflow"));
+    try std.testing.expect(!catalogHas(old, rlm.tool_name));
+
+    rlm.available = true;
+    no_local_tools.lean = true;
+    rlm.sync();
+    const lean_on = try schema.effectiveRootSpecs(arena);
+    try std.testing.expect(catalogHas(lean_on, "subagent"));
+    try std.testing.expect(catalogHas(lean_on, rlm.tool_name));
+    try std.testing.expect(!catalogHas(lean_on, "workflow"));
+    try std.testing.expect(catalogHas(lean_on, "bash"));
+    try std.testing.expect(no_local_tools.leanKeeps("subagent"));
+    try std.testing.expect(!no_local_tools.leanKeeps(rlm.tool_name));
+}
+
+test "runScript empty subagent() reaches execSubagent; persist binds do not break that" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const saved = rlm.available;
+    defer {
+        rlm.available = saved;
+        rlm.resetLive(gpa, io);
+    }
+    rlm.available = true;
+    const ctx = testCtx(gpa, io, &dummy_client);
+    const first = try rlm.runScript(ctx, "prev = sleep_ms(1)");
+    defer gpa.free(first.text);
+    try std.testing.expect(!first.is_error);
+    const miss = try rlm.runScript(ctx, "h = subagent()");
+    defer gpa.free(miss.text);
+    try std.testing.expect(miss.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, miss.text, "missing required") != null);
+    try std.testing.expect(std.mem.indexOf(u8, miss.text, "prompt") != null);
+    const reuse = try rlm.runScript(ctx, "print(prev)");
+    defer gpa.free(reuse.text);
+    try std.testing.expect(!reuse.is_error);
+    try std.testing.expectEqualStrings("slept 1ms", reuse.text);
+}
+
+test "feedLive launches two independent subagent() calls before runScript claims" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const saved = rlm.available;
+    defer {
+        rlm.available = saved;
+        rlm.resetLive(gpa, io);
+    }
+    rlm.available = true;
+    const ctx = testCtx(gpa, io, &dummy_client);
+    rlm.feedLive(ctx, "a = subagent()\n");
+    rlm.feedLive(ctx, "b = subagent(\"\")\n");
+    var claimed = std.StringHashMap(ToolOutput).init(gpa);
+    defer {
+        var it = claimed.iterator();
+        while (it.next()) |e| gpa.free(e.value_ptr.text);
+        claimed.deinit();
+    }
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    rlm_spec.takeLive(ctx, &claimed, arena_state.allocator());
+    try std.testing.expectEqual(@as(usize, 2), claimed.count());
+    var it = claimed.iterator();
+    while (it.next()) |e| {
+        try std.testing.expect(e.value_ptr.is_error);
+        try std.testing.expect(std.mem.indexOf(u8, e.value_ptr.text, "prompt") != null);
+    }
+}
+
+test "rlm prompt: subagent() is advertised as sidecar-only, not a critical-path handoff" {
+    try std.testing.expect(std.mem.indexOf(u8, rlm.tool_desc, "sidecar-only") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rlm.tool_desc, "critical-path") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rlm_spec.system_note, "sidecar-only") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rlm_spec.system_note, "critical-path") != null);
+    try std.testing.expect(rlm.tool_desc.len < 600);
+}
+
+test "runScript refuses an unloaded MCP name and does not treat it as a host tool" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var dummy_client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer dummy_client.deinit();
+    const saved = rlm.available;
+    const saved_mcp = @import("rlm_mcp.zig").host_enabled;
+    defer {
+        rlm.available = saved;
+        @import("rlm_mcp.zig").host_enabled = saved_mcp;
+        rlm.resetLive(gpa, io);
+    }
+    rlm.available = true;
+    @import("rlm_mcp.zig").host_enabled = true;
+    const ctx = testCtx(gpa, io, &dummy_client);
+    const out = try rlm.runScript(ctx, "x = mcp__linear__list_issues()\nprint(x)");
+    defer gpa.free(out.text);
+    try std.testing.expect(out.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, out.text, "MCP not available") != null or std.mem.indexOf(u8, out.text, "load_tool_schemas") != null);
+}

--- a/src/rlm_tests.zig
+++ b/src/rlm_tests.zig
@@ -370,6 +370,8 @@ test "rlm prompt: subagent() is advertised as sidecar-only, not a critical-path 
     try std.testing.expect(std.mem.indexOf(u8, rlm_spec.system_note, "sidecar-only") != null);
     try std.testing.expect(std.mem.indexOf(u8, rlm_spec.system_note, "critical-path") != null);
     try std.testing.expect(rlm.tool_desc.len < 600);
+    try std.testing.expect(std.mem.indexOf(u8, rlm.lean_tool_desc, "load_tool_schemas") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rlm.lean_tool_desc, "MCP") != null);
 }
 
 test "runScript refuses an unloaded MCP name and does not treat it as a host tool" {

--- a/src/schema.zig
+++ b/src/schema.zig
@@ -50,7 +50,7 @@ const empty_schema =
     \\{"type": "object", "properties": {}}
 ;
 
-const base_specs = [_]ToolSpec{
+pub const base_specs = [_]ToolSpec{
     .{
         .name = "bash",
         .desc = "Run a shell command via /bin/sh -c in the current working directory. Returns stdout, stderr, and the exit code. A user-cancelled command reports cancelled (its whole local process group is killed; a remote process started over ssh may survive on the remote host). Foreground commands that are still running after 120s (or timeout ms) are moved to the background and return a job id — the process keeps running. For long-running commands set run_in_background true to skip the wait. You are notified on completion — do not poll. bash_output(wait_ms>0) blocks until exit (up to 10h); omit wait_ms for a snapshot. Stop it with bash_kill.",
@@ -307,7 +307,7 @@ pub fn renderRootTools(
     }
     // Deferred tools ship no entries (codex tool_search pattern); the meta
     // tool's desc lists them, exec.zig layer 2 guards premature calls.
-    for (mcp_tools) |m| if (!mcp_schema_gate.isDeferred(mcp_tools, m) and !(mcp_schema_gate.g_stable_catalog and mcp_schema_gate.policyDeferred(mcp_tools, m)))
+    for (mcp_tools) |m| if (!mcp_schema_gate.omitMcp(m.qualified_name) and !mcp_schema_gate.isDeferred(mcp_tools, m) and !(mcp_schema_gate.g_stable_catalog and mcp_schema_gate.policyDeferred(mcp_tools, m)))
         try writeToolEntry(&s, kind, m.qualified_name, m.description, .{ .value = m.input_schema });
     // GRAFF_STABLE_CATALOG (#476): loaded tools append in LOAD ORDER after the
     // stable head — loads change only tail bytes, the prefix cache survives.
@@ -326,8 +326,8 @@ pub fn effectiveRootSpecs(arena: Allocator) ![]const ToolSpec {
         (if (learn_store.active_agent_loaded) &root_specs else &root_specs_without_learning)
     else
         (if (learn_store.active_agent_loaded) &root_specs_without_clock else &root_specs_without_optional);
-    // Optionals are appended BEFORE the #330 filter, never after (optional ≠ exempt); the --lean token filter chains last.
-    return rlm.maybeAppend(ToolSpec, arena, try no_local_tools.compactLeanSpecs(ToolSpec, arena, try no_local_tools.filterLeanSpecs(ToolSpec, arena, try no_local_tools.filterRootSpecs(ToolSpec, arena, try tool_gates.withAvailable(ToolSpec, arena, chosen, &optional_specs)))));
+    // Optionals before #330 (optional ≠ exempt); lean + licensed surface filter chain inside assembleRoot.
+    return rlm.maybeAppend(ToolSpec, arena, try tool_gates.assembleRoot(ToolSpec, arena, chosen, &optional_specs));
 }
 
 const Schema = union(enum) { raw: []const u8, value: Value };

--- a/src/session_connect_tests.zig
+++ b/src/session_connect_tests.zig
@@ -1,0 +1,47 @@
+//! Companion-connect opt-in: Smolify is not added unless GRAFF_SMOLIFY is set.
+
+const std = @import("std");
+const Io = std.Io;
+
+const args = @import("args.zig");
+const mcp = @import("mcp.zig");
+const session_start = @import("session_start.zig");
+const tool_surface = @import("tool_surface.zig");
+
+test "connectCompanion does not add Smolify tools unless the opt-in env is present" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var env = std.process.Environ.Map.init(std.testing.allocator);
+    defer env.deinit();
+    const flags: args.Flags = .{};
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    var registry = mcp.Registry.empty(std.testing.allocator, std.testing.io);
+    defer registry.deinit();
+    try session_start.connectCompanion(std.testing.io, arena, &registry, flags, &aw.writer, true, env);
+    try std.testing.expectEqual(@as(usize, 0), registry.tools.len);
+    try std.testing.expectEqual(@as(usize, 0), registry.servers.len);
+
+    try env.put("GRAFF_SMOLIFY", "1");
+    var with_opt = mcp.Registry.empty(std.testing.allocator, std.testing.io);
+    defer with_opt.deinit();
+    try session_start.connectCompanion(std.testing.io, arena, &with_opt, flags, &aw.writer, true, env);
+    try std.testing.expect(with_opt.tools.len > 0);
+    try std.testing.expectEqualStrings("smolify", with_opt.servers[0].name);
+    for (with_opt.tools) |t| {
+        try std.testing.expect(std.mem.startsWith(u8, t.qualified_name, "mcp__smolify__"));
+    }
+}
+
+test "skipOptionalServer keeps deepwiki/mobbin out of the default catalog" {
+    var env = std.process.Environ.Map.init(std.testing.allocator);
+    defer env.deinit();
+    try std.testing.expect(tool_surface.skipOptionalServer("deepwiki", env));
+    try std.testing.expect(tool_surface.skipOptionalServer("mobbin", env));
+    try env.put("GRAFF_DEEPWIKI", "1");
+    try std.testing.expect(!tool_surface.skipOptionalServer("deepwiki", env));
+    try std.testing.expect(tool_surface.skipOptionalServer("mobbin", env));
+}

--- a/src/session_settings.zig
+++ b/src/session_settings.zig
@@ -138,7 +138,7 @@ pub fn applyEnvKnobs(arena: Allocator, environ_map: anytype) !void {
         }
     }
     if (environ_map.get("GRAFF_NO_LOCAL_TOOLS")) |v| no_local_tools.enabled = no_local_tools.enabled or no_local_tools.envEnables(v);
-    // GRAFF_LEAN: presence-based, exactly matching session_start.leanSkipsMcp
+    // GRAFF_LEAN: presence-based, matching session_start.leanMode
     // (the MCP half of the same switch) — a "0" still means lean, by design.
     if (environ_map.get("GRAFF_LEAN") != null) no_local_tools.lean = true;
     // GRAFF_REQ_STATS: presence-based request-anatomy print (req_stats).

--- a/src/session_settings.zig
+++ b/src/session_settings.zig
@@ -132,6 +132,10 @@ pub fn applyEnvKnobs(arena: Allocator, environ_map: anytype) !void {
             }
             rlm.sync();
         }
+        if (environ_map.get("GRAFF_RLM_MCP")) |v| {
+            const off = std.mem.eql(u8, v, "0") or std.ascii.eqlIgnoreCase(v, "false") or std.ascii.eqlIgnoreCase(v, "off") or std.ascii.eqlIgnoreCase(v, "no");
+            @import("rlm_mcp.zig").host_enabled = !off;
+        }
     }
     if (environ_map.get("GRAFF_NO_LOCAL_TOOLS")) |v| no_local_tools.enabled = no_local_tools.enabled or no_local_tools.envEnables(v);
     // GRAFF_LEAN: presence-based, exactly matching session_start.leanSkipsMcp

--- a/src/session_settings.zig
+++ b/src/session_settings.zig
@@ -28,6 +28,7 @@ const no_local_tools = @import("no_local_tools.zig"); // #330: GRAFF_NO_LOCAL_TO
 const tool_handle = @import("tool_handle.zig"); // #440: GRAFF_TOOL_HANDLE_BYTES
 const server_compact = @import("agent_server_compact.zig"); // GRAFF_SERVER_COMPACT + #compact-ab assignment
 const provider_mod = @import("provider.zig");
+const xai_hosted = @import("xai_hosted.zig"); // GRAFF_XAI_X_SEARCH
 const skills = @import("skills.zig");
 const anim = @import("anim.zig");
 
@@ -206,6 +207,10 @@ pub fn applyEnvKnobs(arena: Allocator, environ_map: anytype) !void {
     // but "responses") moves it back to chat completions; unset keeps the default.
     if (environ_map.get("GRAFF_XAI_WIRE")) |v| {
         provider_mod.g_xai_responses = std.ascii.eqlIgnoreCase(std.mem.trim(u8, v, " \t"), "responses");
+    }
+    if (environ_map.get("GRAFF_XAI_X_SEARCH")) |v| {
+        const off = std.mem.eql(u8, v, "0") or std.ascii.eqlIgnoreCase(v, "false") or std.ascii.eqlIgnoreCase(v, "off") or std.ascii.eqlIgnoreCase(v, "no");
+        xai_hosted.enabled = !off;
     }
     if (environ_map.get("GRAFF_XAI_URL")) |v| {
         if (v.len > 0) provider_mod.g_xai_url_override = v;

--- a/src/session_settings.zig
+++ b/src/session_settings.zig
@@ -137,6 +137,7 @@ pub fn applyEnvKnobs(arena: Allocator, environ_map: anytype) !void {
             const off = std.mem.eql(u8, v, "0") or std.ascii.eqlIgnoreCase(v, "false") or std.ascii.eqlIgnoreCase(v, "off") or std.ascii.eqlIgnoreCase(v, "no");
             @import("rlm_mcp.zig").host_enabled = !off;
         }
+        if (environ_map.get("GRAFF_RLM_CONTEXT")) |v| native_fold.applyContextEnv(v);
     }
     if (environ_map.get("GRAFF_NO_LOCAL_TOOLS")) |v| no_local_tools.enabled = no_local_tools.enabled or no_local_tools.envEnables(v);
     // GRAFF_LEAN: presence-based, matching session_start.leanMode

--- a/src/session_settings.zig
+++ b/src/session_settings.zig
@@ -231,6 +231,9 @@ pub fn applyEnvKnobs(arena: Allocator, environ_map: anytype) !void {
     if (environ_map.get("GRAFF_WS_FORCE_FAIL_COUNT")) |v| {
         ws.g_force_connect_failure_count = std.fmt.parseInt(u8, std.mem.trim(u8, v, " \t"), 10) catch 0;
     }
+    if (environ_map.get("GRAFF_MAX_TURN_MODEL_CALLS")) |v| {
+        @import("turn_chrome.zig").max_turn_model_calls = @import("turn_chrome.zig").parseMaxTurnCalls(v);
+    }
 }
 
 pub fn setupSkillsAndTheme(io: Io, arena: Allocator, environ_map: anytype, out: *Io.Writer, flags: args.Flags, use_color: bool, json_mode: bool, cwd_display: []const u8) !ThemeSetup {

--- a/src/session_settings_tests.zig
+++ b/src/session_settings_tests.zig
@@ -44,6 +44,7 @@ const knobs = [_]Knob{
     .{ .name = "GRAFF_CLOCK_SLEEP", .value = "1" },
     .{ .name = "GRAFF_RLM", .value = "1" },
     .{ .name = "GRAFF_RLM_MCP", .value = "0" },
+    .{ .name = "GRAFF_RLM_CONTEXT", .value = "32k" },
     .{ .name = "GRAFF_OLD", .value = "1" },
     .{ .name = "GRAFF_NO_LOCAL_TOOLS", .value = "1" },
     .{ .name = "GRAFF_CODEX_WS_IDLE_SECS", .value = "11" },
@@ -92,6 +93,9 @@ const Saved = struct {
     rlm: bool,
     rlm_cli: bool,
     rlm_mcp: bool,
+    rlm_context_off: bool,
+    rlm_context_pct: ?u8,
+    rlm_context_tokens: ?u64,
     stream_stall_ms: u64,
     post_deadline_ms: u64,
     codex_ws_idle_ms: i64,
@@ -118,6 +122,9 @@ const Saved = struct {
             .rlm = @import("rlm.zig").available,
             .rlm_cli = @import("rlm.zig").cli_set,
             .rlm_mcp = @import("rlm_mcp.zig").host_enabled,
+            .rlm_context_off = @import("native_fold.zig").g_context_off,
+            .rlm_context_pct = @import("native_fold.zig").g_context_pct,
+            .rlm_context_tokens = @import("native_fold.zig").g_context_tokens,
             .stream_stall_ms = http.stream_stall_ms,
             .post_deadline_ms = http.post_deadline_ms,
             .codex_ws_idle_ms = agent_ws.codex_ws_idle_ms,
@@ -146,6 +153,9 @@ const Saved = struct {
         @import("rlm.zig").cli_set = s.rlm_cli;
         @import("rlm.zig").sync();
         @import("rlm_mcp.zig").host_enabled = s.rlm_mcp;
+        @import("native_fold.zig").g_context_off = s.rlm_context_off;
+        @import("native_fold.zig").g_context_pct = s.rlm_context_pct;
+        @import("native_fold.zig").g_context_tokens = s.rlm_context_tokens;
         http.stream_stall_ms = s.stream_stall_ms;
         http.post_deadline_ms = s.post_deadline_ms;
         agent_ws.codex_ws_idle_ms = s.codex_ws_idle_ms;
@@ -204,6 +214,7 @@ test "applyEnvKnobs actually applies the values it reads" {
     plugins.disabled = false;
     mcp_schema_gate.g_stable_catalog = false;
     @import("xai_hosted.zig").enabled = true;
+    @import("native_fold.zig").resetContextKnob();
 
     var asked: [knobs.len]bool = @splat(false);
     try session_settings.applyEnvKnobs(arena_state.allocator(), RecordingEnv{ .asked = &asked });
@@ -226,6 +237,7 @@ test "applyEnvKnobs actually applies the values it reads" {
     try std.testing.expect(plugins.disabled);
     try std.testing.expect(mcp_schema_gate.g_stable_catalog); // GRAFF_STABLE_CATALOG=1 wins over GRAFF_NO_STABLE_CATALOG=1
     try std.testing.expect(!@import("xai_hosted.zig").enabled); // GRAFF_XAI_X_SEARCH=0
+    try std.testing.expectEqual(@as(?u64, 32_000), @import("native_fold.zig").g_context_tokens);
 }
 
 const PairEnv = struct {
@@ -287,6 +299,26 @@ test "GRAFF_STABLE_CATALOG=0 / GRAFF_NO_STABLE_CATALOG turn default-on catalog o
     mcp_schema_gate.g_stable_catalog = true;
     try session_settings.applyEnvKnobs(arena_state.allocator(), PairEnv{ .pairs = &.{.{ .name = "GRAFF_NO_STABLE_CATALOG", .value = "1" }} });
     try std.testing.expect(!mcp_schema_gate.g_stable_catalog);
+}
+
+test "GRAFF_RLM_CONTEXT parses percent, absolute tokens, and off" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const saved = Saved.capture();
+    defer saved.restore();
+    const fold = @import("native_fold.zig");
+    fold.resetContextKnob();
+    try session_settings.applyEnvKnobs(arena_state.allocator(), PairEnv{ .pairs = &.{.{ .name = "GRAFF_RLM_CONTEXT", .value = "32k" }} });
+    try std.testing.expectEqual(@as(?u64, 32_000), fold.g_context_tokens);
+    try std.testing.expectEqual(@as(?u64, 32_000), fold.contextThreshold(200_000));
+    fold.resetContextKnob();
+    try session_settings.applyEnvKnobs(arena_state.allocator(), PairEnv{ .pairs = &.{.{ .name = "GRAFF_RLM_CONTEXT", .value = "50%" }} });
+    try std.testing.expectEqual(@as(?u8, 50), fold.g_context_pct);
+    try std.testing.expectEqual(@as(?u64, 40_000), fold.contextThreshold(80_000));
+    fold.resetContextKnob();
+    try session_settings.applyEnvKnobs(arena_state.allocator(), PairEnv{ .pairs = &.{.{ .name = "GRAFF_RLM_CONTEXT", .value = "off" }} });
+    try std.testing.expect(fold.g_context_off);
+    try std.testing.expectEqual(@as(?u64, null), fold.contextThreshold(80_000));
 }
 
 test "GRAFF_XAI_X_SEARCH=0 turns hosted x_search off" {

--- a/src/session_settings_tests.zig
+++ b/src/session_settings_tests.zig
@@ -43,6 +43,7 @@ const knobs = [_]Knob{
     .{ .name = "GRAFF_CODEX_WS", .value = "off" },
     .{ .name = "GRAFF_CLOCK_SLEEP", .value = "1" },
     .{ .name = "GRAFF_RLM", .value = "1" },
+    .{ .name = "GRAFF_RLM_MCP", .value = "0" },
     .{ .name = "GRAFF_OLD", .value = "1" },
     .{ .name = "GRAFF_NO_LOCAL_TOOLS", .value = "1" },
     .{ .name = "GRAFF_CODEX_WS_IDLE_SECS", .value = "11" },
@@ -89,6 +90,7 @@ const Saved = struct {
     clock_sleep: bool,
     rlm: bool,
     rlm_cli: bool,
+    rlm_mcp: bool,
     stream_stall_ms: u64,
     post_deadline_ms: u64,
     codex_ws_idle_ms: i64,
@@ -113,6 +115,7 @@ const Saved = struct {
             .clock_sleep = main_mod.g_clock_sleep,
             .rlm = @import("rlm.zig").available,
             .rlm_cli = @import("rlm.zig").cli_set,
+            .rlm_mcp = @import("rlm_mcp.zig").host_enabled,
             .stream_stall_ms = http.stream_stall_ms,
             .post_deadline_ms = http.post_deadline_ms,
             .codex_ws_idle_ms = agent_ws.codex_ws_idle_ms,
@@ -139,6 +142,7 @@ const Saved = struct {
         @import("rlm.zig").available = s.rlm;
         @import("rlm.zig").cli_set = s.rlm_cli;
         @import("rlm.zig").sync();
+        @import("rlm_mcp.zig").host_enabled = s.rlm_mcp;
         http.stream_stall_ms = s.stream_stall_ms;
         http.post_deadline_ms = s.post_deadline_ms;
         agent_ws.codex_ws_idle_ms = s.codex_ws_idle_ms;
@@ -251,6 +255,17 @@ test "GRAFF_OLD / GRAFF_RLM=0 turn default rlm off; --old is not clobbered by en
     try session_settings.applyEnvKnobs(arena_state.allocator(), PairEnv{ .pairs = &.{.{ .name = "GRAFF_RLM", .value = "1" }} });
     try std.testing.expect(!rlm.available);
     try std.testing.expect(rlm.cli_set);
+}
+
+test "GRAFF_RLM_MCP=0 turns MCP-inside-rlm host functions off" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const saved = Saved.capture();
+    defer saved.restore();
+    const rlm_mcp = @import("rlm_mcp.zig");
+    rlm_mcp.host_enabled = true;
+    try session_settings.applyEnvKnobs(arena_state.allocator(), PairEnv{ .pairs = &.{.{ .name = "GRAFF_RLM_MCP", .value = "0" }} });
+    try std.testing.expect(!rlm_mcp.host_enabled);
 }
 
 test "GRAFF_STABLE_CATALOG=0 / GRAFF_NO_STABLE_CATALOG turn default-on catalog off" {

--- a/src/session_settings_tests.zig
+++ b/src/session_settings_tests.zig
@@ -57,6 +57,7 @@ const knobs = [_]Knob{
     .{ .name = "GRAFF_STABLE_CATALOG", .value = "1" },
     .{ .name = "GRAFF_NO_STABLE_CATALOG", .value = "1" },
     .{ .name = "GRAFF_VERCEL_URL", .value = "https://ai-gateway.vercel.sh/v1/chat/completions" },
+    .{ .name = "GRAFF_XAI_X_SEARCH", .value = "0" },
 };
 
 /// A stand-in for the process environment that records which names were asked
@@ -103,6 +104,7 @@ const Saved = struct {
     ws_fail_count: u8,
     plugins_off: bool,
     stable_catalog: bool,
+    x_search: bool,
 
     fn capture() Saved {
         return .{
@@ -128,6 +130,7 @@ const Saved = struct {
             .ws_fail_count = ws.g_force_connect_failure_count,
             .plugins_off = plugins.disabled,
             .stable_catalog = mcp_schema_gate.g_stable_catalog,
+            .x_search = @import("xai_hosted.zig").enabled,
         };
     }
 
@@ -155,6 +158,7 @@ const Saved = struct {
         ws.g_force_connect_failure_count = s.ws_fail_count;
         plugins.disabled = s.plugins_off;
         mcp_schema_gate.g_stable_catalog = s.stable_catalog;
+        @import("xai_hosted.zig").enabled = s.x_search;
     }
 };
 
@@ -199,6 +203,7 @@ test "applyEnvKnobs actually applies the values it reads" {
     tool_handle.threshold_bytes = tool_handle.default_threshold_bytes;
     plugins.disabled = false;
     mcp_schema_gate.g_stable_catalog = false;
+    @import("xai_hosted.zig").enabled = true;
 
     var asked: [knobs.len]bool = @splat(false);
     try session_settings.applyEnvKnobs(arena_state.allocator(), RecordingEnv{ .asked = &asked });
@@ -220,6 +225,7 @@ test "applyEnvKnobs actually applies the values it reads" {
     try std.testing.expectEqual(@as(u8, 3), ws.g_force_connect_failure_count);
     try std.testing.expect(plugins.disabled);
     try std.testing.expect(mcp_schema_gate.g_stable_catalog); // GRAFF_STABLE_CATALOG=1 wins over GRAFF_NO_STABLE_CATALOG=1
+    try std.testing.expect(!@import("xai_hosted.zig").enabled); // GRAFF_XAI_X_SEARCH=0
 }
 
 const PairEnv = struct {
@@ -281,4 +287,15 @@ test "GRAFF_STABLE_CATALOG=0 / GRAFF_NO_STABLE_CATALOG turn default-on catalog o
     mcp_schema_gate.g_stable_catalog = true;
     try session_settings.applyEnvKnobs(arena_state.allocator(), PairEnv{ .pairs = &.{.{ .name = "GRAFF_NO_STABLE_CATALOG", .value = "1" }} });
     try std.testing.expect(!mcp_schema_gate.g_stable_catalog);
+}
+
+test "GRAFF_XAI_X_SEARCH=0 turns hosted x_search off" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const saved = Saved.capture();
+    defer saved.restore();
+    const hosted = @import("xai_hosted.zig");
+    hosted.enabled = true;
+    try session_settings.applyEnvKnobs(arena_state.allocator(), PairEnv{ .pairs = &.{.{ .name = "GRAFF_XAI_X_SEARCH", .value = "0" }} });
+    try std.testing.expect(!hosted.enabled);
 }

--- a/src/session_start.zig
+++ b/src/session_start.zig
@@ -439,10 +439,10 @@ pub fn initRegistryConsent(io: Io, gpa: Allocator, arena: Allocator, out: *Io.Wr
     }
     const mcp_count = mcp_cli.countMcpServers(merged);
     const defer_join = flags.effectiveYolo() and flags.oneshot_prompt == null and !json_mode;
+    // Lean folds schemas (deferAllRuntime); it does not skip connect.
+    // --yolo / -p still connect so `.mcp.json` works on the default one-shot
+    // (ADR 0029). Interactive without --yolo still asks.
     var connect_mcp = flags.yolo_flag or mcp_count == 0;
-    // Lean: home MCP (Smolify) was 1.4kB of load_tool_schemas on every
-    // turn. Sessions that need MCP pass --no-lean (ADR 0024).
-    if (leanMode(flags.effectiveLean(), environ_map)) connect_mcp = false;
     if (mcp_count > 0 and !flags.yolo_flag and !json_mode and use_color) {
         sink.emit(io, .{ .mcp_consent_prompt = .{ .count = mcp_count } });
         // Still an inline read: only the QUESTION is inverted here, and the

--- a/src/session_start.zig
+++ b/src/session_start.zig
@@ -527,9 +527,8 @@ pub fn connectCompanion(io: Io, arena: Allocator, registry: *mcp.Registry, flags
         }
     }
 
-    // Smolify schemas are bundled and its hosted transport stays offline until
-    // an approved call. Full/authenticated/write tools require explicit opt-in.
-    if (environ_map.get("GRAFF_NO_SMOLIFY") != null) return;
+    // Smolify is opt-in: GRAFF_SMOLIFY=1 or GRAFF_SMOLIFY_ACCESS=public|full.
+    if (!@import("tool_surface.zig").smolifyWanted(environ_map)) return;
     const access = environ_map.get("GRAFF_SMOLIFY_ACCESS") orelse "public";
     const full_access = std.ascii.eqlIgnoreCase(access, "full") or std.ascii.eqlIgnoreCase(access, "authenticated");
     const added = registry.connectSmolify(full_access) catch |err| {

--- a/src/skills.zig
+++ b/src/skills.zig
@@ -67,7 +67,7 @@ pub const skills_registry = [_]SkillDef{
 /// Edits inside the cwd stay native: edit_file/write_file are
 /// /rewind-snapshotted and already splice via zigpatch, whereas codedb-pro
 /// edit/patch/replace bypass /rewind. Explicit external targets use gated bash.
-const codedbpro_note_licensed = "The codedb-pro MCP server is connected and LICENSED — its mcp__codedbpro__* tools (load once per session via load_tool_schemas, e.g. by query) REPLACE the native read/search defaults, which are BLOCKED while the server is healthy: read/search calls are refused with a pointer to the pro equivalent, shell searches to `zigrep` via bash; any codedb-pro failure unblocks the natives for the rest of the session. Size reads to the file: mode=full in ONE call for small files — outline/symbol/lines modes are for files too big to read whole. KEEP EDITS on the native edit_file/write_file tools — codedb-pro edit/patch/replace bypass /rewind; the cwd and explicit-external-target rules above apply unchanged.";
+const codedbpro_note_licensed = "The codedb-pro MCP server is connected and LICENSED — its mcp__codedbpro__* tools (load once per session via load_tool_schemas, e.g. by query) REPLACE native read/search (read_file and the legacy codedb tool are hidden). Shell cat/grep/sed/head of source is redirected or refused. KEEP EDITS on native edit_file/write_file — codedb-pro write tools are hidden because they bypass /rewind. Size reads to the file: mode=full in ONE call for small files — outline/symbol/lines for files too big to read whole. Any codedb-pro failure unblocks the natives for the rest of the session.";
 
 const McpNote = struct { server: []const u8, note: []const u8 };
 pub const mcp_notes = [_]McpNote{

--- a/src/startup.zig
+++ b/src/startup.zig
@@ -127,8 +127,9 @@ pub fn buildSystemPrompt(
     }
     if (unattended) sys_normal = try std.fmt.allocPrint(arena, "{s}{s}", .{ sys_normal, prompts.unattended_note });
     // ADR 0030 / 0011: do not splice rlm_spec.system_note onto the always-on
-    // prefix. Small turns must not advertise rlm/sPTC; discovery is listing
-    // or autoLoad after showcase (--rlm or a wide native batch).
+    // prefix. Small turns must not advertise rlm/sPTC; discovery is the
+    // catalog tail after showcase (--rlm, a wide native batch, or context
+    // ≥50% of compactAt).
     // Codex-style skills: one capability line per installed optional
     // companion (skills_registry) — metadata in context, --help on demand.
     // Lean one-shots do not need companion essays (ADR 0024 prefix tax).

--- a/src/startup.zig
+++ b/src/startup.zig
@@ -126,9 +126,9 @@ pub fn buildSystemPrompt(
         if (@import("repo_map.zig").segment(io, arena)) |map| sys_normal = try std.fmt.allocPrint(arena, "{s}{s}", .{ sys_normal, map });
     }
     if (unattended) sys_normal = try std.fmt.allocPrint(arena, "{s}{s}", .{ sys_normal, prompts.unattended_note });
-    // Lean already puts rlm on the catalog; the system_note is duplicate prefix.
-    if (@import("rlm_spec.zig").available and !@import("no_local_tools.zig").lean)
-        sys_normal = try std.fmt.allocPrint(arena, "{s}{s}", .{ sys_normal, @import("rlm_spec.zig").system_note });
+    // ADR 0030 / 0011: do not splice rlm_spec.system_note onto the always-on
+    // prefix. Small turns must not advertise rlm/sPTC; discovery is listing
+    // or autoLoad after showcase (--rlm or a wide native batch).
     // Codex-style skills: one capability line per installed optional
     // companion (skills_registry) — metadata in context, --help on demand.
     // Lean one-shots do not need companion essays (ADR 0024 prefix tax).

--- a/src/subagent_run.zig
+++ b/src/subagent_run.zig
@@ -277,6 +277,7 @@ pub fn runSub(ctx: ToolCtx, kind: []const u8, label: []const u8, prompt: []const
         .label = label,
         .out = null,
         .approvals = ctx.approvals,
+        .registry = ctx.registry,
         .tracer = ctx.tracer,
         .run_budget = ctx.run_budget,
         .loop_deadline_ms = ctx.loop_deadline_ms, // a timed run's deadline reaches grandchildren too, not just depth 1

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -148,6 +148,10 @@ const plugin_codex = @import("plugin_codex.zig"); // Codex config.toml → Plugi
 // decls, but the hook makes the coverage explicit rather than contingent on
 // that staying true.
 const mcp_config = @import("mcp_config.zig");
+const turn_chrome = @import("turn_chrome.zig"); // #624 pulse + retry chrome
+const tool_surface = @import("tool_surface.zig");
+const agent_catalog = @import("agent_catalog.zig");
+const session_connect_tests = @import("session_connect_tests.zig");
 const effort_route = @import("effort_route.zig");
 
 // #416: two-phase MCP tool exposure. schema.zig/exec.zig reach the gate, but
@@ -320,4 +324,8 @@ test {
     _ = commands_sandbox;
     _ = sandbox_tests;
     _ = provider_tests;
+    _ = turn_chrome;
+    _ = tool_surface;
+    _ = agent_catalog;
+    _ = session_connect_tests;
 }

--- a/src/tool_gates.zig
+++ b/src/tool_gates.zig
@@ -91,6 +91,18 @@ pub fn withAvailable(comptime Spec: type, arena: Allocator, base: []const Spec, 
     return buf[0..i];
 }
 
+/// One catalog-assembly pass: optional tools, then #330/#lean, then the
+/// licensed surface filter (hide read_file/codedb when codedb-pro is in charge).
+pub fn assembleRoot(comptime Spec: type, arena: Allocator, base: []const Spec, optional: []const Spec) ![]const Spec {
+    const no_local_tools = @import("no_local_tools.zig");
+    const tool_surface = @import("tool_surface.zig");
+    const with_opt = try withAvailable(Spec, arena, base, optional);
+    const gated = try no_local_tools.filterRootSpecs(Spec, arena, with_opt);
+    const lean = try no_local_tools.filterLeanSpecs(Spec, arena, gated);
+    const compact = try no_local_tools.compactLeanSpecs(Spec, arena, lean);
+    return tool_surface.filterSpecs(Spec, arena, compact);
+}
+
 test { // the served catalogs' wire-compatibility guard (an unreferenced module's tests never run)
     _ = @import("tool_schema_tests.zig");
     _ = @import("spec_catalog_conformance.zig");

--- a/src/tool_surface.zig
+++ b/src/tool_surface.zig
@@ -1,0 +1,271 @@
+//! Licensed catalog/exec policy: one read/search surface, one edit surface.
+//!
+//! When codedb-pro is licensed, hide native `read_file` and legacy `codedb`.
+//! Companion write tools (edit/patch/create/replace) are omitted always — they
+//! bypass /rewind. Native `edit_file`/`write_file` stay. `subagent` stays.
+//! webfetch is not hidden here (optional extra, not this change).
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const main_mod = @import("main.zig");
+const tools = @import("tools.zig");
+const mcp = @import("mcp.zig");
+
+const companion_write = [_][]const u8{
+    "edit", "patch", "create", "replace", "byte_delta",
+};
+
+const search_bash = [_][]const u8{
+    "grep", "rg", "find", "cat", "head", "tail", "sed", "awk", "egrep", "ripgrep",
+};
+
+pub fn isSearchBash(first: []const u8) bool {
+    for (search_bash) |w| if (std.mem.eql(u8, first, w)) return true;
+    return false;
+}
+
+pub fn isCompanionWrite(qualified: []const u8) bool {
+    const prefixes = [_][]const u8{ "mcp__codedbpro__", "mcp__muonry__" };
+    for (prefixes) |prefix| {
+        if (!std.mem.startsWith(u8, qualified, prefix)) continue;
+        const bare = qualified[prefix.len..];
+        for (companion_write) |w| if (std.mem.eql(u8, bare, w)) return true;
+        return false;
+    }
+    return false;
+}
+
+/// MCP names that must not appear in any catalog (companion writes + bundled
+/// smolify until opt-in connect actually adds it).
+pub fn omitMcp(qualified: []const u8) bool {
+    return isCompanionWrite(qualified);
+}
+
+/// Built-ins hidden from the advertised catalog. Never hides `subagent`.
+pub fn hideBuiltin(name: []const u8) bool {
+    if (!main_mod.g_codedbpro_licensed) return false;
+    return std.mem.eql(u8, name, "read_file") or std.mem.eql(u8, name, "codedb");
+}
+
+pub fn filterSpecs(comptime Spec: type, arena: Allocator, specs: []const Spec) ![]const Spec {
+    var drop: usize = 0;
+    for (specs) |spec| {
+        if (hideBuiltin(spec.name)) drop += 1;
+    }
+    if (drop == 0) return specs;
+    const buf = try arena.alloc(Spec, specs.len - drop);
+    var i: usize = 0;
+    for (specs) |spec| {
+        if (hideBuiltin(spec.name)) continue;
+        buf[i] = spec;
+        i += 1;
+    }
+    return buf[0..i];
+}
+
+/// Worker MCP: companion read/search only (no writes, no smolify).
+pub fn keepWorkerMcp(qualified: []const u8) bool {
+    if (omitMcp(qualified)) return false;
+    return std.mem.startsWith(u8, qualified, "mcp__codedbpro__") or
+        std.mem.startsWith(u8, qualified, "mcp__muonry__");
+}
+
+pub fn filterWorkerMcp(arena: Allocator, all: []const mcp.Tool) ![]const mcp.Tool {
+    var n: usize = 0;
+    for (all) |t| {
+        if (keepWorkerMcp(t.qualified_name)) n += 1;
+    }
+    if (n == all.len) return all;
+    const buf = try arena.alloc(mcp.Tool, n);
+    var i: usize = 0;
+    for (all) |t| {
+        if (!keepWorkerMcp(t.qualified_name)) continue;
+        buf[i] = t;
+        i += 1;
+    }
+    return buf[0..i];
+}
+
+pub const companion_write_refusal =
+    "codedb-pro write tools (edit/patch/create/replace) are hidden — they bypass /rewind. Use native edit_file for existing files and write_file for new files.";
+
+pub fn gate(ctx: tools.ToolCtx, call: tools.ToolCall) ?tools.ToolOutput {
+    if (!isCompanionWrite(call.name)) return null;
+    const text = ctx.gpa.dupe(u8, companion_write_refusal) catch return .{ .text = &.{}, .is_error = true };
+    return .{ .text = text, .is_error = true };
+}
+
+pub fn smolifyWanted(environ_map: anytype) bool {
+    if (environ_map.get("GRAFF_NO_SMOLIFY") != null) return false;
+    return environ_map.get("GRAFF_SMOLIFY") != null or environ_map.get("GRAFF_SMOLIFY_ACCESS") != null;
+}
+
+/// deepwiki / mobbin stay out of the default unauthenticated catalog unless
+/// an explicit opt-in env names them.
+pub fn skipOptionalServer(name: []const u8, environ_map: anytype) bool {
+    if (std.mem.eql(u8, name, "deepwiki")) return !optionalAllowed("deepwiki", environ_map);
+    if (std.mem.eql(u8, name, "mobbin")) return !optionalAllowed("mobbin", environ_map);
+    return false;
+}
+
+fn optionalAllowed(name: []const u8, environ_map: anytype) bool {
+    if (environ_map.get("GRAFF_MCP_OPTIONAL")) |v| {
+        var it = std.mem.tokenizeAny(u8, v, ", ");
+        while (it.next()) |tok| if (std.mem.eql(u8, tok, name)) return true;
+    }
+    if (std.mem.eql(u8, name, "deepwiki") and environ_map.get("GRAFF_DEEPWIKI") != null) return true;
+    if (std.mem.eql(u8, name, "mobbin") and environ_map.get("GRAFF_MOBBIN") != null) return true;
+    return false;
+}
+
+test "companion writes are omitted; reads are not" {
+    try std.testing.expect(isCompanionWrite("mcp__codedbpro__edit"));
+    try std.testing.expect(isCompanionWrite("mcp__codedbpro__patch"));
+    try std.testing.expect(isCompanionWrite("mcp__codedbpro__create"));
+    try std.testing.expect(isCompanionWrite("mcp__muonry__replace"));
+    try std.testing.expect(!isCompanionWrite("mcp__codedbpro__read"));
+    try std.testing.expect(!isCompanionWrite("mcp__codedbpro__faster_search"));
+    try std.testing.expect(!omitMcp("mcp__smolify__search_docs"));
+    try std.testing.expect(!omitMcp("mcp__codedbpro__read"));
+    try std.testing.expect(keepWorkerMcp("mcp__codedbpro__read"));
+    try std.testing.expect(!keepWorkerMcp("mcp__codedbpro__edit"));
+}
+
+test "hideBuiltin drops read_file/codedb only when licensed; never subagent" {
+    const saved = main_mod.g_codedbpro_licensed;
+    defer main_mod.g_codedbpro_licensed = saved;
+    main_mod.g_codedbpro_licensed = false;
+    try std.testing.expect(!hideBuiltin("read_file"));
+    try std.testing.expect(!hideBuiltin("codedb"));
+    try std.testing.expect(!hideBuiltin("subagent"));
+    try std.testing.expect(!hideBuiltin("edit_file"));
+    main_mod.g_codedbpro_licensed = true;
+    try std.testing.expect(hideBuiltin("read_file"));
+    try std.testing.expect(hideBuiltin("codedb"));
+    try std.testing.expect(!hideBuiltin("subagent"));
+    try std.testing.expect(!hideBuiltin("edit_file"));
+    try std.testing.expect(!hideBuiltin("write_file"));
+    try std.testing.expect(!hideBuiltin("webfetch"));
+}
+
+test "isSearchBash covers the licensed first-token list" {
+    try std.testing.expect(isSearchBash("grep"));
+    try std.testing.expect(isSearchBash("rg"));
+    try std.testing.expect(isSearchBash("find"));
+    try std.testing.expect(isSearchBash("cat"));
+    try std.testing.expect(isSearchBash("head"));
+    try std.testing.expect(isSearchBash("tail"));
+    try std.testing.expect(isSearchBash("sed"));
+    try std.testing.expect(isSearchBash("awk"));
+    try std.testing.expect(isSearchBash("egrep"));
+    try std.testing.expect(isSearchBash("ripgrep"));
+    try std.testing.expect(!isSearchBash("git"));
+    try std.testing.expect(!isSearchBash("zig"));
+}
+
+const FakeSpec = struct { name: []const u8 };
+test "filterSpecs drops hidden builtins and leaves the rest" {
+    const saved = main_mod.g_codedbpro_licensed;
+    defer main_mod.g_codedbpro_licensed = saved;
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const specs = [_]FakeSpec{
+        .{ .name = "bash" },
+        .{ .name = "read_file" },
+        .{ .name = "edit_file" },
+        .{ .name = "codedb" },
+        .{ .name = "subagent" },
+    };
+    main_mod.g_codedbpro_licensed = false;
+    const all = try filterSpecs(FakeSpec, arena_state.allocator(), &specs);
+    try std.testing.expectEqual(@as(usize, 5), all.len);
+    main_mod.g_codedbpro_licensed = true;
+    const filtered = try filterSpecs(FakeSpec, arena_state.allocator(), &specs);
+    try std.testing.expectEqual(@as(usize, 3), filtered.len);
+    try std.testing.expectEqualStrings("bash", filtered[0].name);
+    try std.testing.expectEqualStrings("edit_file", filtered[1].name);
+    try std.testing.expectEqualStrings("subagent", filtered[2].name);
+}
+
+test "licensed root catalog drops read_file and codedb, keeps subagent and edit_file" {
+    const schema = @import("schema.zig");
+    const saved = main_mod.g_codedbpro_licensed;
+    defer main_mod.g_codedbpro_licensed = saved;
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    main_mod.g_codedbpro_licensed = false;
+    const off = try schema.effectiveRootSpecs(a);
+    var saw_read = false;
+    var saw_sub = false;
+    for (off) |t| {
+        if (std.mem.eql(u8, t.name, "read_file")) saw_read = true;
+        if (std.mem.eql(u8, t.name, "subagent")) saw_sub = true;
+    }
+    try std.testing.expect(saw_read);
+    try std.testing.expect(saw_sub);
+
+    main_mod.g_codedbpro_licensed = true;
+    const on = try schema.effectiveRootSpecs(a);
+    var saw_edit = false;
+    var saw_sub2 = false;
+    for (on) |t| {
+        try std.testing.expect(!std.mem.eql(u8, t.name, "read_file"));
+        try std.testing.expect(!std.mem.eql(u8, t.name, "codedb"));
+        if (std.mem.eql(u8, t.name, "edit_file")) saw_edit = true;
+        if (std.mem.eql(u8, t.name, "subagent")) saw_sub2 = true;
+        if (std.mem.eql(u8, t.name, "write_file")) {}
+    }
+    try std.testing.expect(saw_edit);
+    try std.testing.expect(saw_sub2);
+}
+
+test "smolifyWanted and skipOptionalServer are opt-in" {
+    var env = std.process.Environ.Map.init(std.testing.allocator);
+    defer env.deinit();
+    try std.testing.expect(!smolifyWanted(env));
+    try std.testing.expect(skipOptionalServer("deepwiki", env));
+    try std.testing.expect(skipOptionalServer("mobbin", env));
+    try std.testing.expect(!skipOptionalServer("codedbpro", env));
+    try env.put("GRAFF_SMOLIFY", "1");
+    try std.testing.expect(smolifyWanted(env));
+    try env.put("GRAFF_MCP_OPTIONAL", "deepwiki,mobbin");
+    try std.testing.expect(!skipOptionalServer("deepwiki", env));
+    try std.testing.expect(!skipOptionalServer("mobbin", env));
+}
+
+test "worker specs drop read_file/codedb; worker MCP keeps reads not writes" {
+    const schema = @import("schema.zig");
+    const saved = main_mod.g_codedbpro_licensed;
+    defer main_mod.g_codedbpro_licensed = saved;
+    main_mod.g_codedbpro_licensed = true;
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    const specs = try filterSpecs(@TypeOf(schema.base_specs[0]), a, schema.base_specs[0..]);
+    var saw_edit = false;
+    for (specs) |t| {
+        try std.testing.expect(!std.mem.eql(u8, t.name, "read_file"));
+        try std.testing.expect(!std.mem.eql(u8, t.name, "codedb"));
+        try std.testing.expect(!std.mem.eql(u8, t.name, "subagent"));
+        if (std.mem.eql(u8, t.name, "edit_file")) saw_edit = true;
+    }
+    try std.testing.expect(saw_edit);
+    const fake = [_]mcp.Tool{
+        .{ .server_index = 0, .original_name = "read", .qualified_name = "mcp__codedbpro__read", .description = "d", .input_schema = .null },
+        .{ .server_index = 0, .original_name = "edit", .qualified_name = "mcp__codedbpro__edit", .description = "d", .input_schema = .null },
+    };
+    const kept = try filterWorkerMcp(a, &fake);
+    try std.testing.expectEqual(@as(usize, 1), kept.len);
+    try std.testing.expectEqualStrings("mcp__codedbpro__read", kept[0].qualified_name);
+    const mcp_gate = @import("mcp_schema_gate.zig");
+    const saved_policy = mcp_gate.g_policy;
+    defer mcp_gate.g_policy = saved_policy;
+    mcp_gate.g_policy = .{ .eager = &.{"codedbpro"} };
+    const json = try schema.renderRootTools(a, .openai, specs, kept);
+    try std.testing.expect(std.mem.indexOf(u8, json, "mcp__codedbpro__read") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "read_file") == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "mcp__codedbpro__edit") == null);
+}

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -195,6 +195,7 @@ pub fn runPostToolHooks(ctx: ToolCtx, call: ToolCall, out: ToolOutput) void {
 /// model adapts — same contract as a pre_tool hook's exit 2.
 pub fn codedbGuard(ctx: ToolCtx, call: ToolCall) ?ToolOutput {
     if (!main_mod.g_codedb_guard) return null;
+    if (main_mod.g_codedbpro_licensed) return null; // licensedGate owns read/search
     if (!std.mem.eql(u8, call.name, "bash")) return null;
     const cmd = strField(call.input, "command") orelse return null;
 

--- a/src/turn_chrome.zig
+++ b/src/turn_chrome.zig
@@ -1,0 +1,80 @@
+//! Dim chrome for long inner-loop turns and API transport retries (retry n/N).
+//!
+//! Production default: unlimited inner-loop model calls (`max_turn_model_calls = 0`).
+//! `GRAFF_MAX_TURN_MODEL_CALLS` is the opt-in cap. JSON mode is dropped inside
+//! `tool_pulse.emitNotice` (ADR 0020: chrome, not output).
+
+const std = @import("std");
+const Io = std.Io;
+
+const main_mod = @import("main.zig");
+const Agent = @import("agent.zig").Agent;
+const tool_pulse = @import("tool_pulse.zig");
+
+/// Per-turn inner-loop cap. 0 = unlimited (the production default).
+pub var max_turn_model_calls: u64 = 0;
+
+pub fn parseMaxTurnCalls(raw: []const u8) u64 {
+    const trimmed = std.mem.trim(u8, raw, " \t");
+    if (trimmed.len == 0) return 0;
+    return std.fmt.parseInt(u64, trimmed, 10) catch 0;
+}
+
+pub fn formatRetryNotice(buf: []u8, class: []const u8, attempt: usize, max_attempts: usize) []const u8 {
+    return std.fmt.bufPrint(buf, "· retry {d}/{d} · {s}", .{ attempt, max_attempts, class }) catch buf[0..0];
+}
+
+pub fn formatTurnPulse(buf: []u8, call_n: u64, cap: u64, tools: u64) []const u8 {
+    if (cap == 0)
+        return std.fmt.bufPrint(buf, "· turn still going · model call {d} · {d} tools", .{ call_n, tools }) catch buf[0..0];
+    return std.fmt.bufPrint(buf, "· turn still going · model call {d}/{d} · {d} tools", .{ call_n, cap, tools }) catch buf[0..0];
+}
+
+pub fn emitRetryNotice(io: Io, class: []const u8, attempt: usize, max_attempts: usize) void {
+    var buf: [120]u8 = undefined;
+    const text = formatRetryNotice(&buf, class, attempt, max_attempts);
+    if (text.len == 0) return;
+    tool_pulse.emitNotice(io, "{s}", .{text});
+}
+
+/// Count this inner-loop request, pulse from call 2, optionally pause if a
+/// non-zero cap is set. Returns pause text or null to proceed. Never pauses
+/// when the cap is 0.
+pub fn beforeRequest(self: *Agent) !?[]const u8 {
+    self.model_calls_this_turn += 1;
+    const cap = max_turn_model_calls;
+    if (self.model_calls_this_turn >= 2 and !self.sub and !main_mod.json_mode) {
+        var buf: [120]u8 = undefined;
+        const text = formatTurnPulse(&buf, self.model_calls_this_turn, cap, self.tool_calls_this_turn);
+        if (text.len > 0) tool_pulse.emitNotice(self.io, "{s}", .{text});
+    }
+    if (cap != 0 and self.model_calls_this_turn > cap) {
+        return try std.fmt.allocPrint(
+            self.arena,
+            "paused after {d} model calls this turn ({d} tools). Reply to continue, or steer.",
+            .{ cap, self.tool_calls_this_turn },
+        );
+    }
+    return null;
+}
+
+test "default inner-loop cap is unlimited / 0 unless an explicit override parses" {
+    try std.testing.expectEqual(@as(u64, 0), max_turn_model_calls);
+    try std.testing.expectEqual(@as(u64, 0), parseMaxTurnCalls(""));
+    try std.testing.expectEqual(@as(u64, 0), parseMaxTurnCalls("   "));
+    try std.testing.expectEqual(@as(u64, 0), parseMaxTurnCalls("nope"));
+    try std.testing.expectEqual(@as(u64, 32), parseMaxTurnCalls("32"));
+    try std.testing.expectEqual(@as(u64, 16), parseMaxTurnCalls(" 16 "));
+}
+
+test "formatRetryNotice names HungRequest and UnknownHostName with attempt n/N" {
+    var buf: [80]u8 = undefined;
+    try std.testing.expectEqualStrings("· retry 3/6 · HungRequest", formatRetryNotice(&buf, "HungRequest", 3, 6));
+    try std.testing.expectEqualStrings("· retry 1/6 · UnknownHostName", formatRetryNotice(&buf, "UnknownHostName", 1, 6));
+}
+
+test "formatTurnPulse omits a denominator when the cap is unlimited" {
+    var buf: [80]u8 = undefined;
+    try std.testing.expectEqualStrings("· turn still going · model call 3 · 11 tools", formatTurnPulse(&buf, 3, 0, 11));
+    try std.testing.expectEqualStrings("· turn still going · model call 3/64 · 11 tools", formatTurnPulse(&buf, 3, 64, 11));
+}

--- a/src/xai_hosted.zig
+++ b/src/xai_hosted.zig
@@ -1,0 +1,104 @@
+//! Hosted xAI tools on the Responses wire (`{"type":"x_search"}`).
+//!
+//! Not a graff catalog function and not on the always-on prefix (ADR 0011 /
+//! 0013). xAI runs the search server-side; graff must never local-exec the
+//! resulting `custom_tool_call` / `x_search_call`. Chat-completions and
+//! non-xAI Responses providers never see this splice.
+//! `GRAFF_XAI_X_SEARCH=0|off|false|no` turns the default off.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Value = std.json.Value;
+const Io = std.Io;
+
+const Provider = @import("provider.zig").Provider;
+
+/// Test / env seam. `applyEnvKnobs` sets this from GRAFF_XAI_X_SEARCH.
+pub var enabled: bool = true;
+
+pub fn active(provider_id: []const u8, kind: Provider.Kind) bool {
+    return enabled and kind == .responses and std.mem.eql(u8, provider_id, "xai");
+}
+
+/// Append `{"type":"x_search"}` when the tools array does not already carry it.
+/// Invalid JSON is returned unchanged so the existing writer path still fires.
+pub fn splice(arena: Allocator, tools_json: []const u8) ![]const u8 {
+    var value = std.json.parseFromSliceLeaky(Value, arena, tools_json, .{ .allocate = .alloc_always }) catch return tools_json;
+    if (value != .array) return tools_json;
+    for (value.array.items) |tool| {
+        if (hostedType(tool)) return tools_json;
+    }
+    var obj: std.json.ObjectMap = .empty;
+    try obj.put(arena, "type", .{ .string = "x_search" });
+    try value.array.append(.{ .object = obj });
+    var aw: Io.Writer.Allocating = .init(arena);
+    var s: std.json.Stringify = .{ .writer = &aw.writer };
+    try s.write(value);
+    return aw.toOwnedSlice();
+}
+
+fn hostedType(tool: Value) bool {
+    if (tool != .object) return false;
+    const t = if (tool.object.get("type")) |v| (if (v == .string) v.string else "") else "";
+    return std.mem.eql(u8, t, "x_search");
+}
+
+/// Server-executed search items: keep them in history, never dispatch locally.
+pub fn isServerSideCall(itype: []const u8, name: []const u8) bool {
+    if (std.mem.eql(u8, itype, "x_search_call") or std.mem.eql(u8, itype, "web_search_call"))
+        return true;
+    if (!std.mem.eql(u8, itype, "custom_tool_call") and !std.mem.eql(u8, itype, "function_call"))
+        return false;
+    return std.mem.eql(u8, name, "x_search") or
+        std.mem.eql(u8, name, "x_keyword_search") or
+        std.mem.eql(u8, name, "x_semantic_search") or
+        std.mem.eql(u8, name, "x_user_search") or
+        std.mem.eql(u8, name, "x_thread_fetch");
+}
+
+test "active only for xAI Responses while enabled" {
+    const saved = enabled;
+    defer enabled = saved;
+    enabled = true;
+    try std.testing.expect(active("xai", .responses));
+    try std.testing.expect(!active("xai", .openai));
+    try std.testing.expect(!active("codex", .responses));
+    try std.testing.expect(!active("openai", .responses));
+    enabled = false;
+    try std.testing.expect(!active("xai", .responses));
+}
+
+test "splice appends hosted x_search once" {
+    const a = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(a);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const tools = "[{\"type\":\"function\",\"name\":\"bash\",\"parameters\":{\"type\":\"object\"}}]";
+    const out = try splice(arena, tools);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"type\":\"x_search\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"name\":\"bash\"") != null);
+    const again = try splice(arena, out);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, again, "\"type\":\"x_search\""));
+}
+
+test "splice of an empty tools array is just x_search" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const out = try splice(arena_state.allocator(), "[]");
+    try std.testing.expectEqualStrings("[{\"type\":\"x_search\"}]", out);
+}
+
+test "splice leaves invalid JSON alone" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    try std.testing.expectEqualStrings("not-json", try splice(arena_state.allocator(), "not-json"));
+}
+
+test "isServerSideCall matches the live xAI shapes and ignores bash" {
+    try std.testing.expect(isServerSideCall("custom_tool_call", "x_keyword_search"));
+    try std.testing.expect(isServerSideCall("x_search_call", ""));
+    try std.testing.expect(isServerSideCall("function_call", "x_search"));
+    try std.testing.expect(!isServerSideCall("function_call", "bash"));
+    try std.testing.expect(!isServerSideCall("function_call", "webfetch"));
+    try std.testing.expect(!isServerSideCall("message", "x_search"));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cut of `release/v0.0.277` at `cfb1493`. **No `v0.0.277` git tag.**

## What was already on the branch (`d422ee8`)

Not a large drop: **+499 / −42** in 21 files.

- Licensed codedb-pro: one read/search surface (`src/tool_surface.zig`)
- Turn / transport pulse; no default 16-call cap
- Smolify / deepwiki / mobbin opt-in (`GRAFF_SMOLIFY`)

## What this cut adds (L works)

Merge of MCP-inside-rlm + learnt slim (ADR 0029). Fat MCP results slim to identity keys; comments fold to `{n, latest_author}`. Shapes persist in `.graff/mcp-shapes.json`.

Full-harness SuperGrok grok-4.6 (`graff-dev-nolean`):

| | wall | in | calls |
|---|---:|---:|---:|
| **L** warm + slim | **14.8s** | 31k | 5 |
| **N** cold + slim | 20.8s | 30k | 5 |
| H pre-slim | 28.0s | 112k | 7 |

L is the later run in the same repo (shapes already on disk). Lean catalog (R) is a different prefix and is not on this front.

Suite on the merge: **1664 pass**, 1 skip. Ratchet floor 1664.

Notes: `CHANGELOG.md`, `docs/releases/v0.0.277.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

