### PR TITLE
Run Pi on SuperGrok the same way as graff-dev SWE

### DIFF
--- a/docs/adr/0043-pi-swe-same-seat.md
+++ b/docs/adr/0043-pi-swe-same-seat.md
@@ -1,0 +1,58 @@
+# 0043. Pi SWE A/B uses the same SuperGrok seat via pi-xai
+
+Status: accepted 2026-08-28
+
+## Context
+
+ADR 0024 compared graff vs grok-build on `--suite swe`. Pi was already
+wired as `pi` (OpenAI/luna) and `pi-codegraff` (Gemini gateway), so it
+never sat on the SuperGrok login those numbers used. A follow-up asked
+to run Pi the same way, and whether that run says we can go faster.
+
+## Decision
+
+`pi-xai` is the same-seat harness: `graff-evals/pi-xai.sh` maps
+`~/.xai/credentials/graff-oauth.json` into `XAI_API_KEY` and execs
+stock `pi -p --mode json --provider xai --model {model} --no-session`.
+Fair A/B is `--suite swe --harness graff-dev,pi-xai --model grok-4.6`.
+Keep Pi on stock defaults (4-tool catalog, thinking on).
+
+Live A/B 2026-08-28 (`graff-evals/results/run-20260828-164346.jsonl`,
+SuperGrok grok-4.6, `-j 6`, one rep):
+
+| harness | pass | wall (sum) | first | RSS | in | out | calls | $ |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| graff-dev | 4/6 | 455.5s | 2.6s | 91.3M | 161066 | 11590 | 30 | $0.0000 |
+| pi-xai | **5/6** | **275.5s** | 0.9s | 165.5M | 186368 | 6501 | 31 | $0.1344 |
+
+| task | graff | pi |
+|---|---|---|
+| config-parse | ✓ 89s / 28k / 5 | ✓ 45s / 27k / 5 |
+| cookie-store | ✓ 86s / 31k / 5 | ✓ 102s / 44k / 6 |
+| json-stream | ✗ 80s / 26k / 5 | **✓ 49s / 42k / 6** |
+| label-sort | ✗ 77s / 26k / 5 | ✗ 38s / 22k / 4 |
+| map-conflict | ✓ 60s / 25k / 5 | ✓ 16s / 26k / 5 |
+| validated | ✓ 64s / 26k / 5 | ✓ 26s / 27k / 5 |
+
+Pi's extra pass is `json-stream` whitespace-only json-seq — the same
+spec-contract miss ADR 0024 already named (grok-build passed it). Both
+miss `label-sort`. Tokens and calls are a wash. Pi `first_out_s` is the
+first JSONL `session` line, not TUI first paint; graff's is the first
+progress line. Pi `$` is list-price; graff SuperGrok is flat-rate.
+
+**Reject:** Pi's 4-tool catalog (ADR 0024 already measured an rlm-only
+keep-list fail). Pi's 165M heap. Treating `first_out` as a TUI steal.
+
+**Next cut (not this revision):** every graff-dev SWE sandbox wrote
+127M `.graff/learn-kit/graff-pinned` (a copy of the binary). Pi's
+sandbox is ~8K. That is a one-shot tax; skip auto-init on `-p` if we
+want the next wall/RSS drop. TUI leftover after the early alt-screen
+claim is first chrome, not another escape.
+
+## Consequences
+
+- `pi-xai` is the SuperGrok Pi harness. `pi` / `pi-codegraff` stay the
+  OpenAI / Gemini seats.
+- Do not raise a catalog or heap change from one Pi pass on
+  `json-stream`.
+- Revisit the learn-kit pin on `-p` when we want the next speed cut.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,6 +52,7 @@ record only when you need the evidence or the edge cases.
 | [0039](0039-local-tools-are-project-scripts.md) | Agent-authored local tools are project scripts under `.graff/tools/`; skills stay instructions. Runtime catalog extras, not `schema.effectiveRootSpecs`. |
 | [0040](0040-codedb-stays-when-licensed.md) | Ordinary reads use native `codedb` / `read_file`; codedb-pro is extra search, not the default reader. |
 | [0041](0041-tui-is-an-acp-client.md) | The fullscreen TUI is an in-process ACP client: session/prompt in, session/update thought/tool/text out. No child `graff acp`. |
+| [0043](0043-pi-swe-same-seat.md) | Pi SWE A/B uses `pi-xai` on the SuperGrok seat; do not steal Pi's catalog or heap from the json-stream pass. |
 
 ## When to write one
 

--- a/graff-evals/README.md
+++ b/graff-evals/README.md
@@ -25,6 +25,8 @@ harness under test spends model calls.
 ```sh
 ./run.py --suite swe --harness graff-dev-old,graff-dev --model grok-4.6 -j 12
 ./run.py --suite core,rlm,swe --harness graff-dev-old,graff-dev -j 8
+# Pi on the same SuperGrok seat (`npm i -g @earendil-works/pi-coding-agent`):
+./run.py --suite swe --harness graff-dev,pi-xai --model grok-4.6 -j 6
 ```
 
 ## Run it
