### PR TITLE
DeepSeek flash thinking off + lean 15s bash (ADR 0050 / 0051)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,10 @@ current is part of cutting a release.
   POST dies on the 30s stall, not a 5-minute watch. SWE **5/6 in 286s**
   (Pi 5/6 in 758s). Same miss (`label-sort`). Do not steal Pi's catalog.
 - Same SWE suite on other Codegraff models (ADR 0047): Gemini graff
-  **5/6 in 103s**; Kimi 4/6 in 583s; DeepSeek flash still one-shots
-  (Pi 5/6). Do not steal Pi's catalog.
+  **5/6 in 103s**; Kimi 4/6 in 583s; DeepSeek flash was 2/6 one-shots.
+- Lean `-p` bounces a first-turn prose-only "done" (ADR 0048). DeepSeek
+  flash SWE **4/6 in 250s** (was 2/6 in 199s). The three 4s no-edits
+  now pass. Same `label-sort` miss. Do not steal Pi's catalog.
 - Interactive `--yolo` queues companion MCP and names the boot phase
   (`mcp:` / `companion:` receipts) so first paint is not the handshake
   (#664). Mid-turn stall/reconnect and `model call N` pulses stay off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ current is part of cutting a release.
   Codegraff follow-up flakes retry (ADR 0049). DeepSeek V4 flash
   default is `thinking.type=disabled` (ADR 0050): `reasoning_effort=low`
   still dumps CoT (cookie-store 75s / 1.9MB). OpenCode on the same
-  seat was 5/6 in 261s / 1.0G; graff stays ~91M. Same `label-sort`
-  miss. Do not steal Pi's catalog or OpenCode's heap.
+  seat was 5/6 in 261s / 1.0G; graff stays ~91M. Lean `-p` bash
+  auto-backgrounds at 15s (ADR 0051) so a hung test does not sit 120s.
+  Same `label-sort` miss. Do not steal Pi's catalog or OpenCode's heap.
 - Interactive `--yolo` queues companion MCP and names the boot phase
   (`mcp:` / `companion:` receipts) so first paint is not the handshake
   (#664). Mid-turn stall/reconnect and `model call N` pulses stay off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,10 @@ current is part of cutting a release.
   Codegraff follow-up flakes retry (ADR 0049). DeepSeek V4 flash
   default is `thinking.type=disabled` (ADR 0050): `reasoning_effort=low`
   still dumps CoT (cookie-store 75s / 1.9MB). OpenCode on the same
-  seat was 5/6 in 261s / 1.0G; graff stays ~91M. Lean `-p` bash
-  auto-backgrounds at 15s (ADR 0051) so a hung test does not sit 120s.
-  Same `label-sort` miss. Do not steal Pi's catalog or OpenCode's heap.
+  seat was 5/6 in 261s / 1.0G; graff stays ~91M. After thinking-off,
+  5/6 in 353s was hung bash; lean `-p` then backgrounds at 15s (ADR
+  0051) — cookie-store 30s, json-stream 22s. Same `label-sort` miss.
+  Do not steal Pi's catalog or OpenCode's heap.
 - Interactive `--yolo` queues companion MCP and names the boot phase
   (`mcp:` / `companion:` receipts) so first paint is not the handshake
   (#664). Mid-turn stall/reconnect and `model call N` pulses stay off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,11 @@ current is part of cutting a release.
 - Same SWE suite on other Codegraff models (ADR 0047): Gemini graff
   **5/6 in 103s**; Kimi 4/6 in 583s; DeepSeek flash was 2/6 one-shots.
 - Lean `-p` bounces a first-turn prose-only "done" (ADR 0048). Short
-  Codegraff follow-up flakes retry (ADR 0049). DeepSeek flash SWE
-  **5/6 in 362s** (was 2/6 in 199s). OpenCode on the same seat is
-  5/6 in 261s / 1.0G RSS; graff stays ~91M. Same `label-sort` miss.
-  Do not steal Pi's catalog or OpenCode's heap.
+  Codegraff follow-up flakes retry (ADR 0049). DeepSeek V4 flash
+  default is `thinking.type=disabled` (ADR 0050): `reasoning_effort=low`
+  still dumps CoT (cookie-store 75s / 1.9MB). OpenCode on the same
+  seat was 5/6 in 261s / 1.0G; graff stays ~91M. Same `label-sort`
+  miss. Do not steal Pi's catalog or OpenCode's heap.
 - Interactive `--yolo` queues companion MCP and names the boot phase
   (`mcp:` / `companion:` receipts) so first paint is not the handshake
   (#664). Mid-turn stall/reconnect and `model call N` pulses stay off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,11 @@ current is part of cutting a release.
   (Pi 5/6 in 758s). Same miss (`label-sort`). Do not steal Pi's catalog.
 - Same SWE suite on other Codegraff models (ADR 0047): Gemini graff
   **5/6 in 103s**; Kimi 4/6 in 583s; DeepSeek flash was 2/6 one-shots.
-- Lean `-p` bounces a first-turn prose-only "done" (ADR 0048). DeepSeek
-  flash SWE **4/6 in 250s** (was 2/6 in 199s). The three 4s no-edits
-  now pass. Same `label-sort` miss. Do not steal Pi's catalog.
+- Lean `-p` bounces a first-turn prose-only "done" (ADR 0048). Short
+  Codegraff follow-up flakes retry (ADR 0049). DeepSeek flash SWE
+  **5/6 in 362s** (was 2/6 in 199s). OpenCode on the same seat is
+  5/6 in 261s / 1.0G RSS; graff stays ~91M. Same `label-sort` miss.
+  Do not steal Pi's catalog or OpenCode's heap.
 - Interactive `--yolo` queues companion MCP and names the boot phase
   (`mcp:` / `companion:` receipts) so first paint is not the handshake
   (#664). Mid-turn stall/reconnect and `model call N` pulses stay off

--- a/docs/adr/0047-codegraff-swe-not-glm-only.md
+++ b/docs/adr/0047-codegraff-swe-not-glm-only.md
@@ -95,7 +95,7 @@ finished four tasks on ~91M RSS.
 | glm-5.3-flash | Codegraff | **5/6 in 286s** | 5/6 in 758s | 0046 |
 | gemini-3.7-flash | Codegraff | **5/6 in 103s** | (tool-loop dead) | this |
 | kimi-k2.6 | Codegraff | 4/6 in 583s | 2/6 (3× API zero) | this |
-| deepseek-v4-flash | Codegraff | 2/6 in 199s* | **5/6 in 492s** | this |
+| deepseek-v4-flash | Codegraff | 2/6 in 199s* / **4/6 in 250s** (0048) | **5/6 in 492s** | this |
 
 \*three 1-call no-edits; isolated retry recovered `map-conflict` and
 `json-stream`. Do not stitch that into the suite score.

--- a/docs/adr/0047-codegraff-swe-not-glm-only.md
+++ b/docs/adr/0047-codegraff-swe-not-glm-only.md
@@ -105,8 +105,8 @@ finished four tasks on ~91M RSS.
 - GLM 5/6 in 286s vs Pi 758s is not a one-off on flash: Gemini graff
   is 5/6 in 103s on the same suite.
 - DeepSeek flash is the exception: Pi's catalog finishes; graff's lean
-  8-tool still one-shots. Do not steal the four-tool catalog to "fix"
-  it.
+  8-tool still one-shots. Bounce that prose-only first turn (ADR 0048).
+  Do not steal the four-tool catalog to "fix" it.
 - Pi + Gemini on this gateway is not a usable A/B until Pi's tool
   follow-up is fixed. That is not a graff TUI steal.
 - `label-sort` still fails across models. Do not chase it.

--- a/docs/adr/0048-lean-oneshot-bounces-prose.md
+++ b/docs/adr/0048-lean-oneshot-bounces-prose.md
@@ -1,0 +1,33 @@
+# 0048. Lean `-p` bounces a first-turn prose-only "done"
+
+Status: accepted 2026-08-29
+
+## Context
+
+ADR 0047 ran Codegraff `deepseek-v4-flash` SWE. Pi 5/6 in 492s. Graff
+2/6 in 199s. The three misses (`map-conflict`, `json-stream`,
+`validated`) were 4-second one-call replies (~1.5k in / ~160 out) that
+described a patch and never called a tool. An isolated retry of those
+three recovered two. Same miss as everyone on `label-sort`.
+
+Empty-completion retry only covers whitespace. A 158-token "I fixed
+it" ends the turn. Forcing `tool_choice=required` is already reserved
+for `--strict` / `--eval`; DeepSeek thinking mode has rejected it
+before. Do not steal Pi's four-tool catalog (ADR 0024).
+
+## Decision
+
+On lean `-p` (unattended, file tools advertised, not review, not a
+subagent), a first-turn completion that has text and zero tool calls
+is not done. Append one user bounce naming `read_file` / `edit_file` /
+`write_file` and re-open the loop. One bounce only (`model_calls == 1`).
+
+Lean intro also says a file change described in prose is not done.
+
+## Consequences
+
+- `graff -p "what is 2+2"` pays one extra call if the first reply has
+  no tool. Acceptable for a coding harness.
+- Interactive REPL / TUI / `--no-lean` / subagents are unchanged.
+- Revisit if a named flash model needs `tool_choice=required` on the
+  first call; do not restore a global force.

--- a/docs/adr/0048-lean-oneshot-bounces-prose.md
+++ b/docs/adr/0048-lean-oneshot-bounces-prose.md
@@ -24,6 +24,31 @@ is not done. Append one user bounce naming `read_file` / `edit_file` /
 
 Lean intro also says a file change described in prose is not done.
 
+## Confirm — `deepseek-v4-flash` after bounce (`run-20260829-063114.jsonl`)
+
+Same `--suite swe -j 6` seat as ADR 0047.
+
+| harness | pass | wall (sum) | first | RSS | in | out | calls |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| graff-dev | **4/6** | 250s | 0.03s | 91.2M | 170k | 25k | 26 |
+
+| task | before (0047) | after |
+|---|---|---|
+| cookie-store | ✓ 91s / 8 | ✓ 133s / 7 |
+| config-parse | ✓ 33s / 4 | ✗ 5s / 1* |
+| label-sort | ✗ 63s / 6 | ✗ 5s / 1* |
+| map-conflict | ✗ 4s / 1 | ✓ 20s / 5 |
+| json-stream | ✗ 4s / 1 | ✓ 65s / 8 |
+| validated | ✗ 4s / 1 | ✓ 20s / 4 |
+
+\*follow-up API error under `-j 6` (resp 110 B, ~450 ms). Isolated
+serial retry (`run-20260829-063451.jsonl`): `config-parse` ✓ 48s / 5,
+`label-sort` ✗ 62s / 5 (check, exit 0). Do not stitch that into 5/6.
+
+The confirm run used tools on the first call (lean intro). Bounce is
+the backstop when the model writes "I fixed it" with zero tools. No
+`fake_done` notes on this run.
+
 ## Consequences
 
 - `graff -p "what is 2+2"` pays one extra call if the first reply has

--- a/docs/adr/0048-lean-oneshot-bounces-prose.md
+++ b/docs/adr/0048-lean-oneshot-bounces-prose.md
@@ -56,3 +56,5 @@ the backstop when the model writes "I fixed it" with zero tools. No
 - Interactive REPL / TUI / `--no-lean` / subagents are unchanged.
 - Revisit if a named flash model needs `tool_choice=required` on the
   first call; do not restore a global force.
+- Follow-up `-j 6` flakes and the OpenCode A/B are ADR 0049 (graff
+  5/6 in 362s after the retry).

--- a/docs/adr/0049-codegraff-flake-retry-opencode.md
+++ b/docs/adr/0049-codegraff-flake-retry-opencode.md
@@ -1,0 +1,53 @@
+# 0049. Retry short Codegraff follow-up flakes; OpenCode A/B on the same seat
+
+Status: accepted 2026-08-29
+
+## Context
+
+ADR 0048 bounced lean `-p` prose-only first turns. DeepSeek flash SWE
+moved 2/6 → 4/6. The leftover miss besides `label-sort` was
+`config-parse` dying in ~5s after a successful 4-tool first batch: a
+~110-byte / ~450 ms `api_error` under `-j 6`. Isolated serial retry
+passed. Overload / `server_error` needles did not match. A missing
+`error.message` becomes `unknown error` (`apiErrorMessage`).
+
+Same-seat OpenCode was missing from `graff-evals`. Fair A/B is the
+same `CODEGRAFF_API_KEY` → `gateway.codegraff.com/v1`. Do not steal
+Pi's four-tool catalog (ADR 0024) or OpenCode's ~1G heap.
+
+## Decision
+
+- Treat short generic envelopes (`unknown error`, `Internal Server
+  Error`, empty `api_error`) and tiny unparseable bodies (≤256 B) as
+  bounded retries (2). `invalid_request` / auth / quota / not-found
+  stay fail-fast.
+- Add `opencode-codegraff` (`opencode run --auto --format json` +
+  tracked `opencode-codegraff.json`). Do not commit OpenCode auth.
+- Eval failures keep a 400-byte `stderr_tail` so the next envelope is
+  visible.
+
+## Confirm — `deepseek-v4-flash` (`run-20260829-072310` + `072758`)
+
+Same `--suite swe -j 6` seat as ADR 0047 / 0048.
+
+| harness | pass | wall (sum) | first | RSS | in | out | calls |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| graff-dev (`072758`) | **5/6** | 362s | 0.05s | 91.1M | 346k | 38k | 38 |
+| opencode-codegraff (`072310`) | **5/6** | 261s | 3.6s | 1064M | 61k | 8k | 36 |
+| pi-codegraff (0047) | **5/6** | 492s | 0.7s | 186M | 480k | 56k | 46 |
+
+The parallel A/B (`072310`) still had graff 4/6 (`config-parse` 5s /
+1). After the `unknown error` / tiny-body retry, graff `072758` is
+5/6; `config-parse` ✓ 30s / 4. Same `label-sort` miss on all three
+harnesses. Do not stitch the two graff suite scores.
+
+OpenCode `first` is the first JSONL event (~3.6s), not TUI paint.
+Graff `first` is the stderr `calling` line. Do not treat 0.05s as a
+TUI steal.
+
+## Consequences
+
+- Score is now tied with Pi and OpenCode. Wall is not: OpenCode 261s
+  vs graff 362s is mostly `cookie-store` variance (89s on `072310`,
+  185s on `072758`). RSS stays ~91M; do not take OpenCode's heap.
+- Revisit if a named 400 should retry; do not retry `invalid_request`.

--- a/docs/adr/0050-deepseek-thinking-disabled-at-low.md
+++ b/docs/adr/0050-deepseek-thinking-disabled-at-low.md
@@ -1,0 +1,34 @@
+# 0050. DeepSeek flash default is thinking off
+
+Status: accepted 2026-08-29
+
+## Context
+
+ADR 0046 maps flash default `.medium` to `reasoning_effort: low`.
+That stops GLM/Gemini thinking novels. DeepSeek V4 is different:
+thinking is **on at high** unless the request carries
+`thinking: {type: disabled}`. Official docs: `low` still thinks;
+it only lowers CoT. `none` is a 400 on Chat Completions.
+
+DeepSeek flash SWE after ADR 0049: graff **5/6 in 362s** vs OpenCode
+**5/6 in 261s**. The 100s gap is not catalog or heap. cookie-store
+call 2 was **75s / 1.9MB** of `reasoning_content` at `low`. An earlier
+A/B without that dump was 89s / 9 calls (OpenCode 76s / 9). Pi sets
+`reasoning: false`. OpenCode omits the field (default = thinking on);
+it still won on a no-dump draw. Do not steal Pi's four-tool catalog
+or OpenCode's ~1G heap.
+
+## Decision
+
+DeepSeek family (native `deepseek`, or a `deepseek*` model on
+codegraff/fireworks) sends `thinking.type=disabled` when the wire
+effort is `low` (flash default). `/effort high` (and any non-low)
+sends `type=enabled` plus that effort. GLM keeps `low` only —
+`type=disabled` still thinks there (ADR 0046). Do not shrink the
+keep-list.
+
+## Consequences
+
+- Flash SWE wall is generation without CoT dumps, not Zig vs JS.
+- `/effort` remains the only way thinking comes back (no auto-flip).
+- Revisit if a named DeepSeek flash pin needs default thinking.

--- a/docs/adr/0050-deepseek-thinking-disabled-at-low.md
+++ b/docs/adr/0050-deepseek-thinking-disabled-at-low.md
@@ -32,3 +32,17 @@ keep-list.
 - Flash SWE wall is generation without CoT dumps, not Zig vs JS.
 - `/effort` remains the only way thinking comes back (no auto-flip).
 - Revisit if a named DeepSeek flash pin needs default thinking.
+
+## Confirm (2026-08-29)
+
+Live `deepseek-v4-flash` pong on `gateway.codegraff.com`:
+
+| knob | reasoning_tokens | rc_len |
+|---|---:|---:|
+| omit | 21 | 79 |
+| `reasoning_effort=low` | 31 | 112 |
+| `thinking.type=disabled` | **0** | **0** |
+| disabled + low | **0** | **0** |
+| enabled + high | 29 | 117 |
+
+`--suite swe -j 6` after this cut (`074142`): 4/6 in **210s** / 91M (cookie-store 83s / 14, no 1.9MB dump). `config-parse` was the 110-byte “Body must be valid JSON” flake (retry in the same branch). After that retry (`074659`): **5/6 in 353s** — leftover wall was hung bash (ADR 0051), not CoT. Same `label-sort` miss. Later 0-token / balance-reservation runs are burnt gateway, not a model result. Do not steal Pi’s catalog.

--- a/docs/adr/0051-lean-oneshot-bash-15s.md
+++ b/docs/adr/0051-lean-oneshot-bash-15s.md
@@ -1,0 +1,24 @@
+# 0051. Lean `-p` bash auto-backgrounds at 15s
+
+Status: accepted 2026-08-29
+
+## Context
+
+ADR 0026 waits 120s before promoting root foreground bash: a human
+may be watching a long compile. Lean `-p` has no human. After ADR
+0050 killed DeepSeek CoT dumps, SWE wall was **5/6 in 353s** —
+`json-stream` sat **120s** on `python3 test_json_stream.py`,
+`cookie-store` **71s** on another hang. API calls were 2–13s.
+OpenCode’s 261s lead was those waits, not catalog or heap.
+
+## Decision
+
+Unattended + lean (`-p` default) auto-backgrounds at **15s**. The
+process is not killed (ADR 0026). An explicit `timeout` still wins.
+Interactive / `--no-lean` stay 120s. Do not steal Pi’s catalog.
+
+## Consequences
+
+A hung test returns a job id in 15s; the model can edit or
+`bash_kill`. A 20-minute compile on `-p` also backgrounds at 15s —
+`bash_output(wait_ms>0)` still waits for exit (ADR 0010).

--- a/docs/adr/0051-lean-oneshot-bash-15s.md
+++ b/docs/adr/0051-lean-oneshot-bash-15s.md
@@ -22,3 +22,11 @@ Interactive / `--no-lean` stay 120s. Do not steal Pi’s catalog.
 A hung test returns a job id in 15s; the model can edit or
 `bash_kill`. A 20-minute compile on `-p` also backgrounds at 15s —
 `bash_output(wait_ms>0)` still waits for exit (ADR 0010).
+
+## Confirm (2026-08-29)
+
+`run-20260829-075402`, thinking off + 15s bash. cookie-store **30s**
+(was 114s / 71s hang). json-stream **22s** (was 155s / 120s hang).
+Suite 4/6 in **143s** / 91M — `validated` died on a concurrent
+reservation / empty balance, not the wait. Same `label-sort` miss.
+0-token follow-ups after that are burnt gateway. Do not stitch.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,6 +59,7 @@ record only when you need the evidence or the edge cases.
 | [0046](0046-flash-omits-default-effort.md) | Flash / Gemini send `reasoning_effort=low` (omit still thinks); lean `-p` shortens tool prose; `-p` streams. |
 | [0047](0047-codegraff-swe-not-glm-only.md) | Codegraff SWE A/B is not GLM-only: Gemini graff 5/6 in 103s; DeepSeek flash still one-shots; do not steal Pi's catalog. |
 | [0048](0048-lean-oneshot-bounces-prose.md) | Lean `-p` bounces a first-turn prose-only "done"; do not steal Pi's catalog. |
+| [0049](0049-codegraff-flake-retry-opencode.md) | Retry short Codegraff follow-up flakes; OpenCode A/B on the same seat is 5/6. |
 
 ## When to write one
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,6 +58,7 @@ record only when you need the evidence or the edge cases.
 | [0045](0045-glm-flash-swe-codegraff.md) | Codegraff `glm-5.3-flash` SWE: Pi 5/6 in 758s, graff 3/6 with three 300s timeouts; do not steal Pi's heap. |
 | [0046](0046-flash-omits-default-effort.md) | Flash / Gemini send `reasoning_effort=low` (omit still thinks); lean `-p` shortens tool prose; `-p` streams. |
 | [0047](0047-codegraff-swe-not-glm-only.md) | Codegraff SWE A/B is not GLM-only: Gemini graff 5/6 in 103s; DeepSeek flash still one-shots; do not steal Pi's catalog. |
+| [0048](0048-lean-oneshot-bounces-prose.md) | Lean `-p` bounces a first-turn prose-only "done"; do not steal Pi's catalog. |
 
 ## When to write one
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,6 +60,7 @@ record only when you need the evidence or the edge cases.
 | [0047](0047-codegraff-swe-not-glm-only.md) | Codegraff SWE A/B is not GLM-only: Gemini graff 5/6 in 103s; DeepSeek flash still one-shots; do not steal Pi's catalog. |
 | [0048](0048-lean-oneshot-bounces-prose.md) | Lean `-p` bounces a first-turn prose-only "done"; do not steal Pi's catalog. |
 | [0049](0049-codegraff-flake-retry-opencode.md) | Retry short Codegraff follow-up flakes; OpenCode A/B on the same seat is 5/6. |
+| [0050](0050-deepseek-thinking-disabled-at-low.md) | DeepSeek flash default is `thinking.type=disabled`; `reasoning_effort=low` still thinks. |
 
 ## When to write one
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,6 +61,7 @@ record only when you need the evidence or the edge cases.
 | [0048](0048-lean-oneshot-bounces-prose.md) | Lean `-p` bounces a first-turn prose-only "done"; do not steal Pi's catalog. |
 | [0049](0049-codegraff-flake-retry-opencode.md) | Retry short Codegraff follow-up flakes; OpenCode A/B on the same seat is 5/6. |
 | [0050](0050-deepseek-thinking-disabled-at-low.md) | DeepSeek flash default is `thinking.type=disabled`; `reasoning_effort=low` still thinks. |
+| [0051](0051-lean-oneshot-bash-15s.md) | Lean `-p` bash auto-backgrounds at 15s; interactive stays 120s (ADR 0026). |
 
 ## When to write one
 

--- a/docs/releases/v0.0.281.md
+++ b/docs/releases/v0.0.281.md
@@ -81,11 +81,13 @@ Same seat (`CODEGRAFF_API_KEY`, `graff-dev` vs `pi-codegraff`,
 | `glm-5.3-flash` (0046) | **5/6 in 286s** | 5/6 in 758s |
 | `gemini-3.7-flash` | **5/6 in 103s** | 0/6 (tool-loop dead) |
 | `kimi-k2.6` | 4/6 in 583s | 2/6 (3× API zero) |
-| `deepseek-v4-flash` | 2/6 in 199s* | **5/6 in 492s** |
+| `deepseek-v4-flash` | **4/6 in 250s** (0048) | **5/6 in 492s** |
 
-\*three 1-call no-edits; an isolated retry recovered `map-conflict`
-and `json-stream`. Pi's Gemini column is not a fair A/B. Do not steal
-Pi's catalog to "fix" DeepSeek. `label-sort` still fails everywhere.
+ADR 0048 bounces a lean `-p` first-turn prose-only "done". The three
+4s no-edits (`map-conflict`, `json-stream`, `validated`) now pass.
+Suite still misses `label-sort` (everyone) and a `-j 6` follow-up
+API flake on `config-parse` (isolated ✓). Do not steal Pi's catalog.
+Pi's Gemini column is not a fair A/B.
 
 ## TUI first paint no longer waits on companion MCP (#664)
 

--- a/docs/releases/v0.0.281.md
+++ b/docs/releases/v0.0.281.md
@@ -81,13 +81,13 @@ Same seat (`CODEGRAFF_API_KEY`, `graff-dev` vs `pi-codegraff`,
 | `glm-5.3-flash` (0046) | **5/6 in 286s** | 5/6 in 758s |
 | `gemini-3.7-flash` | **5/6 in 103s** | 0/6 (tool-loop dead) |
 | `kimi-k2.6` | 4/6 in 583s | 2/6 (3× API zero) |
-| `deepseek-v4-flash` | **4/6 in 250s** (0048) | **5/6 in 492s** |
+| `deepseek-v4-flash` | **5/6 in 362s** (0049) | **5/6 in 492s** |
 
-ADR 0048 bounces a lean `-p` first-turn prose-only "done". The three
-4s no-edits (`map-conflict`, `json-stream`, `validated`) now pass.
-Suite still misses `label-sort` (everyone) and a `-j 6` follow-up
-API flake on `config-parse` (isolated ✓). Do not steal Pi's catalog.
-Pi's Gemini column is not a fair A/B.
+ADR 0048 bounces a lean `-p` first-turn prose-only "done". ADR 0049
+retries short Codegraff follow-up flakes. OpenCode on the same seat
+is **5/6 in 261s** at ~1G RSS; graff stays ~91M. Same `label-sort`
+miss. Do not steal Pi's catalog or OpenCode's heap. Pi's Gemini
+column is not a fair A/B.
 
 ## TUI first paint no longer waits on companion MCP (#664)
 

--- a/docs/releases/v0.0.281.md
+++ b/docs/releases/v0.0.281.md
@@ -81,7 +81,7 @@ Same seat (`CODEGRAFF_API_KEY`, `graff-dev` vs `pi-codegraff`,
 | `glm-5.3-flash` (0046) | **5/6 in 286s** | 5/6 in 758s |
 | `gemini-3.7-flash` | **5/6 in 103s** | 0/6 (tool-loop dead) |
 | `kimi-k2.6` | 4/6 in 583s | 2/6 (3× API zero) |
-| `deepseek-v4-flash` | **5/6 in 362s** (0049) | **5/6 in 492s** |
+| `deepseek-v4-flash` | **5/6 in 353s** (0050; 15s bash then 4/6 in 143s) | **5/6 in 492s** |
 
 ADR 0048 bounces a lean `-p` first-turn prose-only "done". ADR 0049
 retries short Codegraff follow-up flakes. ADR 0050 sends DeepSeek

--- a/docs/releases/v0.0.281.md
+++ b/docs/releases/v0.0.281.md
@@ -84,8 +84,10 @@ Same seat (`CODEGRAFF_API_KEY`, `graff-dev` vs `pi-codegraff`,
 | `deepseek-v4-flash` | **5/6 in 362s** (0049) | **5/6 in 492s** |
 
 ADR 0048 bounces a lean `-p` first-turn prose-only "done". ADR 0049
-retries short Codegraff follow-up flakes. OpenCode on the same seat
-is **5/6 in 261s** at ~1G RSS; graff stays ~91M. Same `label-sort`
+retries short Codegraff follow-up flakes. ADR 0050 sends DeepSeek
+`thinking.type=disabled` at flash default `low` — `reasoning_effort=low`
+still thinks (cookie-store 75s / 1.9MB). OpenCode on the same seat
+was **5/6 in 261s** at ~1G RSS; graff stays ~91M. Same `label-sort`
 miss. Do not steal Pi's catalog or OpenCode's heap. Pi's Gemini
 column is not a fair A/B.
 

--- a/graff-evals/README.md
+++ b/graff-evals/README.md
@@ -31,6 +31,8 @@ harness under test spends model calls.
 CODEGRAFF_API_KEY=cg_sk_… ./run.py --suite swe --harness graff-dev,pi-codegraff --model glm-5.3-flash -j 6
 # same seat, other models (ADR 0047): deepseek-v4-flash, gemini-3.7-flash, kimi-k2.6
 CODEGRAFF_API_KEY=cg_sk_… ./run.py --suite swe --harness graff-dev,pi-codegraff --model deepseek-v4-flash -j 6
+# OpenCode on the same Codegraff seat (opencode on PATH, ~/.opencode/bin is fine):
+CODEGRAFF_API_KEY=cg_sk_… ./run.py --suite swe --harness graff-dev,opencode-codegraff --model deepseek-v4-flash -j 6
 ```
 
 ## Run it

--- a/graff-evals/harnesses.json
+++ b/graff-evals/harnesses.json
@@ -129,6 +129,14 @@
     "default_model": "gemini-3.7-flash",
     "note": "uses ~/.pi/agent/models.json provider codegraff → gateway.codegraff.com; Gemini tool loops need the codegraff-gemini-echo extension"
   },
+  "opencode-codegraff": {
+    "cmd": ["{repo}/graff-evals/opencode-codegraff.sh", "-m", "codegraff/{model}", "--dir", "{cwd}", "{prompt}"],
+    "answer": "opencode-json",
+    "usage": "opencode-json",
+    "capabilities": [],
+    "default_model": "deepseek-v4-flash",
+    "note": "OpenCode on the Codegraff gateway (same CODEGRAFF_API_KEY seat as graff-dev / pi-codegraff). Wrapper needs `opencode` on PATH (~/.opencode/bin)."
+  },
   "pi-xai": {
     "cmd": ["{repo}/graff-evals/pi-xai.sh", "-p", "--mode", "json", "--provider", "xai", "--model", "{model}", "--no-session", "{prompt}"],
     "answer": "pi-json",

--- a/graff-evals/opencode-codegraff.json
+++ b/graff-evals/opencode-codegraff.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "codegraff/deepseek-v4-flash",
+  "provider": {
+    "codegraff": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Codegraff",
+      "options": {
+        "baseURL": "https://gateway.codegraff.com/v1",
+        "apiKey": "{env:CODEGRAFF_API_KEY}",
+        "headers": {
+          "User-Agent": "Mozilla/5.0 (compatible; graff-evals/1.0)"
+        }
+      },
+      "models": {
+        "deepseek-v4-flash": {
+          "name": "DeepSeek V4 Flash"
+        },
+        "glm-5.3-flash": {
+          "name": "GLM 5.3 Flash"
+        },
+        "gemini-3.7-flash": {
+          "name": "Gemini 3.7 Flash"
+        },
+        "kimi-k2.6": {
+          "name": "Kimi K2.6"
+        }
+      }
+    }
+  }
+}

--- a/graff-evals/opencode-codegraff.sh
+++ b/graff-evals/opencode-codegraff.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Drive OpenCode on the Codegraff gateway (same seat as graff-dev / pi-codegraff).
+set -e
+root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+export PATH="${HOME}/.opencode/bin:${PATH}"
+export OPENCODE_CONFIG="${OPENCODE_CONFIG:-$root/graff-evals/opencode-codegraff.json}"
+export OPENCODE_DISABLE_AUTOUPDATE=1
+export OPENCODE_DISABLE_DEFAULT_PLUGINS=1
+if [ -z "${CODEGRAFF_API_KEY:-}" ]; then
+	echo "opencode-codegraff: CODEGRAFF_API_KEY is unset" >&2
+	exit 127
+fi
+if ! command -v opencode >/dev/null 2>&1; then
+	echo "opencode-codegraff: opencode not found (https://opencode.ai/docs)" >&2
+	exit 127
+fi
+exec opencode run --auto --format json --pure "$@"

--- a/graff-evals/run.py
+++ b/graff-evals/run.py
@@ -70,8 +70,8 @@ def materialize(task, sandbox):
         subprocess.run(["/bin/sh", "-c", cmd], cwd=sandbox, capture_output=True, timeout=60)
 
 
-def build_cmd(harness, task, model):
-    subst = {"prompt": task["prompt"], "model": model, "repo": REPO}
+def build_cmd(harness, task, model, sandbox="."):
+    subst = {"prompt": task["prompt"], "model": model, "repo": REPO, "cwd": sandbox}
     cmd = [part.format(**subst) for part in harness["cmd"]]
     if "output-schema" in task.get("requires", []):
         schema = json.dumps(task["schema"], separators=(",", ":"))
@@ -120,6 +120,33 @@ def parse_answer_and_usage(harness, stdout, stderr):
                                  if c.get("type") == "text") or answer
         usage = {"calls": calls, "in": tin + tread + twrite, "cached": tread,
                  "out": tout, "cost_usd": round(cost, 6)}
+    if harness["answer"] == "opencode-json":
+        answer, calls, tin, tout, cached = "", 0, 0, 0, 0
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            typ = ev.get("type")
+            part = ev.get("part") or {}
+            if typ == "text":
+                t = part.get("text") or ev.get("text") or ""
+                if t:
+                    answer = t
+            if typ == "step_finish":
+                calls += 1
+                tok = part.get("tokens") or ev.get("tokens") or {}
+                tin += tok.get("input") or tok.get("inputTokens") or 0
+                tout += tok.get("output") or tok.get("outputTokens") or 0
+                cache = tok.get("cache")
+                if isinstance(cache, dict):
+                    cached += cache.get("read") or 0
+                else:
+                    cached += tok.get("cacheRead") or tok.get("cache_read") or 0
+        usage = {"calls": calls, "in": tin, "cached": cached, "out": tout}
     if harness.get("usage") == "graff-stderr":
         m = GRAFF_USAGE_RE.search(stderr)
         if m:
@@ -207,7 +234,7 @@ def _fmt_mib(kb):
 def one_run(hname, harness, task, model, rep, live=False):
     sandbox = os.path.join(SANDBOX_DIR, f"{hname}-{task['id']}-r{rep}")
     materialize(task, sandbox)
-    cmd = build_cmd(harness, task, model)
+    cmd = build_cmd(harness, task, model, sandbox)
     timeout = task.get("timeout_s", 240)
     t0 = time.monotonic()
     first_out = None

--- a/graff-evals/run.py
+++ b/graff-evals/run.py
@@ -296,6 +296,8 @@ def one_run(hname, harness, task, model, rep, live=False):
     rec.update({f"tok_{k}": v for k, v in usage.items()})
     if check.returncode != 0 and (check.stderr.strip() or check.stdout.strip()):
         rec["check_note"] = (check.stderr.strip() or check.stdout.strip())[:200]
+    if not rec.get("outcome_ok") and stderr.strip():
+        rec["stderr_tail"] = stderr.strip()[-400:]
     return rec
 
 

--- a/src/agent_empty_completion.zig
+++ b/src/agent_empty_completion.zig
@@ -1,14 +1,18 @@
-//! Degenerate-completion policy for Agent.runTurn. A provider completion can
-//! arrive with no text, no tool calls, and no non-"stop" finish reason —
-//! observed live on the chat wire as `content: null`, no `tool_calls`
-//! (mid-task, right after a successful write_file). The step functions then
-//! return "" and the turn ends silently: the session sits there looking dead.
-//! Instead, rewind the history the step function just appended and re-ask,
-//! bounded per turn so a wedged provider can't spin up unbounded spend.
+//! Degenerate-completion policy for Agent.runTurn.
+//!
+//! 1. Empty / whitespace-only completions (no tool calls) used to end the
+//!    turn silently. Rewind and re-ask, bounded.
+//! 2. Lean `-p` text-only first completions (DeepSeek flash SWE): the model
+//!    describes a patch and stops. That is not done — bounce once with a
+//!    user note. Do not steal Pi's four-tool catalog (ADR 0024 / 0047).
+//!
 //! Split from agent.zig (600-line goal); wired only in runTurn.
 
 const std = @import("std");
 const Agent = @import("agent.zig").Agent;
+const main_mod = @import("main.zig");
+const no_local_tools = @import("no_local_tools.zig");
+const messages = @import("messages.zig");
 
 /// Retries allowed per turn for consecutive degenerate completions.
 pub const max_consecutive: u8 = 2;
@@ -21,17 +25,29 @@ pub fn shouldRetry(final_text: []const u8, retries: u8) bool {
     return std.mem.trim(u8, final_text, " \t\r\n").len == 0;
 }
 
-/// Handle a degenerate completion inside runTurn: spend one bounded retry by
-/// rewinding the history the step function just appended (clamped — an
-/// in-request compaction may already have shrunk it) and re-opening the WS
-/// chain, whose watermark is keyed to the dropped messages. Returns true when
-/// the caller should `continue` the loop.
+/// Lean `-p` described a fix and never called a tool. One bounce.
+pub const bounce_note = "You described a change but did not call any tool. Inspect and edit the files with read_file / edit_file / write_file; do not claim the tree is already updated.";
+
+pub fn shouldBounce(unattended: bool, lean: bool, text_only: bool, review: bool, sub: bool, tool_calls: u64, model_calls: u64, final_text: []const u8) bool {
+    if (!unattended or !lean or text_only or review or sub) return false;
+    if (tool_calls != 0 or model_calls != 1) return false;
+    return std.mem.trim(u8, final_text, " \t\r\n").len > 0;
+}
+
+/// Handle a degenerate completion inside runTurn. Returns true when the
+/// caller should `continue` the loop.
 pub fn handle(self: *Agent, final_text: []const u8, hist_len: usize) !bool {
-    if (!shouldRetry(final_text, self.empty_completion_retries)) return false;
-    self.empty_completion_retries += 1;
-    self.closeCodexWs();
-    self.messages.shrinkRetainingCapacity(@min(hist_len, self.messages.items.len));
-    try self.say("[model returned an empty completion — retrying ({d}/{d})]\n", .{ self.empty_completion_retries, max_consecutive });
+    if (shouldRetry(final_text, self.empty_completion_retries)) {
+        self.empty_completion_retries += 1;
+        self.closeCodexWs();
+        self.messages.shrinkRetainingCapacity(@min(hist_len, self.messages.items.len));
+        try self.say("[model returned an empty completion — retrying ({d}/{d})]\n", .{ self.empty_completion_retries, max_consecutive });
+        return true;
+    }
+    if (!shouldBounce(main_mod.unattended, no_local_tools.lean, self.text_only, self.review_mode, self.sub, self.tool_calls_this_turn, self.model_calls_this_turn, final_text))
+        return false;
+    try self.messages.append(try messages.textMessage(self.arena, "user", bounce_note));
+    if (self.tracer) |tr| tr.note("fake_done", "lean -p text-only; bounced");
     return true;
 }
 
@@ -46,4 +62,21 @@ test "whitespace-only completions are degenerate, real text never is" {
     try std.testing.expect(shouldRetry(" \r\n\t", 0));
     try std.testing.expect(!shouldRetry("done", 0));
     try std.testing.expect(!shouldRetry("<|eos|>", 0));
+}
+
+test "lean -p text-only first completion bounces once" {
+    try std.testing.expect(shouldBounce(true, true, false, false, false, 0, 1, "I fixed validated.py"));
+    try std.testing.expect(!shouldBounce(true, true, false, false, false, 0, 2, "I fixed validated.py"));
+    try std.testing.expect(!shouldBounce(true, true, false, false, false, 1, 1, "I fixed validated.py"));
+    try std.testing.expect(!shouldBounce(false, true, false, false, false, 0, 1, "I fixed validated.py"));
+    try std.testing.expect(!shouldBounce(true, false, false, false, false, 0, 1, "I fixed validated.py"));
+    try std.testing.expect(!shouldBounce(true, true, true, false, false, 0, 1, "I fixed validated.py"));
+    try std.testing.expect(!shouldBounce(true, true, false, true, false, 0, 1, "I fixed validated.py"));
+    try std.testing.expect(!shouldBounce(true, true, false, false, true, 0, 1, "I fixed validated.py"));
+    try std.testing.expect(!shouldBounce(true, true, false, false, false, 0, 1, "   "));
+}
+
+test "bounce note names the file tools" {
+    try std.testing.expect(std.mem.indexOf(u8, bounce_note, "edit_file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, bounce_note, "write_file") != null);
 }

--- a/src/agent_empty_completion.zig
+++ b/src/agent_empty_completion.zig
@@ -47,6 +47,7 @@ pub fn handle(self: *Agent, final_text: []const u8, hist_len: usize) !bool {
     if (!shouldBounce(main_mod.unattended, no_local_tools.lean, self.text_only, self.review_mode, self.sub, self.tool_calls_this_turn, self.model_calls_this_turn, final_text))
         return false;
     try self.messages.append(try messages.textMessage(self.arena, "user", bounce_note));
+    try self.say("[described a change with no tool call — asking once more]\n", .{});
     if (self.tracer) |tr| tr.note("fake_done", "lean -p text-only; bounced");
     return true;
 }

--- a/src/agent_gateway_retry.zig
+++ b/src/agent_gateway_retry.zig
@@ -10,6 +10,9 @@
 //!    history it stays a fail-fast 400, exactly as before.
 //! 2. Retry trace notes carry the agent label, so a 5xx can be attributed to
 //!    the subagent that drew it without ms-arithmetic across api spans.
+//! 3. A short generic `api_error` / "Internal Server Error" / empty envelope
+//!    (the DeepSeek flash `-j 6` follow-up flake) is retried bounded. Real
+//!    invalid_request / auth / quota stays fail-fast.
 
 const std = @import("std");
 const Agent = @import("agent.zig").Agent;
@@ -72,12 +75,48 @@ pub fn noteFlake(self: *Agent, state: *GatewayRetryState, err: anyerror) void {
     if (err == error.Timeout) state.transport_timeouts += 1;
 }
 
-/// One gate for the envelope-fatal paths: the pre-existing transient
-/// server-overload retry first (unchanged semantics), then the bounded
-/// gateway-artifact retry when this request already endured >=2 timeouts.
+/// One gate for the envelope-fatal paths: overload first, then a short
+/// Codegraff follow-up flake (ADR 0048 DeepSeek `-j 6` 110-byte / ~450ms
+/// `api_error`), then the timeout-gated body-parse retry.
 pub fn afterServerErrorOrParseReject(self: *Agent, etype: []const u8, code: ?[]const u8, msg: []const u8, server_retries: *usize, state: *GatewayRetryState) !bool {
     if (try policy.retryTransientServerError(self, etype, code, msg, server_retries)) return true;
+    if (try retryShortGatewayFlake(self, etype, code, msg, server_retries)) return true;
     return retryBodyParseAfterTimeouts(self, msg, state);
+}
+
+pub const max_short_flake_retries: usize = 2;
+
+/// Tiny / generic envelopes that are not a real client bug. The DeepSeek
+/// SWE `-j 6` follow-up was ~110 bytes, ~450 ms, `is_error`, no
+/// "overloaded" / "server_error" needle — isolated serial retry passed.
+/// Do not treat invalid_request / auth / quota as a flake.
+pub fn isShortGatewayFlake(etype: []const u8, code: ?[]const u8, msg: []const u8) bool {
+    const hard = [_][]const u8{ "invalid", "authentication", "unauthorized", "insufficient", "quota", "permission", "tool_choice" };
+    for (hard) |n| {
+        if (util.indexOfIgnoreCase(etype, n) != null) return false;
+        if (util.indexOfIgnoreCase(msg, n) != null) return false;
+        if (code) |c| if (util.indexOfIgnoreCase(c, n) != null) return false;
+    }
+    const flakes = [_][]const u8{ "internal", "try again", "temporarily", "unavailable", "bad gateway", "upstream", "capacity" };
+    for (flakes) |n| {
+        if (util.indexOfIgnoreCase(etype, n) != null) return true;
+        if (util.indexOfIgnoreCase(msg, n) != null) return true;
+        if (code) |c| if (util.indexOfIgnoreCase(c, n) != null) return true;
+    }
+    const generic = etype.len == 0 or std.mem.eql(u8, etype, "error") or std.mem.eql(u8, etype, "api_error");
+    return generic and std.mem.trim(u8, msg, " \t\r\n").len == 0;
+}
+
+fn retryShortGatewayFlake(self: *Agent, etype: []const u8, code: ?[]const u8, msg: []const u8, retries: *usize) !bool {
+    if (!isShortGatewayFlake(etype, code, msg)) return false;
+    if (retries.* >= max_short_flake_retries) return false;
+    retries.* += 1;
+    self.partial_text.clearRetainingCapacity();
+    const delay_ms = RetryPlan.delayMs(true, retries.* - 1);
+    try self.say("[gateway flake — retrying in {d}s ({d}/{d})]\n", .{ delay_ms / 1000, retries.*, max_short_flake_retries });
+    if (self.tracer) |tr| tr.note("retry", "short gateway flake");
+    self.sleepInterruptible(delay_ms) catch return error.Interrupted;
+    return true;
 }
 
 /// The gate on the Agent: announce, trace, back off (1·2s — the gateway just
@@ -116,4 +155,16 @@ test "shouldRetryBodyParseAfterTimeouts (#gateway-artifact): timeout history gat
     try std.testing.expect(!shouldRetryBodyParseAfterTimeouts("Body must be valid JSON", 3, max_gateway_parse_retries));
     // an unrelated message never retries, however many timeouts preceded it
     try std.testing.expect(!shouldRetryBodyParseAfterTimeouts("quota exceeded", 5, 0));
+}
+
+test "isShortGatewayFlake: internal/empty api_error retry; invalid/auth/quota do not" {
+    try std.testing.expect(isShortGatewayFlake("api_error", null, "Internal Server Error"));
+    try std.testing.expect(isShortGatewayFlake("api_error", null, ""));
+    try std.testing.expect(isShortGatewayFlake("error", null, "   "));
+    try std.testing.expect(isShortGatewayFlake("", null, "upstream connect error"));
+    try std.testing.expect(!isShortGatewayFlake("invalid_request_error", null, "invalid prompt"));
+    try std.testing.expect(!isShortGatewayFlake("api_error", null, "invalid tool_choice"));
+    try std.testing.expect(!isShortGatewayFlake("authentication_error", null, "invalid api key"));
+    try std.testing.expect(!isShortGatewayFlake("insufficient_quota", null, "You exceeded your current quota"));
+    try std.testing.expect(!isShortGatewayFlake("api_error", null, "model not found"));
 }

--- a/src/agent_gateway_retry.zig
+++ b/src/agent_gateway_retry.zig
@@ -91,13 +91,13 @@ pub const max_short_flake_retries: usize = 2;
 /// "overloaded" / "server_error" needle — isolated serial retry passed.
 /// Do not treat invalid_request / auth / quota as a flake.
 pub fn isShortGatewayFlake(etype: []const u8, code: ?[]const u8, msg: []const u8) bool {
-    const hard = [_][]const u8{ "invalid", "authentication", "unauthorized", "insufficient", "quota", "permission", "tool_choice" };
+    const hard = [_][]const u8{ "invalid", "authentication", "unauthorized", "insufficient", "quota", "permission", "tool_choice", "not found" };
     for (hard) |n| {
         if (util.indexOfIgnoreCase(etype, n) != null) return false;
         if (util.indexOfIgnoreCase(msg, n) != null) return false;
         if (code) |c| if (util.indexOfIgnoreCase(c, n) != null) return false;
     }
-    const flakes = [_][]const u8{ "internal", "try again", "temporarily", "unavailable", "bad gateway", "upstream", "capacity" };
+    const flakes = [_][]const u8{ "internal", "try again", "temporarily", "unavailable", "bad gateway", "upstream", "capacity", "unknown error", "something went wrong", "an error occurred" };
     for (flakes) |n| {
         if (util.indexOfIgnoreCase(etype, n) != null) return true;
         if (util.indexOfIgnoreCase(msg, n) != null) return true;
@@ -105,6 +105,23 @@ pub fn isShortGatewayFlake(etype: []const u8, code: ?[]const u8, msg: []const u8
     }
     const generic = etype.len == 0 or std.mem.eql(u8, etype, "error") or std.mem.eql(u8, etype, "api_error");
     return generic and std.mem.trim(u8, msg, " \t\r\n").len == 0;
+}
+
+/// Unparseable body that is keep-alive comments or a tiny truncated
+/// payload (the 110-byte follow-up). Bounded. Real JSON error envelopes
+/// do not reach this — they go through `afterServerErrorOrParseReject`.
+pub fn retryDegenerateBody(self: *Agent, body: []const u8, retries: *usize) !bool {
+    const tiny = body.len > 0 and body.len <= 256;
+    if (!policy.sseKeepAliveOnly(body) and !tiny) return false;
+    if (retries.* >= max_short_flake_retries) return false;
+    retries.* += 1;
+    self.partial_text.clearRetainingCapacity();
+    const delay_ms = RetryPlan.delayMs(true, retries.* - 1);
+    const what: []const u8 = if (policy.sseKeepAliveOnly(body)) "keep-alive only, no tokens" else "truncated gateway body";
+    try self.say("[provider queued the request ({s}) — retrying in {d}s ({d}/{d})]\n", .{ what, delay_ms / 1000, retries.*, max_short_flake_retries });
+    if (self.tracer) |tr| tr.note("retry", what);
+    self.sleepInterruptible(delay_ms) catch return error.Interrupted;
+    return true;
 }
 
 fn retryShortGatewayFlake(self: *Agent, etype: []const u8, code: ?[]const u8, msg: []const u8, retries: *usize) !bool {
@@ -161,6 +178,7 @@ test "isShortGatewayFlake: internal/empty api_error retry; invalid/auth/quota do
     try std.testing.expect(isShortGatewayFlake("api_error", null, "Internal Server Error"));
     try std.testing.expect(isShortGatewayFlake("api_error", null, ""));
     try std.testing.expect(isShortGatewayFlake("error", null, "   "));
+    try std.testing.expect(isShortGatewayFlake("", null, "unknown error"));
     try std.testing.expect(isShortGatewayFlake("", null, "upstream connect error"));
     try std.testing.expect(!isShortGatewayFlake("invalid_request_error", null, "invalid prompt"));
     try std.testing.expect(!isShortGatewayFlake("api_error", null, "invalid tool_choice"));

--- a/src/agent_gateway_retry.zig
+++ b/src/agent_gateway_retry.zig
@@ -11,8 +11,11 @@
 //! 2. Retry trace notes carry the agent label, so a 5xx can be attributed to
 //!    the subagent that drew it without ms-arithmetic across api spans.
 //! 3. A short generic `api_error` / "Internal Server Error" / empty envelope
-//!    (the DeepSeek flash `-j 6` follow-up flake) is retried bounded. Real
-//!    invalid_request / auth / quota stays fail-fast.
+//!    (the DeepSeek flash `-j 6` follow-up flake) is retried bounded. The
+//!    same 110-byte / ~450ms follow-up also arrives as `invalid_request_error`
+//!    / "Body must be valid JSON" (our stringify just succeeded on call 1).
+//!    That phrase is a flake; auth / quota / a real invalid prompt stay
+//!    fail-fast.
 
 const std = @import("std");
 const Agent = @import("agent.zig").Agent;
@@ -91,6 +94,9 @@ pub const max_short_flake_retries: usize = 2;
 /// "overloaded" / "server_error" needle — isolated serial retry passed.
 /// Do not treat invalid_request / auth / quota as a flake.
 pub fn isShortGatewayFlake(etype: []const u8, code: ?[]const u8, msg: []const u8) bool {
+    // Gateway 110-byte follow-up. etype is often invalid_request_error, which
+    // would otherwise hard-fail on the "invalid" needle. Auth/quota still die.
+    if (isBodyParseRejection(msg)) return true;
     const hard = [_][]const u8{ "invalid", "authentication", "unauthorized", "insufficient", "quota", "permission", "tool_choice", "not found" };
     for (hard) |n| {
         if (util.indexOfIgnoreCase(etype, n) != null) return false;
@@ -185,4 +191,7 @@ test "isShortGatewayFlake: internal/empty api_error retry; invalid/auth/quota do
     try std.testing.expect(!isShortGatewayFlake("authentication_error", null, "invalid api key"));
     try std.testing.expect(!isShortGatewayFlake("insufficient_quota", null, "You exceeded your current quota"));
     try std.testing.expect(!isShortGatewayFlake("api_error", null, "model not found"));
+    try std.testing.expect(isShortGatewayFlake("invalid_request_error", null, "Body must be valid JSON"));
+    try std.testing.expect(isShortGatewayFlake("api_error", null, "Malformed JSON in request body"));
+    try std.testing.expect(!isShortGatewayFlake("invalid_request_error", null, "invalid prompt"));
 }

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -30,20 +30,11 @@ const run_budget_mod = @import("run_budget.zig");
 const wire_messages = @import("messages.zig");
 const policy = @import("agent_request_policy.zig");
 
-const max_server_retries: usize = 3; // bounded retries for a keep-alive-only response body
-
 /// A response body of only SSE comment lines (`: OPENROUTER PROCESSING` …)
 /// means the gateway queued us and never produced tokens — back off and re-ask
 /// like a 5xx instead of dying on an "unparseable" JSON parse.
 fn retryKeepAliveOnlyResponse(self: *Agent, body: []const u8, retries: *usize) !bool {
-    if (!policy.sseKeepAliveOnly(body)) return false;
-    if (retries.* >= max_server_retries) return false;
-    retries.* += 1;
-    self.partial_text.clearRetainingCapacity();
-    const delay_ms = RetryPlan.delayMs(true, retries.* - 1); // 1·2·4s
-    try self.say("[provider queued the request (keep-alive only, no tokens) — retrying in {d}s ({d}/{d})]\n", .{ delay_ms / 1000, retries.*, max_server_retries });
-    self.sleepInterruptible(delay_ms) catch return error.Interrupted;
-    return true;
+    return @import("agent_gateway_retry.zig").retryDegenerateBody(self, body, retries);
 }
 
 const overflow = @import("agent_overflow.zig");

--- a/src/agent_request_body.zig
+++ b/src/agent_request_body.zig
@@ -174,7 +174,7 @@ pub fn buildBody(self: *Agent, tools: ?[]const u8, force_tool: bool, stream: boo
             try s.objectField("prompt_cache_key");
             try s.write(http_headers.requestCacheKey(self.io, self.label, self, self.provider.id, &ckbuf));
             // reasoning_effort (codegraff/deepseek/zai) + Z.AI thinking + Vercel reasoning.effort.
-            try @import("zai_wire.zig").writeChatExtras(&s, self.provider.id, self.sendReasoningEffort(), @import("effort_route.zig").wireEffort(self.provider.model, @tagName(self.reasoning)));
+            try @import("zai_wire.zig").writeChatExtras(&s, self.provider.id, self.provider.model, self.sendReasoningEffort(), @import("effort_route.zig").wireEffort(self.provider.model, @tagName(self.reasoning)));
             // --output-schema: structured outputs (xAI docs' response_format).
             // A provider that rejected json_schema (#543, deepseek) degrades
             // dsh-style: the tools-off formatting turn carries the schema as a

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -26,7 +26,7 @@ pub const changelog_text =
     \\  • SuperGrok SWE 5/6 in 205s / 6.5s CPU (was 4/6 in 456s / 230s)
     \\  • TUI claims alt-screen before boot; live markdown on the cached tail (ADR 0042)
     \\  • companion MCP queues in the background; mid-turn stalls stay off the transcript
-    \\  • Codegraff SWE is not GLM-only: Gemini 5/6 in 103s; DeepSeek flash thinking off at default low (ADR 0050)
+    \\  • Codegraff SWE is not GLM-only: Gemini 5/6 in 103s; DeepSeek flash thinking off; lean -p bash backgrounds at 15s
     \\
     \\0.0.280
     \\  • leftover 279 work: TUI stall/resize, experiment fan-out, /tell /peek, ACP graff-login

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -26,7 +26,7 @@ pub const changelog_text =
     \\  • SuperGrok SWE 5/6 in 205s / 6.5s CPU (was 4/6 in 456s / 230s)
     \\  • TUI claims alt-screen before boot; live markdown on the cached tail (ADR 0042)
     \\  • companion MCP queues in the background; mid-turn stalls stay off the transcript
-    \\  • Codegraff SWE is not GLM-only: Gemini 5/6 in 103s; DeepSeek flash 5/6 after bounce + flake retry (ADR 0049)
+    \\  • Codegraff SWE is not GLM-only: Gemini 5/6 in 103s; DeepSeek flash thinking off at default low (ADR 0050)
     \\
     \\0.0.280
     \\  • leftover 279 work: TUI stall/resize, experiment fan-out, /tell /peek, ACP graff-login

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -26,7 +26,7 @@ pub const changelog_text =
     \\  • SuperGrok SWE 5/6 in 205s / 6.5s CPU (was 4/6 in 456s / 230s)
     \\  • TUI claims alt-screen before boot; live markdown on the cached tail (ADR 0042)
     \\  • companion MCP queues in the background; mid-turn stalls stay off the transcript
-    \\  • Codegraff SWE is not GLM-only: Gemini 5/6 in 103s; DeepSeek flash 4/6 after prose bounce (ADR 0048)
+    \\  • Codegraff SWE is not GLM-only: Gemini 5/6 in 103s; DeepSeek flash 5/6 after bounce + flake retry (ADR 0049)
     \\
     \\0.0.280
     \\  • leftover 279 work: TUI stall/resize, experiment fan-out, /tell /peek, ACP graff-login

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -26,7 +26,7 @@ pub const changelog_text =
     \\  • SuperGrok SWE 5/6 in 205s / 6.5s CPU (was 4/6 in 456s / 230s)
     \\  • TUI claims alt-screen before boot; live markdown on the cached tail (ADR 0042)
     \\  • companion MCP queues in the background; mid-turn stalls stay off the transcript
-    \\  • Codegraff SWE is not GLM-only: Gemini 5/6 in 103s; DeepSeek flash still one-shots (ADR 0047)
+    \\  • Codegraff SWE is not GLM-only: Gemini 5/6 in 103s; DeepSeek flash 4/6 after prose bounce (ADR 0048)
     \\
     \\0.0.280
     \\  • leftover 279 work: TUI stall/resize, experiment fan-out, /tell /peek, ACP graff-login

--- a/src/effort_route.zig
+++ b/src/effort_route.zig
@@ -61,7 +61,9 @@ pub fn omitsDefaultFlashEffort(model: []const u8) bool {
 
 /// Wire `reasoning_effort` for an effort-capable provider. Flash / Gemini
 /// default `medium` becomes `low`: omit still thinks (27 reasoning_tokens
-/// on a `pong`); `low` bills 0. `none` is a 400. `/effort high` unchanged.
+/// on a `pong`); `low` bills 0 on GLM. DeepSeek V4 still thinks at `low`
+/// until `thinking.type=disabled` (ADR 0050). `none` is a 400. `/effort high`
+/// unchanged.
 pub fn wireEffort(model: []const u8, requested: []const u8) []const u8 {
     if (std.mem.eql(u8, requested, "medium") and omitsDefaultFlashEffort(model)) return "low";
     if (std.mem.eql(u8, requested, "ultra")) return "max";

--- a/src/exec_bash.zig
+++ b/src/exec_bash.zig
@@ -27,6 +27,10 @@ const exec_bash_stream = @import("exec_bash_stream.zig");
 /// the job registry instead of being killed (xai-org/grok-build BashTool).
 pub const root_wait_ms: u64 = 120 * 1000;
 
+/// Lean `-p` has no human watching a hung test (ADR 0051). DeepSeek flash
+/// SWE sat 120s on `python3 test_json_stream.py`. Interactive stays 120s.
+pub const lean_oneshot_wait_ms: u64 = 15 * 1000;
+
 /// Wall-clock ceiling for one *subagent* bash command. Subagents run on pool
 /// threads with no TTY, so there is no Esc to kill a runaway command — without
 /// this, a codedb refusal that pushes a subagent onto an unfiltered `grep ~/`
@@ -81,9 +85,15 @@ fn startedText(gpa: Allocator, id: u32, cmd: []const u8, ssh: bool, auto_bg: boo
     return aw.toOwnedSlice();
 }
 
+fn defaultRootWaitMs() u64 {
+    const main_mod = @import("main.zig");
+    if (main_mod.unattended and @import("no_local_tools.zig").lean) return lean_oneshot_wait_ms;
+    return root_wait_ms;
+}
+
 fn rootWaitMs(input: Value) u64 {
-    const t = intField(input, "timeout") orelse return root_wait_ms;
-    if (t <= 0) return root_wait_ms;
+    const t = intField(input, "timeout") orelse return defaultRootWaitMs();
+    if (t <= 0) return defaultRootWaitMs();
     return @min(@as(u64, @intCast(t)), job_wait.wait_cap_ms);
 }
 
@@ -100,6 +110,27 @@ test "rootWaitMs: omitted/zero use 120s; positive values clamp to the 10h cap" {
     const huge = try std.json.parseFromSlice(Value, std.testing.allocator, "{\"timeout\":999999999}", .{});
     defer huge.deinit();
     try std.testing.expectEqual(job_wait.wait_cap_ms, rootWaitMs(huge.value));
+}
+
+test "rootWaitMs: lean unattended oneshot defaults to 15s; timeout still wins" {
+    const main_mod = @import("main.zig");
+    const nlt = @import("no_local_tools.zig");
+    const saved_u = main_mod.unattended;
+    const saved_l = nlt.lean;
+    defer {
+        main_mod.unattended = saved_u;
+        nlt.lean = saved_l;
+    }
+    main_mod.unattended = true;
+    nlt.lean = true;
+    const empty = try std.json.parseFromSlice(Value, std.testing.allocator, "{}", .{});
+    defer empty.deinit();
+    try std.testing.expectEqual(lean_oneshot_wait_ms, rootWaitMs(empty.value));
+    const custom = try std.json.parseFromSlice(Value, std.testing.allocator, "{\"timeout\":5000}", .{});
+    defer custom.deinit();
+    try std.testing.expectEqual(@as(u64, 5_000), rootWaitMs(custom.value));
+    main_mod.unattended = false;
+    try std.testing.expectEqual(root_wait_ms, rootWaitMs(empty.value));
 }
 
 fn formatJobDone(gpa: Allocator, cmd: []const u8, wait: jobs.FgDone) !ToolOutput {

--- a/src/no_local_tools.zig
+++ b/src/no_local_tools.zig
@@ -125,7 +125,7 @@ pub const lean_subagent_desc = "Spawn a sidecar for a self-contained task. Child
 /// One-shot tool prose (ADR 0046). Same names and JSON schemas; shorter
 /// descriptions so flash models start and finish instead of rereading
 /// essays. Do not drop to four tools (ADR 0024).
-pub const lean_bash_desc = "Run /bin/sh -c in cwd. Returns stdout, stderr, exit. Foreground still running after 120s (or timeout ms) backgrounds — bash_output(wait_ms>0) waits; do not poll.";
+pub const lean_bash_desc = "Run /bin/sh -c in cwd. Returns stdout, stderr, exit. Foreground still running after 15s (or timeout ms) backgrounds — bash_output(wait_ms>0) waits; do not poll.";
 pub const lean_read_file_desc = "Read a UTF-8 file. Call before editing. contains=exact-key numbered lines; start_line/end_line for a window.";
 pub const lean_edit_file_desc = "Replace exact text. Prefer one batched edits[] over many calls. Prefer over write_file for an existing file.";
 pub const lean_codedb_desc = "Indexed nav: context <task> · around <name> · callpath A B · list_dir <path> · status. Prefer over bash grep/find/ls.";

--- a/src/prompt_snapshot_tests.zig
+++ b/src/prompt_snapshot_tests.zig
@@ -572,6 +572,7 @@ test "lean drops the todo/constraint capabilities from the prompt, never the loc
     const a = a_state.allocator();
     const lean_prompt = try prompts.composeBase(a, lean);
     try std.testing.expect(lean_prompt.len < prompts.main_system_prompt.len);
+    try std.testing.expect(std.mem.indexOf(u8, lean_prompt, "described in prose is not done") != null);
 }
 
 test "unattended one-shots are told the REAL approval map up front; attended sessions hear nothing" {

--- a/src/prompt_text.zig
+++ b/src/prompt_text.zig
@@ -279,6 +279,7 @@ pub const lean_parallel_note =
 
 pub const lean_intro_note =
     \\You are a coding agent. Use the cataloged tools; never invent one.
+    \\A file change described in prose is not done — call edit_file or write_file.
     \\Independent reads belong in ONE response, not one per turn.
     \\A passing test and attempt_completion belong in ONE response.
 ;

--- a/src/provider_codegraff_tests.zig
+++ b/src/provider_codegraff_tests.zig
@@ -127,6 +127,7 @@ test "Codegraff Gemini sends low for default effort; /effort high still sends" {
     const ds = try deepseek.buildBody(null, false, true, true);
     defer std.testing.allocator.free(ds);
     try std.testing.expect(std.mem.indexOf(u8, ds, "\"reasoning_effort\":\"medium\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ds, "\"thinking\":{\"type\":\"enabled\"}") != null);
 }
 
 test "Codegraff glm-5.3-flash sends low for default effort; /effort high still sends" {
@@ -163,4 +164,49 @@ test "Codegraff glm-5.3-flash sends low for default effort; /effort high still s
     const high = try agent.buildBody(null, false, true, true);
     defer std.testing.allocator.free(high);
     try std.testing.expect(std.mem.indexOf(u8, high, "\"reasoning_effort\":\"high\"") != null);
+}
+
+test "Codegraff DeepSeek flash disables thinking at default low; /effort high still thinks" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var messages = std.json.Array.init(arena);
+    try messages.append(.{ .object = blk: {
+        var obj: std.json.ObjectMap = .empty;
+        try obj.put(arena, "role", .{ .string = "user" });
+        try obj.put(arena, "content", .{ .string = "hello" });
+        break :blk obj;
+    } });
+    var agent: Agent = .{
+        .gpa = std.testing.allocator,
+        .arena = arena,
+        .io = std.testing.io,
+        .client = undefined,
+        .provider = build("deepseek-v4-flash"),
+        .messages = messages,
+        .sub = false,
+        .label = "main",
+        .out = null,
+        .sys_normal = "system",
+    };
+    const low = try agent.buildBody(null, false, true, true);
+    defer std.testing.allocator.free(low);
+    try std.testing.expect(std.mem.indexOf(u8, low, "\"thinking\":{\"type\":\"disabled\"}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, low, "\"reasoning_effort\":\"low\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, low, "\"thinking\":{\"type\":\"enabled\"}") == null);
+
+    agent.reasoning = .high;
+    const high = try agent.buildBody(null, false, true, true);
+    defer std.testing.allocator.free(high);
+    try std.testing.expect(std.mem.indexOf(u8, high, "\"thinking\":{\"type\":\"enabled\"}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, high, "\"reasoning_effort\":\"high\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, high, "\"thinking\":{\"type\":\"disabled\"}") == null);
+
+    var glm: Agent = agent;
+    glm.provider = build("glm-5.3-flash");
+    glm.reasoning = .medium;
+    const glm_body = try glm.buildBody(null, false, true, true);
+    defer std.testing.allocator.free(glm_body);
+    try std.testing.expect(std.mem.indexOf(u8, glm_body, "\"thinking\":{\"type\":\"disabled\"}") == null);
+    try std.testing.expect(std.mem.indexOf(u8, glm_body, "\"reasoning_effort\":\"low\"") != null);
 }

--- a/src/zai_wire.zig
+++ b/src/zai_wire.zig
@@ -33,14 +33,29 @@ pub fn vercelEffort(requested: []const u8) []const u8 {
     return "medium";
 }
 
+/// DeepSeek V4 (native or via codegraff/fireworks): thinking is ON at
+/// high unless `thinking.type` is `disabled`. `reasoning_effort: low`
+/// still emits `reasoning_content` (ADR 0050).
+pub fn isDeepseekFamily(provider_id: []const u8, model: []const u8) bool {
+    if (std.mem.eql(u8, provider_id, "deepseek")) return true;
+    return std.mem.indexOf(u8, model, "deepseek") != null;
+}
+
 /// OpenAI-chat extras after `prompt_cache_key`: Z.AI thinking, Vercel
-/// `reasoning.effort`, then the shared `reasoning_effort` hint.
-pub fn writeChatExtras(s: *std.json.Stringify, provider_id: []const u8, send_effort: bool, requested: []const u8) !void {
+/// `reasoning.effort`, DeepSeek thinking on/off, then `reasoning_effort`.
+pub fn writeChatExtras(s: *std.json.Stringify, provider_id: []const u8, model: []const u8, send_effort: bool, requested: []const u8) !void {
     const is_zai = std.mem.eql(u8, provider_id, "zai");
     const is_vercel = std.mem.eql(u8, provider_id, "vercel");
     if (is_zai) {
         try s.objectField("thinking");
         try s.print("{s}", .{"{\"type\":\"enabled\",\"clear_thinking\":false}"});
+    } else if (isDeepseekFamily(provider_id, model) and send_effort) {
+        // Official off switch. GLM rejects type=disabled; do not send it there.
+        try s.objectField("thinking");
+        try s.print("{s}", .{if (std.mem.eql(u8, requested, "low"))
+            "{\"type\":\"disabled\"}"
+        else
+            "{\"type\":\"enabled\"}"});
     }
     if (is_vercel and send_effort) {
         try s.objectField("reasoning");
@@ -54,6 +69,14 @@ pub fn writeChatExtras(s: *std.json.Stringify, provider_id: []const u8, send_eff
         try s.objectField("reasoning_effort");
         try s.write(if (is_zai) reasoningEffort(requested) else if (std.mem.eql(u8, requested, "ultra")) "max" else requested);
     }
+}
+
+test "DeepSeek family is native id or a deepseek model name" {
+    try std.testing.expect(isDeepseekFamily("deepseek", "deepseek-v4-pro"));
+    try std.testing.expect(isDeepseekFamily("codegraff", "deepseek-v4-flash"));
+    try std.testing.expect(isDeepseekFamily("fireworks", "accounts/fireworks/models/deepseek-v4-flash"));
+    try std.testing.expect(!isDeepseekFamily("codegraff", "glm-5.3-flash"));
+    try std.testing.expect(!isDeepseekFamily("zai", "glm-5.3"));
 }
 
 test "Z.AI maps graff efforts onto low|high|max" {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Hillclimb of DeepSeek flash SWE on the Codegraff seat. Make graff the harder DeepSeek harness than OpenCode without stealing Pi’s four-tool catalog or OpenCode’s ~1G heap.

## Change

1. Lean `-p` bounces a first-turn prose-only “done” (ADR 0048).
2. Short Codegraff follow-up flakes retry twice (ADR 0049), including the 110-byte / ~450ms `invalid_request_error` / “Body must be valid JSON”. Auth / quota / a real invalid prompt stay fail-fast.
3. `graff-evals` gains `opencode-codegraff` on the same `CODEGRAFF_API_KEY` seat.
4. **DeepSeek V4 flash default is `thinking.type=disabled` (ADR 0050).** Official Chat Completions off switch. `reasoning_effort=low` still thinks (cookie-store once dumped 1.9MB / 75s). Live pong: omit/`low` ~20–30 `reasoning_tokens`; `thinking.disabled` bills 0. `/effort high` still thinks. GLM stays `low`-only.
5. **Lean `-p` bash auto-backgrounds at 15s (ADR 0051).** Interactive stays 120s (ADR 0026). After thinking-off, wall was hung tests, not CoT.

## Confirm — `deepseek-v4-flash`, `--suite swe`

| harness | pass | wall | RSS | notes |
|---|---|---|---|---|
| graff (0047) | 2/6 | 199s | 91M | one-shot no-edits |
| graff (0049, `072758`) | **5/6** | 362s | 91M | CoT dump on cookie-store |
| OpenCode (`072310`) | **5/6** | 261s | 1064M | same seat |
| Pi (0047) | **5/6** | 492s | 186M | `reasoning: false` |
| graff thinking off (`074142`) | 4/6 | **210s** | 91M | no 1.9MB dump; config-parse JSON-body flake |
| graff + flake retry (`074659`) | **5/6** | 353s | 91M | json-stream 120s bash, cookie-store 71s bash |
| graff + 15s bash (`075402`) | 4/6 | **143s** | 91M | cookie **30s**, json-stream **22s**; `validated` died on balance reservation |

Same `label-sort` miss on every harness. Do not stitch suite scores. 0-token follow-ups after `075402` are burnt gateway (reservation ~4655 µUSD), not a model result.

OpenCode `first` is the first JSONL event (~3.6s). Graff `first` is the stderr `calling` line. Do not treat 0.05s as a TUI steal.

## Tests

Suite **1782** (baseline 1758). Tier 1 green.

Base is `release/v0.0.281` (fold into #670). Do not merge to main / do not tag.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

