### PR TITLE
Keep mid-turn stalls and call counters off the transcript

### DIFF
--- a/docs/adr/0021-transcript-is-the-task-not-the-bus.md
+++ b/docs/adr/0021-transcript-is-the-task-not-the-bus.md
@@ -21,8 +21,9 @@ Every harness event is one of four classes:
 | Useful operation | a semantic one-liner |
 | New information | model narration |
 
-`note_constraint`, `skill`, `read_tool_result`, and successful compaction are
-bookkeeping (`/debug` still prints compaction). `todo_write` reprints a
+`note_constraint`, `skill`, `read_tool_result`, successful compaction, mid-turn
+stall/reconnect, and inner-loop "model call N" pulses are bookkeeping (`/debug`
+still prints compaction). `todo_write` reprints a
 `WORKING` block only when the checklist changes, and the same block sits
 above `›`. Subagents are `↯ scout` / `✓ scout` one-liners; the `sa-` id is
 not foreground UI. `batch` is `inspect`. Observe, then conclude, then act.

--- a/scripts/test-stall-drop.py
+++ b/scripts/test-stall-drop.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""#134/#132/#56 end-to-end: a forced stream stall/drop first RECONNECTS on a
-fresh stream (#56); only after the reconnect budget is exhausted is the turn saved
-as "[response ended early: ...]" and shown as a stream notice — NEVER a user Esc
-interrupt. Drives the GRAFF_FORCE_STALL_ALWAYS / GRAFF_FORCE_DROP_ALWAYS seams,
-which make EVERY live attempt return error.StreamStalled / error.StreamDropped
-before any network call, so the give-up path runs with no provider/key."""
+"""#134/#132/#56 end-to-end: a forced stream stall/drop first reconnects on a
+fresh stream (#56, silent on the transcript — ADR 0021); only after the
+reconnect budget is exhausted is the turn saved as "[response ended early: ...]"
+and shown as an ending-turn notice — NEVER a user Esc interrupt. Drives the
+GRAFF_FORCE_STALL_ALWAYS / GRAFF_FORCE_DROP_ALWAYS seams, which make EVERY live
+attempt return error.StreamStalled / error.StreamDropped before any network
+call, so the give-up path runs with no provider/key."""
 import json, os, shutil, subprocess, sys, tempfile
 
 _arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
@@ -43,15 +44,18 @@ def check(name, env_flag, marker, notice):
     # the whole point of #134/#132: it must NOT be a user interruption
     assert "interrupted by user" not in assistant, f"{name}: mislabeled [response interrupted by user]!"
     assert "interrupted (esc)" not in out, f"{name}: terminal showed 'interrupted (esc)'!"
-    assert "reconnect" in out, f"{name}: no reconnect attempt shown before giving up (#56)"
-    print(f"ok    {name}: saved {marker!r}, notice shown, never a user Esc")
+    # Reconnect stays off the transcript (ADR 0021). #56 still ran: the
+    # give-up line names the exhausted budget, and mid-turn "reconnecting"
+    # chatter is gone.
+    assert "reconnecting" not in out, f"{name}: mid-turn reconnect leaked onto the transcript"
+    print(f"ok    {name}: saved {marker!r}, ending notice shown, never a user Esc")
 
 
 def main():
     check("stall (#134)", "GRAFF_FORCE_STALL_ALWAYS",
-          "[response ended early: stream stalled]", "stream stalled")
+          "[response ended early: stream stalled]", "stream stalled — ending turn")
     check("drop (#132/#133)", "GRAFF_FORCE_DROP_ALWAYS",
-          "[response ended early: connection dropped]", "connection dropped")
+          "[response ended early: connection dropped]", "connection dropped — response ended early")
     print("all clear: a forced stall/drop is [response ended early: ...], never a user Esc interrupt")
 
 

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -282,8 +282,8 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
                             // the session — codex's WS→SSE fallback, and consistent
                             // with how a WS transport error is already handled (ws_off).
                             if (stall_retries > 1) self.ws_off = true;
-                            const via: []const u8 = if (self.ws_off) " (SSE)" else "";
-                            try self.say("[{s} — reconnecting{s} ({d}/{d})]\n", .{ what, via, stall_retries, max_stall_retries });
+                            // Reconnect is bookkeeping (ADR 0021). Tracer and
+                            // telemetry keep the attempt; the transcript does not.
                             if (self.tracer) |tr| tr.note("stream_retry", what);
                             if (telemetry.g_telem) |t| t.errorEvent("stream_retry", what);
                             self.partial_text.clearRetainingCapacity(); // fresh stream re-streams cleanly, no concat

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -282,8 +282,6 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
                             // the session — codex's WS→SSE fallback, and consistent
                             // with how a WS transport error is already handled (ws_off).
                             if (stall_retries > 1) self.ws_off = true;
-                            // Reconnect is bookkeeping (ADR 0021). Tracer and
-                            // telemetry keep the attempt; the transcript does not.
                             if (self.tracer) |tr| tr.note("stream_retry", what);
                             if (telemetry.g_telem) |t| t.errorEvent("stream_retry", what);
                             self.partial_text.clearRetainingCapacity(); // fresh stream re-streams cleanly, no concat
@@ -291,6 +289,8 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
                             self.sleepInterruptible(stall_reconnect_backoff_ms) catch return error.Interrupted;
                             continue :rebuild;
                         }
+                        // Budget gone: the turn is ending. Mid-turn cuts stayed silent.
+                        @import("engine_sink.zig").forAgent(self).emit(self.io, .{ .transport_aborted = .{ .reason = if (stalled) .stalled else .dropped, .turn_ending = true } });
                         if (stalled) {
                             self.last_api_error = std.fmt.allocPrint(self.arena, "stream stalled: no data from the model for {d}s — ended the turn after {d} reconnect attempts (raise GRAFF_STREAM_STALL_SECS if your model needs longer)", .{ http.stream_stall_ms / 1000, max_stall_retries }) catch null;
                             if (telemetry.g_telem) |t| t.errorEvent("stream_stall", self.last_api_error orelse "stream stalled");

--- a/src/agent_ws.zig
+++ b/src/agent_ws.zig
@@ -163,8 +163,7 @@ pub fn postLive(self: *Agent, body: []const u8) ![]u8 {
 }
 
 /// (#422 slice 1b) A transport cut becomes a typed event; the sink decides
-/// what shows. TuiSink: the old inline ⚠ lines, byte for byte. JsonSink:
-/// nothing — the wire never carried these moments and must not start to.
+/// what shows. Ending-turn only (ADR 0021); mid-turn reconnect is silent.
 fn emitAbort(self: *Agent, reason: engine_events.StreamAbort, turn_ending: bool) void {
     const cut: engine_events.TransportAbort = .{ .reason = reason, .turn_ending = turn_ending };
     engine_sink.forAgent(self).emit(self.io, .{ .transport_aborted = cut });

--- a/src/agent_ws_test.zig
+++ b/src/agent_ws_test.zig
@@ -117,7 +117,7 @@ fn sinkRecord(ctx: *anyopaque, ev: engine_sink.Stamped) void {
 
 // (#422 slice 1b) postLive draws nothing itself anymore: each forced stall/
 // drop seam emits exactly ONE transport_aborted event through the sink
-// (TuiSink renders the old inline ⚠ lines, JsonSink drops it — pinned in
+// (ending-turn ⚠ only; mid-turn is silent — ADR 0021, pinned in
 // engine_sink.zig) and returns the matching transport error. An injected
 // recording sink observes the contract directly — no TTY, no globals read.
 test "postLive force seams emit one transport_aborted through the sink (#422)" {

--- a/src/engine_events.zig
+++ b/src/engine_events.zig
@@ -54,8 +54,8 @@ pub const Delta = struct {
 pub const TransportAbort = struct {
     reason: StreamAbort,
     /// The guard is giving the turn up (its notice says so); false = an
-    /// attempt-level cut the reconnect ladder may still retry, surfaced
-    /// more tersely.
+    /// attempt-level cut the reconnect ladder may still retry — silent on
+    /// the transcript (ADR 0021).
     turn_ending: bool,
 };
 

--- a/src/engine_sink.zig
+++ b/src/engine_sink.zig
@@ -263,17 +263,10 @@ fn tuiEmit(ctx: *anyopaque, ev: Stamped) void {
         // Transport cuts carry no partial answer (nothing streamed on the ws
         // path), so unlike .stream_aborted there is no tail to flush — only
         // the notice, worded exactly as the old inline agent_ws lines were.
-        .transport_aborted => |t| notice(a, switch (t.reason) {
-            .interrupted => return, // deliberate stop: silent, as ever
-            .stalled => if (t.turn_ending)
-                "\n⚠ stream stalled — ending turn\n"
-            else
-                "\n⚠ stream stalled\n",
-            .dropped => if (t.turn_ending)
-                "\n⚠ connection dropped — response ended early\n"
-            else
-                "\n⚠ connection dropped\n",
-        }),
+        .transport_aborted => |t| {
+            const line = transportEndingNotice(t) orelse return;
+            notice(a, line);
+        },
         .stream_aborted => |reason| {
             a.flushStreamTail(); // render any held partial markdown line
             switch (reason) {
@@ -480,6 +473,17 @@ pub fn compactArg(input: std.json.Value) []const u8 {
         if (v == .string and v.string.len > 0) return v.string;
     }
     return "";
+}
+
+/// Mid-turn transport cuts are the reconnect ladder (ADR 0021). Only a
+/// turn that is actually ending earns a ⚠ on the transcript.
+fn transportEndingNotice(t: engine_events.TransportAbort) ?[]const u8 {
+    if (!t.turn_ending or t.reason == .interrupted) return null;
+    return switch (t.reason) {
+        .interrupted => null,
+        .stalled => "\n⚠ stream stalled — ending turn\n",
+        .dropped => "\n⚠ connection dropped — response ended early\n",
+    };
 }
 
 pub fn firstLineCap(text: []const u8, cap: usize) []const u8 {

--- a/src/engine_sink_tests.zig
+++ b/src/engine_sink_tests.zig
@@ -125,15 +125,15 @@ test "TuiSink streams tool-arg prose raw and never ends the answer line (slice 1
     try std.testing.expectEqualStrings("answer prose", aw.writer.buffered());
 }
 
-test "TuiSink transport-abort notices reproduce the old inline lines (slice 1b)" {
+test "TuiSink transport-abort notices only when the turn is ending (ADR 0021)" {
     var aw: Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
     var a = testAgent(&aw.writer);
     const s = tuiSink(&a);
     const cases = [_]struct { ev: engine_events.TransportAbort, want: []const u8 }{
-        .{ .ev = .{ .reason = .stalled, .turn_ending = false }, .want = "\n⚠ stream stalled\n" },
+        .{ .ev = .{ .reason = .stalled, .turn_ending = false }, .want = "" },
         .{ .ev = .{ .reason = .stalled, .turn_ending = true }, .want = "\n⚠ stream stalled — ending turn\n" },
-        .{ .ev = .{ .reason = .dropped, .turn_ending = false }, .want = "\n⚠ connection dropped\n" },
+        .{ .ev = .{ .reason = .dropped, .turn_ending = false }, .want = "" },
         .{ .ev = .{ .reason = .dropped, .turn_ending = true }, .want = "\n⚠ connection dropped — response ended early\n" },
         // A deliberate interrupt was never announced at the transport layer.
         .{ .ev = .{ .reason = .interrupted, .turn_ending = true }, .want = "" },
@@ -143,6 +143,13 @@ test "TuiSink transport-abort notices reproduce the old inline lines (slice 1b)"
         s.emit(undefined, .{ .transport_aborted = c.ev });
         try std.testing.expectEqualStrings(c.want, aw.writer.buffered());
     }
+}
+
+test "stall reconnect is not announced on the transcript (ADR 0021)" {
+    const src = @embedFile("agent_request.zig");
+    try std.testing.expect(std.mem.indexOf(u8, src, "[{s} — reconnecting") == null);
+    try std.testing.expect(std.mem.indexOf(u8, src, "reconnecting{s}") == null);
+    try std.testing.expect(std.mem.indexOf(u8, src, "tr.note(\"stream_retry\"") != null);
 }
 
 test "JsonSink stays silent for moments the wire never carried (slice 1b)" {

--- a/src/tui_sink.zig
+++ b/src/tui_sink.zig
@@ -167,12 +167,16 @@ fn emit(ctx: *anyopaque, ev: engine_sink.Stamped) void {
                 std.fmt.bufPrint(&buf, "{s}{s}", .{ n.lead, n.text }) catch n.lead;
             b.queue.push(.{ .notice = line });
         },
-        .transport_aborted => |t| switch (t.reason) {
-            // A deliberate Esc is silent here as everywhere: finishJob already
-            // writes the one "■ interrupted" row.
-            .interrupted => {},
-            .stalled => b.queue.push(.{ .notice = "⚠ stream stalled" }),
-            .dropped => b.queue.push(.{ .notice = "⚠ connection dropped" }),
+        .transport_aborted => |t| {
+            // Mid-turn cuts are the reconnect ladder (ADR 0021). The pager
+            // already shows Thinking / tool rows; a ⚠ here is what made
+            // people hit Esc on a turn that was still recovering.
+            if (!t.turn_ending) return;
+            switch (t.reason) {
+                .interrupted => {},
+                .stalled => b.queue.push(.{ .notice = "⚠ stream stalled — ending turn" }),
+                .dropped => b.queue.push(.{ .notice = "⚠ connection dropped — response ended early" }),
+            }
         },
         .stream_aborted => |reason| switch (reason) {
             .interrupted => {},
@@ -429,6 +433,31 @@ test "the turn-sink binding is thread-local and released after the turn" {
 
     engine_sink.unbindTurnSink();
     try std.testing.expect(engine_sink.turnSink() == null);
+}
+
+test "mid-turn transport cuts stay off the pager (ADR 0021)" {
+    var qbuf: tui.EventQueue = .{};
+    qbuf.attach(std.testing.allocator);
+    defer qbuf.deinit();
+    var sbuf: [64]u8 = undefined;
+    var stream: repl.StreamBuf = .{ .buf = &sbuf };
+    var bridge: Bridge = .{ .queue = &qbuf, .stream = &stream };
+    const sink = forBridge(&bridge);
+    sink.emit(undefined, .{ .transport_aborted = .{ .reason = .stalled, .turn_ending = false } });
+    sink.emit(undefined, .{ .transport_aborted = .{ .reason = .dropped, .turn_ending = false } });
+    sink.emit(undefined, .{ .transport_aborted = .{ .reason = .interrupted, .turn_ending = true } });
+    {
+        const silent = qbuf.drain();
+        defer qbuf.free(silent);
+        try std.testing.expectEqual(@as(usize, 0), silent.len);
+    }
+    sink.emit(undefined, .{ .transport_aborted = .{ .reason = .stalled, .turn_ending = true } });
+    sink.emit(undefined, .{ .transport_aborted = .{ .reason = .dropped, .turn_ending = true } });
+    const evs = qbuf.drain();
+    defer qbuf.free(evs);
+    try std.testing.expectEqual(@as(usize, 2), evs.len);
+    try std.testing.expectEqualStrings("⚠ stream stalled — ending turn", evs[0].notice);
+    try std.testing.expectEqualStrings("⚠ connection dropped — response ended early", evs[1].notice);
 }
 
 test "acp_owns_transcript leaves thought/tool/text to session/update" {

--- a/src/turn_chrome.zig
+++ b/src/turn_chrome.zig
@@ -1,13 +1,13 @@
 //! Dim chrome for long inner-loop turns and API transport retries (retry n/N).
 //!
 //! Production default: unlimited inner-loop model calls (`max_turn_model_calls = 0`).
-//! `GRAFF_MAX_TURN_MODEL_CALLS` is the opt-in cap. JSON mode is dropped inside
-//! `tool_pulse.emitNotice` (ADR 0020: chrome, not output).
+//! `GRAFF_MAX_TURN_MODEL_CALLS` is the opt-in cap. Inner-loop counters stay
+//! off the transcript (ADR 0021); retry notices still go through
+//! `tool_pulse.emitNotice` (ADR 0020: chrome, not output; --json drops them).
 
 const std = @import("std");
 const Io = std.Io;
 
-const main_mod = @import("main.zig");
 const Agent = @import("agent.zig").Agent;
 const tool_pulse = @import("tool_pulse.zig");
 
@@ -25,9 +25,14 @@ pub fn formatRetryNotice(buf: []u8, class: []const u8, attempt: usize, max_attem
 }
 
 pub fn formatTurnPulse(buf: []u8, call_n: u64, cap: u64, tools: u64) []const u8 {
-    if (cap == 0)
-        return std.fmt.bufPrint(buf, "· turn still going · model call {d} · {d} tools", .{ call_n, tools }) catch buf[0..0];
-    return std.fmt.bufPrint(buf, "· turn still going · model call {d}/{d} · {d} tools", .{ call_n, cap, tools }) catch buf[0..0];
+    // Inner-loop counters are bookkeeping (ADR 0021). Tool rows already
+    // show the work; "model call N · N tools" sat at the same weight as
+    // "Wrote 1 file" and made a turn unreadable.
+    _ = buf;
+    _ = call_n;
+    _ = cap;
+    _ = tools;
+    return "";
 }
 
 pub fn emitRetryNotice(io: Io, class: []const u8, attempt: usize, max_attempts: usize) void {
@@ -37,17 +42,13 @@ pub fn emitRetryNotice(io: Io, class: []const u8, attempt: usize, max_attempts: 
     tool_pulse.emitNotice(io, "{s}", .{text});
 }
 
-/// Count this inner-loop request, pulse from call 2, optionally pause if a
-/// non-zero cap is set. Returns pause text or null to proceed. Never pauses
-/// when the cap is 0.
+/// Count this inner-loop request and optionally pause if a non-zero cap is
+/// set. Returns pause text or null to proceed. Never pauses when the cap is 0.
 pub fn beforeRequest(self: *Agent) !?[]const u8 {
     self.model_calls_this_turn += 1;
     const cap = max_turn_model_calls;
-    if (self.model_calls_this_turn >= 2 and !self.sub and !main_mod.json_mode) {
-        var buf: [120]u8 = undefined;
-        const text = formatTurnPulse(&buf, self.model_calls_this_turn, cap, self.tool_calls_this_turn);
-        if (text.len > 0) tool_pulse.emitNotice(self.io, "{s}", .{text});
-    }
+    // Call 2+ used to print an inner-loop counter line. That line is gone;
+    // formatTurnPulse is the pin that keeps it gone.
     if (cap != 0 and self.model_calls_this_turn > cap) {
         return try std.fmt.allocPrint(
             self.arena,
@@ -73,8 +74,18 @@ test "formatRetryNotice names HungRequest and UnknownHostName with attempt n/N" 
     try std.testing.expectEqualStrings("· retry 1/6 · UnknownHostName", formatRetryNotice(&buf, "UnknownHostName", 1, 6));
 }
 
-test "formatTurnPulse omits a denominator when the cap is unlimited" {
+test "formatTurnPulse stays off the transcript (ADR 0021)" {
     var buf: [80]u8 = undefined;
-    try std.testing.expectEqualStrings("· turn still going · model call 3 · 11 tools", formatTurnPulse(&buf, 3, 0, 11));
-    try std.testing.expectEqualStrings("· turn still going · model call 3/64 · 11 tools", formatTurnPulse(&buf, 3, 64, 11));
+    try std.testing.expectEqualStrings("", formatTurnPulse(&buf, 3, 0, 11));
+    try std.testing.expectEqualStrings("", formatTurnPulse(&buf, 3, 64, 11));
+}
+
+test "beforeRequest does not print an inner-loop pulse (ADR 0021)" {
+    const src = @embedFile("turn_chrome.zig");
+    const start = std.mem.indexOf(u8, src, "pub fn beforeRequest").?;
+    const rest = src[start + 1 ..];
+    const end = std.mem.indexOf(u8, rest, "\ntest ").?;
+    const body = rest[0..end];
+    try std.testing.expect(std.mem.indexOf(u8, body, "emitNotice") == null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "turn still going") == null);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The line REPL was reading as a receipt of the harness, not the task.

A typical turn printed `⚠ stream stalled` while tools were still running, then `· turn still going · model call 4 · 3 tools`, then `[stream stalled — reconnecting (SSE) (2/2)]`. Those lines sit at the same weight as `› Wrote 1 file`. People hit Esc on a turn that was still recovering.

**After this, a turn looks like the work:**

```
#10 › Are you able to open it up for me?
  › Searched 1 pattern
  › Wrote 1 file
  I'll write docs/showcase.html and open it in Chrome.
```

What changed:

- Mid-turn stall/drop (the reconnect ladder) is silent on both the line REPL and the pager. Tracer and telemetry still record `stream_retry`.
- The inner-loop `model call N · N tools` pulse is gone. Tool rows already show the work.
- A ⚠ still prints when the turn actually ends (`stream stalled — ending turn` / `connection dropped — response ended early`).
- `■ interrupted`, `↳ queued`, and `↳ force` stay — those are your actions.

This is ADR 0021 compliance (transcript is the task, not the event bus), not a new decision. Stalls still reconnect (WS, then SSE). Opening Chrome in five model calls is a separate capability gap.

## Test plan

- [x] Mid-turn `transport_aborted` emits no notice (line sink + TUI sink)
- [x] Ending-turn stall/drop still prints the ⚠
- [x] Give-up after `FORCE_STALL_ALWAYS` / `FORCE_DROP_ALWAYS` prints the ending-turn notice (`scripts/test-stall-drop.py`)
- [x] `agent_request` no longer `say`s the reconnect line; `stream_retry` stays on the tracer
- [x] `formatTurnPulse` is empty; `beforeRequest` does not `emitNotice`
- [x] `scripts/eval-tier1.sh` unit/reach/fmt/lines green (suite 1756)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

