### PR TITLE
fix: rebuild tool catalog after wide-native rlm showcase

### DIFF
--- a/docs/adr/0030-rlm-late-showcase.md
+++ b/docs/adr/0030-rlm-late-showcase.md
@@ -67,3 +67,10 @@ sticks for the process. `--old` resets discovery.
 - Revisit if a measured coding one-shot regresses to N serial reads
   because the model never emits a 4-wide batch, never crosses 50% of
   compactAt, and never sees `rlm`.
+- **Showcase must rebuild the cached catalog.** `noticeWideNative` /
+  `noticeContext` only flip `g_loaded`. `invalidateRootTools` without
+  `ensureRootTools` leaves `toolsJson()` as `""`, and the next Responses
+  body is `"tools":,` — xAI 400. The 2026-08-28 grok-build rematch
+  dropped the rlm suite to 3/5 (`scatter-sum`, `multi-read`) while SWE
+  stayed 5/6 (no 4-wide native batch). Call
+  `noticeWideNativeAndRefresh`. Do not revert that to invalidate-only.

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -371,9 +371,12 @@ pub const Agent = struct {
                 const fold = @import("native_fold.zig");
                 if (fold.noticeContext(self.effectiveContextTokens(), self.provider.compactAt())) {
                     self.invalidateRootTools();
-                    try self.ensureRootTools(self.provider.kind);
                 }
             }
+            // Any mid-turn invalidate (wide-native showcase, MCP join, load)
+            // must rebuild before toolsJson() is read. ensure is a no-op when
+            // the active encoding is already populated.
+            try self.ensureRootTools(self.provider.kind);
             const hist_len = self.messages.items.len;
             const root = try self.request(if (self.text_only) null else self.toolsJson());
             const done = switch (self.provider.kind) {

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -373,9 +373,8 @@ pub const Agent = struct {
                     self.invalidateRootTools();
                 }
             }
-            // Any mid-turn invalidate (wide-native showcase, MCP join, load)
-            // must rebuild before toolsJson() is read. ensure is a no-op when
-            // the active encoding is already populated.
+            // Safety net: empty toolsJson after invalidate is `"tools":,`
+            // on Responses (xAI 400). ensure is a no-op if already filled.
             try self.ensureRootTools(self.provider.kind);
             const hist_len = self.messages.items.len;
             const root = try self.request(if (self.text_only) null else self.toolsJson());

--- a/src/agent_tools.zig
+++ b/src/agent_tools.zig
@@ -71,6 +71,9 @@ pub fn runTools(self: *Agent, calls: []const ToolCall) ![]ExecResult {
         var names: [32][]const u8 = undefined;
         const n = @min(calls.len, names.len);
         for (calls[0..n], 0..) |c, i| names[i] = c.name;
+        // ADR 0030: ≥4 native reads/bash showcases rlm. Must rebuild the
+        // cached catalog here — invalidate-only shipped `"tools":,` on the
+        // next request (rlm rematch 2026-08-28). See noticeWideNativeAndRefresh.
         _ = native_fold.noticeWideNativeAndRefresh(self, names[0..n]);
     }
     const results = try self.arena.alloc(ExecResult, calls.len);

--- a/src/agent_tools.zig
+++ b/src/agent_tools.zig
@@ -71,7 +71,7 @@ pub fn runTools(self: *Agent, calls: []const ToolCall) ![]ExecResult {
         var names: [32][]const u8 = undefined;
         const n = @min(calls.len, names.len);
         for (calls[0..n], 0..) |c, i| names[i] = c.name;
-        if (native_fold.noticeWideNative(names[0..n])) self.invalidateRootTools();
+        _ = native_fold.noticeWideNativeAndRefresh(self, names[0..n]);
     }
     const results = try self.arena.alloc(ExecResult, calls.len);
     const eval_index = eval_control.evalCallIndex(calls);

--- a/src/native_fold.zig
+++ b/src/native_fold.zig
@@ -359,6 +359,15 @@ fn refreshAgentCatalog(agent: anytype) void {
     agent.ensureRootTools(agent.provider.kind) catch {};
 }
 
+/// ADR 0030 wide-native showcase: mark rlm loaded and rebuild the cached
+/// catalog. Invalidate-only left `toolsJson()` empty, so the next Responses
+/// body was `"tools":,` and xAI 400'd the rlm-suite scatter tasks.
+pub fn noticeWideNativeAndRefresh(agent: anytype, names: []const []const u8) bool {
+    if (!noticeWideNative(names)) return false;
+    refreshAgentCatalog(agent);
+    return true;
+}
+
 /// The native half of load_tool_schemas, called from agent_tools before the
 /// MCP handler: an input naming folded native tools loads them (real schema
 /// in the result, enabled for the session). Returns null when the input

