### PR TITLE
fix: prompt-cache max for xAI and Codex (git-root + HUD)

### DIFF
--- a/docs/adr/0011-prompt-cache-max-is-visible.md
+++ b/docs/adr/0011-prompt-cache-max-is-visible.md
@@ -19,9 +19,11 @@ intentional. `/debug` counted tokens; it did not say why a miss happened.
 ## Decision
 
 - `/cache` is the content-free cache HUD: prefix hash, last read/write,
-  session hit rate, catalog mode, last bust reason, xAI affinity
-  (`x-grok-conv-id` + `x-grok-session-id` + `prompt_cache_key`), and the
-  remaining max levers. No prompt text, paths, or tool bodies.
+  session hit rate, catalog mode, last bust reason, and the live wire's
+  affinity (xAI keyed headers, Codex `session_id` = `prompt_cache_key`,
+  OpenAI Platform breakpoint, Claude explicit `cache_control` on tools +
+  system + last message, Kimi automatic prefix + chat `prompt_cache_key`).
+  Remaining max levers stay listed. No prompt text, paths, or tool bodies.
 - `/debug` gets one cache row from the same snapshot.
 - Named busts (`goal`, `playbook`, `compact`, `persona`, `tools`, `mcp`) are
   recorded at the mutation site and counted only when the next request's
@@ -66,3 +68,14 @@ arrived already warm (11k–43k). Prefix bytes still have to match — this
 only stops an identical system+tools prefix missing because the sandbox
 path changed. Worktrees of one repo share; a repo CLAUDE.md still misses
 another repo.
+
+Claude (2026-08-28): mark `cache_control` on the last tool, the system
+block, and the last cacheable message. A system-only mark still hashes
+tools (they precede system), but a long tool loop walks the 20-block
+lookback off that write; the tools breakpoint is the earlier slot. Do
+not send top-level automatic `cache_control` next to those three marks
+(fourth slot / no-op). MiniMax stays unmarked.
+
+Kimi (2026-08-28): chat sends `prompt_cache_key` (coding-agent / Code
+Plan). Anthropic-transport Kimi still gets the three explicit marks;
+the server hashes the prefix either way.

--- a/docs/adr/0011-prompt-cache-max-is-visible.md
+++ b/docs/adr/0011-prompt-cache-max-is-visible.md
@@ -37,6 +37,9 @@ intentional. `/debug` counted tokens; it did not say why a miss happened.
 - `/btw` is a grok-build side-call: same system prompt, same tools JSON, same
   `prompt_cache_key` as the parent. The side-question note is appended as a
   user message. Tools are advertised for the prefix and not executed.
+- Root affinity (`x-grok-conv-id` / `prompt_cache_key`) is the **git root**,
+  not the leaf cwd. No repo → the constant `graff-scratch`. Do not hash cwd:
+  sibling sandboxes and worktrees share one prefix and must share one key.
 
 ## Consequences
 
@@ -54,3 +57,12 @@ Live Grok 4.6 (Responses, SuperGrok OAuth, 2026-08-19): same-process
 append-only turn 2 cached 3,712 of turn 1's 3,721 input tokens. `/btw` after
 that turn reused **3,712** tokens (99.8% of the prior prompt). A new process
 in the same folder started cold at 128 — the official first-request write.
+
+Affinity seed (2026-08-28 rematch): the root key is the **git root**, not
+the leaf cwd (`graff-scratch` when there is no repo). xAI partitions cache
+by `prompt_cache_key`; a cwd-derived id made every graff-evals sandbox a
+cold ~8k write (first-call cache 0–512) while grok-build's first calls
+arrived already warm (11k–43k). Prefix bytes still have to match — this
+only stops an identical system+tools prefix missing because the sandbox
+path changed. Worktrees of one repo share; a repo CLAUDE.md still misses
+another repo.

--- a/docs/adr/0028-codex-session-id-is-the-cache-key.md
+++ b/docs/adr/0028-codex-session-id-is-the-cache-key.md
@@ -15,17 +15,25 @@ session (`gpt-5.6-sol`) still recorded multi-million `cache_read_tokens` on
 later calls in a turn, and 0/0 on turns whose usage never landed in `g_cost`.
 The first-party client never splits those two ids.
 
+The 2026-08-28 rematch then showed the cwd-derived root id made every sibling
+sandbox a cold write. ADR 0011 now seeds the root with the git root (or
+`graff-scratch`). Codex uses that same id — it does not get a second scheme.
+The ChatGPT backend still rejects `prompt_cache_options` /
+`prompt_cache_breakpoint` (openai/codex#35300); do not add them.
+
 ## Decision
 
 - Codex `session_id` (HTTP extra headers and the WS handshake) is the same
   value as the Responses body's `prompt_cache_key` (`requestCacheKey`:
-  project root for main/`/btw`, four role lanes for children).
+  git-root / `graff-scratch` for main/`/btw`, four role lanes for children).
 - `sessionId()` stays a per-process UUIDv4 for the persisted graff session
   record. It is not the ChatGPT cache partition.
 - `store: false` is unchanged (openai/codex also sends `store: false`).
+- `/cache` names the Codex key the same way it names the xAI key.
 
 ## Cost
 
 ChatGPT session telemetry now groups by project/lane rather than process.
 That is the cache contract. Do not restore a random `session_id` header
