### PR TITLE
Record glm-5.3-flash SWE on the Codegraff gateway

### DIFF
--- a/docs/adr/0045-glm-flash-swe-codegraff.md
+++ b/docs/adr/0045-glm-flash-swe-codegraff.md
@@ -1,0 +1,50 @@
+# 0045. GLM 5.3-flash SWE via the Codegraff gateway
+
+Status: accepted 2026-08-29
+
+## Context
+
+After ADR 0044 (skip learn auto-init on `-p`), SuperGrok grok-4.6 was
+5/6 in 205s. The same suite was re-run on the Codegraff gateway
+(`CODEGRAFF_API_KEY` → `gateway.codegraff.com/v1`) with `glm-5.3-flash`
+on both `graff-dev` and `pi-codegraff`. Same key, same model, same
+`--suite swe -j 6`. `glm-5.3-flash` is uncatalogued in graff so it
+falls through to the gateway; do not pass `glm-5.3` (that row is zai
+and `MissingKey`s without `ZAI_API_KEY`).
+
+Pi needs `~/.pi/agent/models.json` provider `codegraff` pointing at
+the gateway; `apiKey` is the env var name `CODEGRAFF_API_KEY`.
+
+## Decision
+
+Live A/B 2026-08-29 (`graff-evals/results/run-20260829-034235.jsonl`):
+
+| harness | pass | wall (sum) | first | RSS | in | out | calls |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| graff-dev | 3/6 | 1353s | 6.9s | 90.5M | 96903 | 15085 | 19 |
+| pi-codegraff | **5/6** | **758s** | 0.6s | 166.8M | 223771 | 27294 | 35 |
+
+| task | graff | pi |
+|---|---|---|
+| map-conflict | ✓ 103s / 18k / 4 | ✓ 60s / 33k / 6 |
+| validated | ✓ 164s / 46k / 10 | ✓ 26s / 21k / 5 |
+| config-parse | ✓ 185s / 33k / 5 | ✓ 108s / 45k / 7 |
+| json-stream | ✗ 300s timeout (no edit) | **✓ 117s / 43k / 7** |
+| cookie-store | ✗ 300s timeout (no edit) | **✓ 301s / 44k / 5** |
+| label-sort | ✗ 300s timeout | ✗ 146s / 37k / 5 |
+
+Graff's three misses were SIGKILL at the 300s task cap before a
+`[usage]` line. `json-stream` and `cookie-store` never wrote the
+target file. Pi finished those. Both still miss `label-sort`.
+
+This is not the 38s pin (already skipped; CPU stayed ~1–3s). GLM
+flash through graff spent 3.5–7.5k output tokens on the tasks it
+finished — the clock ran out on the rest. Pi's shorter catalog
+completed the same model. Do not steal Pi's heap (167M vs 23–90M).
+
+## Consequences
+
+- Fair Codegraff A/B is `--model glm-5.3-flash` with `CODEGRAFF_API_KEY`.
+- Next graff cut on this model is finishing inside 300s (fewer / shorter
+  turns), not a catalog shrink to four tools.
+- Rotate any `cg_sk_` pasted into a chat; do not commit it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,6 +52,7 @@ record only when you need the evidence or the edge cases.
 | [0039](0039-local-tools-are-project-scripts.md) | Agent-authored local tools are project scripts under `.graff/tools/`; skills stay instructions. Runtime catalog extras, not `schema.effectiveRootSpecs`. |
 | [0040](0040-codedb-stays-when-licensed.md) | Ordinary reads use native `codedb` / `read_file`; codedb-pro is extra search, not the default reader. |
 | [0041](0041-tui-is-an-acp-client.md) | The fullscreen TUI is an in-process ACP client: session/prompt in, session/update thought/tool/text out. No child `graff acp`. |
+| [0045](0045-glm-flash-swe-codegraff.md) | Codegraff `glm-5.3-flash` SWE: Pi 5/6 in 758s, graff 3/6 with three 300s timeouts; do not steal Pi's heap. |
 
 ## When to write one
 

--- a/graff-evals/README.md
+++ b/graff-evals/README.md
@@ -25,6 +25,8 @@ harness under test spends model calls.
 ```sh
 ./run.py --suite swe --harness graff-dev-old,graff-dev --model grok-4.6 -j 12
 ./run.py --suite core,rlm,swe --harness graff-dev-old,graff-dev -j 8
+# same SuperGrok-shaped A/B on the Codegraff gateway (set CODEGRAFF_API_KEY):
+CODEGRAFF_API_KEY=cg_sk_… ./run.py --suite swe --harness graff-dev,pi-codegraff --model glm-5.3-flash -j 6
 ```
 
 ## Run it


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Same-seat SWE on `gateway.codegraff.com` with `glm-5.3-flash` for both `graff-dev` and `pi-codegraff` (`CODEGRAFF_API_KEY`, `--suite swe -j 6`). Binary includes the ADR 0044 `-p` skip.

## Result (`run-20260829-034235.jsonl`)

| harness | pass | wall | first | RSS | in | out | calls |
|---|---:|---:|---:|---:|---:|---:|---:|
| graff-dev | 3/6 | 1353s | 6.9s | 90.5M | 97k | 15k | 19 |
| pi-codegraff | **5/6** | **758s** | 0.6s | 167M | 224k | 27k | 35 |

Graff’s three misses were SIGKILL at 300s. `json-stream` and `cookie-store` never wrote the target file. Pi finished those. Both still miss `label-sort`.

This is not the 38s pin (already skipped; CPU ~1–3s). GLM flash through graff spent 3.5–7.5k output tokens on the tasks it finished and ran out of clock on the rest. Do not steal Pi’s 167M heap.

`glm-5.3-flash` is uncatalogued so graff falls through to the gateway. Do not pass `glm-5.3` (that row is zai).

Recorded as [ADR 0045](docs/adr/0045-glm-flash-swe-codegraff.md). The `cg_sk_` used for the run was not committed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

