### PR TITLE
TUI /tell and /peek use the existing peer mailbox (#563 leftovers)

### DIFF
--- a/TUI/catalog.zig
+++ b/TUI/catalog.zig
@@ -41,6 +41,8 @@ pub const items = [_]Item{
     .{ .name = "/jump", .desc = "Jump to a previous turn" },
     .{ .name = "/copy", .desc = "Copy the last reply to the clipboard" },
     .{ .name = "/btw", .desc = "Queue an aside without interrupting" },
+    .{ .name = "/tell", .desc = "Message a running graff (/tell all broadcasts)" },
+    .{ .name = "/peek", .desc = "See what a live session is doing" },
     .{ .name = "/vim-mode", .desc = "Vim keys in the scrollback", .aliases = &.{"/vim"} },
     .{ .name = "/help", .desc = "List commands" },
     .{ .name = "/doctor", .desc = "Health check" },
@@ -99,6 +101,8 @@ test "filter: slash prefix and alias" {
     try std.testing.expect(lookup("/debug") != null);
     try std.testing.expect(lookup("/cache") != null);
     try std.testing.expect(lookup("/cost") != null);
+    try std.testing.expect(lookup("/tell") != null);
+    try std.testing.expect(lookup("/peek") != null);
     try std.testing.expect(lookup("/not-a-cmd") == null);
 }
 

--- a/TUI/dispatch.zig
+++ b/TUI/dispatch.zig
@@ -7,6 +7,7 @@ const app = @import("app.zig");
 const bgop = @import("bgop.zig");
 const catalog = @import("catalog.zig");
 const engine = @import("engine.zig");
+const peer_cmd = @import("peer_cmd.zig");
 const meters = @import("meters.zig");
 const theme_mod = @import("theme.zig");
 const turn = @import("turn.zig");
@@ -188,6 +189,8 @@ pub fn runCommand(self: *Model, line: []const u8) Effect {
         self.pushFmt(.system, "vim scrollback: {s}", .{onOff(self.vim_mode)}) catch {};
     } else if (std.mem.eql(u8, canon, "/copy")) {
         copyLastReply(self);
+    } else if (std.mem.eql(u8, canon, "/tell") or std.mem.eql(u8, canon, "/peek")) {
+        peer_cmd.run(self, canon, arg);
     } else if (std.mem.eql(u8, canon, "/btw")) {
         if (arg.len == 0) {
             self.push(.system, "usage: /btw <aside> — queue a note without interrupting") catch {};

--- a/TUI/engine.zig
+++ b/TUI/engine.zig
@@ -176,6 +176,12 @@ pub var g_raw: ?*StreamBuf = null;
 pub const IdleWakeFn = *const fn (turn_ctx: ?*anyopaque, buf: []u8) ?[]const u8;
 pub var g_idle_wake_fn: ?IdleWakeFn = null;
 
+/// Run a peer-talk slash (`/tell`, `/peek`) on the live agent. The TUI does
+/// not post to the room itself — the host implements this with the existing
+/// mailbox (`tellCommand` / `peekCommand`). Caller frees the returned text.
+pub const PeerFn = *const fn (turn_ctx: ?*anyopaque, gpa: std.mem.Allocator, line: []const u8) ?[]const u8;
+pub var g_peer_fn: ?PeerFn = null;
+
 /// A background engine op: `/compact`, `!cmd`, or the @-file list. Same
 /// thread + done-flag contract as Job, so the render+input loop keeps painting
 /// and Esc keeps reaching keys.handle while the engine works (#533). Every
@@ -244,6 +250,7 @@ pub const RunOpts = struct {
     compact_fn: ?CompactFn = null,
     history_fn: ?HistoryFn = null,
     idle_wake_fn: ?IdleWakeFn = null,
+    peer_fn: ?PeerFn = null,
 };
 
 pub var g_turn_fn: ?TurnFn = null;

--- a/TUI/overlaypane.zig
+++ b/TUI/overlaypane.zig
@@ -256,6 +256,8 @@ const help_body =
     \\  /jump             jump to a previous turn
     \\  /copy             copy the last reply
     \\  /btw              queue an aside mid-turn
+    \\  /tell             message a live graff (/tell all broadcasts)
+    \\  /peek             see what a live session is doing
     \\  /vim-mode         vim keys in the scrollback
 ;
 
@@ -270,11 +272,11 @@ test "help overlay names the advertised pager commands" {
     defer arena.deinit();
     const text = try overlay(&m, arena.allocator(), 80);
     for ([_][]const u8{
-        "/quit",     "/help", "/new", "/home", "/model", "/settings", "/usage", "/debug", "/cache", "/plan", "/always-approve",
-        "Shift+Tab", "PgUp",  "PgDn",
+        "/quit", "/help", "/new",      "/home", "/model", "/settings", "/usage", "/debug", "/cache", "/plan", "/always-approve",
+        "/tell", "/peek", "Shift+Tab", "PgUp",  "PgDn",
         "←",
         "→",
-        "Tab",       "Enter", "Esc",
+        "Tab",   "Enter", "Esc",
     }) |name| {
         try testing.expect(std.mem.indexOf(u8, text, name) != null);
     }

--- a/TUI/peer_cmd.zig
+++ b/TUI/peer_cmd.zig
@@ -17,7 +17,7 @@ pub fn run(self: *Model, canon: []const u8, arg: []const u8) void {
         const line = if (arg.len == 0) canon else (std.fmt.bufPrint(&buf, "{s} {s}", .{ canon, arg }) catch canon);
         if (f(engine.g_turn_ctx, self.alloc, line)) |text| {
             defer self.alloc.free(text);
-            const trimmed = std.mem.trimRight(u8, text, " \t\r\n");
+            const trimmed = std.mem.trimEnd(u8, text, " \t\r\n");
             if (trimmed.len > 0) self.push(.system, trimmed) catch {};
         }
         return;

--- a/TUI/peer_cmd.zig
+++ b/TUI/peer_cmd.zig
@@ -1,0 +1,30 @@
+//! TUI `/tell` and `/peek`: thin client of the engine mailbox.
+//! Posting lives in `src/peer_channel.zig`; this file only routes the slash.
+
+const std = @import("std");
+
+const app = @import("app.zig");
+const engine = @import("engine.zig");
+const Model = app.Model;
+
+pub const tell_usage = "usage: /tell <session|all> <text> — all reaches every live session on this device, any folder";
+pub const peek_usage = "usage: /peek <session> — what a live session is doing right now";
+pub const offline_note = "peer talk needs a live session (offline)";
+
+pub fn run(self: *Model, canon: []const u8, arg: []const u8) void {
+    if (engine.g_peer_fn) |f| {
+        var buf: [2048]u8 = undefined;
+        const line = if (arg.len == 0) canon else (std.fmt.bufPrint(&buf, "{s} {s}", .{ canon, arg }) catch canon);
+        if (f(engine.g_turn_ctx, self.alloc, line)) |text| {
+            defer self.alloc.free(text);
+            const trimmed = std.mem.trimRight(u8, text, " \t\r\n");
+            if (trimmed.len > 0) self.push(.system, trimmed) catch {};
+        }
+        return;
+    }
+    if (arg.len == 0) {
+        self.push(.system, if (std.mem.eql(u8, canon, "/peek")) peek_usage else tell_usage) catch {};
+    } else {
+        self.push(.system, offline_note) catch {};
+    }
+}

--- a/TUI/peer_tests.zig
+++ b/TUI/peer_tests.zig
@@ -1,0 +1,101 @@
+//! #563 Slice B: TUI `/tell` / `/peek` are catalogued and route through the
+//! engine. Drive the pager with `sim.Term` — no PTY, no Ghostty window.
+
+const std = @import("std");
+
+const app = @import("app.zig");
+const catalog = @import("catalog.zig");
+const dispatch = @import("dispatch.zig");
+const engine = @import("engine.zig");
+const peer_cmd = @import("peer_cmd.zig");
+const sim = @import("sim.zig");
+
+test "catalog lists /tell and /peek" {
+    try std.testing.expect(catalog.lookup("/tell") != null);
+    try std.testing.expect(catalog.lookup("/peek") != null);
+    try std.testing.expectEqualStrings("/tell", catalog.lookup("/tell").?.name);
+    try std.testing.expectEqualStrings("/peek", catalog.lookup("/peek").?.name);
+}
+
+test "bare /tell and /peek print usage when the engine is offline" {
+    var m: app.Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    _ = dispatch.applyLine(&m, "/tell");
+    try std.testing.expect(std.mem.indexOf(u8, m.history.items[m.history.items.len - 1].text, "usage: /tell") != null);
+    _ = dispatch.applyLine(&m, "/peek");
+    try std.testing.expect(std.mem.indexOf(u8, m.history.items[m.history.items.len - 1].text, "usage: /peek") != null);
+}
+
+test "/tell from the pager reaches the engine and shows the posted line" {
+    const Seen = struct {
+        var line: []u8 = &.{};
+        var room: std.ArrayList(u8) = .empty;
+        fn f(_: ?*anyopaque, gpa: std.mem.Allocator, raw: []const u8) ?[]const u8 {
+            if (line.len > 0) gpa.free(line);
+            line = gpa.dupe(u8, raw) catch return null;
+            room.appendSlice(gpa, raw) catch {};
+            room.append(gpa, '\n') catch {};
+            return gpa.dupe(u8, "⇢ posted to the device-wide room") catch null;
+        }
+    };
+    Seen.line = &.{};
+    Seen.room = .empty;
+    engine.g_peer_fn = Seen.f;
+    defer {
+        engine.g_peer_fn = null;
+        if (Seen.line.len > 0) std.testing.allocator.free(Seen.line);
+        Seen.room.deinit(std.testing.allocator);
+    }
+
+    var term: sim.Term = undefined;
+    term.init(std.testing.allocator, 80, 24);
+    defer term.deinit();
+    _ = term.typeText("/tell all hold the tree");
+    _ = term.enter();
+
+    try std.testing.expectEqualStrings("/tell all hold the tree", Seen.line);
+    try std.testing.expect(std.mem.indexOf(u8, Seen.room.items, "hold the tree") != null);
+    try std.testing.expect(term.model.history.items.len > 0);
+    const last = term.model.history.items[term.model.history.items.len - 1].text;
+    try std.testing.expect(std.mem.indexOf(u8, last, "posted to the device-wide room") != null);
+
+    const vis = try term.screen();
+    defer std.testing.allocator.free(vis);
+    try std.testing.expect(std.mem.indexOf(u8, vis, "posted to the device-wide room") != null);
+}
+
+test "/peek from the pager reaches the engine" {
+    const Seen = struct {
+        var line: []u8 = &.{};
+        fn f(_: ?*anyopaque, gpa: std.mem.Allocator, raw: []const u8) ?[]const u8 {
+            if (line.len > 0) gpa.free(line);
+            line = gpa.dupe(u8, raw) catch return null;
+            return gpa.dupe(u8, "⚡ other · pid 9 · goal: refactor") catch null;
+        }
+    };
+    Seen.line = &.{};
+    engine.g_peer_fn = Seen.f;
+    defer {
+        engine.g_peer_fn = null;
+        if (Seen.line.len > 0) std.testing.allocator.free(Seen.line);
+    }
+
+    var term: sim.Term = undefined;
+    term.init(std.testing.allocator, 80, 24);
+    defer term.deinit();
+    _ = term.typeText("/peek other");
+    _ = term.enter();
+    try std.testing.expectEqualStrings("/peek other", Seen.line);
+    const last = term.model.history.items[term.model.history.items.len - 1].text;
+    try std.testing.expect(std.mem.indexOf(u8, last, "goal: refactor") != null);
+}
+
+test "offline /tell with a payload explains instead of posting" {
+    engine.g_peer_fn = null;
+    var m: app.Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    _ = dispatch.applyLine(&m, "/tell all hi");
+    try std.testing.expectEqualStrings(peer_cmd.offline_note, m.history.items[m.history.items.len - 1].text);
+}

--- a/TUI/root.zig
+++ b/TUI/root.zig
@@ -35,6 +35,7 @@ pub const CompactOut = engine.CompactOut;
 pub const CompactFn = engine.CompactFn;
 pub const HistoryOp = engine.HistoryOp;
 pub const HistoryFn = engine.HistoryFn;
+pub const PeerFn = engine.PeerFn;
 pub const RunOpts = run_mod.RunOpts;
 pub const run = run_mod.run;
 pub const restore = @import("restore.zig");
@@ -54,6 +55,8 @@ test {
     _ = app;
     _ = @import("app_tests.zig");
     _ = @import("dispatch.zig");
+    _ = @import("peer_cmd.zig");
+    _ = @import("peer_tests.zig");
     _ = @import("prompt_history.zig");
     _ = @import("meters.zig");
     _ = @import("key.zig");

--- a/TUI/run.zig
+++ b/TUI/run.zig
@@ -56,6 +56,7 @@ pub fn run(
     engine.g_compact_fn = opts.compact_fn;
     engine.g_history_fn = opts.history_fn;
     engine.g_idle_wake_fn = opts.idle_wake_fn;
+    engine.g_peer_fn = opts.peer_fn;
     engine.g_model_name = opts.model_name;
     engine.g_model_provider = opts.model_provider;
     engine.g_model_entries = opts.model_entries;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -170,7 +170,7 @@ pub const changelog_text =
     \\
     \\0.0.244
     \\  • Co-resident graff sessions now see each other: a startup warning names any live session already in your worktree, and the first git mutation, file write, or shell move against a peer's tree pauses once for a deliberate re-issue — two agents can no longer silently tear one tree
-    \\  • Sessions can message each other: the peer_message tool and /tell post to a shared channel every co-resident session hears (address one by name, "all" reaches every session on the device), delivered mid-task at step boundaries with the sender's current goal attached
+    \\  • Sessions can message each other: peer_message posts to this folder's room, or names one session as a DM (not "all" — retired for the model). /tell <session> is a human DM; /tell all is the user's device-wide broadcast. Delivery is at the receiver's next step boundary, with the sender's current goal attached
     \\  • The model is told up front who else is live and what they're working on, so it coordinates — or picks disjoint work — before any collision
     \\  • /peek <session> shows what a live co-resident session is doing right now — its last prompt, last action, last tool
     \\  • Session recaps ride the event stream: settled turns carry a Completed or Needs-input status with a one-line recap for the GUI agent overview

--- a/src/presence.zig
+++ b/src/presence.zig
@@ -428,6 +428,24 @@ pub fn resetRoomCursorForTest() void {
     g_tail_seeked = false;
 }
 
+/// Tests only. `announce` is a no-op under `is_test`; this wires the same
+/// process-local handle so `postTo` / `postToDevice` can write a tmp registry.
+/// Caller owns the slices — do not `deinit` after this; call `unbindForTest`.
+pub fn bindForTest(dir_path: []const u8, identity: []const u8, session: []const u8, self: proc_identity.Record) void {
+    g_dir = dir_path;
+    g_identity = identity;
+    g_session = session;
+    g_self = self;
+}
+
+pub fn unbindForTest() void {
+    g_dir = null;
+    g_identity = "";
+    g_session = "";
+    g_self = .{};
+    resetRoomCursorForTest();
+}
+
 /// Every live session on this device, any worktree (self excluded) — the
 /// /tell target list. Like liveTreePeers but identity-blind.
 pub fn liveAllPeers(io: Io, arena: Allocator) []const Owner {

--- a/src/repl_glue.zig
+++ b/src/repl_glue.zig
@@ -61,6 +61,9 @@ pub const ReplCtx = struct {
     last_context_tokens: u64 = 0,
     context_local_tokens: u64 = 0,
     last_cache_read: u64 = 0,
+    /// Live root session, when the host has one. TUI `/tell` / `/peek` reach
+    /// the real mailbox through this; the line REPL already holds `root`.
+    root: ?*Agent = null,
 };
 
 /// The engine-owned conversation, in repl_convo.zig (move+alias, #123).

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -334,4 +334,5 @@ test {
     _ = @import("commands_experiment.zig");
     _ = @import("acp_engine.zig");
     _ = @import("libgraff.zig");
+    _ = @import("tui_peer.zig");
 }

--- a/src/tui_launch.zig
+++ b/src/tui_launch.zig
@@ -16,6 +16,7 @@ const repl = @import("repl.zig");
 const repl_bash = @import("repl_bash.zig");
 const repl_glue = @import("repl_glue.zig");
 const tui = @import("tui");
+const tui_peer = @import("tui_peer.zig");
 const engine_sink = @import("engine_sink.zig");
 const tui_sink = @import("tui_sink.zig");
 const job_notify = @import("job_notify.zig");
@@ -88,6 +89,7 @@ pub fn run(
         .tools_anthropic = root.tools_anthropic,
         .tools_openai = root.tools_openai,
         .tools_responses = root.tools_responses,
+        .root = root,
     };
     // #551: the session's conversation belongs to the engine and outlives every
     // turn, so tool_use/tool_result blocks accumulate the way mainloop's root
@@ -118,6 +120,7 @@ pub fn run(
         .compact_fn = compactCb,
         .history_fn = historyCb,
         .idle_wake_fn = idleWakeCb,
+        .peer_fn = tui_peer.peerCb,
     });
 }
 
@@ -382,6 +385,7 @@ test {
     _ = tui;
     _ = tui_sink;
     _ = repl_bash;
+    _ = tui_peer;
 }
 
 test "hudCb usage/debug use the cost-tally renderer, not chars" {

--- a/src/tui_peer.zig
+++ b/src/tui_peer.zig
@@ -1,0 +1,69 @@
+//! Host side of TUI `/tell` / `/peek`: the pager is a thin client; this
+//! calls the existing mailbox (`tellCommand` / `peekCommand`) on the live
+//! agent. Wired from `tui_launch` as `engine.PeerFn`.
+
+const std = @import("std");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+
+const agent_mod = @import("agent.zig");
+const peer_channel = @import("peer_channel.zig");
+const presence = @import("presence.zig");
+const proc_identity = @import("proc_identity.zig");
+const repl_glue = @import("repl_glue.zig");
+
+const Agent = agent_mod.Agent;
+
+/// Run a `/tell` or `/peek` line against `root`. Caller frees the returned
+/// text. Null only when the line is not a peer slash or allocation failed.
+pub fn runSlash(root: *Agent, gpa: Allocator, line: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trim(u8, line, " \t\r\n");
+    const is_tell = std.mem.startsWith(u8, trimmed, "/tell") and
+        (trimmed.len == 5 or trimmed[5] == ' ' or trimmed[5] == '\t');
+    const is_peek = std.mem.startsWith(u8, trimmed, "/peek") and
+        (trimmed.len == 5 or trimmed[5] == ' ' or trimmed[5] == '\t');
+    if (!is_tell and !is_peek) return null;
+
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    var buf: [8192]u8 = undefined;
+    var w: Io.Writer = .fixed(&buf);
+    const ok = if (is_tell)
+        peer_channel.tellCommand(root, arena_state.allocator(), trimmed, &w)
+    else
+        peer_channel.peekCommand(root, arena_state.allocator(), trimmed, &w);
+    _ = ok catch return gpa.dupe(u8, "peer talk failed") catch null;
+    return gpa.dupe(u8, w.buffered()) catch null;
+}
+
+/// `engine.PeerFn` — reads the live agent off `ReplCtx.root`.
+pub fn peerCb(ctx: ?*anyopaque, gpa: Allocator, line: []const u8) ?[]const u8 {
+    const c: *repl_glue.ReplCtx = @ptrCast(@alignCast(ctx orelse return null));
+    const root = c.root orelse return gpa.dupe(u8, "peer talk needs a live session") catch null;
+    return runSlash(root, gpa, line);
+}
+
+test "TUI /tell all appends a device-room line the other session would hear" {
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try std.fmt.allocPrint(gpa, ".zig-cache/tmp/{s}", .{std.mem.sliceTo(&tmp.sub_path, 0)});
+    defer gpa.free(dir_path);
+
+    presence.bindForTest(dir_path, "/repo/.git", "s-tui", proc_identity.selfRecord(io));
+    defer presence.unbindForTest();
+
+    var root: Agent = undefined;
+    root.io = io;
+    const text = runSlash(&root, gpa, "/tell all hold the tree from the pager") orelse
+        return error.ExpectedPosted;
+    defer gpa.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "posted") != null);
+
+    const room = tmp.dir.readFileAlloc(io, presence.device_room, gpa, .limited(4096)) catch
+        return error.ExpectedRoomFile;
+    defer gpa.free(room);
+    try std.testing.expect(std.mem.indexOf(u8, room, "hold the tree from the pager") != null);
+    try std.testing.expect(std.mem.indexOf(u8, room, "\"from_user\":true") != null);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#563 leftovers only — peer talk already exists (#469 + ADR 0004). This does not rebuild the channel.

## Slice A — tell the truth

`graff`'s 0.0.244 changelog still claimed the **model** `peer_message` tool could target `"all"`. It cannot (retired; floods every folder). The line now matches the tool: room or named DM for the model; `/tell all` stays the **human** device-wide broadcast.

Schema / `tool_desc` / the collision gate were already honest. `#469` stays in comments and old-transcript prefix matchers only.

## Slice B — pager verbs

The line REPL already had `/tell` and `/peek`. The TUI catalog did not, so the pager answered `unknown command`.

- Catalog + `/help` list both verbs
- Dispatch routes them through `engine.PeerFn` — the TUI does not post
- `tui_launch` implements the callback with the existing `tellCommand` / `peekCommand`
- Headless `TUI/sim.Term` covers catalog, dispatch, and a `/tell` that shows the posted confirmation
- `src/tui_peer.zig` posts `/tell all` into `chan-all.jsonl` (`from_user: true`) so another session would hear it

## Not in this PR (still #563)

Slices C–E: typed channel events, model `peer_peek`, posted-vs-delivered / `in_reply_to`. Mid-turn inject stays #430.

Leave #563 open until those land or are split out.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