@@ -59,10 +61,13 @@ the last run for post-mortems; both are disposable.
 
 `harnesses.json` declares each harness as a command template plus parsers:
 
-- `answer` — where the final answer text comes from (`stdout`, or
-  `grok-stream` for grok's `streaming-messages-json` result event).
+- `answer` — where the final answer text comes from (`stdout`,
+  `grok-stream` for grok's `streaming-messages-json` result event, or
+  `pi-json` for Pi's `--mode json` `message_end` text).
 - `usage` — how to extract token counts (`graff-stderr` parses graff's
-  `[usage]` line; `grok-stream` reads the result event's usage).
+  `[usage]` line; `grok-stream` / `pi-json` read the harness event).
+  Pi `first_out_s` is the first JSONL line (`session`), not TUI first paint.
+  Pi `cost.total` is list-price; SuperGrok on graff is `$0.0000` flat-rate.
 - `capabilities` — feature gates; a task listing `requires` a capability is
   skipped on harnesses that lack it (e.g. `output-schema` structured outputs).
 

--- a/graff-evals/harnesses.json
+++ b/graff-evals/harnesses.json
@@ -127,5 +127,13 @@
     "capabilities": [],
     "default_model": "gemini-3.7-flash",
     "note": "uses ~/.pi/agent/models.json provider codegraff → gateway.codegraff.com; Gemini tool loops need the codegraff-gemini-echo extension"
+  },
+  "pi-xai": {
+    "cmd": ["{repo}/graff-evals/pi-xai.sh", "-p", "--mode", "json", "--provider", "xai", "--model", "{model}", "--no-session", "{prompt}"],
+    "answer": "pi-json",
+    "usage": "pi-json",
+    "capabilities": [],
+    "default_model": "grok-4.6",
+    "note": "same SuperGrok seat as graff-dev. Wrapper reads graff-oauth.json into XAI_API_KEY. `pi` must be on PATH."
   }
 }

--- a/graff-evals/pi-extensions/README.md
+++ b/graff-evals/pi-extensions/README.md
@@ -20,3 +20,11 @@ Smoke:
 ```bash
 python3 graff-evals/run.py --harness pi-codegraff --model gemini-3.7-flash --task fix-fib
 ```
+
+For a same-seat SWE A/B against graff (SuperGrok / grok-4.6), skip the
+gateway and use `pi-xai`:
+
+```bash
+# pi-xai.sh reads ~/.xai/credentials/graff-oauth.json (same as `graff login xai`)
+cd graff-evals && ./run.py --suite swe --harness graff-dev,pi-xai --model grok-4.6 -j 6
+```

--- a/graff-evals/pi-xai.sh
+++ b/graff-evals/pi-xai.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Drive Pi on graff's SuperGrok seat (same-login A/B as ADR 0024 grok-build).
+# Reads ~/.xai/credentials/graff-oauth.json unless XAI_API_KEY is already set.
+set -e
+oauth="${GRAFF_XAI_OAUTH:-$HOME/.xai/credentials/graff-oauth.json}"
+if [ -z "${XAI_API_KEY:-}" ] && [ -f "$oauth" ]; then
+	XAI_API_KEY=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["access_token"])' "$oauth")
+	export XAI_API_KEY
+fi
+if [ -z "${XAI_API_KEY:-}" ]; then
+	echo "pi-xai: no XAI_API_KEY and no $oauth — run \`graff login xai\`" >&2
+	exit 127
+fi
+if [ -n "${PI:-}" ]; then
+	exec "$PI" "$@"
+fi
+if command -v pi >/dev/null 2>&1; then
+	exec pi "$@"
+fi
+if [ -x "$HOME/.local/bin/pi" ]; then
+	exec "$HOME/.local/bin/pi" "$@"
+fi
+echo "pi-xai: pi not found (install @earendil-works/pi-coding-agent)" >&2
+exit 127

--- a/graff-evals/run.py
+++ b/graff-evals/run.py
@@ -10,6 +10,7 @@ outcome, and writes JSONL results plus a summary table.
   ./run.py --harness graff --model grok-4.6              # full suite (core + rlm + swe)
   ./run.py --suite rlm --harness graff-dev-old,graff-dev # scatter-gather A/B
   ./run.py --suite swe --harness graff-dev-old,graff-dev -j 12  # DeepSWE-shaped A/B, parallel
+  ./run.py --suite swe --harness graff-dev,pi-xai --model grok-4.6 -j 6  # same SuperGrok seat
   ./run.py --suite mcp --harness graff-dev-old-nolean,graff-dev-rlm-struct,graff-dev-nolean
   ./run.py --harness grok --task fix-fib --reps 3        # one task, 3 reps
   ./run.py --interactive                                 # pick + watch live

