### PR TITLE
Hide rlm/sPTC on small turns; showcase later

### DIFF
--- a/docs/adr/0022-rlm-is-opt-in-speculative-ptc.md
+++ b/docs/adr/0022-rlm-is-opt-in-speculative-ptc.md
@@ -84,8 +84,9 @@ regression* without a catalog tax. Per-task swings are one-rep variance.
   only). Launch flags `--rlm` / `--old` are in the `--schema` flags list.
 - Semicolons (outside strings) are statements, so a one-line script still
   speculates. Host positional fields include `bash` / `webfetch`. `print(a, b)`
-  joins binds. A short system note is spliced only while the flag is on so
-  the folded spec is discoverable without paying its schema.
+  joins binds. Do not splice `system_note` onto the always-on prefix
+  (ADR 0011 / 0030): small turns hide `rlm` until `--rlm` or a wide
+  native batch. sPTC stays wired for after unfold.
 - Scatter-gather tasks live in the `rlm` eval suite (`graff-evals/run.py
   --suite rlm`). Default `--suite all` runs core + rlm + swe. Measured
   2026-08-25 on grok-4.6 (one rep): both **4/4**, native **86.8s / 53564

--- a/docs/adr/0024-three-harness-compare-prompt-subagent-rss.md
+++ b/docs/adr/0024-three-harness-compare-prompt-subagent-rss.md
@@ -52,9 +52,9 @@ compare only.
 
 **Prompt hell-optimize (this revision):**
 
