### PR TITLE
docs: add Trendshift badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/84216?utm_source=repository-badge&utm_medium=badge&utm_campaign=badge-repository-84216" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/84216" alt="justrach/codegraff | Trendshift" width="250" height="55"></a>
+</p>
+
+<p align="center">
   <strong>The most token-efficient coding harness we've built so far.</strong><br/>
   Prompt-cache max keeps repeated prefixes hot. RLM + spec-ptc turns wide work
   into a small streaming program. Learnt slimming keeps fat results out of history.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
README-only. Adds the [Trendshift](https://trendshift.io/repositories/84216) badge under the existing shields. No harness change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