--- a/src/native_fold.zig
+++ b/src/native_fold.zig
@@ -193,7 +193,9 @@ fn unmark(name: []const u8) void {
 /// showcase — that re-invites the each() footgun (ADR 0029).
 const wide_native = [_][]const u8{ "read_file", "codedb", "bash", "webfetch" };
 
-/// True when this batch newly showcased rlm (caller rebuilds the catalog).
+/// True when this batch newly showcased rlm. Does NOT rebuild the Agent
+/// catalog — `g_loaded` alone leaves `toolsJson()` empty after invalidate.
+/// Production call sites must use `noticeWideNativeAndRefresh`.
 pub fn noticeWideNative(names: []const []const u8) bool {
     if (listed() or !@import("rlm_spec.zig").available) return false;
     var n: usize = 0;
@@ -359,9 +361,12 @@ fn refreshAgentCatalog(agent: anytype) void {
     agent.ensureRootTools(agent.provider.kind) catch {};
 }
 
-/// ADR 0030 wide-native showcase: mark rlm loaded and rebuild the cached
-/// catalog. Invalidate-only left `toolsJson()` empty, so the next Responses
-/// body was `"tools":,` and xAI 400'd the rlm-suite scatter tasks.
+/// ADR 0030 wide-native showcase + catalog rebuild. The 2026-08-28 rematch
+/// (`scatter-sum` / `multi-read`) 400'd because `runTools` called
+/// `noticeWideNative` then `invalidateRootTools` and never `ensureRootTools`.
+/// Next xAI Responses body was `"tools":,` (`toolsJson()` is `""` after
+/// invalidate). Do not "fix" this back to invalidate-only — SWE hid it
+/// (no 4-wide native batch) while the rlm suite dropped to 3/5.
 pub fn noticeWideNativeAndRefresh(agent: anytype, names: []const []const u8) bool {
     if (!noticeWideNative(names)) return false;
     refreshAgentCatalog(agent);

--- a/src/native_fold_rlm.zig
+++ b/src/native_fold_rlm.zig
@@ -161,6 +161,7 @@ test "wide native batch showcases rlm; MCP fan-out does not" {
     try std.testing.expect(fold.listed());
 }
 
+// Guards the 2026-08-28 rematch 400: showcase without rebuild emptied toolsJson.
 test "wide-native showcase rebuilds the cached catalog (not invalidate-only)" {
     const provider_mod = @import("provider.zig");
     const FakeAgent = struct {

--- a/src/native_fold_rlm.zig
+++ b/src/native_fold_rlm.zig
@@ -161,6 +161,45 @@ test "wide native batch showcases rlm; MCP fan-out does not" {
     try std.testing.expect(fold.listed());
 }
 
+test "wide-native showcase rebuilds the cached catalog (not invalidate-only)" {
+    const provider_mod = @import("provider.zig");
+    const FakeAgent = struct {
+        provider: struct { kind: provider_mod.Provider.Kind } = .{ .kind = .responses },
+        invalidations: usize = 0,
+        rebuilds: usize = 0,
+        pub fn invalidateRootTools(self: *@This()) void {
+            self.invalidations += 1;
+        }
+        pub fn ensureRootTools(self: *@This(), kind: provider_mod.Provider.Kind) !void {
+            try std.testing.expectEqual(provider_mod.Provider.Kind.responses, kind);
+            self.rebuilds += 1;
+        }
+    };
+
+    const saved_spec = rlm_spec.available;
+    defer {
+        rlm_spec.available = saved_spec;
+        fold.resetRlmDiscovery();
+    }
+    isolate();
+    rlm_spec.available = true;
+
+    var agent: FakeAgent = .{};
+    try std.testing.expect(!fold.noticeWideNativeAndRefresh(&agent, &.{ "read_file", "codedb", "bash" }));
+    try std.testing.expectEqual(@as(usize, 0), agent.invalidations);
+    try std.testing.expectEqual(@as(usize, 0), agent.rebuilds);
+
+    try std.testing.expect(fold.noticeWideNativeAndRefresh(&agent, &.{ "read_file", "codedb", "bash", "webfetch" }));
+    try std.testing.expect(fold.listed());
+    try std.testing.expect(fold.isLoaded("rlm"));
+    try std.testing.expectEqual(@as(usize, 1), agent.invalidations);
+    try std.testing.expectEqual(@as(usize, 1), agent.rebuilds);
+
+    try std.testing.expect(!fold.noticeWideNativeAndRefresh(&agent, &.{ "read_file", "codedb", "bash", "webfetch" }));
+    try std.testing.expectEqual(@as(usize, 1), agent.invalidations);
+    try std.testing.expectEqual(@as(usize, 1), agent.rebuilds);
+}
+
 test "context below 50% of compactAt does not showcase; crossing it does" {
     const saved_spec = rlm_spec.available;
     defer {

--- a/src/serde.zig
+++ b/src/serde.zig
@@ -334,6 +334,9 @@ pub fn writeKimiTools(s: *std.json.Stringify, arena: Allocator, raw: []const u8)
 /// catalog that needs no repair, or that we cannot parse, goes out as its
 /// original bytes so the usual request keeps a byte-identical cached prefix.
 pub fn writeOpenAITools(s: *std.json.Stringify, arena: Allocator, raw: []const u8) !void {
+    // Empty catalog must still be a JSON array. Printing the raw empty slice
+    // after `"tools":` produced `"tools":,` (xAI 400).
+    if (raw.len == 0) return s.print("[]", .{});
     const value = std.json.parseFromSliceLeaky(Value, arena, raw, .{ .allocate = .alloc_always }) catch return s.print("{s}", .{raw});
     if (value != .array) return s.print("{s}", .{raw});
     var repaired = false;
@@ -484,4 +487,10 @@ test "openai and responses tools give a typeless MCP root schema type object (#2
     const composed = "[{\"type\":\"function\",\"function\":{\"name\":\"t\",\"description\":\"\",\"parameters\":{\"anyOf\":[{\"type\":\"object\"}]}}}]";
     try std.testing.expectEqualStrings(composed, try renderOpenAITools(arena, composed));
     try std.testing.expectEqualStrings("not json", try renderOpenAITools(arena, "not json"));
+}
+
+test "empty OpenAI tools catalog writes [] not a missing JSON value" {
+    var arena_state: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena_state.deinit();
+    try std.testing.expectEqualStrings("[]", try renderOpenAITools(arena_state.allocator(), ""));
 }

--- a/src/serde.zig
+++ b/src/serde.zig
@@ -334,8 +334,10 @@ pub fn writeKimiTools(s: *std.json.Stringify, arena: Allocator, raw: []const u8)
 /// catalog that needs no repair, or that we cannot parse, goes out as its
 /// original bytes so the usual request keeps a byte-identical cached prefix.
 pub fn writeOpenAITools(s: *std.json.Stringify, arena: Allocator, raw: []const u8) !void {
-    // Empty catalog must still be a JSON array. Printing the raw empty slice
-    // after `"tools":` produced `"tools":,` (xAI 400).
+    // Last-resort: `toolsJson()` after invalidate is "". Printing that after
+    // `"tools":` is `"tools":,` — xAI 400, rlm rematch 2026-08-28. Write []
+    // so a missed rebuild cannot ship invalid JSON. The real fix is
+    // noticeWideNativeAndRefresh + ensureRootTools before the next request.
     if (raw.len == 0) return s.print("[]", .{});
     const value = std.json.parseFromSliceLeaky(Value, arena, raw, .{ .allocate = .alloc_always }) catch return s.print("{s}", .{raw});
     if (value != .array) return s.print("{s}", .{raw});
@@ -489,6 +491,7 @@ test "openai and responses tools give a typeless MCP root schema type object (#2
     try std.testing.expectEqualStrings("not json", try renderOpenAITools(arena, "not json"));
 }
 
+// Pin the last-resort: empty toolsJson must not become `"tools":,` on the wire.
 test "empty OpenAI tools catalog writes [] not a missing JSON value" {
     var arena_state: std.heap.ArenaAllocator = .init(std.testing.allocator);
     defer arena_state.deinit();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
ADR 0030 showcased `rlm` after a 4-wide native `read_file`/`codedb`/`bash`/`webfetch` batch and only **invalidated** the cached catalog. The next xAI Responses request read `toolsJson() == ""` and `writeOpenAITools` printed the empty slice after the field name, so the body was `"tools":,`. xAI 400'd: `Failed to parse the request body as JSON: tools: expected value`.

That is why the grok-build rematch on latest 280 went **3/5** on the rlm suite (`scatter-sum`, `multi-read`). Both tasks did four parallel reads, showcased rlm, then died on the follow-up call. SWE stayed 5/6 because those tasks never hit a 4-wide native batch.

**Fix**
- `noticeWideNativeAndRefresh` invalidates **and** rebuilds (same as `#492` load-native).
- `runTurn` calls `ensureRootTools` before every `toolsJson()` read, so any mid-turn invalidate cannot ship an empty catalog.
- `writeOpenAITools("")` writes `[]` instead of a missing JSON value.

**Comments for later agents** (follow-up commit): call sites + ADR 0030 now name the 2026-08-28 rematch 400 and say not to revert this to invalidate-only. SWE hid the bug; the rlm suite is what catches it.

**Tests**
- FakeAgent: a 4-wide batch rebuilds once; a 3-wide batch does not.
- Empty catalog serializes as `[]`.
- Suite 1725 (was 1723 on main). +2 tests.

**Live rematch** SuperGrok OAuth, grok-4.6, grok-build 1.0.5, `graff-dev`:

SWE (cookie-store retry after one SIGABRT): **5/6 vs 5/6**, graff 259s / 9.4M / 158k vs grok 330s / 156M / 120k. Both miss `label-sort`.

RLM: **5/5 vs 5/5**, graff 46s / 8.6M / 70k vs grok 120s / 160M / 54k.

Core (new): shared 11 tasks **11/11 vs 11/11**, graff 89s / 9.1M / 144k vs grok 141s / 156M / 111k. `schema-output` is graff-only (grok has no `--output-schema`); graff missed it this rep (stdout was pulse chrome, not JSON).

Cherry-pick onto 280: #656.

Tier 1: fmt/lines/reach/build/tests/sdk green. `test-tui-hover.py` flaked in the parallel pool, then passed solo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