-- `rlm_spec.system_note` stays on the root prefix only (children use
-  `sub_system_prompt` — they never see `rlm(code)`). Shorten the note
-  without dropping persist / sidecar / print.
+- `rlm_spec.system_note` is not on the always-on prefix (ADR 0030).
+  Children already use `sub_system_prompt` and never see `rlm(code)`.
+  Keep the note short (persist / sidecar / print) for `--rlm` / load.
 - Child brief: do not broaden, do not narrate tool calls (grok + kimi).
 - Do not reshuffle messages. Keep `reasoning_content` replay (already
   pinned; grok's official top Chat cache-miss cause).

--- a/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
+++ b/docs/adr/0029-mcp-inside-rlm-and-return-shapes.md
@@ -109,6 +109,8 @@ signal. H/I 7-call structured is the stable cheap path today.
 - A later `len`/`for` would cut C/D/F/G retries; do not grow a general
   language without that measurement.
 - Prompting "prefer one rlm script" is not free. Default no-hint.
+- Small MCP/coding turns do not advertise `rlm` or sPTC (ADR 0030).
+  Do not showcase on first slim or an MCP comment fan-out.
 
 ## Pareto front (wall / tok_in / calls)
 

--- a/docs/adr/0030-rlm-late-showcase.md
+++ b/docs/adr/0030-rlm-late-showcase.md
@@ -1,0 +1,47 @@
+# 0030. Hide `rlm` on small turns; showcase later (sPTC rides unfold)
+
+Status: accepted 2026-08-25
+
+## Context
+
+L and N (Linear MCP, `--no-lean`, no `each()` hint) are the cheap path:
+structured `load_tool_schemas` → list + comments → `report.json`. They
+never call `rlm`. Advertising the spec on every turn still costs:
+
+- `--no-lean` spliced `rlm_spec.system_note` onto the always-on prefix
+  (~360 bytes, every request) and listed `rlm` among Folded-native tools;
+- `--lean` / `-p` unfolded the full schema onto the catalog (ADR 0024:
+  one-shots were doing N structured calls instead of one script).
+
+sPTC (`src/spec_ptc.zig` + `rlm.feedLive`) is not a catalog tool. It
+only runs when an `rlm` script streams. Listing `rlm` is what invites
+speculation — and on grok-4.6, an `each()` hint is a footgun (ADR 0029).
+Showcasing because MCP slims would push Linear back into that dialect.
+
+## Decision
+
+Fold `rlm` whenever it is available, including `--lean`. Omit it from
+the Folded-native listing and from `composeBase` / lean notes until a
+showcase. Do not splice `system_note` onto the prefix (ADR 0011).
+
+Showcase (listing + `markLoaded`, so the next catalog can carry the
+schema and sPTC is live) when:
+
+- `--rlm` / `setFromCli(true)` — immediate;
+- a structured batch of **≥4 native** host tools (`read_file`, `codedb`,
+  `bash`, `webfetch`) — the scatter-gather that sPTC overlaps;
+- explicit `load_tool_schemas tools=["rlm"]` (already `markLoaded`).
+
+Do **not** showcase on MCP-only fan-out, first slim, or fat-payload
+size. `/new` and `/clear` hide a session-discovered showcase; `--rlm`
+sticks for the process.
+
+## Consequences
+
+- L/N keep the structured MCP path: no `rlm` name, no system note, no
+  sPTC invitation. Token win is prefix + listing, not another hint.
+- Scatter-gather one-shots pay one wide native batch, then see `rlm`
+  and can stream-speculate. `--rlm` skips the wait.
+- Auto-load on a confident `rlm` call still works (`gateExec`).
+- Revisit if a measured coding one-shot regresses to N serial reads
+  because the model never emits a 4-wide batch and never sees `rlm`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,7 @@ record only when you need the evidence or the edge cases.
 | [0027](0027-kimi-identity-is-graff.md) | Kimi Coding User-Agent is `graff/<version>`, not a spoofed `kimi-code-cli` token. X-Msh device fields follow kimi-code's shapes. |
 | [0028](0028-codex-session-id-is-the-cache-key.md) | Codex HTTP/WS `session_id` is the `prompt_cache_key` (openai/codex ModelClient default), not a per-process random UUID. |
 | [0029](0029-mcp-inside-rlm-and-return-shapes.md) | Loaded MCP tools are rlm host functions; persist return shapes on the load result, never the prefix; fat MCP results auto-slim; default `-p` connects `.mcp.json` (folded, not skipped). |
+| [0030](0030-rlm-late-showcase.md) | Small turns hide `rlm` (and sPTC). Showcase on `--rlm`, a ≥4 native batch, or an explicit load — never on MCP fan-out or the prefix. |
 
 ## When to write one
 

--- a/src/agent_tools.zig
+++ b/src/agent_tools.zig
@@ -67,6 +67,12 @@ const rawNonblockStdin = Agent.rawNonblockStdin;
 /// Bash calls must clear the permission gate before dispatch. Results
 /// are returned in call order, arena-owned.
 pub fn runTools(self: *Agent, calls: []const ToolCall) ![]ExecResult {
+    if (!self.sub and calls.len >= 4) {
+        var names: [32][]const u8 = undefined;
+        const n = @min(calls.len, names.len);
+        for (calls[0..n], 0..) |c, i| names[i] = c.name;
+        if (native_fold.noticeWideNative(names[0..n])) self.invalidateRootTools();
+    }
     const results = try self.arena.alloc(ExecResult, calls.len);
     const eval_index = eval_control.evalCallIndex(calls);
     const blocks_completion = eval_control.batchBlocksCompletion(calls);

--- a/src/commands_session.zig
+++ b/src/commands_session.zig
@@ -79,6 +79,7 @@ pub fn resetConversationSteering(root: *Agent) void {
     // attempt_completion ended their steering - #318 through the /clear door.
     if (root.goal_flag) |g| root.goal = goal_flow.standingGoalFromFlag(g, null, root.todos.items, 0);
     @import("rlm_spec.zig").resetBindsSession(root.io);
+    @import("native_fold.zig").resetSession();
 }
 
 /// Try to handle a session/environment slash command. Returns false (line

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -460,6 +460,7 @@ test { // main.zig is at the 600-line cap; exec.zig is these modules' importer, 
     _ = @import("rlm_mcp.zig");
     _ = @import("rlm_reduce.zig");
     _ = @import("rlm_tests.zig");
+    _ = @import("native_fold_rlm.zig");
     _ = @import("mcp_shapes.zig");
     _ = @import("spec_ptc.zig");
 }

--- a/src/mcp_schema_gate.zig
+++ b/src/mcp_schema_gate.zig
@@ -507,7 +507,8 @@ pub fn descWithListing(arena: Allocator, all: []const mcp.Tool) ![]const u8 {
     var natives: std.ArrayList([]const u8) = .empty;
     if (native_fold.anyFolded() and !@import("no_local_tools.zig").lean) {
         for (native_fold.folded) |name| {
-            if (!native_fold.isFolded(name)) continue; // rlm stays off the default listing
+            if (!native_fold.isFolded(name)) continue;
+            if (std.mem.eql(u8, name, "rlm") and !native_fold.listed()) continue;
             if (!g_stable_catalog and native_fold.isLoaded(name)) continue;
             if (tool_surface.hideBuiltin(name)) continue;
             try natives.append(arena, name);

--- a/src/native_fold.zig
+++ b/src/native_fold.zig
@@ -55,8 +55,9 @@ pub const folded = [_][]const u8{
     "agent_output",
     "skill",
     "webfetch",
-    // ADR 0022: isFolded is false under --old so the structured-only
-    // load_tool_schemas listing stays byte-stable.
+    // ADR 0022 / 0030: isFolded is false under --old so the structured-only
+    // load_tool_schemas listing stays byte-stable. The name stays hidden
+    // until listed() — small turns do not advertise rlm or sPTC.
     "rlm",
 };
 
@@ -64,16 +65,81 @@ pub const folded = [_][]const u8{
 /// `rlm` joins the stack while available (default); `--old` drops it so the
 /// structured-only catalog and the meta-tool listing stay unchanged.
 pub fn isFolded(name: []const u8) bool {
-    // --lean / -p: rlm is the default loop (ADR 0022), not a late power
-    // tool. Folding it behind load_tool_schemas on a 5–10 turn one-shot
-    // made the model do N structured calls instead of one script (ADR 0024
-    // leftover token tax vs grok-build).
-    if (std.mem.eql(u8, name, "rlm"))
-        return @import("rlm_spec.zig").available and !@import("no_local_tools.zig").lean;
+    if (std.mem.eql(u8, name, "rlm")) return @import("rlm_spec.zig").available;
     for (folded) |tool| {
         if (std.mem.eql(u8, name, tool)) return true;
     }
     return false;
+}
+
+/// Session-discovered rlm (a wide native batch). `--rlm` sets `g_cli_forced`
+/// so /new does not hide it again. Never set this because MCP slims.
+var g_showcased: bool = false;
+var g_cli_forced: bool = false;
+
+/// Folded-native listing and catalog discovery: hidden on small turns.
+pub fn listed() bool {
+    return g_showcased or isLoaded("rlm");
+}
+
+pub fn showcaseRlm() void {
+    if (!@import("rlm_spec.zig").available) return;
+    g_showcased = true;
+}
+
+/// `--rlm` / `setFromCli(true)`: schema on the first catalog, sPTC live.
+pub fn showcaseFromCli() void {
+    if (!@import("rlm_spec.zig").available) return;
+    g_showcased = true;
+    g_cli_forced = true;
+    markLoaded("rlm");
+}
+
+/// `/new` and `/clear`: hide a session-discovered showcase. `--rlm` sticks.
+pub fn resetSession() void {
+    if (g_cli_forced) return;
+    g_showcased = false;
+    unmark("rlm");
+}
+
+/// Test + `--old` path: drop CLI-forced showcase too.
+pub fn resetRlmDiscovery() void {
+    g_cli_forced = false;
+    g_showcased = false;
+    unmark("rlm");
+}
+
+fn unmark(name: []const u8) void {
+    var i: usize = 0;
+    while (i < g_loaded_len) : (i += 1) {
+        if (std.mem.eql(u8, g_loaded[i], name)) {
+            if (i + 1 < g_loaded_len) g_loaded[i] = g_loaded[g_loaded_len - 1];
+            g_loaded_len -= 1;
+            return;
+        }
+    }
+}
+
+/// Host tools sPTC can overlap. MCP fan-out (Linear comments) must not
+/// showcase — that re-invites the each() footgun (ADR 0029).
+const wide_native = [_][]const u8{ "read_file", "codedb", "bash", "webfetch" };
+
+/// True when this batch newly showcased rlm (caller rebuilds the catalog).
+pub fn noticeWideNative(names: []const []const u8) bool {
+    if (listed() or !@import("rlm_spec.zig").available) return false;
+    var n: usize = 0;
+    for (names) |name| {
+        for (wide_native) |w| {
+            if (std.mem.eql(u8, name, w)) {
+                n += 1;
+                break;
+            }
+        }
+    }
+    if (n < 4) return false;
+    showcaseRlm();
+    markLoaded("rlm");
+    return true;
 }
 
 /// Whether the fold is live at all — hiddenSpec consults this so
@@ -374,115 +440,4 @@ test "explicit native loads rebuild the active provider catalog (#492)" {
     try std.testing.expect(isLoaded("workflow"));
     try std.testing.expectEqual(@as(usize, 1), agent.invalidations);
     try std.testing.expectEqual(@as(usize, 1), agent.rebuilds);
-}
-
-test "rlm joins the fold only while available (off under --old)" {
-    const rlm_spec = @import("rlm_spec.zig");
-    const saved_avail = rlm_spec.available;
-    const saved_enabled = enabled;
-    const saved_loaded = g_loaded;
-    const saved_loaded_len = g_loaded_len;
-    defer {
-        rlm_spec.available = saved_avail;
-        enabled = saved_enabled;
-        g_loaded = saved_loaded;
-        g_loaded_len = saved_loaded_len;
-    }
-    enabled = true;
-    g_loaded_len = 0;
-    rlm_spec.available = false;
-    try std.testing.expect(!isFolded("rlm"));
-    try std.testing.expect(!blocked("rlm"));
-
-    rlm_spec.available = true;
-    try std.testing.expect(isFolded("rlm"));
-    try std.testing.expect(blocked("rlm"));
-    markLoaded("rlm");
-    try std.testing.expect(isLoaded("rlm"));
-    try std.testing.expect(!blocked("rlm"));
-}
-
-test "folded rlm is a listing name, not a catalog schema; off stays off the listing" {
-    const schema_mod = @import("schema.zig");
-    const rlm = @import("rlm.zig");
-    const rlm_spec = @import("rlm_spec.zig");
-    const saved_avail = rlm.available;
-    const saved_spec = rlm_spec.available;
-    const saved_enabled = enabled;
-    const saved_loaded = g_loaded;
-    const saved_loaded_len = g_loaded_len;
-    defer {
-        rlm.available = saved_avail;
-        rlm_spec.available = saved_spec;
-        rlm.sync();
-        enabled = saved_enabled;
-        g_loaded = saved_loaded;
-        g_loaded_len = saved_loaded_len;
-    }
-    enabled = true;
-    g_loaded_len = 0;
-
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-    const meta = [_]schema_mod.ToolSpec{.{
-        .name = mcp_schema_gate.tool_name,
-        .desc = mcp_schema_gate.tool_desc,
-        .schema = mcp_schema_gate.tool_schema,
-    }};
-    const with_rlm = [_]schema_mod.ToolSpec{
-        meta[0],
-        .{ .name = rlm.tool_name, .desc = rlm.tool_desc, .schema = rlm.tool_schema },
-    };
-
-    rlm.available = false;
-    rlm.sync();
-    const off = try schema_mod.renderRootTools(arena, .openai, &meta, &.{});
-    try std.testing.expect(std.mem.indexOf(u8, off, "rlm") == null);
-
-    rlm.available = true;
-    rlm.sync();
-    const on = try schema_mod.renderRootTools(arena, .openai, &with_rlm, &.{});
-    try std.testing.expect(std.mem.indexOf(u8, on, "rlm") != null); // listing
-    try std.testing.expect(std.mem.indexOf(u8, on, "llm_query") == null); // full desc/schema stay folded
-    try std.testing.expect(std.mem.indexOf(u8, on, rlm.tool_schema) == null);
-}
-
-test "lean unfolds rlm into the catalog (one-shot loop, not a listing stub)" {
-    const schema_mod = @import("schema.zig");
-    const rlm = @import("rlm.zig");
-    const rlm_spec = @import("rlm_spec.zig");
-    const no_local = @import("no_local_tools.zig");
-    const saved_avail = rlm.available;
-    const saved_spec = rlm_spec.available;
-    const saved_enabled = enabled;
-    const saved_lean = no_local.lean;
-    const saved_loaded = g_loaded;
-    const saved_loaded_len = g_loaded_len;
-    defer {
-        rlm.available = saved_avail;
-        rlm_spec.available = saved_spec;
-        rlm.sync();
-        enabled = saved_enabled;
-        no_local.lean = saved_lean;
-        g_loaded = saved_loaded;
-        g_loaded_len = saved_loaded_len;
-    }
-    enabled = true;
-    g_loaded_len = 0;
-    no_local.lean = true;
-    rlm.available = true;
-    rlm.sync();
-    try std.testing.expect(!isFolded("rlm"));
-    try std.testing.expect(!catalogSkips("rlm"));
-
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-    const specs = [_]schema_mod.ToolSpec{
-        .{ .name = rlm.tool_name, .desc = rlm.tool_desc, .schema = rlm.tool_schema },
-    };
-    const json = try schema_mod.renderRootTools(arena, .openai, &specs, &.{});
-    try std.testing.expect(std.mem.indexOf(u8, json, "llm_query") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, rlm.tool_schema) != null);
 }

--- a/src/native_fold_rlm.zig
+++ b/src/native_fold_rlm.zig
@@ -116,7 +116,7 @@ test "lean keeps rlm folded until showcase; --rlm puts the schema on" {
     fold.showcaseFromCli();
     try std.testing.expect(fold.listed());
     try std.testing.expect(fold.isLoaded("rlm"));
-    try std.testing.expect(!fold.catalogSkips("rlm"));
+    // Stable catalog still skips the mid-array slot; the schema rides the tail.
     const shown = try schema_mod.renderRootTools(arena, .openai, &specs, &.{});
     try std.testing.expect(std.mem.indexOf(u8, shown, "llm_query") != null);
     try std.testing.expect(std.mem.indexOf(u8, shown, rlm.tool_schema) != null);

--- a/src/native_fold_rlm.zig
+++ b/src/native_fold_rlm.zig
@@ -1,0 +1,155 @@
+//! Late-showcase tests for folded `rlm` (ADR 0030). Split out of
+//! native_fold.zig so that file stays under the 600-line ceiling.
+
+const std = @import("std");
+const fold = @import("native_fold.zig");
+const schema_mod = @import("schema.zig");
+const rlm = @import("rlm.zig");
+const rlm_spec = @import("rlm_spec.zig");
+const mcp_schema_gate = @import("mcp_schema_gate.zig");
+const no_local = @import("no_local_tools.zig");
+
+fn isolate() void {
+    fold.enabled = true;
+    fold.resetRlmDiscovery();
+}
+
+test "rlm joins the fold only while available (off under --old)" {
+    const saved_avail = rlm_spec.available;
+    const saved_enabled = fold.enabled;
+    defer {
+        rlm_spec.available = saved_avail;
+        fold.enabled = saved_enabled;
+        fold.resetRlmDiscovery();
+    }
+    isolate();
+    rlm_spec.available = false;
+    try std.testing.expect(!fold.isFolded("rlm"));
+    try std.testing.expect(!fold.blocked("rlm"));
+
+    rlm_spec.available = true;
+    try std.testing.expect(fold.isFolded("rlm"));
+    try std.testing.expect(fold.blocked("rlm"));
+    fold.markLoaded("rlm");
+    try std.testing.expect(fold.isLoaded("rlm"));
+    try std.testing.expect(!fold.blocked("rlm"));
+}
+
+test "folded rlm stays off the listing until showcase; off stays off" {
+    const saved_avail = rlm.available;
+    const saved_spec = rlm_spec.available;
+    const saved_enabled = fold.enabled;
+    defer {
+        rlm.available = saved_avail;
+        rlm_spec.available = saved_spec;
+        rlm.sync();
+        fold.enabled = saved_enabled;
+        fold.resetRlmDiscovery();
+    }
+    isolate();
+
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const meta = [_]schema_mod.ToolSpec{.{
+        .name = mcp_schema_gate.tool_name,
+        .desc = mcp_schema_gate.tool_desc,
+        .schema = mcp_schema_gate.tool_schema,
+    }};
+    const with_rlm = [_]schema_mod.ToolSpec{
+        meta[0],
+        .{ .name = rlm.tool_name, .desc = rlm.tool_desc, .schema = rlm.tool_schema },
+    };
+
+    rlm.available = false;
+    rlm.sync();
+    const off = try schema_mod.renderRootTools(arena, .openai, &meta, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, off, "rlm") == null);
+
+    rlm.available = true;
+    rlm.sync();
+    try std.testing.expect(fold.isFolded("rlm"));
+    try std.testing.expect(!fold.listed());
+    const hidden = try schema_mod.renderRootTools(arena, .openai, &with_rlm, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, hidden, "rlm") == null);
+    try std.testing.expect(std.mem.indexOf(u8, hidden, "llm_query") == null);
+
+    fold.showcaseRlm();
+    try std.testing.expect(fold.listed());
+    const shown = try schema_mod.renderRootTools(arena, .openai, &with_rlm, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, shown, "rlm") != null);
+    try std.testing.expect(std.mem.indexOf(u8, shown, "llm_query") == null);
+    try std.testing.expect(std.mem.indexOf(u8, shown, rlm.tool_schema) == null);
+}
+
+test "lean keeps rlm folded until showcase; --rlm puts the schema on" {
+    const saved_avail = rlm.available;
+    const saved_spec = rlm_spec.available;
+    const saved_enabled = fold.enabled;
+    const saved_lean = no_local.lean;
+    defer {
+        rlm.available = saved_avail;
+        rlm_spec.available = saved_spec;
+        rlm.sync();
+        fold.enabled = saved_enabled;
+        no_local.lean = saved_lean;
+        fold.resetRlmDiscovery();
+    }
+    isolate();
+    no_local.lean = true;
+    rlm.available = true;
+    rlm.sync();
+    try std.testing.expect(fold.isFolded("rlm"));
+    try std.testing.expect(fold.catalogSkips("rlm"));
+    try std.testing.expect(!fold.listed());
+
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const specs = [_]schema_mod.ToolSpec{
+        .{ .name = rlm.tool_name, .desc = rlm.tool_desc, .schema = rlm.tool_schema },
+    };
+    const hidden = try schema_mod.renderRootTools(arena, .openai, &specs, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, hidden, "llm_query") == null);
+    try std.testing.expect(std.mem.indexOf(u8, hidden, rlm.tool_schema) == null);
+
+    fold.showcaseFromCli();
+    try std.testing.expect(fold.listed());
+    try std.testing.expect(fold.isLoaded("rlm"));
+    try std.testing.expect(!fold.catalogSkips("rlm"));
+    const shown = try schema_mod.renderRootTools(arena, .openai, &specs, &.{});
+    try std.testing.expect(std.mem.indexOf(u8, shown, "llm_query") != null);
+    try std.testing.expect(std.mem.indexOf(u8, shown, rlm.tool_schema) != null);
+}
+
+test "wide native batch showcases rlm; MCP fan-out does not" {
+    const saved_spec = rlm_spec.available;
+    defer {
+        rlm_spec.available = saved_spec;
+        fold.resetRlmDiscovery();
+    }
+    isolate();
+    rlm_spec.available = true;
+
+    try std.testing.expect(!fold.noticeWideNative(&.{ "read_file", "codedb", "bash" }));
+    try std.testing.expect(!fold.listed());
+    try std.testing.expect(!fold.noticeWideNative(&.{
+        "mcp__linear__list_comments",
+        "mcp__linear__list_comments",
+        "mcp__linear__list_comments",
+        "mcp__linear__list_comments",
+    }));
+    try std.testing.expect(!fold.listed());
+
+    try std.testing.expect(fold.noticeWideNative(&.{ "read_file", "codedb", "bash", "webfetch" }));
+    try std.testing.expect(fold.listed());
+    try std.testing.expect(fold.isLoaded("rlm"));
+
+    fold.resetSession();
+    try std.testing.expect(!fold.listed());
+    try std.testing.expect(!fold.isLoaded("rlm"));
+
+    fold.showcaseFromCli();
+    fold.resetSession();
+    try std.testing.expect(fold.listed());
+}

--- a/src/no_local_tools.zig
+++ b/src/no_local_tools.zig
@@ -379,7 +379,7 @@ test "lean prompt diet: no fan-out / trace / issue-filing; short local-tools not
     try std.testing.expect(std.mem.indexOf(u8, out, "Parallelize") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "ONE response") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "not covered by /rewind") == null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "rlm") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "rlm") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "SPEC.md") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "discard work") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "Fix root causes") == null);
