### PR TITLE
fix(#601,#602): row nouns without mode names; trajectory shapes and shows what turns did

### DIFF
--- a/src/agent_tool_label.zig
+++ b/src/agent_tool_label.zig
@@ -357,9 +357,14 @@ fn interpretJson(s: []const u8, buf: []u8) []const u8 {
     if (jsonQuoted(s, "matches")) |m|
         return std.fmt.bufPrint(buf, "{s} matches", .{m}) catch m;
     if (jsonQuoted(s, "mode")) |mode| {
+        // #601: the CodeDB mode name is not the decision. A read that carried
+        // content says how much came back (`161 lines`) — the row's detail
+        // column already names the file, so `lines · 161 lines` was a
+        // tautology. A mode that IS the fact (`outline`, `symbol`) stays.
         const lines = if (jsonQuoted(s, "content")) |c| escapedNewlineCount(c) else 0;
         if (lines > 1)
-            return std.fmt.bufPrint(buf, "{s} · {d} lines", .{ mode, lines }) catch mode;
+            return std.fmt.bufPrint(buf, "{d} lines", .{lines}) catch mode;
+        if (std.mem.eql(u8, mode, "lines") or std.mem.eql(u8, mode, "full")) return "";
         return mode;
     }
     return "";
@@ -494,10 +499,21 @@ test "interpretJson never leaks a CodeDB envelope" {
     const section =
         \\{"ok":true,"file":"/Users/rachpradhan/codedb/docs/architecture.md","mode":"section","content":"a\nb\nc"}
     ;
-    try std.testing.expectEqualStrings("section · 3 lines", interpret("mcp__codedbpro__read", section, &buf));
+    try std.testing.expectEqualStrings("3 lines", interpret("mcp__codedbpro__read", section, &buf));
     try std.testing.expectEqualStrings("5 matches", interpret("mcp__codedbpro__faster_search", "{\"ok\":true,\"matches\":5}", &buf));
     try std.testing.expectEqualStrings("outline", interpret("mcp__codedbpro__read", "{\"ok\":true,\"mode\":\"outline\"}", &buf));
     try std.testing.expectEqualStrings("", interpret("mcp__codedbpro__read", "{\"ok\":true,\"file\":\"x.md\"}", &buf));
+}
+
+test "#601: a content-bearing read says how much, never the mode name" {
+    var buf: [48]u8 = undefined;
+    // `lines · 161 lines` was a tautology; `full · 72 lines` only slightly
+    // better. The file is the detail column; the decision is the count.
+    try std.testing.expectEqualStrings("22 lines", interpret("mcp__codedbpro__read", "{\"ok\":true,\"file\":\"docs/architecture.md\",\"mode\":\"lines\",\"content\":\"a\\nb\\nc\\nd\\ne\\nf\\ng\\nh\\ni\\nj\\nk\\nl\\nm\\nn\\no\\np\\nq\\nr\\ns\\nt\\nu\\nv\"}", &buf));
+    try std.testing.expectEqualStrings("3 lines", interpret("mcp__codedbpro__read", "{\"ok\":true,\"mode\":\"full\",\"content\":\"a\\nb\\nc\"}", &buf));
+    // A mode with no content still names itself; a bare lines/full does not.
+    try std.testing.expectEqualStrings("symbol", interpret("mcp__codedbpro__read", "{\"ok\":true,\"mode\":\"symbol\",\"name\":\"foo\"}", &buf));
+    try std.testing.expectEqualStrings("", interpret("mcp__codedbpro__read", "{\"ok\":true,\"mode\":\"lines\"}", &buf));
 }
 
 test "mcp file detail is the basename, not the absolute path" {

--- a/src/agent_tool_render.zig
+++ b/src/agent_tool_render.zig
@@ -527,5 +527,5 @@ test "codedb JSON read is basename plus mode, not the envelope" {
         .text = "{\"ok\":true,\"file\":\"/Users/rachpradhan/codedb/docs/architecture.md\",\"mode\":\"section\",\"content\":\"a\\nb\\nc\"}",
         .is_error = false,
     });
-    try std.testing.expectEqualStrings("  ✓ read  architecture.md  section · 3 lines\n", aw.writer.buffered());
+    try std.testing.expectEqualStrings("  ✓ read  architecture.md  3 lines\n", aw.writer.buffered());
 }

--- a/src/commands_session.zig
+++ b/src/commands_session.zig
@@ -1,6 +1,6 @@
 //! Session/environment slash commands, split out of main.zig's handleCommand
 //! (600-line goal, issue #123): /clear /new /rename /goal /loop /bash /agents
-//! /animation /theme /hooks /skills /trajectory /plan, plus #554's /snapshot
+//! /animation /theme /hooks /skills /plan (/trajectory lives in commands_trajectory.zig), plus #554's /snapshot
 //! and the snapshot half of /rewind (dispatched to commands_sandbox.zig).
 
 const std = @import("std");
@@ -23,7 +23,6 @@ const Keys = provider_mod.Keys;
 const ToolCall = tools_mod.ToolCall;
 const saveSession = session_mod.saveSession;
 const unixMs = util.unixMs;
-const utf8Prefix = util.utf8Prefix;
 const session_ext = session_mod.session_ext;
 
 const ansi = @import("ansi.zig");
@@ -32,6 +31,7 @@ const style = &ansi.style;
 const exec = @import("exec.zig");
 const execTool = exec.execTool;
 const commands_sandbox = @import("commands_sandbox.zig"); // #554 /snapshot + /rewind <id>
+const commands_trajectory = @import("commands_trajectory.zig"); // /trajectory (#602)
 const workspace_switch = @import("workspace_switch.zig");
 const plugins = @import("plugins.zig");
 
@@ -90,6 +90,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
     // #554: claims /snapshot, and /rewind ONLY when its argument is a snapshot
     // id — a numeric /rewind falls through to the conversation rewind below.
     if (try commands_sandbox.tryHandle(root, arena, line, out)) return true;
+    if (try commands_trajectory.tryHandle(root, arena, line, out)) return true;
     if (try workspace_switch.slashCommand(root, arena, line, out)) return true;
     if (try plugins.slashCommand(root.io, arena, root.home, line, out)) return true;
     if (std.mem.eql(u8, line, "/clear")) {
@@ -484,105 +485,6 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
             });
         }
         try out.writeAll("  install/enable: /skills add <name> · disable: /skills remove <name>\n");
