### PR TITLE
Skip learn auto-init on -p — that was Pi’s wall win

### DIFF
--- a/docs/adr/0044-oneshot-skips-learn-auto.md
+++ b/docs/adr/0044-oneshot-skips-learn-auto.md
@@ -46,3 +46,31 @@ TUI steal.
   timeout to hide the tax.
 - Revisit if a one-shot should ever seed learning (it should not: the
   sandbox is thrown away).
+
+## Confirm (2026-08-29, after this revision)
+
+`graff-evals/results/run-20260829-031139.jsonl`, SuperGrok grok-4.6,
+`--suite swe --harness graff-dev -j 6`. No `graff-pinned`. Sandbox
+100–164K.
+
+| harness | pass | wall (sum) | first | RSS | in | out | calls | CPU |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| before (0043) | 4/6 | 455.5s | 2.6s | 91.3M | 161066 | 11590 | 30 | 230s |
+| after | **5/6** | **205.2s** | 2.5s | 90.8M | 159700 | 11351 | 30 | **6.5s** |
+
+| task | after |
+|---|---|
+| map-conflict | ✓ 17s / 25k / 5 |
+| validated | ✓ 19s / 24k / 5 |
+| label-sort | ✗ 34s / 26k / 5 |
+| config-parse | ✓ 40s / 27k / 5 |
+| json-stream | **✓ 47s / 27k / 5** |
+| cookie-store | ✓ 47s / 30k / 5 |
+
+Wall **−55%**, CPU **−97%**, same tokens/calls. `json-stream` passed
+this rep: the model kept "no RS → empty" instead of inventing a
+missing-delimiter raise (the 0043 miss). That is one-rep model noise,
+not a catalog gap — Pi's earlier 5/6 was the same clause, not a
+smarter loop. `label-sort` still fails (hidden natural-order /
+leading-ws); grok-build and Pi miss it too. RSS ~91M is the process,
+not the pin. Pi could not re-run here (OAuth bearer 403 as `XAI_API_KEY`).

--- a/docs/adr/0044-oneshot-skips-learn-auto.md
+++ b/docs/adr/0044-oneshot-skips-learn-auto.md
@@ -1,0 +1,48 @@
+# 0044. `-p` and `--json` skip learn auto-init
+
+Status: accepted 2026-08-29
+
+## Context
+
+ADR 0043 ran Pi on the same SuperGrok SWE seat as graff-dev. Tokens and
+calls were a wash (30 vs 31). Pi's wall was 276s vs graff's 456s. That
+gap is not Pi's 4-tool catalog.
+
+Every graff-dev SWE task made exactly 5 API calls — the
+`learn_auto` bootstrap floor — then `startBackgroundLearning` copied
+132M `.graff/learn-kit/graff-pinned` and generated suites. `cpu_sample_s`
+was 38.3–38.5s on every task; Pi's was ~1s. Subtract that tax and
+model-wait (wall − CPU) matches or beats Pi on 5/6 tasks:
+
+| task | graff wall − CPU | Pi wall − CPU |
+|---|---:|---:|
+| map-conflict | 21s | 15s |
+| validated | 26s | 25s |
+| label-sort | 39s | 37s |
+| json-stream | 42s | 48s |
+| cookie-store | 48s | 101s |
+| config-parse | 50s | 44s |
+
+Pi's extra pass is still the `json-stream` whitespace-only json-seq
+clause (ADR 0024). Both miss `label-sort`. The same 38s copy is why
+`test-learn-auto-init.py`'s 45s exit wait flakes on CI.
+
+## Decision
+
+`startBackgroundLearning` is a no-op when `unattended` (`-p`) or
+`--json`. Interactive REPL/TUI/ACP still auto-init after 5 model calls.
+`GRAFF_LEARN_AUTO=off` still kills the whole trigger. `graff learn init`
+is unchanged.
+
+Do not steal Pi's catalog or heap. Do not treat Pi `first_out_s` as a
+TUI steal.
+
+## Consequences
+
+- `graff -p` / eval sandboxes no longer write 132M or spend ~38s of
+  local CPU on the way out. Interactive workspaces still earn a store.
+- The CI learn-auto probe is an interactive PTY session; it still
+  copies the pin. A later cut can speed that copy. Do not raise its
+  timeout to hide the tax.
+- Revisit if a one-shot should ever seed learning (it should not: the
+  sandbox is thrown away).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,6 +52,7 @@ record only when you need the evidence or the edge cases.
 | [0039](0039-local-tools-are-project-scripts.md) | Agent-authored local tools are project scripts under `.graff/tools/`; skills stay instructions. Runtime catalog extras, not `schema.effectiveRootSpecs`. |
 | [0040](0040-codedb-stays-when-licensed.md) | Ordinary reads use native `codedb` / `read_file`; codedb-pro is extra search, not the default reader. |
 | [0041](0041-tui-is-an-acp-client.md) | The fullscreen TUI is an in-process ACP client: session/prompt in, session/update thought/tool/text out. No child `graff acp`. |