@@ -398,6 +398,6 @@ test "lean catalog drops overflow pager and empty load_tool_schemas" {
     const json = try schema.renderRootTools(arena, .openai, specs, &.{});
     try std.testing.expect(std.mem.indexOf(u8, json, "read_tool_result") == null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"load_tool_schemas\"") == null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"rlm\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"rlm\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"read_file\"") != null);
 }

--- a/src/prompt_text.zig
+++ b/src/prompt_text.zig
@@ -262,9 +262,8 @@ pub const lean_local_tools_note =
     \\
     \\read_file before editing; prefer edit_file for existing files and
     \\write_file only for new files. Navigate with codedb (context, around,
-    \\callpath, list_dir, status) or one rlm script of those functions.
-    \\print(read_file("path")) returns the file — do not read it again.
-    \\Independent reads belong in ONE response or one rlm script, not a chain of turns.
+    \\callpath, list_dir, status).
+    \\Independent reads belong in ONE response, not a chain of turns.
     \\A passing verify command and attempt_completion belong in ONE response.
 ;
 
@@ -280,7 +279,7 @@ pub const lean_parallel_note =
 
 pub const lean_intro_note =
     \\You are a coding agent. Use the cataloged tools; never invent one.
-    \\Independent reads belong in ONE response (or one rlm script), not one per turn.
+    \\Independent reads belong in ONE response, not one per turn.
     \\A passing test and attempt_completion belong in ONE response.
 ;
 