-without measuring a live `cached_tokens` regression.
+without measuring a live `cached_tokens` regression. Do not emit a GPT-5.6
+Platform breakpoint on this wire.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,7 +21,7 @@ record only when you need the evidence or the edge cases.
 | [0008](0008-synthetic-evals-use-external-verifiers.md) | Synthetic coding evals promote only external-verifier passes; model judges may tiebreak correctness, never decide it. |
 | [0009](0009-gpt-5-6-explicit-prompt-cache-boundary.md) | GPT-5.6 OpenAI Platform marks the stable prefix explicitly; Codex and xAI stay on their supported keyed automatic-cache paths. |
 | [0010](0010-background-jobs-wait-for-exit.md) | `bash_output`/`agent_output` `wait_ms>0` blocks until exit (10h cap); do not poll every 30s. |
-| [0011](0011-prompt-cache-max-is-visible.md) | Prompt-cache max is on: stable catalog by default; `/cache` is the HUD; `/btw` rides the parent prefix; children share role-lane `x-grok-conv-id` / `prompt_cache_key` (not the root id). |
+| [0011](0011-prompt-cache-max-is-visible.md) | Prompt-cache max is on: stable catalog by default; `/cache` is the HUD; `/btw` rides the parent prefix; children share role-lane keys; root affinity is git-root (or `graff-scratch`), not cwd. |
 | [0012](0012-overflow-handles-named-limits-extra-roots.md) | Fat tool results become `tr_N` handles; named `--context-limit` caps prefix bytes; `--add-dir` extra roots are PathConfine allow-lists, not cwd/skill/session sources. |
 | [0013](0013-list-dir-lives-in-codedb.md) | Directory listing is `codedb list_dir` (in-process BFS, gitignore, 10k cap), not a new always-on catalog tool. |
 | [0014](0014-session-resume-carries-the-room-cursor.md) | `/resume` restores the peer-channel byte cursor and inbox; it does not replay the room into history. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,7 +38,7 @@ record only when you need the evidence or the edge cases.
 | [0025](0025-io-uring-is-not-the-process-io.md) | Process Io stays Zig `Threaded`. spec-ptc is already the default loop (ADR 0022). Do not take ublk or switch `main` to `std.Io.Uring`. |
 | [0026](0026-foreground-bash-auto-backgrounds.md) | Root foreground `bash` auto-backgrounds after 120s (or `timeout` ms); it is not killed. Subagents still kill at 120s (#93). |
 | [0027](0027-kimi-identity-is-graff.md) | Kimi Coding User-Agent is `graff/<version>`, not a spoofed `kimi-code-cli` token. X-Msh device fields follow kimi-code's shapes. |
-| [0028](0028-codex-session-id-is-the-cache-key.md) | Codex HTTP/WS `session_id` is the `prompt_cache_key` (openai/codex ModelClient default), not a per-process random UUID. |
+| [0028](0028-codex-session-id-is-the-cache-key.md) | Codex HTTP/WS `session_id` is the `prompt_cache_key` (same git-root id as xAI), not a per-process random UUID; no Platform breakpoint. |
 | [0029](0029-mcp-inside-rlm-and-return-shapes.md) | Loaded MCP tools are rlm host functions; persist return shapes on the load result, never the prefix; fat MCP results auto-slim; default `-p` connects `.mcp.json` (folded, not skipped). |
 | [0030](0030-rlm-late-showcase.md) | Small turns hide `rlm` (and sPTC). Showcase on `--rlm`, a ≥4 native batch, context ≥50% of compactAt, or an explicit load — never on MCP fan-out or the prefix. |
 | [0031](0031-xai-hosted-x-search.md) | xAI Responses splices hosted `x_search` onto tools turns. It is not a catalog function; `GRAFF_XAI_X_SEARCH=0` opts out. |

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -228,7 +228,7 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
             var aff_buf: [96]u8 = undefined;
             hud.noteAffinity(
                 http_headers.promptCacheKey(self.io, self.label, self, &aff_buf),
-                std.mem.eql(u8, self.provider.id, "xai"),
+                hud.affinityKind(self.provider.id),
                 self.provider.kind == .responses,
             );
         }

--- a/src/agent_request_body.zig
+++ b/src/agent_request_body.zig
@@ -69,13 +69,14 @@ pub fn buildBody(self: *Agent, tools: ?[]const u8, force_tool: bool, stream: boo
                     try s.print("{s}", .{thinking_obj});
                 }
             }
-            // Prompt caching (Anthropic): a block-level cache_control breakpoint
-            // on the system block caches the whole stable prefix (system+tools);
-            // other anthropic-format providers (minimax) get a plain string.
+            // Prompt caching (Anthropic + Kimi-anthropic): tools → system →
+            // last message, the documented agentic breakpoints. MiniMax stays
+            // a plain string — it is not the Claude cache contract.
             try s.objectField("system");
             const sys = try @import("agent_request_body_responses.zig").schemaAwarePrompt(self);
             const cc = "{\"type\":\"ephemeral\"}";