-        try out.flush();
-        return true;
-    }
-    if (std.mem.eql(u8, line, "/trajectory")) {
-        const data = trace.readTrajectoryArchive(root.io, arena, 4 << 20);
-        const S = struct {
-            fn str(o: std.json.ObjectMap, k: []const u8) []const u8 {
-                const v = o.get(k) orelse return "";
-                return if (v == .string) v.string else "";
-            }
-            fn int(o: std.json.ObjectMap, k: []const u8) i64 {
-                const v = o.get(k) orelse return 0;
-                return if (v == .integer) v.integer else 0;
-            }
-            fn flag(o: std.json.ObjectMap, k: []const u8) bool {
-                const v = o.get(k) orelse return false;
-                return v == .bool and v.bool;
-            }
-            // Latest score recorded for a prompt fingerprint, across the
-            // whole archive (scores persist between sessions).
-            fn scoreFor(all: []const std.json.ObjectMap, sha: []const u8) ?f64 {
-                var found: ?f64 = null;
-                for (all) |o| {
-                    if (!std.mem.eql(u8, str(o, "kind"), "score")) continue;
-                    if (!std.mem.eql(u8, str(o, "prompt_sha"), sha)) continue;
-                    const v = o.get("score") orelse continue;
-                    found = switch (v) {
-                        .float => |x| x,
-                        .integer => |x| @floatFromInt(x),
-                        else => found,
-                    };
-                }
-                return found;
-            }
-        };
-        var objs: std.ArrayList(std.json.ObjectMap) = .empty;
-        var it = std.mem.tokenizeScalar(u8, data, '\n');
-        while (it.next()) |ln| {
-            const v = std.json.parseFromSliceLeaky(Value, arena, ln, .{ .allocate = .alloc_always }) catch continue;
-            if (v == .object) objs.append(arena, v.object) catch {};
-        }
-        // Tree shows this invocation; scores still come from the whole archive.
-        const current_run_id = if (root.tracer) |tr| tr.identity.run_id else if (trace.g_traj) |tj| tj.identity.run_id else "";
-        var turns: usize = 0;
-        for (objs.items) |o| {
-            if (!std.mem.eql(u8, S.str(o, "run_id"), current_run_id)) continue;
-            if (std.mem.eql(u8, S.str(o, "kind"), "turn")) turns += 1;
-        }
-        if (turns == 0) {
-            try out.print("no trajectory recorded yet — run a turn first (current file: {s})\n", .{if (trace.g_traj) |tj| tj.path else trace.trajectories_dir});
-            try out.flush();
-            return true;
-        }
-        try out.print("{s}session trajectory{s} — {d} turn(s); current: {s}; archive: {s} ({d} record(s) total)\n", .{ style.bold, style.reset, turns, if (trace.g_traj) |tj| tj.path else "", trace.trajectories_dir, objs.items.len });
-        for (objs.items) |o| {
-            if (!std.mem.eql(u8, S.str(o, "run_id"), current_run_id)) continue;
-            if (!std.mem.eql(u8, S.str(o, "kind"), "turn")) continue;
-            const turn_id = S.int(o, "id");
-            out.print("{s}●{s} turn {d} {s} {d}ms · prompt {s}{s}{s}{s} · {s}", .{
-                style.accent,
-                style.reset,
-                turn_id,
-                if (S.flag(o, "ok")) "✓" else "✗",
-                S.int(o, "ms"),
-                style.dim,
-                S.str(o, "prompt_sha"),
-                if (S.flag(o, "prompt_mutated")) " (mutated)" else "",
-                style.reset,
-                utf8Prefix(S.str(o, "task"), 80),
-            }) catch {};
-            if (S.scoreFor(objs.items, S.str(o, "prompt_sha"))) |sc|
-                out.print(" {s}· score {d:.2}{s}", .{ style.green, sc, style.reset }) catch {};
-            out.writeAll("\n") catch {};
-            // children: subagents / workflow tasks spawned during this turn
-            var remaining: usize = 0;
-            for (objs.items) |c| {
-                if (!std.mem.eql(u8, S.str(c, "run_id"), current_run_id)) continue;
-                if (S.int(c, "parent") == turn_id and !std.mem.eql(u8, S.str(c, "kind"), "turn")) remaining += 1;
-            }
-            for (objs.items) |c| {
-                if (!std.mem.eql(u8, S.str(c, "run_id"), current_run_id)) continue;
-                if (S.int(c, "parent") != turn_id or std.mem.eql(u8, S.str(c, "kind"), "turn")) continue;
-                remaining -= 1;
-                out.print("  {s} {s} {s} {d}ms · prompt {s}{s}{s}{s} · {s}", .{
-                    if (remaining == 0) "└─" else "├─",
-                    S.str(c, "label"),
-                    if (S.flag(c, "ok")) "✓" else "✗",
-                    S.int(c, "ms"),
-                    style.dim,
-                    S.str(c, "prompt_sha"),
-                    if (S.flag(c, "prompt_mutated")) " (variant)" else "",
-                    style.reset,
-                    utf8Prefix(S.str(c, "task"), 70),
-                }) catch {};
-                if (S.scoreFor(objs.items, S.str(c, "prompt_sha"))) |sc|
-                    out.print(" {s}· score {d:.2}{s}", .{ style.green, sc, style.reset }) catch {};
-                out.writeAll("\n") catch {};
-            }
-        }
         try out.flush();
         return true;
     }