+| [0044](0044-oneshot-skips-learn-auto.md) | `-p` and `--json` skip learn auto-init; the Pi SWE wall gap was a 38s `graff-pinned` copy, not their catalog. |
 
 ## When to write one
 

--- a/docs/local-learning.md
+++ b/docs/local-learning.md
@@ -11,9 +11,12 @@ active parent → deterministic mutation seeds → paired evaluation
 
 ## Nothing to run
 
-Learning is on by default. The first session in a workspace that does real
-model work (at least 5 calls, so a one-off question never triggers it) sets the
-workspace up on its way out:
+Learning is on by default for an interactive session. The first REPL/TUI/ACP
+session in a workspace that does real model work (at least 5 calls, so a
+one-off question never triggers it) sets the workspace up on its way out.
+`-p` and `--json` never do this — those exits are not a workspace opting
+into a spending cadence (evals hit the 5-call floor and then spent ~38s
+copying `graff-pinned` + generating suites).
 
 ```text
 ↺ setting this workspace up to learn from sessions like this one

--- a/src/session_run.zig
+++ b/src/session_run.zig
@@ -506,10 +506,19 @@ fn autoInitLearning(gpa: Allocator, arena: Allocator, io: Io, environ_map: *cons
     return true;
 }
 
+/// One-shots and `--json` are not a workspace opting into a spending cadence.
+/// `-p` evals land on exactly 5 model calls (the bootstrap floor) and then
+/// copy 132M `graff-pinned` + generate suites (~38s CPU). Interactive
+/// REPL/TUI/ACP still auto-init. Off with `GRAFF_LEARN_AUTO=off`.
+pub fn shouldAutoLearn(unattended: bool, json_mode: bool) bool {
+    return !unattended and !json_mode;
+}
+
 /// Closing the learning loop: a session that did real model work counts toward
 /// this workspace's next trial and, on cadence, starts one in the background.
 /// The first such session in a workspace also creates the store it counts into.
 pub fn startBackgroundLearning(gpa: Allocator, arena: Allocator, io: Io, environ_map: *const std.process.Environ.Map, budget: *const run_budget_mod.RunBudget, telemetry_allowed: bool) void {
+    if (!shouldAutoLearn(main_mod.unattended, main_mod.json_mode)) return;
     const options: learn_auto.Options = .{
         .model_calls = budget.used(),
         // A session launched with --no-telemetry keeps its trial local, even
@@ -546,4 +555,11 @@ fn unwrapFencedJson(text: []const u8) []const u8 {
 test "unwrapFencedJson strips a markdown fence and leaves bare JSON alone" {
     try std.testing.expectEqualStrings("{\"a\":1}", unwrapFencedJson("```json\n{\"a\":1}\n```\n"));
     try std.testing.expectEqualStrings("{\"a\":1}", unwrapFencedJson("{\"a\":1}"));
+}
+
+test "one-shot and --json do not auto-init a learning store" {
+    try std.testing.expect(!shouldAutoLearn(true, false));
+    try std.testing.expect(!shouldAutoLearn(false, true));
+    try std.testing.expect(!shouldAutoLearn(true, true));
+    try std.testing.expect(shouldAutoLearn(false, false));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pi was not a smarter catalog. Same-seat SWE (`run-20260828-164346`, ADR 0043) was a wash on tokens and calls (30 vs 31). Pi’s 276s vs graff’s 456s was **38s of local CPU on every task**.

Every graff-dev SWE task made exactly 5 API calls — the `learn_auto` bootstrap floor — then `startBackgroundLearning` copied 132M `.graff/learn-kit/graff-pinned` and generated suites.

## Change

`startBackgroundLearning` is a no-op on `-p` / `--json`. Interactive REPL/TUI/ACP still auto-init after 5 model calls.

## Confirm (`run-20260829-031139.jsonl`)

| | pass | wall | CPU | sandbox |
|---|---:|---:|---:|---:|
| before | 4/6 | 456s | 230s | 127M pin |
| after | **5/6** | **205s** | **6.5s** | 100–164K |

`json-stream` passed this rep (the model kept “no RS → empty” instead of inventing a missing-delimiter raise). That earlier Pi 5/6 vs graff 4/6 was one-rep noise on the same SPEC clause, not a catalog gap. `label-sort` still fails — grok-build and Pi miss it too.

Do not steal Pi’s 4-tool catalog or heap. RSS ~91M is the process, not the pin.

Recorded as [ADR 0044](docs/adr/0044-oneshot-skips-learn-auto.md).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