--- a/graff-evals/seed-pi-xai.py
+++ b/graff-evals/seed-pi-xai.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Map graff's SuperGrok OAuth into Pi's auth.json (same seat as graff-dev).
+
+`graff login xai` writes ~/.xai/credentials/graff-oauth.json (grok-build's
+public client). ADR 0024 mapped that file into ~/.grok/auth.json for the
+grok-build A/B. This writes ~/.pi/agent/auth.json as type=api_key: stock
+Pi xai is an API-key provider and ignores type=oauth ("No API key for
+provider: xai"). The SuperGrok access token is accepted as Bearer.
+
+The eval path is `pi-xai.sh` (XAI_API_KEY). This mapper is optional.
+
+Does not print tokens. Overwrites only the `xai` key; other providers stay.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+GRAFF = Path.home() / ".xai/credentials/graff-oauth.json"
+PI_AUTH = Path.home() / ".pi/agent/auth.json"
+
+
+def main() -> int:
+    if not GRAFF.is_file():
+        print(f"no SuperGrok OAuth at {GRAFF} — run `graff login xai`", file=sys.stderr)
+        return 1
+    src = json.loads(GRAFF.read_text())
+    access = src.get("access_token") or ""
+    if not access:
+        print("graff-oauth.json has no access_token", file=sys.stderr)
+        return 1
+    PI_AUTH.parent.mkdir(parents=True, exist_ok=True)
+    data = {}
+    if PI_AUTH.is_file():
+        try:
+            data = json.loads(PI_AUTH.read_text())
+        except json.JSONDecodeError:
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+    # Built-in xai is an API-key provider. The SuperGrok access token is
+    # accepted as XAI_API_KEY / auth.json key (same Bearer graff sends).
+    # OAuth type is ignored by stock xai ("No API key for provider: xai").
+    data["xai"] = {"type": "api_key", "key": access}
+    tmp = PI_AUTH.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data, indent=2) + "\n")
+    os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
+    tmp.replace(PI_AUTH)
+    print(f"wrote {PI_AUTH} (xai api_key from graff-oauth.json)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
ADR 0024 compared graff vs grok-build on `--suite swe`. Pi was already wired as `pi` (OpenAI/luna) and `pi-codegraff` (Gemini gateway) — not the SuperGrok seat those numbers used.

This adds `pi-xai`: a wrapper that maps `graff login xai` (`~/.xai/credentials/graff-oauth.json`) into `XAI_API_KEY` so stock Pi spends the same subscription. Stock Pi xai is an API-key provider; `type=oauth` is ignored.

```sh
cd graff-evals && ./run.py --suite swe --harness graff-dev,pi-xai --model grok-4.6 -j 6
```

## Live A/B (2026-08-28, `run-20260828-164346.jsonl`)

Same 6 DeepSWE-shaped tasks, grok-4.6, SuperGrok, `-j 6`, one rep. Pi on stock defaults (4-tool catalog, thinking on).

| harness | pass | wall (sum) | first | RSS | in | out | calls | $ |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| graff-dev | 4/6 | 455.5s | 2.6s | 91.3M | 161066 | 11590 | 30 | $0.0000 |
| pi-xai | **5/6** | **275.5s** | 0.9s | 165.5M | 186368 | 6501 | 31 | $0.1344 |

| task | graff | pi |
|---|---|---|
| config-parse | ✓ 89s / 28k / 5 | ✓ 45s / 27k / 5 |
| cookie-store | ✓ 86s / 31k / 5 | ✓ 102s / 44k / 6 |
| json-stream | ✗ 80s / 26k / 5 | **✓ 49s / 42k / 6** |
| label-sort | ✗ 77s / 26k / 5 | ✗ 38s / 22k / 4 |
| map-conflict | ✓ 60s / 25k / 5 | ✓ 16s / 26k / 5 |
| validated | ✓ 64s / 26k / 5 | ✓ 26s / 27k / 5 |

Pi's extra pass is `json-stream` whitespace-only json-seq — the same spec-contract miss ADR 0024 already named (grok-build passed it). Both miss `label-sort`. Tokens and calls are a wash.

Caveats: Pi `first_out_s` is the first JSONL `session` line, not TUI first paint. Pi `$` is list-price; graff SuperGrok is flat-rate `$0.0000`.

**Reject:** Pi's 4-tool catalog, Pi's 165M heap, treating `first_out` as a TUI steal.

**Next speed cut (not this PR):** every graff-dev SWE sandbox wrote 127M `.graff/learn-kit/graff-pinned` (a copy of the binary). Pi's sandbox is ~8K. Skip auto-init on `-p` if we want the next wall/RSS drop. TUI leftover after the early alt-screen claim is first chrome, not another escape.

Recorded as [ADR 0043](docs/adr/0043-pi-swe-same-seat.md). 0042 is the TUI claim on #666.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