--- a/src/commands_trajectory.zig
+++ b/src/commands_trajectory.zig
@@ -1,0 +1,154 @@
+//! /trajectory (#602): the DGM fitness archive rendered for a human — each
+//! turn with what it DID (model calls, tool count, errors, cache hit, response
+//! shape), its subagent children, and any recorded scores. Split out of
+//! commands_session.zig (600-line ceiling); same tryHandle contract.
+
+const std = @import("std");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+const Value = std.json.Value;
+
+const agent_mod = @import("agent.zig");
+const Agent = agent_mod.Agent;
+const trace = @import("trace.zig");
+const util = @import("util.zig");
+const utf8Prefix = util.utf8Prefix;
+
+const ansi = @import("ansi.zig");
+const style = &ansi.style;
+
+/// Handles only "/trajectory"; anything else returns false untouched.
+pub fn tryHandle(root: *Agent, arena: Allocator, line: []const u8, out: *Io.Writer) !bool {
+    if (!std.mem.eql(u8, line, "/trajectory")) return false;
+    const data = trace.readTrajectoryArchive(root.io, arena, 4 << 20);
+    const S = struct {
+        fn str(o: std.json.ObjectMap, k: []const u8) []const u8 {
+            const v = o.get(k) orelse return "";
+            return if (v == .string) v.string else "";
+        }
+        fn int(o: std.json.ObjectMap, k: []const u8) i64 {
+            const v = o.get(k) orelse return 0;
+            return if (v == .integer) v.integer else 0;
+        }
+        fn flag(o: std.json.ObjectMap, k: []const u8) bool {
+            const v = o.get(k) orelse return false;
+            return v == .bool and v.bool;
+        }
+        /// A tools bag is comma-joined names ("bash,bash,read_file").
+        fn bagCount(bag: []const u8) usize {
+            if (bag.len == 0) return 0;
+            var n: usize = 1;
+            for (bag) |c| {
+                if (c == ',') n += 1;
+            }
+            return n;
+        }
+        /// Cache-hit percent from the node's token counters, null when the
+        /// turn recorded none.
+        fn cachePercent(cache_read: i64, uncached: i64) ?u32 {
+            const total = cache_read + uncached;
+            if (total <= 0 or cache_read < 0) return null;
+            return @intCast(@divTrunc(cache_read * 100, total));
+        }
+        // Latest score recorded for a prompt fingerprint, across the
+        // whole archive (scores persist between sessions).
+        fn scoreFor(all: []const std.json.ObjectMap, sha: []const u8) ?f64 {
+            var found: ?f64 = null;
+            for (all) |o| {
+                if (!std.mem.eql(u8, str(o, "kind"), "score")) continue;
+                if (!std.mem.eql(u8, str(o, "prompt_sha"), sha)) continue;
+                const v = o.get("score") orelse continue;
+                found = switch (v) {
+                    .float => |x| x,
+                    .integer => |x| @floatFromInt(x),
+                    else => found,
+                };
+            }
+            return found;
+        }
+    };
+    var objs: std.ArrayList(std.json.ObjectMap) = .empty;
+    var it = std.mem.tokenizeScalar(u8, data, '\n');
+    while (it.next()) |ln| {
+        const v = std.json.parseFromSliceLeaky(Value, arena, ln, .{ .allocate = .alloc_always }) catch continue;
+        if (v == .object) objs.append(arena, v.object) catch {};
+    }
+    // Tree shows this invocation; scores still come from the whole archive.
+    const current_run_id = if (root.tracer) |tr| tr.identity.run_id else if (trace.g_traj) |tj| tj.identity.run_id else "";
+    var turns: usize = 0;
+    for (objs.items) |o| {
+        if (!std.mem.eql(u8, S.str(o, "run_id"), current_run_id)) continue;
+        if (std.mem.eql(u8, S.str(o, "kind"), "turn")) turns += 1;
+    }
+    if (turns == 0) {
+        try out.print("no trajectory recorded yet — run a turn first (current file: {s})\n", .{if (trace.g_traj) |tj| tj.path else trace.trajectories_dir});
+        try out.flush();
+        return true;
+    }
+    try out.print("{s}session trajectory{s} — {d} turn(s); current: {s}; archive: {s} ({d} record(s) total)\n", .{ style.bold, style.reset, turns, if (trace.g_traj) |tj| tj.path else "", trace.trajectories_dir, objs.items.len });
+    for (objs.items) |o| {
+        if (!std.mem.eql(u8, S.str(o, "run_id"), current_run_id)) continue;
+        if (!std.mem.eql(u8, S.str(o, "kind"), "turn")) continue;
+        const turn_id = S.int(o, "id");
+        out.print("{s}●{s} turn {d} {s} {d}ms · prompt {s}{s}{s}{s} · {s}", .{
+            style.accent,
+            style.reset,
+            turn_id,
+            if (S.flag(o, "ok")) "✓" else "✗",
+            S.int(o, "ms"),
+            style.dim,
+            S.str(o, "prompt_sha"),
+            if (S.flag(o, "prompt_mutated")) " (mutated)" else "",
+            style.reset,
+            utf8Prefix(S.str(o, "task"), 80),
+        }) catch {};
+        if (S.scoreFor(objs.items, S.str(o, "prompt_sha"))) |sc|
+            out.print(" {s}· score {d:.2}{s}", .{ style.green, sc, style.reset }) catch {};
+        // #602: the node already carries what the turn DID — print it
+        // instead of leaving the row a prompt sha and a task prefix.
+        {
+            const calls = S.int(o, "model_calls");
+            const tool_n = S.bagCount(S.str(o, "tools"));
+            const errs = S.int(o, "tool_errors");
+            const resp_types = S.str(o, "resp_types");
+            const hit = S.cachePercent(S.int(o, "cache_read_tokens"), S.int(o, "uncached_tokens"));
+            if (calls > 0 or tool_n > 0 or errs > 0 or resp_types.len > 0 or hit != null) {
+                out.print(" {s}·", .{style.dim}) catch {};
+                if (calls > 0) out.print(" {d} call{s}", .{ calls, if (calls == 1) "" else "s" }) catch {};
+                if (tool_n > 0) out.print(" · {d} tool{s}", .{ tool_n, if (tool_n == 1) "" else "s" }) catch {};
+                if (errs > 0) out.print(" · {d} err", .{errs}) catch {};
+                if (hit) |h| out.print(" · cache {d}%", .{h}) catch {};
+                if (resp_types.len > 0) out.print(" · {s}", .{resp_types}) catch {};
+                out.print("{s}", .{style.reset}) catch {};
+            }
+        }
+        out.writeAll("\n") catch {};
+        // children: subagents / workflow tasks spawned during this turn
+        var remaining: usize = 0;
+        for (objs.items) |c| {
+            if (!std.mem.eql(u8, S.str(c, "run_id"), current_run_id)) continue;
+            if (S.int(c, "parent") == turn_id and !std.mem.eql(u8, S.str(c, "kind"), "turn")) remaining += 1;
+        }
+        for (objs.items) |c| {
+            if (!std.mem.eql(u8, S.str(c, "run_id"), current_run_id)) continue;
+            if (S.int(c, "parent") != turn_id or std.mem.eql(u8, S.str(c, "kind"), "turn")) continue;
+            remaining -= 1;
+            out.print("  {s} {s} {s} {d}ms · prompt {s}{s}{s}{s} · {s}", .{
+                if (remaining == 0) "└─" else "├─",
+                S.str(c, "label"),
+                if (S.flag(c, "ok")) "✓" else "✗",
+                S.int(c, "ms"),
+                style.dim,
+                S.str(c, "prompt_sha"),
+                if (S.flag(c, "prompt_mutated")) " (variant)" else "",
+                style.reset,
+                utf8Prefix(S.str(c, "task"), 70),
+            }) catch {};
+            if (S.scoreFor(objs.items, S.str(c, "prompt_sha"))) |sc|
+                out.print(" {s}· score {d:.2}{s}", .{ style.green, sc, style.reset }) catch {};
+            out.writeAll("\n") catch {};
+        }
+    }
+    try out.flush();
+    return true;
+}