-            if (std.mem.eql(u8, self.provider.id, "anthropic") or is_kimi) {
+            const cache_prefix = std.mem.eql(u8, self.provider.id, "anthropic") or is_kimi;
+            if (cache_prefix) {
                 try s.beginArray();
                 try s.beginObject();
                 try s.objectField("type");
@@ -91,7 +92,7 @@ pub fn buildBody(self: *Agent, tools: ?[]const u8, force_tool: bool, stream: boo
             }
             if (tools) |t| {
                 try s.objectField("tools");
-                try writeAnthropicTools(&s, self.scratchAlloc(), t, is_kimi);
+                try writeAnthropicTools(&s, self.scratchAlloc(), t, cache_prefix);
                 if (force_tool) {
                     try s.objectField("tool_choice");
                     try s.print("{s}", .{"{\"type\":\"any\"}"});
@@ -102,11 +103,9 @@ pub fn buildBody(self: *Agent, tools: ?[]const u8, force_tool: bool, stream: boo
                 try @import("agent_request_body_responses.zig").writeAnthropicStructuredTool(&s, self.output_schema.?);
             }
             try s.objectField("messages");
-            // Cache the conversation prefix too (not just system) on the real
-            // Anthropic API and Kimi's declared Anthropic transport. Kimi also
-            // normalizes all string content into Anthropic text blocks.
-            const cache_msgs = std.mem.eql(u8, self.provider.id, "anthropic") or is_kimi;
-            try writeAnthropicMessages(&s, self.messages, cache_msgs, is_kimi);
+            // Last cacheable block (including tool_result). Kimi also
+            // normalizes every string into an Anthropic text block.
+            try writeAnthropicMessages(&s, self.messages, cache_prefix, is_kimi);
         },
         .openai => {
             // graff's MakeOpenAiCompat: OpenAI deprecated max_tokens in

--- a/src/cache_affinity.zig
+++ b/src/cache_affinity.zig
@@ -1,0 +1,153 @@
+//! Sticky prompt-cache partition (`x-grok-conv-id` / `prompt_cache_key`).
+//!
+//! xAI caches prefix bytes on the server a key routes to. A cwd-derived key
+//! made every sibling sandbox a cold ~8k write (rematch 2026-08-28: graff
+//! first-call cache 0–512, grok 11k–43k already warm). The seed is the git
+//! root when cwd sits in a repo — worktrees and eval sandboxes under that
+//! tree share — else the constant `scratch_seed` so scratch `-p` shares too.
+//! Prefix bytes still have to match; a repo CLAUDE.md does not hit another
+//! repo. ADR 0011.
+
+const std = @import("std");
+const Io = std.Io;
+
+pub const scratch_seed = "graff-scratch";
+const salt = "graff-cache-affinity-v2";
+
+var id_buf: [36]u8 = undefined;
+var id_len: usize = 0;
+var id_lock: std.atomic.Value(bool) = .init(false);
+
+fn hasGit(io: Io, dir_abs: []const u8) bool {
+    var buf: [std.fs.max_path_bytes + 8]u8 = undefined;
+    const p = std.fmt.bufPrint(&buf, "{s}/.git", .{dir_abs}) catch return false;
+    Io.Dir.cwd().access(io, p, .{}) catch return false;
+    return true;
+}
+
+/// Directory that contains `.git` (file or dir) at or above `start_abs`.
+/// Worktree `.git` is a file; `access` sees it. Does not chdir.
+pub fn gitRootOf(io: Io, start_abs: []const u8, out: []u8) ?[]const u8 {
+    if (start_abs.len == 0 or start_abs.len > out.len) return null;
+    @memcpy(out[0..start_abs.len], start_abs);
+    var end = start_abs.len;
+    while (end > 1 and out[end - 1] == '/') end -= 1;
+    while (true) {
+        const dir = out[0..end];
+        if (hasGit(io, dir)) return dir;
+        if (end == 1 and dir[0] == '/') return null;
+        const slash = std.mem.lastIndexOfScalar(u8, dir, '/') orelse return null;
+        if (slash == 0) {
+            if (hasGit(io, out[0..1])) return out[0..1];
+            return null;
+        }
+        end = slash;
+    }
+}
+
+/// Git root of `cwd_abs`, or `scratch_seed` when the tree is not a repo.
+pub fn affinitySeed(io: Io, cwd_abs: []const u8, buf: []u8) []const u8 {
+    return gitRootOf(io, cwd_abs, buf) orelse scratch_seed;
+}
+
+pub fn uuid5(seed: []const u8) [36]u8 {
+    var raw: [16]u8 = undefined;
+    var digest: [32]u8 = undefined;
+    var h = std.crypto.hash.sha2.Sha256.init(.{});
+    h.update(salt);
+    h.update(seed);
+    h.final(&digest);
+    @memcpy(&raw, digest[0..16]);
+    raw[6] = (raw[6] & 0x0f) | 0x50;
+    raw[8] = (raw[8] & 0x3f) | 0x80;
+    const hex = std.fmt.bytesToHex(raw, .lower);
+    var out: [36]u8 = undefined;
+    @memcpy(out[0..8], hex[0..8]);
+    out[8] = '-';
+    @memcpy(out[9..13], hex[8..12]);
+    out[13] = '-';
+    @memcpy(out[14..18], hex[12..16]);
+    out[18] = '-';
+    @memcpy(out[19..23], hex[16..20]);
+    out[23] = '-';
+    @memcpy(out[24..36], hex[20..32]);
+    return out;
+}
+
+/// Process-cached root partition. First cwd realpath + walk wins for the
+/// process (graff does not chdir). Tests that need a fresh mint call `reset`.
+pub fn rootId(io: Io) []const u8 {
+    while (id_lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) std.atomic.spinLoopHint();
+    defer id_lock.store(false, .release);
+    if (id_len == 0) {
+        var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const n = Io.Dir.cwd().realPathFile(io, ".", &cwd_buf) catch blk: {
+            @memcpy(cwd_buf[0..1], ".");
+            break :blk 1;
+        };
+        var seed_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const seed = affinitySeed(io, cwd_buf[0..n], &seed_buf);
+        id_buf = uuid5(seed);
+        id_len = 36;
+    }
+    return id_buf[0..id_len];
+}
+
+pub fn reset() void {
+    while (id_lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) std.atomic.spinLoopHint();
+    defer id_lock.store(false, .release);
+    id_len = 0;
+}
+
+fn tmpAbs(io: Io, tmp: *std.testing.TmpDir, buf: []u8) ![]const u8 {
+    return buf[0..try tmp.dir.realPath(io, buf)];
+}
+
+test "uuid5 is durable and version-5" {
+    const a = uuid5("/repo");
+    const b = uuid5("/repo");
+    try std.testing.expectEqualStrings(&a, &b);
+    try std.testing.expectEqual(@as(u8, '5'), a[14]);
+    try std.testing.expect(!std.mem.eql(u8, &a, &uuid5("/other")));
+    try std.testing.expect(!std.mem.eql(u8, &a, &uuid5(scratch_seed)));
+}
+
+test "nested dir under a repo shares the git root; a scratch tree does not use cwd" {
+    const io = std.testing.io;
+    var repo = std.testing.tmpDir(.{ .iterate = true });
+    defer repo.cleanup();
+    repo.dir.writeFile(io, .{ .sub_path = ".git", .data = "gitdir: /somewhere\n" }) catch unreachable;
+    repo.dir.createDirPath(io, "sandboxes/task-a") catch unreachable;
+
+    var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_abs = try tmpAbs(io, &repo, &cwd_buf);
+    var nest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const nest = try std.fmt.bufPrint(&nest_buf, "{s}/sandboxes/task-a", .{root_abs});
+
+    var a: [std.fs.max_path_bytes]u8 = undefined;
+    var b: [std.fs.max_path_bytes]u8 = undefined;
+    try std.testing.expectEqualStrings(root_abs, gitRootOf(io, nest, &a).?);
+    try std.testing.expectEqualStrings(root_abs, affinitySeed(io, nest, &b));
+    try std.testing.expectEqualStrings(&uuid5(root_abs), &uuid5(affinitySeed(io, nest, &a)));
+
+    // zig-cache tmp dirs sit inside this repo, so a no-git case has to start
+    // on a path whose parents are not a checkout (`/proc/...` is enough).
+    const outside = "/proc/graff-cache-affinity-missing";
+    var seed_buf: [std.fs.max_path_bytes]u8 = undefined;
+    try std.testing.expect(gitRootOf(io, outside, &seed_buf) == null);
+    try std.testing.expectEqualStrings(scratch_seed, affinitySeed(io, outside, &seed_buf));
+}
+
+test "rootId matches uuid5 of this process's affinity seed" {
+    reset();
+    defer reset();
+    const io = std.testing.io;
+    const got = rootId(io);
+    try std.testing.expectEqual(@as(usize, 36), got.len);
+    var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = Io.Dir.cwd().realPathFile(io, ".", &cwd_buf) catch return error.TestUnexpectedResult;
+    var seed_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const seed = affinitySeed(io, cwd_buf[0..n], &seed_buf);
+    try std.testing.expectEqualStrings(&uuid5(seed), got);
+    try std.testing.expectEqualStrings(got, rootId(io)); // cached
+}

--- a/src/http_headers.zig
+++ b/src/http_headers.zig
@@ -5,6 +5,7 @@ const Io = std.Io;
 const Provider = @import("provider.zig").Provider;
 const root = @import("main.zig");
 const kimi_catalog = @import("kimi_catalog.zig");
+const cache_affinity = @import("cache_affinity.zig");
 
 var session_id_buf: [36]u8 = undefined;
 var session_id_len: usize = 0;
@@ -70,51 +71,13 @@ pub fn requestCacheKey(io: Io, label: []const u8, agent: *const anyopaque, provi
     return promptCacheKey(io, label, agent, buf);
 }
 
-var project_id_buf: [36]u8 = undefined;
-var project_id_len: usize = 0;
-var project_id_lock: std.atomic.Value(bool) = .init(false);
-
-/// Durable per-project id (cwd-derived UUIDv5, no state to persist). A new
-/// session in the same repo reuses the bucket the last session wrote, so
-/// turn 1 can hit the warm system+tools prefix if the provider still has
-/// it. Different models do not share a cache (the server keys by model);
-/// they each get this same routing id so *their* later sessions can find
-/// *their* prefix. Same-project conversation tails may evict each other;
-/// the expensive prefix still hits.
+/// Durable project partition (UUIDv5, no state to persist). Seed is the git
+/// root when cwd is inside a repo, else `graff-scratch` — not the leaf cwd
+/// (ADR 0011 / rematch 2026-08-28). Worktrees and sibling eval sandboxes
+/// under one repo share the bucket so turn 1 can hit a warm system+tools
+/// prefix. Different models do not share a cache (the server keys by model).
 pub fn projectRootId(io: Io) []const u8 {
-    while (project_id_lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) std.atomic.spinLoopHint();
-    defer project_id_lock.store(false, .release);
-    if (project_id_len == 0) {
-        var raw: [16]u8 = undefined;
-        {
-            var cwd_buf: [4096]u8 = undefined;
-            const n = Io.Dir.cwd().realPathFile(io, ".", &cwd_buf) catch blk: {
-                @memcpy(cwd_buf[0..1], ".");
-                break :blk 1;
-            };
-            const cwd = cwd_buf[0..n];
-            var digest: [32]u8 = undefined;
-            var h = std.crypto.hash.sha2.Sha256.init(.{});
-            h.update("graff-kimi-project-cache-v1");
-            h.update(cwd);
-            h.final(&digest);
-            @memcpy(&raw, digest[0..16]);
-            raw[6] = (raw[6] & 0x0f) | 0x50; // version 5: name-derived
-            raw[8] = (raw[8] & 0x3f) | 0x80; // variant 1
-        }
-        const hex = std.fmt.bytesToHex(raw, .lower);
-        @memcpy(project_id_buf[0..8], hex[0..8]);
-        project_id_buf[8] = '-';
-        @memcpy(project_id_buf[9..13], hex[8..12]);
-        project_id_buf[13] = '-';
-        @memcpy(project_id_buf[14..18], hex[12..16]);
-        project_id_buf[18] = '-';
-        @memcpy(project_id_buf[19..23], hex[16..20]);
-        project_id_buf[23] = '-';
-        @memcpy(project_id_buf[24..36], hex[20..32]);
-        project_id_len = 36;
-    }
-    return project_id_buf[0..project_id_len];
+    return cache_affinity.rootId(io);
 }
 
 /// Side-calls that replay the parent history (`/btw`) share the root

--- a/src/prompt_cache_hud.zig
+++ b/src/prompt_cache_hud.zig
@@ -44,8 +44,19 @@ var pending: Bust = .none;
 var g_io: ?Io = null;
 var g_aff: [64]u8 = undefined;
 var g_aff_len: usize = 0;
-var g_xai: bool = false;
+var g_kind: AffinityKind = .unknown;
 var g_responses: bool = false;
+
+/// Which wire last recorded an affinity key. `/cache` names Codex the same
+/// way it names xAI — both use `cache_affinity.rootId` (ADR 0011 / 0028).
+pub const AffinityKind = enum { unknown, xai, codex, openai };
+
+pub fn affinityKind(provider_id: []const u8) AffinityKind {
+    if (std.mem.eql(u8, provider_id, "xai")) return .xai;
+    if (std.mem.eql(u8, provider_id, "codex")) return .codex;
+    if (std.mem.eql(u8, provider_id, "openai")) return .openai;
+    return .unknown;
+}
 
 fn acquire() void {
     while (lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) std.atomic.spinLoopHint();
@@ -61,7 +72,7 @@ pub fn reset() void {
     pending = .none;
     g_io = null;
     g_aff_len = 0;
-    g_xai = false;
+    g_kind = .unknown;
     g_responses = false;
 }
 
@@ -122,12 +133,12 @@ pub fn noteRequest(io: Io, system: []const u8, tools: []const u8) void {
     snap.requests += 1;
 }
 
-/// Content-free xAI routing id (`x-grok-conv-id` / `prompt_cache_key`).
-/// Official docs: same value on Chat header and Responses body.
-pub fn noteAffinity(key: []const u8, xai: bool, responses: bool) void {
+/// Content-free routing id. xAI: `x-grok-conv-id` / `prompt_cache_key`.
+/// Codex: HTTP+WS `session_id` / `prompt_cache_key` (ADR 0028, same bytes).
+pub fn noteAffinity(key: []const u8, kind: AffinityKind, responses: bool) void {
     acquire();
     defer release();
-    g_xai = xai;
+    g_kind = kind;
     g_responses = responses;
     const n = @min(key.len, g_aff.len);
     @memcpy(g_aff[0..n], key[0..n]);
@@ -202,12 +213,26 @@ pub fn render(w: *Io.Writer) !void {
         try w.print("  busts      {d}  last: {s}\n", .{ s.busts, bustLabel(s.last_bust) });
     }
     try w.print("  catalog    {s}\n", .{if (mcp_schema_gate.g_stable_catalog) "stable (loads append tail only)" else "mutating (a load rewrites tools JSON)"});
-    if (g_xai and g_aff_len > 0) {
-        try w.print("  xAI        {s}  (automatic prefix cache)\n", .{if (g_responses) "responses" else "chat"});
-        try w.print("  affinity   {s}\n", .{g_aff[0..g_aff_len]});
-        try w.writeAll("             x-grok-conv-id + x-grok-session-id + prompt_cache_key\n");
+    if (g_aff_len > 0) {
+        switch (g_kind) {
+            .xai => {
+                try w.print("  xAI        {s}  (automatic prefix cache)\n", .{if (g_responses) "responses" else "chat"});
+                try w.print("  affinity   {s}\n", .{g_aff[0..g_aff_len]});
+                try w.writeAll("             x-grok-conv-id + x-grok-session-id + prompt_cache_key\n");
+            },
+            .codex => {
+                try w.print("  Codex      {s}  (session_id = prompt_cache_key)\n", .{g_aff[0..g_aff_len]});
+                try w.writeAll("             HTTP + WS session_id; no prompt_cache_breakpoint\n");
+            },
+            .openai => {
+                try w.print("  OpenAI     {s}  (prompt_cache_key)\n", .{g_aff[0..g_aff_len]});
+                try w.writeAll("             gpt-5.6* also send prompt_cache_options + breakpoint\n");
+            },
+            .unknown => try w.print("  affinity   {s}\n", .{g_aff[0..g_aff_len]}),
+        }
     } else {
         try w.writeAll("  xAI        x-grok-conv-id + x-grok-session-id + prompt_cache_key\n");
+        try w.writeAll("  Codex      session_id + prompt_cache_key (same value)\n");
     }
     try w.writeAll(
         \\  remaining max
@@ -220,7 +245,8 @@ pub fn render(w: *Io.Writer) !void {
         \\    Vercel                  gateway implicit cache (cached_tokens); coding-agent /v1
         \\    /btw                    parent tools + system + cache key; note is the user message
         \\    subagents               role-lane x-grok-conv-id / prompt_cache_key (not the root id)
-        \\    affinity                git-root or graff-scratch, not cwd (sibling sandboxes share)
+        \\    affinity                git-root or graff-scratch, not cwd (xAI and Codex share)
+        \\    Codex                   session_id == prompt_cache_key (ADR 0028); no breakpoint
         \\
     );
 }
@@ -312,6 +338,8 @@ test "render stays content-free and names remaining levers" {
     try std.testing.expect(contains(text, "subagents"));
     try std.testing.expect(contains(text, "git-root"));
     try std.testing.expect(contains(text, "graff-scratch"));
+    try std.testing.expect(contains(text, "Codex"));
+    try std.testing.expect(contains(text, "ADR 0028"));
     try std.testing.expect(!contains(text, "SECRET-PROMPT"));
     try std.testing.expect(!contains(text, "/Users/me"));
     try std.testing.expect(!contains(text, "bash"));
@@ -321,7 +349,7 @@ test "render shows xAI affinity without prompt text" {
     reset();
     defer reset();
     noteRequest(std.testing.io, "SECRET-PROMPT", "[]");
-    noteAffinity("b79ad29b-b3f9-463c-bca6-041d5058d366", true, true);
+    noteAffinity("b79ad29b-b3f9-463c-bca6-041d5058d366", .xai, true);
     var buf: [2048]u8 = undefined;
     var w: Io.Writer = .fixed(&buf);
     try render(&w);
@@ -330,6 +358,29 @@ test "render shows xAI affinity without prompt text" {
     try std.testing.expect(contains(text, "b79ad29b-b3f9-463c-bca6-041d5058d366"));
     try std.testing.expect(contains(text, "prompt_cache_key"));
     try std.testing.expect(!contains(text, "SECRET-PROMPT"));
+}
+
+test "render shows Codex session_id affinity without prompt text" {
+    reset();
+    defer reset();
+    noteRequest(std.testing.io, "SECRET-PROMPT", "[]");
+    noteAffinity("c0de0000-0000-5000-8000-000000000001", .codex, true);
+    var buf: [2048]u8 = undefined;
+    var w: Io.Writer = .fixed(&buf);
+    try render(&w);
+    const text = w.buffered();
+    try std.testing.expect(contains(text, "Codex"));
+    try std.testing.expect(contains(text, "session_id = prompt_cache_key"));
+    try std.testing.expect(contains(text, "c0de0000-0000-5000-8000-000000000001"));
+    try std.testing.expect(contains(text, "no prompt_cache_breakpoint"));
+    try std.testing.expect(!contains(text, "SECRET-PROMPT"));
+}
+
+test "affinityKind maps xai / codex / openai" {
+    try std.testing.expectEqual(AffinityKind.xai, affinityKind("xai"));
+    try std.testing.expectEqual(AffinityKind.codex, affinityKind("codex"));
+    try std.testing.expectEqual(AffinityKind.openai, affinityKind("openai"));
+    try std.testing.expectEqual(AffinityKind.unknown, affinityKind("kimi"));
 }
 
 test "renderLine is one content-free row" {

--- a/src/prompt_cache_hud.zig
+++ b/src/prompt_cache_hud.zig
@@ -220,6 +220,7 @@ pub fn render(w: *Io.Writer) !void {
         \\    Vercel                  gateway implicit cache (cached_tokens); coding-agent /v1
         \\    /btw                    parent tools + system + cache key; note is the user message
         \\    subagents               role-lane x-grok-conv-id / prompt_cache_key (not the root id)
+        \\    affinity                git-root or graff-scratch, not cwd (sibling sandboxes share)
         \\
     );
 }
@@ -309,6 +310,8 @@ test "render stays content-free and names remaining levers" {
     try std.testing.expect(contains(text, "x-grok-conv-id"));
     try std.testing.expect(contains(text, "append-only"));
     try std.testing.expect(contains(text, "subagents"));
+    try std.testing.expect(contains(text, "git-root"));
+    try std.testing.expect(contains(text, "graff-scratch"));
     try std.testing.expect(!contains(text, "SECRET-PROMPT"));
     try std.testing.expect(!contains(text, "/Users/me"));
     try std.testing.expect(!contains(text, "bash"));

--- a/src/prompt_cache_hud.zig
+++ b/src/prompt_cache_hud.zig
@@ -47,14 +47,16 @@ var g_aff_len: usize = 0;
 var g_kind: AffinityKind = .unknown;
 var g_responses: bool = false;
 
-/// Which wire last recorded an affinity key. `/cache` names Codex the same
-/// way it names xAI — both use `cache_affinity.rootId` (ADR 0011 / 0028).
-pub const AffinityKind = enum { unknown, xai, codex, openai };
+/// Which wire last recorded an affinity key. `/cache` names each live
+/// contract: xAI/Codex/OpenAI keyed, Claude explicit, Kimi automatic+key.
+pub const AffinityKind = enum { unknown, xai, codex, openai, anthropic, kimi };
 
 pub fn affinityKind(provider_id: []const u8) AffinityKind {
     if (std.mem.eql(u8, provider_id, "xai")) return .xai;
     if (std.mem.eql(u8, provider_id, "codex")) return .codex;
     if (std.mem.eql(u8, provider_id, "openai")) return .openai;
+    if (std.mem.eql(u8, provider_id, "anthropic")) return .anthropic;
+    if (std.mem.eql(u8, provider_id, "kimi")) return .kimi;
     return .unknown;
 }
 
@@ -228,11 +230,21 @@ pub fn render(w: *Io.Writer) !void {
                 try w.print("  OpenAI     {s}  (prompt_cache_key)\n", .{g_aff[0..g_aff_len]});
                 try w.writeAll("             gpt-5.6* also send prompt_cache_options + breakpoint\n");
             },
+            .anthropic => {
+                try w.writeAll("  Claude     explicit cache_control (tools + system + last message)\n");
+                try w.writeAll("             no prompt_cache_key; do not copy Codex/xAI knobs\n");
+            },
+            .kimi => {
+                try w.print("  Kimi       {s}  (prompt_cache_key on chat)\n", .{g_aff[0..g_aff_len]});
+                try w.writeAll("             automatic prefix; key is the coding-agent session id\n");
+            },
             .unknown => try w.print("  affinity   {s}\n", .{g_aff[0..g_aff_len]}),
         }
     } else {
         try w.writeAll("  xAI        x-grok-conv-id + x-grok-session-id + prompt_cache_key\n");
         try w.writeAll("  Codex      session_id + prompt_cache_key (same value)\n");
+        try w.writeAll("  Claude     cache_control on tools + system + last message\n");
+        try w.writeAll("  Kimi       automatic prefix + prompt_cache_key on chat\n");
     }
     try w.writeAll(
         \\  remaining max
@@ -247,6 +259,8 @@ pub fn render(w: *Io.Writer) !void {
         \\    subagents               role-lane x-grok-conv-id / prompt_cache_key (not the root id)
         \\    affinity                git-root or graff-scratch, not cwd (xAI and Codex share)
         \\    Codex                   session_id == prompt_cache_key (ADR 0028); no breakpoint
+        \\    Claude                  explicit cache_control; no top-level automatic (3 of 4 slots)
+        \\    Kimi                    automatic prefix; chat prompt_cache_key (Code Plan requires it)
         \\
     );
 }
@@ -340,6 +354,8 @@ test "render stays content-free and names remaining levers" {
     try std.testing.expect(contains(text, "graff-scratch"));
     try std.testing.expect(contains(text, "Codex"));
     try std.testing.expect(contains(text, "ADR 0028"));
+    try std.testing.expect(contains(text, "Claude"));
+    try std.testing.expect(contains(text, "Kimi"));
     try std.testing.expect(!contains(text, "SECRET-PROMPT"));
     try std.testing.expect(!contains(text, "/Users/me"));
     try std.testing.expect(!contains(text, "bash"));
@@ -376,11 +392,43 @@ test "render shows Codex session_id affinity without prompt text" {
     try std.testing.expect(!contains(text, "SECRET-PROMPT"));
 }
 
-test "affinityKind maps xai / codex / openai" {
+test "affinityKind maps xai / codex / openai / anthropic / kimi" {
     try std.testing.expectEqual(AffinityKind.xai, affinityKind("xai"));
     try std.testing.expectEqual(AffinityKind.codex, affinityKind("codex"));
     try std.testing.expectEqual(AffinityKind.openai, affinityKind("openai"));
-    try std.testing.expectEqual(AffinityKind.unknown, affinityKind("kimi"));
+    try std.testing.expectEqual(AffinityKind.anthropic, affinityKind("anthropic"));
+    try std.testing.expectEqual(AffinityKind.kimi, affinityKind("kimi"));
+    try std.testing.expectEqual(AffinityKind.unknown, affinityKind("minimax"));
+}
+
+test "render shows Claude explicit breakpoints without a fake key" {
+    reset();
+    defer reset();
+    noteRequest(std.testing.io, "SECRET-PROMPT", "[]");
+    noteAffinity("should-not-print-as-claude-key", .anthropic, false);
+    var buf: [2048]u8 = undefined;
+    var w: Io.Writer = .fixed(&buf);
+    try render(&w);
+    const text = w.buffered();
+    try std.testing.expect(contains(text, "explicit cache_control"));
+    try std.testing.expect(contains(text, "tools + system + last message"));
+    try std.testing.expect(!contains(text, "should-not-print-as-claude-key"));
+    try std.testing.expect(!contains(text, "SECRET-PROMPT"));
+}
+
+test "render shows Kimi automatic prefix plus the coding-agent key" {
+    reset();
+    defer reset();
+    noteRequest(std.testing.io, "SECRET-PROMPT", "[]");
+    noteAffinity("kimi-session-key", .kimi, false);
+    var buf: [2048]u8 = undefined;
+    var w: Io.Writer = .fixed(&buf);
+    try render(&w);
+    const text = w.buffered();
+    try std.testing.expect(contains(text, "Kimi"));
+    try std.testing.expect(contains(text, "kimi-session-key"));
+    try std.testing.expect(contains(text, "automatic prefix"));
+    try std.testing.expect(!contains(text, "SECRET-PROMPT"));
 }
 
 test "renderLine is one content-free row" {

--- a/src/spec_prompt_cache_conformance.zig
+++ b/src/spec_prompt_cache_conformance.zig
@@ -151,6 +151,7 @@ test "prompt cache: xAI Responses header and body agree; OpenAI Responses has a 
     var cbuf: [12]std.http.Header = undefined;
     const ch = http_headers.providerHeadersWithConv(ca.io, ca.provider, "Bearer k", &cbuf, body_key);
     try std.testing.expectEqualStrings(body_key, headerNamed(ch, "session_id") orelse return error.SessionIdHeaderMissing);
+    try std.testing.expectEqualStrings(http_headers.projectRootId(ca.io), body_key);
 }
 
 test "prompt cache: effort is never auto-flipped (prefix stays)" {

--- a/src/spec_prompt_cache_conformance.zig
+++ b/src/spec_prompt_cache_conformance.zig
@@ -154,6 +154,30 @@ test "prompt cache: xAI Responses header and body agree; OpenAI Responses has a 
     try std.testing.expectEqualStrings(http_headers.projectRootId(ca.io), body_key);
 }
 
+test "prompt cache: native Anthropic marks tools + system + last message" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    const spec = provider_mod.specFor("anthropic").?;
+    var root = try agentFor(a, spec, "main", .anthropic);
+    const tools = "[{\"name\":\"bash\",\"description\":\"\",\"input_schema\":{\"type\":\"object\"}}]";
+    const body = try root.buildBody(tools, false, true, true);
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"system\":[{\"type\":\"text\",\"text\":\"system\",\"cache_control\":{\"type\":\"ephemeral\"}}]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"input_schema\":{\"type\":\"object\"},\"cache_control\":{\"type\":\"ephemeral\"}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"text\":\"hello\",\"cache_control\":{\"type\":\"ephemeral\"}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"prompt_cache_key\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"prompt_cache_options\"") == null);
+    // Top-level automatic would be a 4th slot next to three explicit marks.
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"max_tokens\":16000,\"cache_control\"") == null);
+
+    var mm = try agentFor(a, spec, "main", .anthropic);
+    mm.provider.id = "minimax";
+    const plain = try mm.buildBody(tools, false, true, true);
+    defer std.testing.allocator.free(plain);
+    try std.testing.expect(std.mem.indexOf(u8, plain, "cache_control") == null);
+}
+
 test "prompt cache: effort is never auto-flipped (prefix stays)" {
     try std.testing.expect(!effort_route.shouldRouteLookupLow(false, true, "what does runEval do?"));
     try std.testing.expect(!effort_route.shouldRouteLookupLow(true, true, "explain the permission gate?"));

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -327,6 +327,7 @@ test {
     _ = sandbox_tests;
     _ = provider_tests;
     _ = turn_chrome;
+    _ = @import("cache_affinity.zig"); // ADR 0011: git-root / scratch partition, not cwd
     _ = tool_surface;
     _ = agent_catalog;
     _ = session_connect_tests;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prompt-cache max for both wires, not just xAI. Verified OOTB against Codex (DeepWiki / `ModelClient`), Claude’s current `cache_control` docs, and Kimi’s context-cache + chat OpenAPI.

## What was already true

Codex HTTP/WS `session_id` already equals the Responses `prompt_cache_key` (ADR 0028). Both wires call `projectRootId`. We do **not** send `prompt_cache_options` / `prompt_cache_breakpoint` on Codex — the ChatGPT backend 400s them (openai/codex#35300).

## What was wrong

1. That id hashed the **leaf cwd**. Sibling sandboxes with the same system+tools prefix were different partitions (rematch: graff first-call cache 0–512, grok 11k–43k already warm).
2. `/cache` only named xAI headers. A Codex session looked like it had no affinity.
3. Native Claude marked system + last message, but **not** the last tool (`writeAnthropicTools(..., is_kimi)`). A long tool loop can walk Anthropic’s 20-block lookback off the system write.

## This PR

- Root affinity is the **git root** (or `graff-scratch` with no repo). Worktrees and eval sandboxes share. Includes #659.
- `/cache` prints Codex as `session_id = prompt_cache_key` on the same id. OpenAI Platform still gets the ADR 0009 breakpoint. Claude and Kimi are named on their own contracts (no fake Claude key).
- Native Anthropic now marks **tools + system + last message**. MiniMax stays unmarked. No top-level automatic `cache_control` (that would be a 4th slot / no-op).
- Kimi chat already sent `prompt_cache_key` (Code Plan / coding-agent). Unchanged.
- ADR 0028: same git-root id as xAI; no Platform breakpoint on this wire.

You can just use it: pick the provider, `/cache` names the live contract. Merge this one if you want both wires in one shot (stacks on #659).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

