### PR TITLE
fix: TUI first paint no longer waits on companion MCP

### DIFF
--- a/TUI/render_tests.zig
+++ b/TUI/render_tests.zig
@@ -36,6 +36,15 @@ test "welcome frame has chrome, prompt, and no offline stub" {
     try std.testing.expect(std.mem.indexOf(u8, frame, "offline") == null);
     try std.testing.expect(std.mem.indexOf(u8, frame, "Fullscreen") == null);
     try std.testing.expect(std.mem.indexOf(u8, frame, "click") == null);
+    // Boot receipts (plugins:/mcp:/companion:) print before alt-screen.
+    try std.testing.expect(std.mem.indexOf(u8, frame, "plugins:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, frame, "companion:") == null);
+    if (std.c.getenv("GRAFF_DUMP_WELCOME")) |path_z| {
+        const vis = try dump_mod.visible(std.testing.allocator, frame);
+        defer std.testing.allocator.free(vis);
+        const io = std.Io.Threaded.global_single_threaded.io();
+        std.Io.Dir.cwd().writeFile(io, .{ .sub_path = std.mem.span(path_z), .data = vis }) catch {};
+    }
 }
 
 test "click on a painted fold header expands the tools" {

--- a/docs/adr/0035-first-turn-skips-deferred-mcp-join.md
+++ b/docs/adr/0035-first-turn-skips-deferred-mcp-join.md
@@ -16,8 +16,20 @@ model had not even been called.
 turn. MCP catalogs merge on the next request, `/mcp`, or teardown. A dim
 notice says so when a TUI sink is attached.
 
+Companion auto-connect (`codedb-pro --mcp`) is the same wait. Interactive
+`--yolo` queues it onto `pending_starts` instead of `addServer` on the
+main thread. `codedb-pro probe` is capped (2s), never `timeout 0`. A
+`defer_join` fan-out that cannot `io.concurrent` skips that server
+rather than falling back to inline `io.async`.
+
+Interactive boots print a dim receipt after `plugins:` (`mcp: N server(s)
+in background`, `companion: codedb-pro (background)`) and name any boot
+phase ≥80ms, so a hang is visible without `GRAFF_BOOT_DEBUG`.
+
 ## Consequences
 
 A one-shot first turn that *only* has MCP tools will not see them until
 the second request. `/mcp` still blocks. Revisit if a session is MCP-only
-and the first prompt must use those tools.
+and the first prompt must use those tools. A licensed companion's eager
+pin and system-prompt note wait until the handshake joins; first paint
+uses native tools.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,7 +45,7 @@ record only when you need the evidence or the edge cases.
 | [0032](0032-acp-streams-mid-turn.md) | `graff acp` streams thought / tool / text `session/update`s mid-turn. The native app is an ACP client; it does not need `graff serve`. |
 | [0033](0033-user-can-retire-a-standing-constraint.md) | Only the user retires a standing constraint: TTY `/never` picker (two confirms), ACP/`rm`, or an explicit override. The model cannot. |
 | [0034](0034-remote-images-stay-native.md) | JSON/serve image inputs are a typed URL/base64 union, validated atomically and preserved as native provider vision blocks; never flatten pixels into prompt text. |
-| [0035](0035-first-turn-skips-deferred-mcp-join.md) | First model call after a deferred MCP boot does not wait for the handshake; native tools run now, MCP catalogs merge on the next request. |
+| [0035](0035-first-turn-skips-deferred-mcp-join.md) | First model call after a deferred MCP boot does not wait for the handshake; companion auto-connect is the same defer; native tools run now. |
 | [0036](0036-computer-use-keeps-the-signed-codex-bridge.md) | Codex Computer Use keeps its authenticated node_repl process chain: Graff launches it through the signed Codex sandbox wrapper, never embeds V8 or spoofs the service. |
 | [0037](0037-experiment-pool-is-opt-in.md) | `--experiment N` / `/experiment N` pre-mints a child worktree pool; the root must spawn; pool trees are listed and delivered back, never auto-deleted. |
 | [0038](0038-in-process-acp-core.md) | Same-process embed is `libgraff` + `graff-core.wasm` + `createGraffAgent()` (ACP core, echo turn). Live coding stays `graff acp`. |

--- a/src/companion_boot.zig
+++ b/src/companion_boot.zig
@@ -1,0 +1,108 @@
+//! Companion auto-connect (codedb-pro / muonry), split out of session_start
+//! so the TUI boot path can name the hang and stay under 600 lines.
+//!
+//! Interactive `--yolo` used to call `Registry.addServer` on the main thread
+//! after the plugin receipt. The registry is still empty on a deferred MCP
+//! boot (ADR 0035), so a PATH-installed companion looked "not connected" and
+//! the handshake (stdio probe + 15s cap) sat in front of the first paint.
+//! Queue it onto `pending_starts` instead; native tools run now.
+
+const std = @import("std");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+
+const args = @import("args.zig");
+const engine_events = @import("engine_events.zig");
+const engine_sink = @import("engine_sink.zig");
+const mcp = @import("mcp.zig");
+const mcp_boot = @import("mcp_boot.zig");
+const mcp_schema_gate = @import("mcp_schema_gate.zig");
+const skills = @import("skills.zig");
+
+/// Same gate as MCP `defer_join`: interactive yolo, not `--json` / `-p`.
+pub fn deferCompanion(flags: args.Flags, json_mode: bool) bool {
+    return flags.effectiveYolo() and flags.oneshot_prompt == null and !json_mode;
+}
+
+pub fn probeLicensed(gpa: Allocator, io: Io) bool {
+    return skills.probeCodedbproLicensed(gpa, io);
+}
+
+/// A licensed codedb-pro still pins these tools eager (search/batch extras;
+/// ADR 0040: not the default reader). Skipping that pin costs a measured
+/// ~2 load_tool_schemas discovery turns per task that does need pro search.
+pub fn pinCompanionEager(arena: Allocator) void {
+    if (mcp_schema_gate.pinnedEager("codedbpro")) return;
+    const gate = &mcp_schema_gate.g_policy;
+    const eager = arena.alloc([]const u8, gate.eager.len + 1) catch return;
+    @memcpy(eager[0..gate.eager.len], gate.eager);
+    eager[gate.eager.len] = "codedbpro";
+    gate.eager = eager;
+}
+
+pub fn probeLicensedPinningEager(gpa: Allocator, io: Io, arena: Allocator) bool {
+    const licensed = probeLicensed(gpa, io);
+    if (licensed) pinCompanionEager(arena);
+    return licensed;
+}
+
+fn dimNotice(text: []const u8) engine_events.EngineEvent {
+    return .{ .session_notice = .{ .text = text, .tone = .dim } };
+}
+
+fn interactive(flags: args.Flags, json_mode: bool) bool {
+    return !json_mode and flags.oneshot_prompt == null;
+}
+
+/// Spawn the first PATH-installed companion that is not already connected
+/// or queued. Interactive `--yolo` queues a background handshake (ADR 0035);
+/// every other path still `addServer`s on this thread.
+pub fn connectCompanion(io: Io, arena: Allocator, registry: *mcp.Registry, flags: args.Flags, out: *Io.Writer, json_mode: bool, environ_map: anytype) !void {
+    const sink = engine_sink.writerSink(out);
+    const speak = interactive(flags, json_mode);
+    const background = deferCompanion(flags, json_mode);
+    _ = environ_map;
+    connect: {
+        for (skills.companion_servers) |c| {
+            if (mcp_boot.alreadyStarting(registry, c.server)) break :connect;
+            if (skills.mcpServerConnected(registry.tools, c.server)) break :connect;
+        }
+        for (skills.companion_servers) |c| {
+            if (skills.companionDisabled(c.server) or !skills.binOnPath(io, c.bin)) continue;
+            if (background) {
+                if (speak) sink.emit(io, dimNotice(try std.fmt.allocPrint(arena, "companion: {s} (background)", .{c.bin})));
+                mcp_boot.queueStdio(registry, c.server, c.bin, &.{"--mcp"});
+                break;
+            }
+            if (speak) sink.emit(io, dimNotice(try std.fmt.allocPrint(arena, "companion: connecting {s}...", .{c.bin})));
+            if (registry.addServer(c.server, c.bin, &.{"--mcp"})) |_| {
+                break;
+            } else |err| {
+                if (speak) sink.emit(io, dimNotice(try std.fmt.allocPrint(arena, "[mcp:{s}] auto-connect failed ({t}) — native tools only", .{ c.server, err })));
+            }
+        }
+    }
+}
+
+test "deferCompanion: interactive yolo only" {
+    try std.testing.expect(deferCompanion(.{ .yolo_flag = true }, false));
+    try std.testing.expect(!deferCompanion(.{ .yolo_flag = true }, true));
+    try std.testing.expect(!deferCompanion(.{ .yolo_flag = true, .oneshot_prompt = "hi" }, false));
+    try std.testing.expect(!deferCompanion(.{}, false));
+    try std.testing.expect(!deferCompanion(.{ .oneshot_prompt = "hi" }, false));
+}
+
+test "a licensed companion is pinned eager, once, so no discovery round-trip is needed" {
+    const saved = mcp_schema_gate.g_policy;
+    defer mcp_schema_gate.g_policy = saved;
+    mcp_schema_gate.g_policy = .{};
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    try std.testing.expect(!mcp_schema_gate.pinnedEager("codedbpro"));
+    pinCompanionEager(arena);
+    try std.testing.expect(mcp_schema_gate.pinnedEager("codedbpro"));
+    pinCompanionEager(arena);
+    try std.testing.expectEqual(@as(usize, 1), mcp_schema_gate.g_policy.eager.len);
+}

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -94,6 +94,9 @@ pub const Registry = struct {
     task_arenas: []std.heap.ArenaAllocator = &.{},
     /// Unjoined startServer futures from a deferred --yolo boot.
     pending_starts: []Io.Future(mcp_boot.StartOutcome) = &.{},
+    /// Names paired with `pending_starts` so companion auto-connect can skip
+    /// a second spawn of a server the deferred fan-out already queued.
+    pending_names: []const []const u8 = &.{},
     /// First model call already declined to wait on `pending_starts` (ADR 0035).
     first_request_join_skipped: bool = false,
 

--- a/src/mcp_boot.zig
+++ b/src/mcp_boot.zig
@@ -108,8 +108,10 @@ pub fn init(gpa: Allocator, io: Io, config_path: []const u8, global_path: ?[]con
     }
 
     const futures = try gpa.alloc(Io.Future(StartOutcome), entries.items.len);
+    const started_names = try a.alloc([]const u8, entries.items.len);
     // concurrent, not async: io.async may run the handshake inline, so two
     // remote servers paid SUM(latency) instead of max(latency) at REPL start.
+    // defer_join must not take that fallback — inline handshake is the TUI hang.
     const ctx = StartCtx{
         .gpa = gpa,
         .io = io,
@@ -117,17 +119,86 @@ pub fn init(gpa: Allocator, io: Io, config_path: []const u8, global_path: ?[]con
         .show_diagnostics = show_diagnostics,
         .stdio_probe = reg.stdio_probe,
     };
-    for (entries.items, futures) |e, *fut| {
+    var started: usize = 0;
+    for (entries.items) |e| {
         const args = .{ ctx, e.name, e.cfg };
-        fut.* = io.concurrent(startServerTask, args) catch io.async(startServerTask, args);
+        if (io.concurrent(startServerTask, args)) |fut| {
+            futures[started] = fut;
+            started_names[started] = e.name;
+            started += 1;
+        } else |_| {
+            if (defer_join) continue;
+            futures[started] = io.async(startServerTask, args);
+            started_names[started] = e.name;
+            started += 1;
+        }
     }
     if (defer_join) {
-        reg.pending_starts = futures;
+        if (started == 0) {
+            gpa.free(futures);
+            return reg;
+        }
+        if (started < futures.len) {
+            const slim = try gpa.alloc(Io.Future(StartOutcome), started);
+            @memcpy(slim, futures[0..started]);
+            gpa.free(futures);
+            reg.pending_starts = slim;
+        } else {
+            reg.pending_starts = futures;
+        }
+        reg.pending_names = started_names[0..started];
         return reg;
     }
     defer gpa.free(futures);
-    mergeOutcomes(&reg, futures);
+    mergeOutcomes(&reg, futures[0..started]);
     return reg;
+}
+
+/// True when `name` is already live or queued on a deferred boot.
+pub fn alreadyStarting(reg: *const Registry, name: []const u8) bool {
+    for (reg.servers) |s| if (std.mem.eql(u8, s.name, name)) return true;
+    for (reg.pending_names) |n| if (std.mem.eql(u8, n, name)) return true;
+    return false;
+}
+
+fn startCtx(reg: *const Registry) StartCtx {
+    return .{
+        .gpa = reg.gpa,
+        .io = reg.io,
+        .home = reg.home,
+        .show_diagnostics = reg.show_diagnostics,
+        .stdio_probe = reg.stdio_probe,
+    };
+}
+
+/// Queue a stdio server onto `pending_starts` without waiting. Used by
+/// companion auto-connect so first paint is not the handshake. If the
+/// thread pool cannot take the task, skip — do not run `io.async` inline.
+pub fn queueStdio(reg: *Registry, name: []const u8, command: []const u8, args: []const []const u8) void {
+    if (alreadyStarting(reg, name)) return;
+    const a = reg.arena();
+    const n = a.dupe(u8, name) catch return;
+    var cfg: std.json.ObjectMap = .empty;
+    cfg.put(a, "command", .{ .string = a.dupe(u8, command) catch return }) catch return;
+    var argv = std.json.Array.init(a);
+    for (args) |arg| argv.append(.{ .string = a.dupe(u8, arg) catch return }) catch return;
+    cfg.put(a, "args", .{ .array = argv }) catch return;
+    const fut = reg.io.concurrent(startServerTask, .{ startCtx(reg), n, cfg }) catch return;
+    appendPending(reg, fut, n);
+}
+
+fn appendPending(reg: *Registry, fut: Io.Future(StartOutcome), name: []const u8) void {
+    const old = reg.pending_starts;
+    const next = reg.gpa.alloc(Io.Future(StartOutcome), old.len + 1) catch return;
+    @memcpy(next[0..old.len], old);
+    next[old.len] = fut;
+    if (old.len > 0) reg.gpa.free(old);
+    reg.pending_starts = next;
+    const a = reg.arena();
+    const names = a.alloc([]const u8, reg.pending_names.len + 1) catch return;
+    @memcpy(names[0..reg.pending_names.len], reg.pending_names);
+    names[reg.pending_names.len] = name;
+    reg.pending_names = names;
 }
 
 fn mergeOutcomes(reg: *Registry, futures: []Io.Future(StartOutcome)) void {
@@ -211,6 +282,7 @@ pub fn joinPending(reg: *Registry) bool {
     const t0 = Io.Timestamp.now(reg.io, .awake);
     const futures = reg.pending_starts;
     reg.pending_starts = &.{};
+    reg.pending_names = &.{};
     mergeOutcomes(reg, futures);
     reg.gpa.free(futures);
     const waited = @max(0, t0.untilNow(reg.io, .awake).toMilliseconds());
@@ -229,6 +301,23 @@ test "MCP boot fans server handshakes out with io.concurrent" {
     try std.testing.expect(std.mem.indexOf(u8, src, "io.concurrent(startServerTask") != null);
     try std.testing.expect(std.mem.indexOf(u8, src, "io.async(startServerTask") != null);
     try std.testing.expect(std.mem.indexOf(u8, src, "defer_join") != null);
+}
+
+test "defer_join does not fall back to inline io.async" {
+    const src = @embedFile("mcp_boot.zig");
+    try std.testing.expect(std.mem.indexOf(u8, src, "if (defer_join) continue") != null);
+}
+
+test "alreadyStarting sees pending names before the handshake finishes" {
+    const io = std.testing.io;
+    var reg = Registry.empty(std.testing.allocator, io);
+    defer reg.deinit();
+    try std.testing.expect(!alreadyStarting(&reg, "codedbpro"));
+    const pending = [_][]const u8{"codedbpro"};
+    reg.pending_names = &pending;
+    try std.testing.expect(alreadyStarting(&reg, "codedbpro"));
+    try std.testing.expect(!alreadyStarting(&reg, "other"));
+    reg.pending_names = &.{};
 }
 
 test "joinPending is a no-op on an empty registry" {

--- a/src/session_connect_tests.zig
+++ b/src/session_connect_tests.zig
@@ -44,6 +44,34 @@ test "connectCompanion on interactive yolo queues instead of addServer" {
     try std.testing.expect(std.mem.indexOf(u8, src, "companion: {s} (background)") != null);
 }
 
+test "connectCompanion yolo writes the companion receipt and does not addServer" {
+    const main_mod = @import("main.zig");
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.symLink(io, "/bin/false", "codedb-pro", .{});
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &path_buf);
+    const saved_path = main_mod.g_path_env;
+    defer main_mod.g_path_env = saved_path;
+    main_mod.g_path_env = path_buf[0..n];
+
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var env = std.process.Environ.Map.init(std.testing.allocator);
+    defer env.deinit();
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    var registry = mcp.Registry.empty(std.testing.allocator, io);
+    defer registry.deinit();
+
+    try session_start.connectCompanion(io, arena_state.allocator(), &registry, .{ .yolo_flag = true }, &aw.writer, false, env);
+    const out = aw.writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, out, "companion: codedb-pro (background)") != null);
+    try std.testing.expectEqual(@as(usize, 0), registry.servers.len);
+    try std.testing.expectEqual(@as(usize, 0), registry.tools.len);
+}
+
 test "skipOptionalServer keeps deepwiki/mobbin out of the default catalog" {
     var env = std.process.Environ.Map.init(std.testing.allocator);
     defer env.deinit();

--- a/src/session_connect_tests.zig
+++ b/src/session_connect_tests.zig
@@ -5,6 +5,7 @@ const Io = std.Io;
 
 const args = @import("args.zig");
 const mcp = @import("mcp.zig");
+const companion_boot = @import("companion_boot.zig");
 const session_start = @import("session_start.zig");
 const tool_surface = @import("tool_surface.zig");
 
@@ -33,6 +34,14 @@ test "connectCompanion never injects a bundled Smolify server" {
     try session_start.connectCompanion(std.testing.io, arena, &with_opt, flags, &aw.writer, true, env);
     try std.testing.expectEqual(@as(usize, 0), with_opt.tools.len);
     try std.testing.expectEqual(@as(usize, 0), with_opt.servers.len);
+}
+
+test "connectCompanion on interactive yolo queues instead of addServer" {
+    try std.testing.expect(companion_boot.deferCompanion(.{ .yolo_flag = true }, false));
+    const src = @embedFile("companion_boot.zig");
+    try std.testing.expect(std.mem.indexOf(u8, src, "queueStdio") != null);
+    try std.testing.expect(std.mem.indexOf(u8, src, "addServer") != null);
+    try std.testing.expect(std.mem.indexOf(u8, src, "companion: {s} (background)") != null);
 }
 
 test "skipOptionalServer keeps deepwiki/mobbin out of the default catalog" {

--- a/src/session_render.zig
+++ b/src/session_render.zig
@@ -238,6 +238,30 @@ test "slice 2: a notice's tone colors the line, a badge colors only itself" {
     );
 }
 
+test "slice 2: yolo boot receipts match the plugins line (dim, then reset)" {
+    const saved = ansi.style;
+    ansi.style = ansi.Style.ansi;
+    defer ansi.style = saved;
+    var aw: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    const plugins = "plugins: 16 plugin(s) in 1ms (7 dirs)";
+    const mcp = "mcp: 3 server(s) in background";
+    const companion = "companion: codedb-pro (background)";
+    try std.testing.expectEqualStrings(
+        "\x1b[2m" ++ plugins ++ "\x1b[0m\n",
+        renderTest(&aw, .{ .session_notice = .{ .text = plugins, .tone = .dim } }),
+    );
+    try std.testing.expectEqualStrings(
+        "\x1b[2m" ++ mcp ++ "\x1b[0m\n",
+        renderTest(&aw, .{ .session_notice = .{ .text = mcp, .tone = .dim } }),
+    );
+    try std.testing.expectEqualStrings(
+        "\x1b[2m" ++ companion ++ "\x1b[0m\n",
+        renderTest(&aw, .{ .session_notice = .{ .text = companion, .tone = .dim } }),
+    );
+}
+
 test "slice 2: the failover notice, with a frontend and without one" {
     const saved = ansi.style;
     ansi.style = .{};

--- a/src/session_start.zig
+++ b/src/session_start.zig
@@ -37,7 +37,6 @@ const main_mod = @import("main.zig");
 const provider_mod = @import("provider.zig");
 const keys_cli = @import("keys_cli.zig");
 const pricing = @import("pricing.zig");
-const skills = @import("skills.zig");
 const mcp = @import("mcp.zig");
 const mcp_cli = @import("mcp_cli.zig");
 const mcp_config = @import("mcp_config.zig");
@@ -53,6 +52,11 @@ const obs = @import("obs.zig");
 const util = @import("util.zig");
 const engine_sink = @import("engine_sink.zig"); // #429: startup's lines are typed events, not prints
 const engine_events = @import("engine_events.zig");
+const companion_boot = @import("companion_boot.zig");
+pub const probeLicensed = companion_boot.probeLicensed;
+pub const pinCompanionEager = companion_boot.pinCompanionEager;
+pub const probeLicensedPinningEager = companion_boot.probeLicensedPinningEager;
+pub const connectCompanion = companion_boot.connectCompanion;
 const title_mod = @import("title.zig");
 const fallback_config = @import("fallback_config.zig");
 const repl = @import("repl.zig");
@@ -448,6 +452,16 @@ pub fn initRegistryConsent(io: Io, gpa: Allocator, arena: Allocator, out: *Io.Wr
     }
     const mcp_count = mcp_cli.countMcpServers(merged);
     const defer_join = flags.effectiveYolo() and flags.oneshot_prompt == null and !json_mode;
+    // Name the next phase the way `plugins:` already does. Without this, a
+    // handshake that still runs on this thread looks like a hung boot.
+    if (!json_mode and flags.oneshot_prompt == null and mcp_count > 0) {
+        const mcp_line = if (defer_join)
+            try std.fmt.allocPrint(arena, "mcp: {d} server(s) in background", .{mcp_count})
+        else
+            try std.fmt.allocPrint(arena, "mcp: connecting {d} server(s)...", .{mcp_count});
+        sink.emit(io, dimNotice(mcp_line));
+    }
+    const mcp_t0 = Io.Timestamp.now(io, .awake);
     // Lean folds schemas (deferAllRuntime); it does not skip connect.
     // --yolo / -p still connect so `.mcp.json` works on the default one-shot
     // (ADR 0029). Interactive without --yolo still asks.
@@ -474,65 +488,12 @@ pub fn initRegistryConsent(io: Io, gpa: Allocator, arena: Allocator, out: *Io.Wr
     registry.global_config_path = global_path;
     registry.global_is_override = mcp_config.isEnvOverride(environ_map);
     registry.show_diagnostics = json_mode or flags.oneshot_prompt != null or environ_map.get("GRAFF_REPL_DEBUG") != null;
-    return registry;
-}
-
-/// Licensed startup path (main.zig): probe the companion's license so the
-/// session can lean into the paid tools. Schemas stay DEFERRED like every
-/// other server: routing to the suite is enforced by the codedbpro guard
-/// (codedbpro_report.nativeRefusal blocks the native read/search tools and
-/// points at the pro replacements), so the old eager pin paid ~17 KiB of
-/// schema bytes on every request for behavior the guard already guarantees
-/// (#476). GRAFF_MCP_EAGER=codedbpro restores the eager surface opt-in.
-pub fn probeLicensed(gpa: Allocator, io: Io) bool {
-    return skills.probeCodedbproLicensed(gpa, io);
-}
-
-/// A licensed codedb-pro still pins these tools eager (search/batch extras;
-/// ADR 0040: not the default reader). Skipping that pin costs a measured
-/// ~2 load_tool_schemas discovery turns per task that does need pro search.
-/// (#476 kept it deferred; traces showed every such run paying the dance.)
-pub fn pinCompanionEager(arena: Allocator) void {
-    if (mcp_schema_gate.pinnedEager("codedbpro")) return; // env/config already pinned
-    const gate = &mcp_schema_gate.g_policy;
-    const eager = arena.alloc([]const u8, gate.eager.len + 1) catch return;
-    @memcpy(eager[0..gate.eager.len], gate.eager);
-    eager[gate.eager.len] = "codedbpro";
-    gate.eager = eager;
-}
-
-/// The startup license probe plus its one side effect: a licensed companion
-/// is pinned eager so its full schemas ride the first catalog render instead
-/// of arriving via a load_tool_schemas discovery turn.
-pub fn probeLicensedPinningEager(gpa: Allocator, io: Io, arena: Allocator) bool {
-    const licensed = probeLicensed(gpa, io);
-    if (licensed) pinCompanionEager(arena);
-    return licensed;
-}
-
-/// Companion auto-activation: if the metered code-intelligence companion
-/// (codedb-pro, formerly muonry) is installed but nothing connected it (no
-/// workspace .mcp.json entry, or consent declined), spawn it directly — a
-/// user-installed companion at the same trust level as the skills
-/// auto-detection, NOT arbitrary workspace config. Failure just falls back
-/// to native tools. Opt out like a skill: {"skills": {"codedbpro": false}}.
-/// Moved out of main() (600-line goal); mutates `registry` in place (it's
-/// already main()-owned and stable by the time this is called, so a pointer
-/// is all that's needed — no return-by-value trickery here).
-pub fn connectCompanion(io: Io, arena: Allocator, registry: *mcp.Registry, flags: args.Flags, out: *Io.Writer, json_mode: bool, environ_map: anytype) !void {
-    const sink = engine_sink.writerSink(out);
-    const speak = !json_mode and flags.oneshot_prompt == null and environ_map.get("GRAFF_REPL_DEBUG") != null;
-    connect: {
-        for (skills.companion_servers) |c| if (skills.mcpServerConnected(registry.tools, c.server)) break :connect;
-        for (skills.companion_servers) |c| {
-            if (skills.companionDisabled(c.server) or !skills.binOnPath(io, c.bin)) continue;
-            if (registry.addServer(c.server, c.bin, &.{"--mcp"})) |_| {
-                break;
-            } else |err| {
-                if (speak) sink.emit(io, dimNotice(try std.fmt.allocPrint(arena, "[mcp:{s}] auto-connect failed ({t}) — native tools only", .{ c.server, err })));
-            }
-        }
+    if (!json_mode and flags.oneshot_prompt == null) {
+        const ms = @max(0, mcp_t0.untilNow(io, .awake).toMilliseconds());
+        if (ms >= 80)
+            sink.emit(io, dimNotice(try std.fmt.allocPrint(arena, "mcp: ready in {d}ms", .{ms})));
     }
+    return registry;
 }
 
 /// The startup cluster's most common line: dim, no badge. A helper rather than

--- a/src/skills.zig
+++ b/src/skills.zig
@@ -178,10 +178,14 @@ pub fn companionDisabled(server: []const u8) bool {
     return false;
 }
 
+/// License probe cap. `runCapped(..., 0)` waited forever; a hung `codedb-pro
+/// probe` sat in front of the first TUI paint with no receipt after plugins.
+pub const codedbpro_probe_ms: u64 = 2_000;
+
 /// Run the companion's `probe` — its own harness-gating capability check, the
 /// same gate the codedb-pro CLI hooks use. Exit 0 == licensed and usable.
 pub fn probeCodedbproLicensed(gpa: Allocator, io: Io) bool {
-    const run = runCapped(gpa, io, &.{ "codedb-pro", "probe" }, 256, 256, 0) catch return false;
+    const run = runCapped(gpa, io, &.{ "codedb-pro", "probe" }, 256, 256, codedbpro_probe_ms) catch return false;
     defer {
         gpa.free(run.stdout);
         gpa.free(run.stderr);
@@ -393,6 +397,14 @@ test "codedbproNote: licensed flips codedbpro to the lean-in note" {
     try std.testing.expect(std.mem.indexOf(u8, codedbpro_note_licensed, "/rewind") != null);
     try std.testing.expect(std.mem.indexOf(u8, codedbpro_note_licensed, "Do not use mcp__codedbpro__read") != null);
     try std.testing.expect(std.mem.indexOf(u8, codedbpro_note_licensed, "READ with native codedb") != null);
+}
+
+test "codedb-pro license probe is bounded" {
+    try std.testing.expect(codedbpro_probe_ms > 0);
+    try std.testing.expect(codedbpro_probe_ms <= 5_000);
+    const src = @embedFile("skills.zig");
+    try std.testing.expect(std.mem.indexOf(u8, src, "codedbpro_probe_ms") != null);
+    try std.testing.expect(std.mem.indexOf(u8, src, "256, 256, 0") == null);
 }
 
 test "skillIndex: registry lookup" {

--- a/src/skills.zig
+++ b/src/skills.zig
@@ -403,8 +403,7 @@ test "codedb-pro license probe is bounded" {
     try std.testing.expect(codedbpro_probe_ms > 0);
     try std.testing.expect(codedbpro_probe_ms <= 5_000);
     const src = @embedFile("skills.zig");
-    try std.testing.expect(std.mem.indexOf(u8, src, "codedbpro_probe_ms") != null);
-    try std.testing.expect(std.mem.indexOf(u8, src, "256, 256, 0") == null);
+    try std.testing.expect(std.mem.indexOf(u8, src, "256, 256, codedbpro_probe_ms") != null);
 }
 
 test "skillIndex: registry lookup" {

--- a/src/startup_timing.zig
+++ b/src/startup_timing.zig
@@ -36,7 +36,8 @@ pub const Tracker = struct {
             .phase_ms = @max(0, cumulative_ms - self.last_ms),
         };
         self.last_ms = cumulative_ms;
-        if (self.debug) std.debug.print("[boot +{d}ms, phase {d}ms] {s}\n", .{ phase.cumulative_ms, phase.phase_ms, label });
+        if (shouldPrint(self.debug, phase.phase_ms))
+            std.debug.print("[boot +{d}ms, phase {d}ms] {s}\n", .{ phase.cumulative_ms, phase.phase_ms, label });
         if (self.tracer) |tracer| {
             emit(tracer, phase);
         } else if (self.phases_len < self.phases.len) {
@@ -50,6 +51,12 @@ pub const Tracker = struct {
         self.tracer = tracer;
         for (self.phases[0..self.phases_len]) |phase| emit(tracer, phase);
         self.phases_len = 0;
+    }
+
+    /// `GRAFF_BOOT_DEBUG` prints every phase. Interactive boots also name
+    /// anything ≥80ms so a hang after `plugins:` is visible without an env var.
+    pub fn shouldPrint(debug: bool, phase_ms: i64) bool {
+        return debug or phase_ms >= 80;
     }
 
     fn emit(tracer: *trace.Tracer, phase: Phase) void {
@@ -72,4 +79,11 @@ test "startup phases retain order and non-negative deltas before attach" {
     try std.testing.expectEqualStrings("credentials", tracker.phases[1].label);
     try std.testing.expect(tracker.phases[0].phase_ms >= 0);
     try std.testing.expect(tracker.phases[1].cumulative_ms >= tracker.phases[0].cumulative_ms);
+}
+
+test "slow boot phases print without GRAFF_BOOT_DEBUG" {
+    try std.testing.expect(!Tracker.shouldPrint(false, 0));
+    try std.testing.expect(!Tracker.shouldPrint(false, 79));
+    try std.testing.expect(Tracker.shouldPrint(false, 80));
+    try std.testing.expect(Tracker.shouldPrint(true, 0));
 }

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -330,6 +330,7 @@ test {
     _ = tool_surface;
     _ = agent_catalog;
     _ = session_connect_tests;
+    _ = @import("companion_boot.zig");
     _ = @import("experiment_pool.zig");
     _ = @import("commands_experiment.zig");
     _ = @import("acp_engine.zig");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What you saw

```
graff tui --yolo
plugins: 16 plugin(s) in 1ms (7 dirs)
```

Then nothing for a long time. Plugin scan was already fine. The hang was the **next** work, with no receipt.

## Where the time went

After `plugins:`, interactive `--yolo` still did two things on the main thread before the alt screen:

1. **Companion auto-connect.** Deferred MCP leaves `registry.tools` empty, so a PATH-installed `codedb-pro` looked “not connected” and `addServer` ran the full stdio probe + handshake (5s / 15s caps) in front of first paint.
2. **`codedb-pro probe` with timeout 0.** If that binary blocks, boot never continues.

A `defer_join` fan-out that could not `io.concurrent` also fell back to `io.async`, which can run the handshake inline.

## What we did

- Print dim receipts after `plugins:` so the next phase is named:
  - `mcp: N server(s) in background` / `mcp: connecting N server(s)...`
  - `mcp: ready in Xms` if that wait is ≥80ms
  - `companion: codedb-pro (background)`
- Queue companion onto `pending_starts` on interactive `--yolo` (same as ADR 0035 MCP defer). Native tools run now; catalogs merge on the next request.
- Cap `codedb-pro probe` at 2s.
- Skip a server rather than inline-`async` when `defer_join` cannot get a thread.
- Print any boot phase ≥80ms without `GRAFF_BOOT_DEBUG`.

## How it looks

Line REPL (`graff --yolo`) keeps the same dim `plugins:` line and adds two siblings:

```
plugins: 16 plugin(s) in 1ms (7 dirs)
mcp: 3 server(s) in background
companion: codedb-pro (background)
```

`graff tui --yolo` prints those, then takes the alt screen. First paint is the welcome composer — no `plugins:` / `companion:` on the grid.

## Check

`graff tui --yolo` should paint right after the plugin line. You should see `companion: codedb-pro (background)` if the binary is on PATH. MCP tools still arrive on the next turn / `/mcp`.

Opt out of the companion the same way as before: `{"skills": {"codedbpro": false}}`.

Tier 1 green (1762 tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