--- a/src/mainloop_trace.zig
+++ b/src/mainloop_trace.zig
@@ -87,7 +87,15 @@ pub fn finalResponseShape(messages: []const Value) ResponseShape {
         const kind = jsonStr(obj, "type");
         if (role.len > 0) {
             if (!std.mem.eql(u8, role, "assistant")) break; // user turn / tool result
-        } else if (!isModelItem(kind)) break; // function_call_output, …
+        } else if (!isModelItem(kind)) {
+            // #602: a Responses history can END on tool results — a turn cut
+            // after execution, attempt_completion's final call, a crash. Those
+            // trailing `function_call_output` items are not the response; skip
+            // them so the shape still describes the last model-authored run
+            // instead of archiving `resp_blocks=0` for every tool-using turn.
+            if (std.mem.eql(u8, kind, "function_call_output")) continue;
+            break;
+        }
         countEntry(&shape, obj, kind);
     }
     return shape;
@@ -324,4 +332,16 @@ test "#270: openai and Responses histories shape the same way" {
     try std.testing.expectEqual(@as(u32, 2), responses.blocks);
     try std.testing.expectEqual(@as(u64, "done".len), responses.text_len);
     try std.testing.expectEqualStrings("text+reasoning", responses.typeSet(&buf));
+
+    // #602: the same history with the turn cut AFTER execution — the tail is
+    // tool results, and there is no final message. The shape must describe the
+    // model-authored run that preceded them, not archive zero blocks.
+    const cut_after_tools = try testShape(
+        \\ [{"type":"message","role":"assistant","content":[{"type":"output_text","text":"merging"}]},
+        \\ {"type":"reasoning","summary":[]},
+        \\ {"type":"function_call","call_id":"c1","name":"bash","arguments":"{}"},
+        \\ {"type":"function_call_output","call_id":"c1","output":"ok"}]
+    );
+    try std.testing.expectEqual(@as(u32, 3), cut_after_tools.blocks);
+    try std.testing.expectEqualStrings("text+tool_use+reasoning", cut_after_tools.typeSet(&buf));
 }