--- a/src/rlm.zig
+++ b/src/rlm.zig
@@ -50,6 +50,7 @@ pub fn setFromCli(on: bool) void {
     available = on;
     cli_set = true;
     sync();
+    if (on) @import("native_fold.zig").showcaseFromCli() else @import("native_fold.zig").resetRlmDiscovery();
 }
 
 pub fn resetLive(gpa: Allocator, io: Io) void {
@@ -63,10 +64,10 @@ pub fn feedLive(ctx: ToolCtx, delta: []const u8) void {
     rlm_spec.feedLive(ctx, delta);
 }
 
-/// Append `rlm` after the lean/no-local filters so the default `-p` still
-/// sees it. The spec is folded behind `load_tool_schemas` (native_fold)
-/// until the model loads or calls it — the prefix stays the lean catalog
-/// plus a name. No-op when `--old` or embedder mode stripped host tools.
+/// Append `rlm` after the lean/no-local filters so a later showcase can
+/// put the spec on the catalog. Folded and unlisted until `--rlm`, a
+/// wide native batch, or an explicit load (ADR 0030). No-op when `--old`
+/// or embedder mode stripped host tools.
 pub fn maybeAppend(comptime Spec: type, arena: Allocator, specs: []const Spec) ![]const Spec {
     sync();
     if (!available or no_local_tools.enabled) return specs;

--- a/src/startup.zig
+++ b/src/startup.zig
@@ -126,9 +126,9 @@ pub fn buildSystemPrompt(
         if (@import("repo_map.zig").segment(io, arena)) |map| sys_normal = try std.fmt.allocPrint(arena, "{s}{s}", .{ sys_normal, map });
     }
     if (unattended) sys_normal = try std.fmt.allocPrint(arena, "{s}{s}", .{ sys_normal, prompts.unattended_note });
-    // Lean already puts rlm on the catalog; the system_note is duplicate prefix.
-    if (@import("rlm_spec.zig").available and !@import("no_local_tools.zig").lean)
-        sys_normal = try std.fmt.allocPrint(arena, "{s}{s}", .{ sys_normal, @import("rlm_spec.zig").system_note });
+    // ADR 0030 / 0011: do not splice rlm_spec.system_note onto the always-on
+    // prefix. Small turns must not advertise rlm/sPTC; discovery is listing
+    // or autoLoad after showcase (--rlm or a wide native batch).
     // Codex-style skills: one capability line per installed optional
     // companion (skills_registry) — metadata in context, --help on demand.
     // Lean one-shots do not need companion essays (ADR 0024 prefix tax).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Small MCP/coding turns (L and N) should not pay for `rlm` or speculative PTC. The cheap Linear path never calls `rlm`; advertising it still costs prefix bytes and invites the `each()` footgun.

**What changes**

- Fold `rlm` even under `--lean` (no full schema on small catalogs).
- Omit `rlm` from the Folded-native listing until a showcase.
- Do **not** splice `rlm_spec.system_note` onto the always-on prefix (ADR 0011).
- Drop “or one rlm script” from lean `composeBase` notes.

**Showcase later** (listing + load, so the next catalog can carry the schema and sPTC is live):

- `--rlm` / `setFromCli(true)` — immediate
- a batch of **≥4 native** host tools (`read_file`, `codedb`, `bash`, `webfetch`) — the scatter-gather sPTC overlaps
- explicit `load_tool_schemas tools=["rlm"]`

MCP-only fan-out (8× `list_comments`) does **not** showcase. `/new` and `/clear` hide a session-discovered showcase; `--rlm` sticks.

sPTC is unchanged: it only runs after an unfolded `rlm` script streams.

ADR 0030. Suite 1666 (was 1664+skip); +1 net test.

**Not in this PR:** SuperGrok L/N remeasure. After merge, a `--no-lean` re-run should keep `rlm_calls: 0` and can only drop tokens from the missing note/listing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