### PR DESCRIPTION
## What changed

- **#601** — `interpretJson` no longer surfaces the CodeDB mode name verbatim. A content-bearing read now interprets as `161 lines` instead of `lines · 161 lines` (tautology) or `full · 72 lines`; modes that are themselves the fact (`outline`, `symbol`) stay.
- **#602 (2 of 5 slices)** —
  - `finalResponseShape` broke its backward walk on a trailing bare `function_call_output`, so every tool-using turn whose history ends on tool results (turn cut after execution, crash, attempt_completion's final call) archived `resp_blocks=0` — indistinguishable from an empty turn. Those items are now skipped; the shape describes the last model-authored run.
  - `/trajectory` printed only `turn N ✓ 95s · prompt <sha> · <task>`. The row now appends what the node already carried: model calls, tool count, tool errors, cache-hit percent, and response shape (`text+reasoning`), when present.
  - `commands_session.zig` crossed the 600-line ceiling with the above; the `/trajectory` handler moved verbatim into `commands_trajectory.zig`.

## Why

The recorder bug made the DGM archive lie about tool-using turns: #270 added `resp_*` precisely to separate 'text-only refusal' from 'empty turn', but the Responses+tools path defeated it, so a history ending on tool results was never covered by a test. And `/trajectory` is the human inspect path — it ignored fields already on the turn node, leaving a run unreadable compared with a grok-build session folder.

## Out of scope (kept open on #602)

Live turn stubs in the DGM file, periodic session-transcript flush, and `first_token`/`call_id` on operational traces. Behavior lifecycle (`turn_committed`/`run_finished`) already landed earlier. Click-to-expand for line-REPL rows (#601's progressive disclosure) stays out per ADR 0019 — `/debug` remains the raw path.

## Verification

- New tests: mode-noun cases in `agent_tool_label.zig`; cut-after-execution shaping case in `mainloop_trace.zig`. Updated the one render test that asserted the old `section · N lines` string.
- `zig build test` green; `scripts/eval-tier1.sh` green locally (twice) and via the pre-push hook.