### PR TITLE
In-house evals: six more shipped-PR verifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 </p>
 
 <p align="center">
-  Install it on your Mac, Linux, or Windows machine, sign in with the AI subscription you
-  <em>already have</em>, and hand it real tasks. graff writes and runs code,
-  automates the boring stuff, digs through your files, researches the web, and
-  runs its own experiments, on its own, until the job is done.<br/>
+  Install it on your Mac, Linux, or Windows machine, sign in with the AI
+  subscription you <em>already have</em>, and hand it real tasks. graff writes
+  and runs code, automates the boring stuff, digs through your files, researches
+  the web, and runs its own experiments until the job is done.<br/>
   <strong>You don't chat with it. You give it work.</strong>
 </p>
 
@@ -27,17 +27,11 @@
   <a href="https://trendshift.io/repositories/84216?utm_source=repository-badge&utm_medium=badge&utm_campaign=badge-repository-84216" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/84216" alt="justrach/codegraff | Trendshift" width="250" height="55"></a>
 </p>
 
-<p align="center">
-  <strong>The most token-efficient coding harness we've built so far.</strong><br/>
-  Prompt-cache max keeps repeated prefixes hot. RLM + spec-ptc turns wide work
-  into a small streaming program. Learnt slimming keeps fat results out of history.
-</p>
-
 ```sh
 curl -fsSL https://github.com/justrach/codegraff/releases/latest/download/install.sh | sh
 ```
 
-<p align="center"><sub>Prefer a window? Grab the <a href="#install">desktop app</a>. Then just run <code>graff</code> and tell it what you need.</sub></p>
+<p align="center"><sub>Prefer a window? Grab the <a href="#install">desktop app</a>. Then run <code>graff</code> and tell it what you need.</sub></p>
 
 ## What can I ask it?
 
@@ -49,1629 +43,171 @@ If you could do it at a computer, you can ask graff to do it for you:
 - *"Scrape these five pages and summarize them."*
 - *"Run an experiment: try three versions of this and tell me which scores best."*
 
-It works in your real terminal, on your real files, with the real internet, and it can spin up a whole team of sub-agents to work in parallel. It even keeps score of which approaches work and gets better over time.
+It works in your real terminal, on your real files, with the real internet, and
+it can spin up a team of sub-agents in parallel.
 
-> **Don't write code?** You don't have to. Say what you want in plain English; graff figures out the steps and does them.
+> **Don't write code?** You don't have to. Say what you want in plain English.
 
----
+## Same model, fewer tokens
 
-## Token-efficient by construction
+Same grok-4.6, same SuperGrok seat, same tasks. graff vs grok-build vs OpenCode.
+Lower is better on every named axis. Full tables:
+[graff-evals/hillclimb/baseline.md](graff-evals/hillclimb/baseline.md).
 
-<p align="center">
-  <img src="token-efficient-loop.png" alt="Stable cache layers feed a small programmatic loop that tests parallel tool paths, keeps the useful path, and gathers one slim result" width="960">
-  <br/>
-  <sub>Stable prefix → small program → parallel tools → slim result. Faint branches are measured variants; the proven path continues.</sub>
-</p>
+**12 shipped-PR fixtures** (`run-20260830-141658`, `--suite inhouse`):
 
-There is no single “token trick.” graff compounds three separate cuts:
+| harness | pass | wall | calls | tokens | list$ | RSS |
+|---|---:|---:|---:|---:|---:|---:|
+| **graff** | **12/12** | **192s** | **52** | **228k** | **$0.35** | **92M** |
+| grok-build | 12/12 | 462s | 63 | 1.18M | $1.12 | 170M |
+| OpenCode | 12/12 | 236s | 74 | 675k | $0.79 | 1.1G |
 
-- **Keep the reusable prefix stable.** Prompt-cache max holds the system prompt
-  and tool-catalog head byte-identical, keeps provider cache keys sticky, and
-  shows the last hit rate in the UI. A live same-process grok-4.6 `/btw` turn
-  reused **3,712 of 3,721 prior prompt tokens (99.8%)**.
-- **Program over context instead of pasting it back.** The default Recursive
-  Language Model (RLM) loop is a Zig port of
-  [Alex Zhang's RLM](https://github.com/alexzhang13/rlm) and
-  [spec-ptc](https://alexzhang13.github.io/blog/2026/spec-ptc/) (speculative
-  programmatic tool calling): the model writes a tiny program, finished host
-  calls start while the rest of it is still streaming, and useful binds persist
-  across turns.
-- **Return the useful shape, not the payload.** Folded schemas, structural
-  `codedb` reads, 4 KB tool-result handles, and learnt MCP slimming keep bulky
-  tool output out of the model's working set.
+Graff is the unique frontier on pass, wall, calls, tokens, list$, and RSS.
+(First-token is not scored on that run — graff's `0.02s` is a boot mark, not
+first model SSE.)
 
-The [Darwin Gödel Machine-style evolutionary archive](#an-evolutionary-harness)
-supplies the measuring discipline: record prompt/persona variants, score them,
-and keep what holds up. Prompt-cache max is a separate harness decision built
-with that same measure-and-keep instinct; the archive did not autonomously
-invent the cache layout.
+On the 3-task spine (exact-reply + file-ops + fix-fib) graff was **19.9s /
+8 calls / $0.048** vs grok 32.3s / 8 / $0.147 and OpenCode 31.2s / 8 / $0.101.
 
-### One stable RLM reuse case
-
-Live grok-4.6, same task, one rep. The model reads a file into a bind and reuses
-it on the next RLM call:
-
-| harness | wall | input tokens | model calls |
-|---|---:|---:|---:|
-| structured-only (`--old`) | 99.6s | 135k | 11 |
-| default RLM | **39.2s** | **25.3k** | **5** |
-| reduction | **61%** | **81%** | **55%** |
-
-The broader five-task RLM suite kept the same **5/5** pass rate while cutting
-input from **203k to 105k**, output from **4,186 to 1,669**, and wall time from
-**161s to 136s**. SuperGrok OAuth is flat-rate; on a metered xAI key, the token
-cut is the bill. Full method and caveats: [v0.0.276 release notes](docs/releases/v0.0.276.md).
-
-### Same grok-4.6, same six coding tasks
+How: a stable prompt-cache prefix, an RLM + spec-ptc loop that programs over
+context instead of pasting it back, and slim tool results (4 KB handles,
+learnt MCP shapes). The learn pin is a **hardlink**, not a 127M copy, and
+`learn init` is detached so `-p` and the REPL share one path. Hosted `x_search`
+stays on (ADR 0031). We do not steal grok-build's heap or a 4-tool catalog
+(ADR 0024).
 
 <p align="center">
-  <img src="social/graff-vs-grok-build-grok46.png" alt="Same-model comparison on six coding tasks: graff and grok-build both pass 5 of 6; graff uses 198 seconds summed wall time, 106k input tokens, 24 calls, and 8.5 MB RSS versus grok-build at 506 seconds, 194k input tokens, 39 calls, and 177 MB RSS" width="960">
+  <img src="token-efficient-loop.png" alt="Stable cache layers feed a small programmatic loop that tests parallel tool paths and keeps a slim result" width="960">
 </p>
-
-At the same **5/6** pass rate, graff used **61% less summed wall time, 45% less
-input, 38% fewer model calls, and 95% less peak RSS**. This is one live rep of
-six DeepSWE-shaped tasks, not a universal leaderboard; `label-sort` failed both
-harnesses. The exact run and the rejected shortcuts are documented in
-[v0.0.276](docs/releases/v0.0.276.md).
-
-Much of this implementation and benchmark work was made possible by
-[Cursor Cloud Agents](https://cursor.com/docs/cloud-agent): parallel agents in
-isolated environments, with measured evidence merged back into the harness.
-
-### What shipped in v0.0.277–v0.0.281
-
-- **MCP results learn to slim themselves.** On the Linear fixture, the warm
-  learnt path moved from **28.0s to 14.8s**, **112k to 31k input**, and **7 to 5
-  calls**. Return shapes ride the load result, never the stable prefix.
-- **grok-4.6 gets xAI's hosted X search.** The same live prompt moved from a
-  seven-call scrape (**101s, 64k input**) to one hosted call (**37s, 28k**),
-  without adding another catalog tool.
-- **Small turns stay small.** RLM and spec-ptc appear when work gets wide, the
-  context crosses its measured threshold, or you explicitly ask for them; tiny
-  turns do not pay the schema tax.
-- **Removed images really leave.** The v0.0.278 privacy follow-up drops a pasted
-  screenshot if its composer chip is removed, collapses duplicate payloads, and
-  makes `/image clear` clear the whole queue before anything reaches the model.
-- **The native app speaks ACP.** Thinking and tool chips stream mid-turn from
-  `graff acp` (ADR 0032). `graff serve` is not required.
-- **v0.0.280 leftover cut.** TUI `/tell` `/peek`, experiment fan-out,
-  ACP `graff-login`, local tools, `/schedule`, and JSONL channel workers.
-  Native `codedb` / `read_file` stay the default readers when codedb-pro
-  is licensed (ADR 0040).
-- **One-shots skip the 38s learn pin.** `-p` / `--json` no longer copy
-  132M `graff-pinned`. SuperGrok SWE went **4/6 in 456s → 5/6 in 205s**
-  (CPU 230s → 6.5s). Interactive sessions still auto-init (ADR 0044).
-
-Read the full [v0.0.277 notes](docs/releases/v0.0.277.md), the
-[v0.0.278 privacy follow-up](docs/releases/v0.0.278.md), the
-[v0.0.279 ACP native cut](docs/releases/v0.0.279.md), the
-[v0.0.280 leftover cut](docs/releases/v0.0.280.md), and the
-[v0.0.281 skip](docs/releases/v0.0.281.md).
-
-### Broader comparison: model choice, footprint, and startup
-
-<p align="center">
-  <img src="comparison.png" alt="graff vs Claude Code vs Codex: ~20x cheaper ($0.022 vs $0.51 vs $0.42 per task), ~25 MB vs ~410 MB vs ~206 MB peak memory, 4.4s vs 8.9s one-shot gpt-5.5 latency" width="860">
-</p>
-
-The older cross-provider comparison answers a different question: what do model
-choice and a tiny native harness cost on three read-only repo tasks plus an
-eight-trial startup test?
-
-**Model choice.** On `deepseek-v4-pro`, graff averaged **$0.022 per task**,
-against Claude Code's **$0.51** (Opus 4.8) and Codex's **$0.42** (gpt-5.5).
-That roughly 20× result comes from choosing a cheaper model; it is not the
-same-model harness comparison above.
-
-**Footprint.** The focused runs used about **25 MB** of memory, against Claude
-Code's steady **~410 MB** and Codex's **~206 MB**.
-
-**One-shot startup.** On the identical ChatGPT endpoint, graff completed a
-gpt-5.5 turn in **4.4s** versus Codex's **8.9s** in every paired trial. Long
-interactive sessions settle to model latency; this is a CLI/CI startup result,
-not a blanket speed claim.
-
-<sub><b>Method:</b> macOS, same machine, read-only code questions on this repo. Cost is each tool's own reported usage at <a href="https://codegraff.com/docs/models">codegraff gateway prices</a>; memory is peak RSS via <code>/usr/bin/time -l</code>; latency is 8 concurrent graff/Codex pairs on a tool-free prompt with reasoning effort matched. Your numbers will vary with the task, the model, and the network. Reproduce it yourself: <a href="benchmarks/">benchmarks/</a>.</sub>
-
----
-## Under the hood
-
-<strong>the super simple harness.</strong> A minimal agentic coding harness in Zig 0.17 dev. One <strong>2.7&nbsp;MB</strong> binary, zero runtime dependencies. Talks to <strong>Anthropic</strong>, any <strong>OpenAI-compatible</strong> endpoint (DeepSeek, OpenAI, …), or your <strong>ChatGPT subscription</strong>.
-
-```
-user text ─→ POST ─→ model asks for tools?
-                  ↑           │
-                  │  results  ▼
-                  └─ io.async ×N  (parallel: bash/files/subagents)
-              … repeat until the model stops
-```
-
-A REPL that talks to the model directly over HTTPS (`std.http.Client`),
-hand-rolls every JSON wire format (`std.json`), and runs tool calls (subagents
-included) in parallel on the std.Io thread pool. It also compacts its own
-context when the conversation gets long.
-
-**Contents**
-
-- [Token-efficient by construction](#token-efficient-by-construction)
-- [Install](#install) · [give it a key](#give-it-a-key) · [run it](#run-it)
-- [Why](#why)
-- [Code intelligence](#code-intelligence-token-efficient-by-default)
-- [An evolutionary harness](#an-evolutionary-harness)
-- [Providers & models](#providers--models)
-- [CLI reference](#cli-reference)
-- [REPL commands](#repl-commands)
-- [Permission modes](#permission-modes)
-- [SDKs: TypeScript & Python](#sdks-typescript--python)
-- [Reference](#reference)
-- [Coming soon](#coming-soon)
-
----
 
 ## Install
 
-### Desktop app: macOS (Apple Silicon)
+**Desktop (macOS Apple Silicon).** Download the latest signed, notarized
+[release](https://github.com/justrach/codegraff/releases/latest), drag it to
+Applications. First launch puts `graff` and `codegraff <path>` on your PATH.
 
-Prefer a window over a terminal? Download the latest signed, notarized build, drag it to Applications, and open it. The desktop app is **fully self-contained**: it bundles the `graff` agent, so there's nothing else to install to start coding, and it keeps itself up to date automatically. On first launch it drops two commands on your PATH: `codegraff <path>` (opens that folder in the app, `code`-style) and `graff` itself (the agent CLI, in your terminal), so the one install covers both the window and the command line. The terminal `graff` is symlinked into the app, so it auto-updates along with it. Not on Apple Silicon, or want a standalone CLI? Use the command-line install below.
-
-<p align="center">
-  <a href="https://github.com/justrach/codegraff/releases/download/v0.0.190/Codegraff.dmg"><img alt="Download Codegraff for macOS" src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white"></a>
-  <br/>
-  <sub><a href="https://github.com/justrach/codegraff/releases/latest">or browse all releases</a></sub>
-</p>
-
-### Command line: macOS · Linux · Windows
-
-Grab the latest prebuilt release binary: macOS builds are Developer ID signed
-and Apple notarized; on any other platform the installer builds from source with
-Zig `0.17.0-dev.813+2153f8143` (select it with `zigup`):
+**CLI (macOS · Linux · Windows).**
 
 ```sh
 curl -fsSL https://github.com/justrach/codegraff/releases/latest/download/install.sh | sh
 ```
 
-From a checkout, just run `./install.sh`. The binary lands in `~/bin` by default
-(override with `HARNESS_DIR`). The installer appends that directory to your
-`~/.zshrc` (and `~/.bashrc` / fish config when those are your shell or already
-exist), so a new terminal finds `graff` — the usual "it installed but
-`graff: command not found`" miss. Skip with `HARNESS_NO_PATH=1`. Open a new tab
-or `source ~/.zshrc` once after install:
-
-| tool      | purpose |
-| --------- | ------- |
-| `graff`   | the agent CLI + REPL: the one binary this script installs |
-| `codedb`  | optional code-intelligence companion (structural search/outline/callers). graff auto-detects it and points at the [one-line install](https://github.com/justrach/codedb) if it's missing; everything else works without it |
-| `kuri`    | optional [browser companion](https://github.com/justrach/kuri) backing `webfetch`'s markdown path, web crawling, and the kuri skill. Installed by default alongside graff; opt out with `HARNESS_NO_KURI=1`, never fatal if it fails |
-
-On Windows, grab `graff-x86_64-windows.tar.gz` (or `aarch64`) from the
-[latest release](https://github.com/justrach/codegraff/releases/latest), unpack
-it, and put `graff.exe` on your `PATH`; the shell installer itself is
-Unix-only and points Windows at WSL.
-
-### Give it a key
-
-Three ways, pick whichever is easiest:
+From a checkout: `./install.sh` (binary in `~/bin`; `HARNESS_NO_PATH=1` skips
+PATH edits). Windows: unpack `graff-*-windows.tar.gz` from the latest release
+and put `graff.exe` on `PATH`.
 
 ```sh
-graff login                     # free codegraff key (device-code OAuth, no signup forms)
-graff login kimi                # Kimi Code subscription OAuth (device-code)
-graff key set deepseek sk-...   # store ANY provider's key (macOS Keychain, else 0600 file)
-export DEEPSEEK_API_KEY=sk-...  # or just an env var (env always wins)
+graff login                     # free codegraff key
+graff login kimi                # Kimi Code OAuth
+graff login codex               # ChatGPT / Codex (or reuse ~/.codex/auth.json)
+graff key set deepseek sk-...   # any other provider
+graff                           # REPL
+graff --model grok-4.6          # pin a model
+graff -p "how many TODOs in src/?"
 ```
 
-Already logged into the Codex CLI? Skip this step. Your ChatGPT subscription is
-picked up automatically from `${CODEX_HOME:-~/.codex}/auth.json`. Or run
-`graff login codex`.
-
-> **Note on `login`:** `graff login` is the free codegraff key, `graff login
-> codex` is the ChatGPT-subscription OAuth, and `graff login kimi` is Kimi
-> Code's device-code OAuth. **Every other provider** (deepseek, openai,
-> anthropic, xai, zai, minimax, xiaomi) is a key: set it with
-> `graff key set <provider> <key>` or its `<PROVIDER>_API_KEY` env var, then
-> select a model with `--model` / `/model`. See [Providers & models](#providers--models).
-
-### Run it
-
-```sh
-graff                            # starts on the first provider you have a key for
-graff --model deepseek-reasoner  # or pin one explicitly
-```
-
-First things to try once you're at the `›` prompt:
-
-```
-› what's in this directory? summarize the build setup.
-› /model sonnet                  # fuzzy-switches to claude-sonnet-4-6
-› spawn three subagents to summarize src/, count TODOs, and check git status, in parallel
-› ultracode audit this repo for error-handling gaps   # codeword → multi-agent workflow mode
-› /help                          # everything else
-```
-
-### Zed (External Agents / ACP)
-
-`graff acp` speaks the Agent Client Protocol, so Zed can drive it as an
-External Agent. The same spawn is the hosted-agent recipe — see
-[Embedding graff](docs/embedding.md). There is no "Install from Registry"
-row yet; the submit recipe and the auth blocker are
-[ACP Registry](docs/acp-registry.md) (#613). Until that lands, register it
-in `~/.config/zed/settings.json`:
-
-```json
-{
-  "agent_servers": {
-    "graff": {
-      "type": "custom",
-      "command": "/path/to/graff",
-      "args": ["acp", "--model", "<default-model>"],
-      "env": {}
-    }
-  }
-}
-```
-
-Then fully quit and reopen Zed (`agent_servers` is read at startup), and start
-a thread via `agent: new external agent thread` in the command palette — or the
-Agent Panel's new-thread menu → **graff** under External Agents.
-
-Gotchas worth knowing:
-
-- **Pin a default model** (`--model <name>`) — otherwise the ACP turn fails
-  with `no language model configured`. Verify the route first with `graff route <name>`.
-- **Zed's own model picker is empty for external agents** — it shows
-  "no match / configure a provider", which looks like an error but isn't.
-  Switch models inside the thread with `/model`.
-- **Old threads stay broken**: a thread created before auth/model was
-  configured keeps failing even after restart; start a fresh one.
-- Provider logins are shared with terminal graff (codegraff OAuth etc.), but
-  e.g. Codex models need their own `graff login codex`.
-- Debugging: `dev: open acp logs` in Zed shows the raw ACP traffic.
-
----
-
-## Why
-
-Measured, not vibes: arm64 macOS, ReleaseFast; methodology and the budgets each
-change is held to live in [architecture.md](architecture.md):
-
-| metric                      | measured                                        |
-| --------------------------- | ----------------------------------------------- |
-| binary                      | **2.74 MB**, self-contained with zero runtime dependencies |
-| cold start                  | **~1.8 ms**                                     |
-| full agentic turn           | **12 MB** peak RSS, ~4% CPU (network-bound)     |
-| 8 parallel subagents        | **+0.4 MB each** (15 MB total)                  |
-| tool output into history    | one 4 KB handle, whatever the result's size: a 500 MB python child process never touches the harness's footprint |
-
-Benchmarked against the Rust codegraff ([justrach/codegraff](https://github.com/justrach/codegraff),
-39 MB binary, 934 crates) on the *same model through the same endpoint*,
-interleaved 3×: turn speed was a dead tie (2.94 s vs 2.93 s; the network and
-the model dominate the turn), but the Zig harness ran in **4.3× less memory**
-(11.3 MB vs 48.5 MB), starts roughly 3× faster, and is about 14× smaller on disk. An agent
-CLI rarely wins on turn speed; it can win on the cost of being there.
-
----
-
-## Code intelligence: token-efficient by default
-
-The fastest way to blow a context window is to read whole files into it. graff
-ships with a built-in **`codedb`** tool: read-only, structural code
-intelligence over a local index of the repo
-([github.com/justrach/codedb](https://github.com/justrach/codedb)), and the
-system prompt steers the model to reach for it *before* `grep` or
-whole-file reads. Instead of paying for a 2,000-line file to find one function,
-the model asks for exactly the shape it needs:
-
-```
-codedb outline src/main.zig          # just the symbol map, functions/types, no bodies
-codedb symbol switchProvider --body  # one function, by name
-codedb callers recordUsage           # who calls it (call sites, not files)
-codedb search "parse SSE"            # indexed search, ranked hits, not a grep dump
-codedb context "add a new provider"  # task-shaped orientation across the codebase
-```
-
-Why this keeps token cost low:
-
-- **Structural slices, not files.** `outline`/`symbol`/`callers`/`deps` return a
-  function map or a single definition, tens of lines where a `read_file` would
-  spend thousands. The index is queried, not the raw bytes streamed into history.
-- **It's free and indexed; the metered tools come second.** The system prompt
-  encodes an explicit search order: try the free, indexed `codedb` first;
-  fall to (metered) `muonry`/raw search only for literal/regex or non-indexed
-  files. The cheap path is the default path.
-- **Hard output cap.** A query is truncated at **64 KB** with a marker that nudges
-  the model back toward targeted queries (`outline`, `symbol --body`) rather than
-  whole-file reads, so even a broad search can't balloon the context.
-- **Same index powers the `@` file picker** (`codedb glob`), so attaching a file
-  by name never shells out to a directory walk.
-
-Pure-Zig client to a pure-Zig server, zero dependencies on either side. Allowed
-subcommands: `search · symbol · callers · find · outline · read · tree ·
-context · word · deps · glob · ls · file · hot`. Not installed? The tool says so
-and points at the one-line install; everything else keeps working without it.
-
----
-
-## An evolutionary harness
-
-graff doesn't just run an agent; it records every run as a node in a
-**Darwin Gödel Machine-style archive tree** ([arXiv:2505.22954](https://arxiv.org/abs/2505.22954)),
-so the harness itself is the substrate for agent self-improvement. Each run
-writes a unique `.graff/trajectories/<run-id>.jsonl`; archive readers aggregate
-the directory, so concurrent processes never share a truncate/append cursor:
-
-- **A lineage tree, not a flat log.** Interactive root turns form a spine (each
-  turn's parent is the previous one); every subagent and workflow task hangs off
-  the turn that spawned it. Each node carries a **fingerprint of the system prompt
-  it ran with** (`prompt_sha` = first 8 bytes of SHA-256), so prompt mutations (
-  `set_system_prompt` on the spine, per-child `system_prompt` overrides on the
-  fan-out) show up as hash changes along edges. A lineage can be replayed or
-  scored offline.
-- **Personas are variants.** Subagents pick a persona with `agent` (built-ins:
-  `reviewer · researcher · implementer · skeptic`, plus anything in
-  `.harness/agents/`) or take a custom `system_prompt`; either way the
-  trajectory records the lineage, so you can mine *which agent variant actually
-  worked*.
-- **A fitness ledger with integrity.** The `score` channel appends evaluation
-  records (`prompt_sha`, `score`, `parent_sha`; the lineage edge DGM parent
-  selection counts children with). Because the archive lives in the working
-  directory, a forged `score` row could manufacture fitness, so every score the
-  harness writes is **HMAC-signed** (keyed by `GRAFF_SCORE_KEY_FILE`, a secret
-  outside the cwd that the evolving agent's confined tools can't reach). Readers
-  recompute the HMAC and reject unsigned or forged rows. Signing is opt-in and
-  backward-compatible (no key → unsigned, accepted as before).
-- **Tool-use is mined too.** Each agent logs its tool calls (name + error flag,
-  in order): the process signal behind "which tool combinations work",
-  joinable to scores via `prompt_sha`.
-- **Consent-scoped fleet loop.** Learning contributes prompt-free aggregate
-  fitness by default, announced once per machine; `/privacy local` opts out
-  entirely, and individually reviewed reusable templates need an exact
-  per-artifact approval on top. `/trajectory` renders the current session's
-  agent tree; see [docs/hyperagents.md](docs/hyperagents.md) for the full design.
-
-For controlled local hill-climbing, `graff learn` adds a separate
-parent → mutate → paired-evaluate → select loop with immutable evidence, manual
-promotion by default, explicitly gated automatic promotion, atomic activation,
-and rollback. It never treats trajectories or best-effort telemetry as promotion
-authority. See [Local prompt-policy learning](docs/local-learning.md), including
-the no-sandbox trust boundary and the collective-learning design that is **not**
-yet an implemented remote authority.
-
----
-
-## Providers & models
-
-Direct API-key and OAuth providers across three wire formats. A
-`ProviderSpec` table holds each built-in provider's
-endpoint, auth style, env var, and default model; base URLs and key names come
-from [models.dev](https://models.dev)'s `api.json` (snapshot 2026-06-10).
-
-| Provider    | Wire format / auth          | Key env var          |
-|-------------|-----------------------------|----------------------|
-| `anthropic` | Anthropic Messages, x-api-key | `ANTHROPIC_API_KEY`  |
-| `codegraff` | OpenAI chat, bearer         | `CODEGRAFF_API_KEY` (`cg_sk_...`) |
-| `deepseek`  | OpenAI chat, bearer         | `DEEPSEEK_API_KEY`   |
-| `openai`    | OpenAI chat, bearer         | `OPENAI_API_KEY`     |
-| `minimax`   | Anthropic Messages, bearer  | `MINIMAX_API_KEY`    |
-| `xiaomi` (MiMo) | OpenAI chat, bearer     | `XIAOMI_API_KEY`     |
-| `kilo`      | OpenAI chat, bearer         | `KILO_API_KEY`       |
-| `groq`      | OpenAI chat, bearer         | `GROQ_API_KEY`       |
-| `cerebras`  | OpenAI chat, bearer         | `CEREBRAS_API_KEY`   |
-| `vercel`    | OpenAI chat, bearer (AI Gateway coding-agent) | `AI_GATEWAY_API_KEY` |
-| `openrouter` | OpenAI chat, bearer | `OPENROUTER_API_KEY` |
-| `mistral`   | OpenAI chat, bearer         | `MISTRAL_API_KEY`    |
-| `kimi` | Live catalog-selected: native Kimi chat + bearer, or Anthropic beta Messages + x-api-key when declared | `graff login kimi` or `KIMI_API_KEY` |
-| `xai` (grok) / `zai` (GLM) | OpenAI chat, bearer | `XAI_API_KEY` / `ZAI_API_KEY` (via `graff key set`) |
-| `codex`     | Responses API, ChatGPT login | `${CODEX_HOME:-~/.codex}/auth.json` (no API key) |
-
-**Using a specific provider directly** is always the same two steps: give it
-the key, then name a model. For example, DeepSeek straight to `api.deepseek.com`:
-
-```sh
-graff key set deepseek sk-...          # or: export DEEPSEEK_API_KEY=sk-...
-graff --model deepseek-reasoner        # models: deepseek-v4-pro · deepseek-v4-flash · deepseek-chat · deepseek-reasoner
-```
-
-The same pattern works for every API-key row above: swap in the provider id
-and one of its models (`graff key set openai sk-...` → `--model gpt-...`,
-`graff key set anthropic sk-ant-...` → `--model sonnet`, and so on).
-
-To add one workspace-local OpenAI-compatible router without changing Graff,
-create `.graff/.config.router`:
-
-```json
-{
-  "id": "myrouter",
-  "name": "My Router",
-  "base_url": "https://router.example.com/v1",
-  "env_key": "MYROUTER_API_KEY",
-  "default_model": "example/model"
-}
-```
-
-`name` is optional. `takes_effort: true` is also available for routers that
-accept OpenAI-style reasoning-effort requests. The file contains no secret;
-use `export MYROUTER_API_KEY=...` or `graff key set myrouter ...`.
-Select it with `graff --model myrouter` or `/model myrouter`;
-`graff models refresh` pulls its full catalog. Graff derives
-`/chat/completions` and `/models` from `base_url`, caches that router's model
-catalog in `.graff/.models.router`, and exposes it to the CLI and GUI schema.
-Only one additional router is configured per workspace. `.graff/` is ignored
-by Git in this repository.
-
-A model is routed to the first provider (in the table order above) that both has
-a key set **and** lists the model in the active catalog. Codex names, rollout
-visibility, ordering, and context windows come from its account-scoped `/models`
-endpoint, cached for five minutes with Graff's supported Codex protocol version
-(a separately installed older Codex CLI cannot hide newer models). Baked Codex
-rows are only the logged-out/offline fallback, currently including `gpt-5.6-sol`,
-Terra, and Luna. Unknown `claude*` models
-fall back to Anthropic; any other unknown model falls back to the codegraff
-gateway, and `/model` prints a warning when that fallback fires, since a typo'd
-name will be rejected by the API on the first request. The startup default is
-the first provider with a key, on its default model. `/models` prints the full
-table: context window, compaction point, provider, and which providers you have
-keys for; `/model <name>` switches (a bare `/model` opens an interactive fuzzy
-picker). `graff models refresh` forces a fresh Codex catalog request and refreshes
-the Codegraff/workspace-router catalogs plus the independent models.dev
-price/context metadata cache.
-
-<details>
-<summary><strong>Codex login (ChatGPT subscription)</strong> · <strong>why no Claude login</strong></summary>
-
-<br/>
-
-If you're logged into the Codex CLI, the harness reads the ChatGPT OAuth token
-from `${CODEX_HOME:-~/.codex}/auth.json` at startup (the same on-disk-credential
-trick used for the codegraff key) and prints `logged into Codex (ChatGPT account …)`. Switch to
-it with `/model codex`; Graff selects the first visible model in your live,
-account-scoped Codex catalog. This is a third wire format: the
-**Responses API** against the ChatGPT backend
-(`chatgpt.com/backend-api/codex/responses`), not `api.openai.com`, so it uses
-your ChatGPT Pro/Plus subscription rather than a paid API key. Text, tool
-calling, compaction, and `/save`/`/resume` all work on it. Not logged in?
-`graff login codex` runs the PKCE browser flow itself.
-
-Claude models route through a real `ANTHROPIC_API_KEY` or the codegraff gateway
-only. There is deliberately no Claude-subscription login: reusing a Claude Code
-OAuth token outside the official client violates Anthropic's terms of service.
-
-Tool definitions are written once as comptime specs and rendered into both
-formats (Anthropic `input_schema` vs OpenAI `function.parameters`) at compile
-time. See `anthropicToolsJson` / `openaiToolsJson` in `src/main.zig`.
-
-</details>
-
----
-
-## CLI reference
-
-```
-usage:
-  graff [flags]                    start the REPL
-  graff [-p] "prompt"              one-shot: run the prompt, print the answer, exit
-  graff login                      get a codegraff key (device-code OAuth)
-  graff login codex [--refresh]    ChatGPT/Codex OAuth login (PKCE)
-  graff key set <provider> <key>   store a key (macOS Keychain, else 0600 file)
-  graff key list                   show which providers have keys
-  graff mcp add <name> -- <cmd>     add an MCP server to .mcp.json
-  graff mcp                         list configured MCP servers
-  graff plugins                     list Cursor/Claude/Grok/Codex plugin trees (in place)
-  graff learn <command>             local prompt-policy learning and rollback
-  graff --schema                   print the machine-readable interface (SDK codegen)
-
-flags:
-  --model <name>            start on this model (same fuzzy resolution as /model)
-  --subagent-model <name>   pin children/workflows/judges to this model on the root provider
-  --subagent-provider <id>  route pinned workers through this explicit provider
-  --allow-cross-provider-subagents
-                            consent to worker prompts/code going to another provider
-  --yolo                    skip all permission prompts for the session
-  --no-local-tools          embedder mode: hard-disable the built-in bash/file/codedb
-                            tools process-wide (see "Embedder mode" below)
-  -p, --print               one-shot print mode (answer on stdout, tool progress on stderr)
-  --timing                  show per-tool wall-clock on result lines (✓ (312ms) …)
-  --cost                    show running session spend in the prompt ([model · 12k tok · $0.0042])
-  --json                    structured stdio protocol (JSON in, JSONL events out, SDK transport)
-  --max-model-calls N  cap provider calls across root, children, retries, titles, compaction, and judges (default 0 = unlimited)
-  -h, --help       usage
-  -V, --version    version
-```
-
-Unknown flags are an error (with a pointer to `--help`), missing model-flag
-values are errors, and `--help`/`--version` are handled before subcommand
-dispatch, so `graff login --help` prints usage instead of starting an OAuth
-flow. With no key configured at all, startup fails with the three quickest fixes
-spelled out rather than a bare env-var list.
-
-`graff learn help` lists the local learning commands. Configuration, adapter
-protocols, statistical gates, activation semantics, and security limitations are
-specified in [docs/local-learning.md](docs/local-learning.md).
-
-**One-shot mode** makes the harness scriptable without the SDK: `graff -p "how
-many TODOs in src/?"` runs a full agentic turn (tools included), prints only the
-final answer on stdout (progress lines go to stderr), and exits non-zero on
-failure. There's no human to ask, so the permission gate denies anything not
-already allowed. Pre-approve commands in `.harness/settings.json` or pass
-`--yolo`.
-
----
-
-## REPL commands
-
-A bare `/` opens the whole list as a filterable full-screen menu (type to
-narrow, Enter runs it); **Esc during a response interrupts the turn**:
-generation stops (it works from the moment the request is sent, including a slow
-provider connect), what already streamed stays in history with an
-`[interrupted]` marker, and you're back at the prompt. A bare Esc at the prompt
-clears the input line.
-
-While a response streams you stay in control: besides Esc to interrupt,
-**Ctrl-T (`^T`) folds/unfolds the live "Thinking" block** in place, and the mouse
-wheel scrolls your terminal's own scrollback: the REPL doesn't grab the mouse, so
-scrolling up to re-read earlier output works like any normal terminal (parity with
-Claude Code). Folding the Thinking block is keyboard-only (`^T`). There is no
-click-to-fold.
-
-Streaming Markdown is rendered for terminal readability: heading levels get a
-clear colored hierarchy; bullets, numbered items, nested lists, task checkboxes,
-and blockquotes use terminal-native markers; bold and inline code drop their raw
-delimiters; tables align; and fenced code stays copyable without decorative
-prefixes on body lines.
-
-The interactive UI uses Codegraff's accent-only **Ensō** palette: vermilion
-coral marks the model, prompt, active selections, tools, and primary Markdown
-structure; ordinary text and supporting metadata stay neutral. Success,
-warning, and error colors remain semantic, the terminal background is never
-overridden, and `NO_COLOR` is respected. The quiet `enso` thinking animation is
-the stable default; `/animation random` restores per-request variety and the
-other animation names remain available.
-
-The full catalog, straight from the `/` menu (a bare `/` opens it as a
-filterable full-screen picker; `/help` prints this same list in the REPL).
-`/models` pings every keyed provider catalog live on each listing, so new
-gateway rollouts appear without a restart.
-
-```
-/model <name>             switch model/provider, fuzzy match (e.g. "sonnet", "opus")
-/models [health]          list known models, context windows, compaction points; health shows live state
-/clear                    wipe the conversation and start fresh
-/new                      start a fresh autosaved session
-/rename <title>           set the current session title
-/goal [30m] [text|pause|resume|status|clear]
-                          set a standing objective and work it autonomously; an optional 30s/30m/2h budget paces the run; pause/resume steering, status shows state, clear removes it
-/loop [30m] <prompt>      the same autonomous run as /goal, without adopting a standing objective
-/review <target or instructions>
-                          run one isolated read-only review pass; no edits, delegation, or workflows
-/never [<text>|rm <id-or-text>]
-                          standing constraints that ride every subagent brief and survive compaction; bare lists them, rm <id-or-text> retires one (alias /constraint)
-/tell <session|all> <text>
-                          message a running graff: <session> is a DM (only it hears, any folder); all broadcasts to every graff on this device; /sessions lists who's around
-/peek <session>           see what a live co-resident session is doing right now (its transcript tail)
-/routes [<set>|add <set> <frontier|mid|small> <provider/model>]
-                          your own priced model lanes across providers: view the set and which seat wins each lane now
-/plan                     toggle plan mode: read-only explore + propose; writes/edits denied
-/ultracode                toggle persistent workflow mode; bare opens an on/off picker, or /ultracode on|off
-/fallback [allow|remove|off]
-                          opt-in cross-provider fallback for this workspace (same-provider rollout stays on)
-/key [provider secret]    show API-key status; /key <provider> <secret> adds one live (+ Keychain)
-/login [codegraff|codex|kimi]
-                          OAuth sign-in (no key to paste); bare opens a picker (codex alias: oai)
-/keepcontext              toggle keeping the conversation when /model switches wire format (default on)
-/effort                   reasoning depth: low|medium|high|... (codex, deepseek, codegraff; persists)
-/reasoning                alias for /effort
-/fast                     codex only: priority service tier for lower latency (toggle, persists)
-/thinking                 stream reasoning live vs spinner only (toggle, persists)
-/title                    name the tab from your first prompt (AI session title; toggle, persists)
-/strict                   toggle "every message is a tool" mode
-/yolo                     toggle bash auto-approval (skip permission prompts)
-/trace                    toggle this run's JSONL event trace (and show its path)
-/privacy [local|aggregate|templates|examples]
-                          control prompt-learning data egress for this session
-/trajectory               show this session's agent tree: turns + spawned subagents
-/agents                   list agent types: builtin personas + .harness/agents/*.md
-/skills [add|remove <name>]
-                          list SKILL.md playbooks + companion tools; add/remove enables or disables one
-/plugins                  list Cursor/Claude/Grok/Codex plugin trees graff is reading in place
-/hooks                    list lifecycle hooks and the built-in codedb guard
-/doctor                   read-only health check: goal/todo invariants, and why steering will or will not be appended
-/btw <question>           ask one side question about this conversation: billed, never added, rides the parent cache prefix
-/compact                  compact history into a fresh context (OpenAI server-side when available)
-/rewind [n]               list past prompts; /rewind <n> drops prompt n+after & reverts its file edits
-/image <path>             attach an image to your next message (vision models only)
-/images                   open image URLs from the last response (e.g. issue attachments) in your browser
-/paste                    attach the clipboard image: macOS; also Ctrl-V (⌘V can't be captured)
-/bash <command>           run a shell command directly
-/save [name]              write the conversation to <name>.session.json (default: current)
-/resume [name]            restore a saved conversation (no arg → interactive picker)
-/sessions                 list saved sessions in the cwd
-/todo                     show the current task list
-/jobs                     list background jobs
-/cost                     session token usage and cost
-/usage                    alias for /cost
-/debug                    live content-free observability HUD (turns, tokens, tools, last events)
-/tools                    session tool balance: codedb-pro vs zigrep vs native usage, gate refusals, skew
-/animation                pick the thinking animation; persists to settings
-/theme [name]             pick a color theme; /theme off resets to your terminal default; persists
-/fleet [on|off]           federated DGM contribution (propose/submit/elite_pull)
-/mcp [add …]              list MCP servers/tools; /mcp add <name> <cmd> [args...] connects one live
-/import-claude            copy Claude/Cursor MCP servers and skills into ~/.codegraff and this repo
-/help                     list every command
-exit | ctrl-d             quit (also /exit; ctrl-c on an empty line)
-```
-
-`/plan`, `/yolo`, and `/strict` change how the permission gate behaves for the
-session. See [Permission modes](#permission-modes).
-
-`/goal <objective>` sets a standing objective that steers every turn as a live
-checklist, and starts working it right away: it runs turn after turn (plan, act,
-verify) instead of pausing for confirmation between routine steps. `/goal pause`
-stops the steering without losing the objective, `/goal resume` turns it back on,
-and `/goal status` shows the objective and its current state.
-`/loop <prompt>` is the same autonomous run for a one-off task, without adopting
-a standing objective.
-Either way the run stops on its own with a named outcome: accepted once the work
-is done, idle when the model stops making tool progress without claiming
-completion, cancelled or blocked when you step in or it needs you, exhausted when
-a safety limit is hit, and expired when a time budget runs out.
-Start with a duration to give the run one: `/goal 30m fix the flaky test` (also
-`45s`, `2h`). Each continuation turn then tells the model where it stands: which
-continuation it is on, how long the run has taken, how much of the budget is
-left, and one phase hint (explore, implement, finish, wrap up).
-Nothing is enforced except the stop itself, and the model is never cut off
-mid-turn. Subagents spawned during a timed run are told the parent's remaining
-time, minus a margin for the parent to integrate their results.
-`/review <target or instructions>` is the deliberately narrower path for code
-review: it suppresses goal/eval/ultracode steering, admits only local
-read/search tools and read-only shell inspection, and runs with fresh
-model-visible history. There are no implicit review-specific tool or model-call
-limits; the ordinary invocation budget is unlimited by default, while explicit
-`--max-tool-calls` and `--max-model-calls` settings still apply. Only the request
-and final report join the parent transcript. Use a later, explicit turn to fix
-accepted findings.
-
-### Skills
-
-A skill is a markdown playbook graff loads only when a task calls for it. Drop
-one in `.harness/skills/<name>/SKILL.md` (or `~/.harness/skills/` for every
-project), give it `name` and `description` frontmatter, and write the
-instructions in the body. Skills already written for Claude Code, Cursor,
-Grok, or Codex work as they are: `.claude/skills/`, `~/.cursor/skills-cursor/`,
-`~/.grok/skills/`, plugin `skills/` and Claude `commands/*.md` trees, and
-`~/.agents/skills/` are read in place (not copied). A Claude plugin works the
-same way it does in Claude Code: `commands/`, a root `SKILL.md`, inline
-`mcpServers`, and `${CLAUDE_PLUGIN_ROOT}` are honored. `/plugins` and
-`graff plugins` list the trees; `/plugins load <name>` shows one.
-`GRAFF_NO_PLUGINS=1` skips them.
-
-Only the name and description enter the system prompt, so a large skill library
-costs one line each. The model calls the `skill` tool to pull a body in when it
-needs it, and a skill written mid-session is loadable straight away.
-
-Two skills ship inside the binary: `skill-creator` (how to author and install
-new skills) and `mcp-config` (how to inspect and change the MCP servers below).
-`/skills` lists everything with its source, `/skills remove <name>` hides one,
-and `/skills add <name>` brings it back. See
-[docs/skills.md](docs/skills.md) for the full reference.
-
-### MCP servers
-
-Graff speaks both MCP transports directly: local stdio servers and remote
-Streamable HTTP servers. Servers already configured for Claude, Cursor, or
-Grok are read in place (plugin `mcp.json` / `.mcp.json`, `~/.claude.json`,
-`~/.cursor/mcp.json`, `.cursor/mcp.json`) and fill names graff does not
-already define; they still need `/mcp trust` or `--yolo`. Plugin manifests
-may also declare `mcpServers` inline or as a path (Claude's shape).
-`/plugins` and `graff plugins` show which plugin trees contributed. Other
-servers can be added from the shell or during a session:
-
-```sh
-graff mcp add context7 -- npx -y @upstash/context7-mcp
-graff mcp add mobbin --url https://api.mobbin.com/mcp
-graff mcp login mobbin   # OAuth discovery + browser PKCE flow
-# In the REPL: /mcp add mobbin --url https://api.mobbin.com/mcp
-```
-
-The equivalent `.mcp.json` URL entry is
-`{"mcpServers":{"mobbin":{"url":"https://api.mobbin.com/mcp"}}}`. Remote
-responses may use either `application/json` or `text/event-stream`; Graff keeps
-`Mcp-Session-Id` state and sends `MCP-Protocol-Version` on requests.
-For OAuth-protected endpoints, `graff mcp login <name>` performs protected
-resource and authorization-server discovery, dynamic client registration, and
-a browser PKCE flow. Tokens are stored outside the repository under
-`~/.simple-harness-mcp` with user-only permissions and refreshed automatically.
-Static HTTP headers can alternatively be added with
-`--header 'Authorization=Bearer TOKEN'` (they are stored in `.mcp.json`, so
-prefer a restricted token and do not commit that file).
-
-The line editor supports ↑/↓ history (persisted to `~/.simple-harness-history`),
-Tab completion (commands, and model names after `/model `), and emacs-style
-editing (Ctrl-A/E/W/U/K, Option+Delete, word moves). The selected model is
-remembered in `~/.simple-harness-model` and resumed next launch
-(`--model <name>` overrides). If the remembered provider/model is absent from
-the current catalog or its credentials are missing, graff falls back for that
-session with a note, without overwriting the preference. If the preferred
-provider later returns a clear authentication, access, removed-model, quota, or
-credit failure before producing text or running tools, graff tries the next
-configured provider and keeps the saved preference for a future launch. The
-prompt is a small statusline:
-`[model · Fast · Extra high · Plan · cwd /repo · 12345/800k tok (1%) · ⚡cached]`.
-Fast stays immediately beside the model. Active reasoning/workflow modes are
-visible at a glance: Low is green, Medium/Extra high/Ultra/Ultracode use the
-Codegraff coral accent, High/Plan are yellow, and Max/Strict are red. YOLO is
-reported
-as an explicit warning when enabled instead of occupying the compact prompt.
-Badges for unsupported settings are hidden instead of implying they apply. The
-tail shows context used vs the compaction budget, last cache hit, and (for
-metered providers) session spend.
-Errors aim to be actionable: `/resume nope` says the session file wasn't found
-and points at `/sessions`; an unknown `/foo` points at `/help`.
-
----
-
-## Permission modes
-
-By default graff **asks before doing anything that can change your machine.**
-File writes (`write_file`/`edit_file`), MCP tool calls, and any bash command
-that isn't read-only stop at a permission gate:
-
-```
-⚠ rm -rf build/
-[y]es once · [a]lways allow "rm" (saved to .harness/settings.json) · [n]o ›
-```
-
-- **y** runs it once · **a** runs it *and* remembers the rule · **n** denies it
-  (the model is told and picks another path).
-- **Always** appends a prefix rule to `.harness/settings.json` under `"allow"`,
-  so that command never prompts again, this session or a future one. Pre-seed
-  that file by hand to allow commands up front (it lives next to your hooks; the
-  harness preserves the rest of the file).
-- Read-only commands are auto-allowed and never prompt: `ls cat head tail wc
-  grep rg pwd which file`, `git status|diff|log|show`, `zig build|fmt`, but
-  only while every path stays inside the working directory (`cat /etc/passwd`
-  still asks), and only as a plain command. A pipe, redirect, `&&`, or `$(…)`
-  always prompts, so a second command can't be smuggled past a prefix match.
-
-Three session-wide modes change the gate. Set on the CLI, or flip them live in
-the REPL:
-
-| mode       | turn on              | what it does |
-| ---------- | -------------------- | ------------ |
-| **yolo**   | `--yolo` · `/yolo`   | Skip **every** prompt: bash, edits, and MCP all run without asking. For sandboxes, CI, and `-p`/`--json` runs where there's no human to answer. `--yolo` starts the session in it; `/yolo` toggles mid-session. |
-| **plan**   | `/plan`              | Read-only: the model explores and *proposes* a plan; the gate hard-denies writes, edits, MCP, and any bash beyond the read-only seed (even your saved allow-list) until you `/plan` again to execute. The prompt shows a yellow `Plan` badge. |
-| **strict** | `/strict`            | "Every message is a tool": the model must call exactly one tool per message and finish with `attempt_completion`. Useful for deterministic, scriptable agent loops. |
-
-**One-shot mode** (`graff -p "…"` or `--json`) has no human to answer the
-prompt, so the gate denies anything not already allowed. Pre-approve commands
-in `.harness/settings.json` or pass `--yolo`.
-
-### Hooks
-
-Shell hooks in `.harness/settings.json` run at tool-call boundaries — your
-own policy layer next to the built-in gate:
-
-```json
-{
-  "hooks": {
-    "pre_tool":  [{ "match": "write_file|edit_file",
-                    "command": "./scripts/guard.sh",
-                    "suggest": "the mcp edit tool",
-                    "timeout_ms": 5000 }],
-    "post_tool": [{ "match": "write_file", "command": "zig fmt ." }],
-    "turn_end":  [{ "command": "./scripts/notify.sh" }]
-  }
-}
-```
-
-- **`match`** — tool name, `|`-separated list, or `*` (default). **`command`**
-  runs via `/bin/sh -c` with the event JSON on stdin:
-  `{"event","tool","input"}` (post_tool adds `"is_error"`,`"output"`).
-- **`pre_tool`**: exit **2 blocks the call** — the hook's stderr becomes the
-  tool error the model sees. Add **`suggest`** to name the sanctioned
-  replacement; the denial becomes
-  `blocked by pre_tool hook: <stderr> — use instead: <suggest>`, turning a
-  blocked call into a one-call recovery instead of a guess-and-retry spiral.
-  Any other exit code, timeout, or spawn failure allows — a broken hook never
-  bricks the loop.
-- **`post_tool`** runs sequentially after the call (a formatter finishes
-  before the next tool runs); exit codes are ignored. **`turn_end`** fires
-  once per completed turn. Default timeout 10 s (`timeout_ms` to change);
-  stderr is capped at 4 KiB.
-
----
-
-## SDKs: TypeScript & Python
-
-graff is scriptable from your own code. `graff --json` is a structured stdio
-protocol (JSON requests in, JSONL events out; `ask_user` is answered with a
-structured `{"type":"answer","text":"...","cancelled":false}` line) and `graff --schema` prints the
-machine-readable interface, and the **TypeScript and Python SDKs in
-[`sdk/`](sdk/) are auto-generated from that schema**, so they never drift from
-the binary. On every release tag a GitHub Action rebuilds, regenerates, fails if
-the committed SDKs are stale, and publishes to npm (`@codegraff/sdk`) and PyPI
-(`simple-harness-sdk`).
+`graff acp` is the [Agent Client Protocol](docs/embedding.md) spawn (Zed
+External Agents). Recipe: [docs/acp-registry.md](docs/acp-registry.md).
+
+## Why it's small
+
+| metric | measured |
+| --- | --- |
+| binary | **~3 MB**, zero runtime deps |
+| cold start | **~1.8 ms** |
+| full agentic turn | **~12 MB** peak RSS |
+| 8 parallel subagents | **+0.4 MB** each |
+| fat tool output | one **4 KB** handle, whatever the result's size |
+
+Same model, same endpoint, the older Rust codegraff used **4.3×** the memory
+and **~14×** the disk for a dead-heat turn. Method:
+[architecture.md](architecture.md).
+
+## Script it
 
 ```python
-# Python
 from harness_sdk import Harness
-
 with Harness(yolo=True, model="gpt-5.5") as h:
     print(h.ask("what is 2+2?"))
-    for ev in h.chat("read foo.txt"):
-        print(ev["type"], ev)
 ```
 
 ```ts
-// TypeScript
-import { Harness, runAgent } from "@codegraff/sdk";
-
-// one-shot, streamed
-for await (const ev of runAgent({ prompt: "summarize README.md", model: "gpt-5.5", yolo: true })) {
+import { runAgent } from "@codegraff/sdk";
+for await (const ev of runAgent({ prompt: "summarize README.md", yolo: true })) {
   if (ev.type === "text") process.stdout.write(ev.text);
-  if (ev.type === "turn") console.log("\ncost $", ev.cost_usd);
-}
-
-// long-lived, multi-turn
-const session = Harness.init({ model: "claude-opus-4-8", yolo: true }).session();
-console.log(await session.ask("what files are here?"));
-session.close();
-```
-
-Can't spawn a local process (edge runtimes, browsers, other machines)? Run
-`graff serve` and both SDKs ship matching **remote clients** that drive it over
-HTTP: `@codegraff/sdk/remote` (fetch-only: Workers/Deno/Bun/browsers) and
-Python's `RemoteHarness` (stdlib only). Same method surface, same event stream.
-Both remote clients accept URL/base64 `images` on a turn and preserve them as
-native provider vision parts through `graff serve`; no encoded pixels are
-flattened into prompt text.
-See [`sdk/README.md`](sdk/README.md). A host that wants ACP (thought / tool /
-text `session/update`s) instead of `--json` events should spawn `graff acp` —
-recipe and `@codegraff/sdk/acp` helper in [Embedding graff](docs/embedding.md).
-
----
-
-## Embedder mode: run the harness outside the sandbox
-
-If you are embedding graff in a product, the safe shape is to run the agent loop
-on your trusted backend and let it reach an isolated sandbox only through tool
-calls. How to spawn the binary (ACP vs `--json`) is [Embedding graff](docs/embedding.md).
-`--no-local-tools` is what makes the sandbox shape enforceable:
-
-```bash
-graff --json --no-local-tools --model gpt-5.5
-
-# same thing, for a process whose argv you don't control:
-GRAFF_NO_LOCAL_TOOLS=1 graff --json
-```
-
-With the gate on, `bash`, `bash_output`, `bash_kill`, `read_file`, `edit_file`,
-`write_file` and `codedb` are hard-disabled for the whole process. It is a gate
-in the binary, not a permission rule the model can talk its way past, and it
-works in two layers because either one alone would be a promise rather than a
-guarantee:
-
-1. those tools are never advertised, so no provider is told they exist;
-2. if a provider hallucinates one anyway, dispatch refuses it with a tool error
-   naming the flag, before anything runs.
-
-Subagents and workflow workers inherit the gate, since they run in the same
-process. `--yolo` does not lift it.
-
-**Where the coding tools come from.** Point graff at your sandbox as an MCP
-server. MCP tools are untouched by the gate, which is the entire point: you
-stand up a thin proxy that maps exec/read/write onto your microVM provider, and
-the model gets those in place of the local ones.
-
-```bash
-graff mcp add sandbox --url https://sandbox-proxy.example.com/mcp
-graff --json --no-local-tools
-```
-
-`webfetch` stays available (plain HTTP from your own host, with no sandbox to
-escape), and so do the orchestration tools: `subagent`, `workflow`, the todo
-list, and `eval`.
-
-**Why it's worth the wiring.** The tenant provider key stays on your backend
-instead of sitting inside the same VM where prompt-injected commands run, so a
-hijacked agent can't read it. Run state lives with your supervisor rather than
-in a disposable machine. And because the sandbox is now something a tool call
-reaches rather than something the harness lives inside, your MCP proxy can
-create the VM lazily, on the first call that actually needs one. Runs that
-answer from model knowledge plus `webfetch` never boot a machine at all: they
-get web-request economics, and no boot-and-provision tax on time to first token.
-
----
-
-## Reference
-
-<details>
-<summary><strong>Tools & the permission gate</strong></summary>
-
-<br/>
-
-| Tool                 | Kind     | Implementation                                            |
-|----------------------|----------|-----------------------------------------------------------|
-| `bash`               | built-in | `std.process.run` → `/bin/sh -c`, stdout+stderr+exit code |
-| `read_file`          | built-in | `Io.Dir.cwd().readFileAlloc` (256 KB cap)                 |
-| `edit_file`          | built-in | exact string replace; unique match required unless `replace_all` |
-| `write_file`         | built-in | `Io.Dir.cwd().writeFile`                                  |
-| `codedb`             | built-in | shells out to [codedb](https://github.com/justrach/codedb): read-only code-intel (search/symbol/callers/outline/…) |
-| `subagent`           | built-in | this same agent loop, recursively (root agent only)       |
-| `workflow`           | built-in | phases of parallel subagents; `{{prev}}` carries results forward (root only) |
-| `todo_write`/`_read` | meta     | mutate/read the agent's own task list                     |
-| `ask_user`           | meta     | ask the human a question; their reply returns as the result |
-| `attempt_completion` | meta     | carry the final answer out; ends the turn                 |
-| `mcp__<server>__*`   | MCP      | tools discovered from `.mcp.json` servers (see below)     |
-
-**Meta tools** act on the agent or the conversation, not the outside world, so
-the orchestrator handles them inline rather than on a pool thread. `ask_user` +
-`attempt_completion` make the human↔agent conversation fully tool-mediated: the
-agent asks via a tool, the person's reply comes back as that tool's result, and
-the agent finishes via another tool. In `/strict` mode the model is forced to
-call a tool every turn, so *every* message is a tool call or tool result.
-
-**Permission gate.** The gate (`gateTool`) covers `bash`, `write_file`,
-`edit_file`, and MCP tool calls. A call that isn't pre-approved prompts at the
-REPL: `[y]es once · [a]lways allow "<key>" (saved) · [n]o`. The approval key is
-the command's first word for bash, the tool name for writes/MCP. "Always"
-**persists**: it's written to `.harness/settings.json` in the cwd
-(`{"allow": ["touch", "write_file", …]}`) and loaded back on every launch in
-that project. Edit the file by hand to revoke or pre-approve. A small seed
-allowlist (read-only basics like `ls`/`cat`/`rg`, plus `zig build`/`zig fmt` and
-`git status`/`diff`/`log`/`show`) never prompts; `find` is deliberately excluded
-(its `-exec`/`-delete` make it an exec tool). Commands containing chaining,
-pipes, redirection, substitution, or newlines never match a prefix: they always
-prompt. Approving an interpreter as a bash word (`python3`, `node`, …) prints a
-heads-up that it grants arbitrary code execution.
-
-**Path confinement.** `read_file`/`write_file`/`edit_file` are confined to the
-working-directory subtree: no absolute paths, no `..`. This is structural (not
-bypassed by `/yolo`): `read_file /etc/shadow` and `write_file ../../x` are
-refused with an error. When the user explicitly names a sibling repository, the
-root agent can continue there through permission-gated bash without relaunching;
-it checks the target's git status first and quotes its path. Those external edits
-are deliberately not tracked by `/rewind`, and subagents remain confined.
-
-**bash is cwd-locked by default too.** A seed/approved command auto-runs only
-when all its path arguments stay in the cwd (`escapesCwd` rejects absolute, `~`,
-and `..` tokens). So `cat local.txt` runs free but `cat /etc/passwd` falls
-through to a prompt at the root (you can still approve it per-call) and is denied
-for subagents. `/yolo` lifts this.
-
-**Subagents** have no stdin, so they're gated structurally, not by prompt: bash
-is allowlist-only (unapproved → denied), file writes are allowed but
-path-confined, and MCP isn't exposed to them at all. `/yolo` turns the prompt
-gate off (path confinement stays).
-
-</details>
-
-<details>
-<summary><strong>MCP servers</strong></summary>
-
-<br/>
-
-The harness is an MCP **client** (`src/mcp.zig`). Drop a `.mcp.json` in the
-working directory and it spawns each server, speaks JSON-RPC 2.0 over stdio,
-discovers their tools, and offers them to the model namespaced
-`mcp__<server>__<tool>`:
-
-```json
-{
-  "mcpServers": {
-    "codedb":      { "command": "codedb", "args": ["mcp", "."] },
-    "everything":  { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-everything"] }
-  }
 }
 ```
 
-Pointing it at `codedb mcp .` gives the agent 22 structural code-intelligence
-tools: pure-Zig client to pure-Zig server, zero dependencies on either side.
-`/mcp` lists what connected; `/mcp add <name> <cmd> [args…]` connects a server
-live and saves it to `.mcp.json`. From a shell, use the Codex-style form
-`graff mcp add <name> [--env KEY=VALUE ...] -- <cmd> [args…]`; for example,
-`graff mcp add context7 -- npx -y @upstash/context7-mcp`. `graff mcp` lists the
-servers already saved in `.mcp.json`. Workspace servers auto-connect only with
-`--yolo` (trusted) or per-session consent.
-
-One known companion is exempt from the workspace gate: if the `muonry` binary is
-on PATH (the fast code-intelligence suite), the harness auto-connects it in
-every workspace (it's a user-installed tool, not arbitrary repo config) and
-injects its usage note so the model prefers `mcp__muonry__read`/`search` over
-native navigation, falling back to the native tools whenever a call fails. Opt
-out with `{"skills": {"muonry": false}}` in `.harness/settings.json`.
-
-</details>
+`graff --json` / `graff --schema` generate the SDKs ([`sdk/`](sdk/)). Remote:
+`graff serve`. Embedders: `--no-local-tools` + a sandbox MCP —
+[Embedding graff](docs/embedding.md).
 
 <details>
-<summary><strong>ultracode & workflows: multi-agent fan-out</strong></summary>
+<summary><strong>CLI, slash commands, providers, permissions</strong></summary>
 
 <br/>
 
-**ultracode: the multi-agent codeword.** Put the word **ultracode** anywhere in
-a message and the harness augments that turn with a note steering the model into
-multi-agent workflow mode: it prints `⚡ ultracode: multi-agent workflow mode
-engaged`, records an `ultracode` trace event, and asks the model to fan the work
-out across phases of parallel subagents (then synthesize) via the `workflow`
-tool rather than doing it solo. It's a per-turn toggle: no flag, no mode to
-remember, just the keyword.
+```
+graff [flags]                 REPL
+graff -p "prompt"             one-shot (answer on stdout)
+graff login [codegraff|codex|kimi]
+graff key set <provider> <key>
+graff mcp add <name> -- <cmd>
+graff learn <command>
+graff --schema
 
-**Workflows.** Dynamic workflows as data (inspired by pi-dynamic-workflows,
-minus the JS sandbox): the model calls the `workflow` tool with a JSON plan of up
-to 5 sequential phases, each holding up to 8 tasks that run in parallel as
-isolated subagents. From phase 2 on, `{{prev}}` in a task prompt is replaced
-with the labeled results of the previous phase (auto-appended if omitted), and
-the final phase's results return to the root agent. Good for fan-out +
-synthesis: audits, multi-perspective review, parallel research.
-
-</details>
-
-<details>
-<summary><strong>Subagents</strong></summary>
-
-<br/>
-
-A subagent is just a tool whose executor is the same `Agent` loop with a fresh
-history, its own arena, and a subagent-specific system prompt (`execSubagent`).
-Because tool calls already fan out via `io.async`, the model spawning three
-subagents in one response gets three agent loops running concurrently, each
-making its own HTTPS calls through the shared (thread-safe) `std.http.Client`.
-Absent an explicit pin, subagents default onto a provider-local worker tier
-ladder one rung cheaper than the root model (codex/openai gpt-5.6 sol/flagship
--> terra -> luna; anthropic opus -> sonnet -> haiku; deepseek pro -> flash),
-so a fan-out of file-reading researchers doesn't run on the flagship by
-default. The ladder only ever resolves within the root's own provider; a root
-model outside the ladder, or already at its cheapest rung, inherits unchanged.
-`--no-subagent-tier` (or an explicit `--subagent-model`) opts out and restores
-plain inherit-root. A model shape can also pin all direct children, workflow
-workers/retries, and LLM judges to a specific model on the same
-provider/account:
-
-```sh
-graff --model gpt-5.6-sol --subagent-model gpt-5.6-terra
-# equivalent lower-precedence worker setting:
-GRAFF_SUBAGENT_MODEL=gpt-5.6-terra graff --model gpt-5.6-sol
-# force every worker onto the root model, ignoring the default ladder:
-graff --model gpt-5.6-sol --no-subagent-tier
+--model <name>   --yolo   --json   --no-local-tools
+--subagent-model <name>   --max-model-calls N
 ```
 
-This keeps orchestration/synthesis on Sol and parallel execution on Terra
-without silently crossing credential, billing, or data-boundary domains.
-Cross-provider workers require an explicit provider and a separate consent
-flag—for example, when both Codex and Kimi are available:
+One-shot has no human at the gate: pre-approve in `.harness/settings.json` or
+pass `--yolo`. Full flag list: `graff --help`. Learning:
+[docs/local-learning.md](docs/local-learning.md). Skills:
+[docs/skills.md](docs/skills.md).
 
-```sh
-graff --model gpt-5.6-sol \
-  --subagent-provider kimi --subagent-model k3 \
-  --allow-cross-provider-subagents
+```
+/model /models /clear /new /goal /loop /review /never
+/plan /yolo /strict /effort /compact /rewind /btw
+/skills /plugins /mcp /save /resume /sessions /help
 ```
 
-Both of those are session-wide. A **persona** can pin itself in its
-`.harness/agents/<name>.md` frontmatter, and a **single spawn** can override
-either, so one fan-out can put reviewers on a frontier model and mechanical
-workers on the cheap one:
+Bare `/` is a filterable menu. Esc interrupts the turn. `/help` is the live
+catalog.
 
-```markdown
----
-name: implementer
-tier: mid              # a rung of the current provider's ladder — preferred,
-                       # it stays correct when the root model changes
-# model: gpt-5.6-terra # …or pin an exact name instead
-effort: max            # reasoning depth for this worker (low|medium|high|xhigh|max);
-                       # unpinned workers run at medium
-isolation: worktree
----
-```
+| mode | what it does |
+| --- | --- |
+| default | ask before writes, MCP, and non-read-only bash |
+| `--yolo` / `/yolo` | skip every prompt (CI, `-p`) |
+| `/plan` | read-only explore |
+| `/strict` | every message is a tool |
 
-```jsonc
-// one subagent call, overriding everything above for that child only
-{"description": "extract imports", "prompt": "…", "agent": "implementer", "tier": "small", "effort": "low"}
-```
-
-Precedence, highest first: **`model`/`tier` on the spawn → the persona's
-`model:`/`tier:` frontmatter → `--subagent-model` → the default tier ladder →
-the root model.** Within one level an exact `model` beats a `tier`. Reasoning
-**effort** follows the same spawn → persona → default chain (default: medium)
-but is an independent axis — an effort-only override keeps the persona's model
-pin, so `effort: max` on a `model: gpt-5.6-luna` persona is exactly a "Luna
-Max" worker. Pins are
-provider-local — they pick a different model on the child's *current* provider
-and never move work across a provider boundary, which stays with
-`--subagent-provider` + `--allow-cross-provider-subagents`. A pin that cannot
-be honored (unknown or ambiguous model name, a model this provider does not
-serve, a tier this family has no rung for) is **ignored with a trace note and
-the spawn still runs** on the session default — a fan-out never dies partway
-through because a persona file names a model the catalog has since renamed.
-Workflow phase tasks and pipeline stages deliberately do *not* take pins: the
-fleet judges a phase's variants against each other and files the winner under
-the prompt genome, so a phase with mixed models would attribute model effects
-to the prompt.
-
-The consent matters because worker prompts, selected code, and tool results go
-to Kimi while root calls continue to go to Codex; telemetry/upload settings are
-independent of that model traffic. Omitting the consent flag fails closed. Put
-`ultracode` in a task (or run `/ultracode on`) when you want the root to
-actively fan work out; the model split itself does not force delegation. If
-`/model` later crosses to another provider, a provider-local pin follows the
-current root until it is compatible again. An explicitly consented cross-
-provider pin remains fixed.
-
-- Depth capped at one level: subagents don't get the `subagent` tool.
-- Subagents don't share the root agent's context, so the orchestrator must put
-  everything needed into the prompt (the tool description tells it so).
-- Progress lines (`[label] ⚙ bash …`) go to stderr via `std.debug.print`, which
-  locks stderr and is safe from pool threads.
-- Operational API traces and child trajectory nodes record the provider and
-  model that actually handled each child.
+Providers: Anthropic, OpenAI, DeepSeek, xAI, Z.AI, Kimi, Codex (ChatGPT login),
+Vercel, OpenRouter, MiniMax, Xiaomi, Groq, Cerebras, Mistral, plus one
+workspace router in `.graff/.config.router`. `graff models refresh` pulls
+catalogs. Claude-subscription OAuth is deliberately not supported.
 
 </details>
-
-<details>
-<summary><strong>Sessions & compaction</strong></summary>
-
-<br/>
-
-**Session persistence.** `/save [name]` writes the conversation (messages +
-provider + strict flag) to `<name>.session.json` in the cwd (default name
-`last`); `/resume [name]` restores it (provider, model, and full history) in
-any later run, and `/sessions` lists the saved ones. The stored message array is
-already the provider-native wire shape, so resume is a verbatim restore and
-works across providers (including codex's Responses-format items).
-
-**Compaction**, client-side, provider-agnostic:
-
-1. Every response's `usage` is recorded (`input+output+cache` tokens for
-   Anthropic, `total_tokens` for OpenAI) and shown in the prompt.
-2. Past the model's compaction threshold, 80% of its context window, from a
-   comptime model table (`/models` prints it: 800k for the 1M-context models,
-   160k for `claude-haiku-4-5`, 160k fallback for unknown models), or on
-   `/compact`, the harness sends the history plus a handoff instruction *with no
-   tools offered*, so the model must reply with a text summary covering goals,
-   decisions, file paths, code state, and pending work.
-3. History is replaced by a single user message embedding that summary, and the
-   token counter resets.
-
-If the summary request fails, history is left untouched.
-
-</details>
-
-<details>
-<summary><strong>KV-cache efficiency (Manus lessons)</strong></summary>
-
-<br/>
-
-Following [Manus's context-engineering notes](https://manus.im/blog/Context-Engineering-for-AI-Agents-Lessons-from-Building-Manus),
-the loop is built to keep the prompt prefix cacheable: the system prompt is
-stable (no per-request timestamps), history is strictly append-only, and tool
-definitions are rendered once at comptime so their order never shifts. On the
-real Anthropic API the harness also sets an explicit `cache_control` breakpoint.
-Cache reads are surfaced: `recordUsage` parses `cache_read_input_tokens`
-(Anthropic) and `prompt_cache_hit_tokens` / `prompt_tokens_details.cached_tokens`
-(OpenAI/DeepSeek), and every `api` trace line carries a `cache_read_tokens` field
-so you can see the hit rate in the current `.graff/traces/<run-id>.jsonl`.
-
-The one deliberate exception is `set_system_prompt` (--json protocol / SDK
-`setSystemPrompt`): the system prompt is the *first* token of the cached prefix,
-so mutating it, even appending, invalidates the KV-cache for the entire
-conversation and the next request re-reads everything at full input price. Treat
-it as a task-boundary operation: prefer the spawn-time
-`--system-prompt`/`--append-system-prompt` flags, and never flip the prompt back
-and forth inside an agent loop.
-
-</details>
-
-<details>
-<summary><strong>Tracing & telemetry</strong></summary>
-
-<br/>
-
-**Tracing: the harness can debug itself.** Every API round trip (latency,
-request/response bytes, context tokens) and every tool execution (duration,
-result size, errors, root-vs-subagent) is appended as one JSON line to the
-run's unique `.graff/traces/<run-id>.jsonl`. Every line carries the run id, PID,
-and runtime session id; concurrent processes therefore remain independently
-inspectable. API/tool rows also carry the active behavioral `turn` when one
-exists. The system prompt tells the agent how to locate the file, so
-"profile yourself" or "why was that slow?" makes it answer from data. `/trace`
-toggles tracing and prints the exact path.
-
-Startup also emits structured `startup_phase` receipts with cumulative and
-per-phase milliseconds. Each turn emits a `recipe_outcome` keyed by an exact
-recipe fingerprint: provider, model, effort, prompt, toolset, harness version,
-and an observational task class, alongside success, latency, model/tool calls,
-tool errors, uncached/cache-read tokens, and estimated cost. These records are
-the data plane for task-aware recipe comparison; they do not silently switch
-models or effort levels.
-
-**Tool results are handles, not payload.** A result over the handle threshold
-(4 KB by default, `GRAFF_TOOL_HANDLE_BYTES`) never enters the conversation
-whole. Its complete bytes are written under `.graff/tool-results/` and what the
-model gets back is a bounded preview, that file's absolute path, the byte count,
-and a one-line shape hint measured from the payload — the line count, or the
-top-level keys of a JSON result. The model then slices what it needs with
-`read_file`, grep-style bash, or `codedb`, so one result costs one threshold of
-context however large it is, and nothing is thrown away to keep it there. The
-tool-time threshold is clamped under the send-time per-model result cap, which
-therefore only ever fires on history graff did not produce (a session resumed
-from an older build); when it does, the full bytes go to
-`.graff/sessions/<session>/artifacts/` the same way, bounded per session and
-reclaimed once the session file they belong to is gone. Responses
-requests are explicitly capped at 16k output tokens (4k for compaction and 64
-for titles), while compaction carries the latest clean ~8k-token user-turn
-suffix forward verbatim. A shared atomic run budget allows at most four model
-calls concurrently and one subagent level; set the total provider-call ceiling
-with `--max-model-calls N` or the lower-precedence `GRAFF_MAX_MODEL_CALLS`.
-
-**Behavioral trajectories are a separate experimental stream.** Each initialized
-agent session can write an exclusively-created
-`.graff/behavior/<run_id>.jsonl` with an ordered, attributable lifecycle
-envelope. The local JSONL is never uploaded wholesale. Local capture defaults on
-and is independently disabled with `GRAFF_BEHAVIOR_TRACE=off`. Set
-`GRAFF_BEHAVIOR_TRACE=full` to additionally record tool names/arguments and
-completed assistant text in that local file (opt-in and capped). That plaintext
-file is never uploaded wholesale. Metadata upload still receives only a
-separately built, content-free projection; exact rich fields require the
-additional `GRAFF_BEHAVIOR_UPLOAD=content` opt-in.
-
-When ordinary telemetry is enabled, Codegraff also defaults to one bounded,
-end-of-run **field-allowlisted metadata** POST. A terminal `/v1/logs` path is
-replaced with `/v1/behavior`; otherwise `/v1/behavior` is appended to the
-configured base path. Query parameters are preserved and URL fragments omitted.
-Disable it with `GRAFF_BEHAVIOR_UPLOAD=off` or either ordinary telemetry opt-out.
-Only exact lowercase `metadata` or `content` values enable an explicit upload
-mode; `content` opts into caller-supplied adapter content and unknown/case/
-whitespace variants fail closed. `GRAFF_TELEMETRY_KEY` supplies an optional
-bounded `x-harness-key` token to both OTLP and behavioral requests. Metadata mode
-includes lifecycle/correlation fields, a controlled client class (`harness`,
-`sdk-ts`, or `sdk-py`), an initial run-start provider/model/effort snapshot,
-drop/completeness status, and content-free per-turn API/tool-category aggregates.
-When rich capture is enabled, that allowlist can also carry rich-event
-correlation, broad tool class, byte/duration/error counters, and truncation
-flags—never exact tool names, arguments, results, or assistant text.
-The local prompt fingerprint is omitted from default metadata because a
-low-entropy prompt can be recovered by enumeration. It has no dedicated fields for prompts, generated text or hidden
-reasoning, source code or diffs, filesystem paths or repository names, tool
-arguments/results, commands, arbitrary environment values, or exact private MCP
-names. Provider and model identifiers are included exactly as configured; Phase
-1 does not inspect, classify, or redact those identifier values.
-
-Most Phase 1 runs contain lifecycle events only. With
-`GRAFF_BEHAVIOR_TRACE=full`, tool/action/text events are added locally and their
-content-free projections become eligible for metadata upload; their exact
-names, arguments, and text are sent only in explicit content mode.
-The eval-driven loop (`--eval`/`--until`) is the first built-in caller of the
-typed commitment/misprediction APIs, committing to a target before running
-the scoring command and recording a misprediction only on a nonzero exit or a
-missed target, with no command text, stdout, or stderr ever entering either
-field. No other built-in adapter calls them.
-Content mode adds fields supplied through those APIs, with no redactor or secret
-scanner; the local prompt fingerprint remains excluded. This is not yet a
-generic predict → act → verify → repair loop
-or a behavioral score source. Individual collector rows are not publicly exposed;
-public behavioral statistics are aggregate-only, and opted-in content rows expire
-after 30 days. See [the schema, privacy policy, and current
-limitations](docs/behavioral-trajectories.md).
-
-**Telemetry, pseudonymous, opt-out, on by default.** *Every* build (release,
-source, and dev) bakes in a default OTLP endpoint (pass `-Dtelemetry-endpoint=""`
-to disable it at build time). A default session ships best-effort operational
-OTLP/HTTP JSON POSTs to `<endpoint>/v1/logs` (at exit, plus mid-session batches)
-and the metadata-only behavioral POST described above. **Opt out of both** with
-`--no-telemetry` or `GRAFF_NO_TELEMETRY=1`; setting
-`OTEL_EXPORTER_OTLP_ENDPOINT` (or `GRAFF_OTEL_ENDPOINT`) redirects both paths to
-your own collector instead. `GRAFF_BEHAVIOR_UPLOAD=off` disables only the
-behavioral POST.
-
-It's *pseudonymous, not anonymous*: records carry a **random** per-install id
-(`~/.simple-harness-install-id`, generated with `io.random`, not derived from your
-name, host, or user) plus your request IP, version, OS, and arch. The
-**operational OTLP payload** is counts, hashes, and tool names: a `session`
-summary (duration, turns, API/tool call+error counts, models used,
-workflow/ultracode counts), plus per-`workflow` and per-error records. When
-learning privacy is `aggregate` or higher it also admits per-run/score records
-keyed by a one-way **system-prompt fingerprint** with a tool-**name** sequence (for example,
-`read_file, bash, edit_file`). It does not send prompts, code, file contents,
-file paths, or tool arguments. The separately bounded behavioral payload follows
-the metadata/content rules above; only explicit content mode permits opaque
-adapter fields that may contain task content.
-
-**Fleet / evolution signals default to `aggregate`,** and the first session that
-could contribute says so once per machine. `/privacy` selects a session-scoped
-learning ceiling: `local` sends nothing automatically (the bundled
-`learn_candidate` tool can request one aggregate-only send); `aggregate` (the
-default) permits signed grades and prompt-free fleet metadata; `templates`
-additionally offers each private reusable persona/template for an exact preview
-approval; and
-`examples` reserves a future one-shot reviewed-example channel (raw example
-upload is not implemented). `GRAFF_LEARNING_PRIVACY` or
-`--learning-privacy` can select the same mode, while `GRAFF_FLEET=off` or
-`/fleet off` remains a master kill switch. Template approvals never persist,
-are not bypassed by `--yolo`, and are re-scanned at the final egress point.
-Raw task prompts, bindings, code, paths, reports, tool results, and traces have
-no fleet upload path. See [Learning privacy and consent](docs/learning-privacy.md).
-
-</details>
-
-<details>
-<summary><strong>Project instructions (AGENTS.md / CLAUDE.md)</strong></summary>
-
-<br/>
-
-At startup the harness reads the first of `AGENTS.md`, `HARNESS.md`, or
-`CLAUDE.md` it finds in the working directory and appends it to the root system
-prompt (subagents keep the lean prompt). It prints `loaded project instructions
-from AGENTS.md (N bytes)`. Because the system prompt stays frozen for the
-session, this is KV-cache-friendly. Drop conventions, codewords, or do/don't
-rules in `AGENTS.md` and the harness picks them up like any real coding agent.
-
-</details>
-
-<details>
-<summary><strong>Install details, keys & SDKs</strong></summary>
-
-<br/>
-
-`install.sh` compiles `graff` (ReleaseFast) and installs it to `~/bin` (override
-with `HARNESS_DIR=`); it builds the current checkout, or clones the repo if run
-standalone. It detects the platform (Windows → WSL hint), checks for the pinned
-Zig 0.17 development build, and appends the install dir to `~/.zshrc` /
-`~/.bashrc` so `graff` is on PATH in the next terminal (`HARNESS_NO_PATH=1`
-skips). Alternatively, run in place:
-
-```sh
-zig build run            # or: ./zig-out/bin/graff
-zig build test           # the test suite (also run by CI, .github/workflows/ci.yml)
-```
-
-**Releases & verification.** Tagged releases ship a prebuilt **darwin-arm64**
-binary that is **codesigned with a Developer ID certificate and notarized by
-Apple**, so it runs without Gatekeeper prompts. Verify a download:
-
-```sh
-codesign --verify --strict --verbose=2 graff   # → valid on disk; satisfies its Designated Requirement
-codesign -dv --verbose=4 graff 2>&1 | grep Authority
-#   Authority=Developer ID Application: Rachit Pradhan (WWP9DLJ27P)
-```
-
-Keys can come from env vars, or be stored safely with `graff key set <provider>
-<key>`. On macOS that's the login **Keychain** (service `simple-harness`),
-elsewhere a `0600` `~/.simple-harness-keys.json`; the harness auto-loads them at
-startup for any provider whose env var isn't set (env always wins). `graff key
-list` shows which providers have a stored key. Providers
-(OpenAI/Anthropic-format, matched to graff): anthropic, openai, deepseek,
-**kimi**, **xai** (grok), **zai** (GLM), **vercel** (AI Gateway), **openrouter**, minimax, xiaomi, codegraff, plus the
-codex & claude subscription logins.
-
-`graff login` runs graff's codegraff device-code flow (a `user_code` to enter at
-codegraff.com/cli/auth → poll → key, saved to `~/.simple-harness-codegraff.json`);
-the codegraff key is also auto-picked-up from graff's own
-`~/forge/.credentials.json` if present, so no env var is needed. `graff login
-codex` runs the Codex/ChatGPT OAuth browser flow (PKCE → localhost callback →
-token) and `graff login codex --refresh` refreshes it. `graff login kimi` runs
-Kimi Code's device flow and stores its refreshable credential separately under
-`~/.kimi/credentials/`. Kimi models, context sizes, thinking efforts, and
-native-vs-Anthropic wire protocol are refreshed from the authenticated catalog
-at startup; `--model kimi` follows the newest pure Kimi generation. Codex auth
-lives in `~/.codex/auth.json`; set `CODEX_HOME` when reusing credentials from a
-custom Codex CLI home.
-
-**SDKs.** `graff --json` exposes a structured stdio protocol (JSON requests in,
-JSONL events out) and `graff --schema` prints the machine-readable interface.
-Together they are the foundation for the auto-generated TypeScript + Python SDKs
-in [`sdk/`](sdk/) (regenerated on release by `sdk/generate.py` /
-`.github/workflows/sdk.yml`).
-
-`graff serve` puts that same protocol on HTTP for clients that can't spawn a
-local process (edge runtimes, browsers, other machines): each session is a real
-`graff --json` child, one non-answer POST is one protocol request, and the
-response streams NDJSON events until that request's terminal event. `answer`
-POSTs can be sent while the original stream is waiting on `ask_user`; they ack
-immediately and the original stream continues to the `tool_result`/`turn`.
-Bearer auth via `--token`/`HARNESS_SERVE_TOKEN` (required to bind beyond
-loopback); CORS opens only when a token gates access. The SDKs ship matching
-remote clients: `@codegraff/sdk/remote` (fetch-only: Workers/Deno/Bun/browsers)
-and Python's `RemoteHarness` (stdlib urllib). Endpoints are documented under the
-`serve` key of `graff --schema`.
-
-Streams are resumable. Every event carries a monotonic `seq`, and the bridge
-persists each one to `.graff/serve/<session>.events.jsonl` while it keeps
-draining the child even after a client disconnects, so a supervisor that dies
-mid-turn does not stall the run. It reconnects with
-`GET /v1/sessions/{id}/events?from=N` (or `?from=N` on the next request) and
-gets exactly the events it missed. Sessions are durable too: the session id is
-the graff session name, the child runs as `graff --json --resume <id>`, and
-posting the same name to a replacement `graff serve` in the same workspace
-picks the run up from the last persisted turn with the sequence continuing.
-
-</details>
-
-<details>
-<summary><strong>Why Zig & implementation notes</strong></summary>
-
-<br/>
-
-- An agent harness is I/O-bound, so you don't need an async runtime. Zig 0.17's
-  new `std.Io` interface gives you one anyway: `io.async(fn, args)` returns a
-  typed `Future`, executed on a thread pool you configure (`std.Io.Threaded`).
-  Parallel tools and parallel subagents are the same ~6 lines (see
-  `runToolsParallel`).
-- The new `pub fn main(init: std.process.Init)` entry point hands you `io`, a
-  thread-safe gpa, a process-lifetime arena, and the environment map.
-- Compiles in well under a second; the binary is self-contained (TLS included,
-  no libcurl/openssl).
-- The payoff is measurable. Same model, same endpoint, the Rust codegraff burns
-  4.3× the memory and 23× the disk for an identical-speed turn. See [Why](#why)
-  and `architecture.md` for the methodology.
-
-Notes:
-
-- UI/UX changes are tracked in [uxlog.md](uxlog.md): what changed, what it
-  replaced, and the design reasoning (newest first).
-- Anthropic requests use adaptive thinking with a summarized display, so the
-  reasoning stream is not empty; the assistant's full `content` array
-  (including thinking blocks and signatures) is echoed back verbatim, as the API
-  requires for tool-use loops.
-- OpenAI tool arguments arrive as *stringified* JSON and are parsed before
-  dispatch; tool results go back as `role: "tool"` messages.
-- History lives in an arena per agent; per-request buffers use the gpa.
-- Root requests **stream**: text deltas print live as the SSE events arrive (all
-  three wire formats), then the buffered events are reassembled into the
-  non-streaming response shape so the rest of the loop is unchanged. Subagents
-  and compaction stay buffered. `max_tokens: 16000`.
-
-</details>
-
-<details>
-<summary><strong>Status & roadmap</strong></summary>
-
-<br/>
-
-Honest list of what the harness still lacks, roughly in the order it hurts.
-
-**Foundational:**
-1. ~~**A public repo + signed release.**~~ **Done, v0.0.1.** The repo is public at
-   [`justrach/codegraff`](https://github.com/justrach/codegraff), and releases ship
-   a prebuilt **darwin-arm64 binary that is codesigned (Developer ID) and notarized
-   by Apple**. The release workflow (`.github/workflows/release.yml`) cross-compiles
-   the rest on every `v*` tag; `install.sh` prefers the prebuilt download over a
-   source build, so `curl … | bash` now installs in one command with no toolchain.
-
-**Later:**
-
-2. ~~**Windows support.**~~ **Done, v0.0.167.** Every release ships prebuilt
-   `graff-{x86_64,aarch64}-windows.tar.gz`; install.sh itself is still
-   Unix-only (points Windows at WSL, or unpack the tarball by hand).
-3. Shell completions (zsh/bash) and a man page.
-4. A config file for defaults (`--timing`/`--cost`/model) so flags don't have to
-   be retyped.
-5. Esc during *tool execution* (the interrupt currently lands at the next
-   stream; a long-running bash call still runs to completion).
-6. ~~Honor `Retry-After` on 429s.~~ **Done, v0.0.204.** Retry/stall/reconnect
-   handling now matches opencode and codex: `Retry-After` honored, in-stream
-   overload and quota-429s recovered, WS falls back to SSE.
-
-Recently shipped (see [CHANGELOG.md](CHANGELOG.md) for the release-by-release
-view): SKILL.md skills with a bundled skill-creator · the local learning loop,
-zero-config and privacy-bounded (`graff learn init`) · `/goal` standing
-objectives with epochs and time budgets, `/loop` folded into the same
-autonomous run · embedder mode (hard `--no-local-tools` gate + resumable
-`serve` streams, schema 0.10) · verified `edit_file` with per-path write
-serialization · provider-robustness parity with opencode/codex (Retry-After,
-in-stream overload, WS→SSE) · kuri browser companion installed by default ·
-`/images` · summarized thinking for Anthropic models · prebuilt Windows
-binaries.
-
-</details>
-
----
-
-## Coming soon
-
-Active directions. See [CHANGELOG.md](CHANGELOG.md) for what already landed,
-the **Status & roadmap** details above for the full list, and the GitHub
-issues for what's in flight:
-
-- **Sandboxes.** Run the agent's `bash`/file tools inside an isolated sandbox
-  (ephemeral container / microVM) so untrusted or destructive steps can't touch
-  the host. It's the natural next layer above today's cwd-confinement and
-  permission gate, and the safe substrate for hands-off evolutionary runs.
-  [Embedder mode](#embedder-mode-run-the-harness-outside-the-sandbox) is the
-  first half of this today: `--no-local-tools` plus a sandbox MCP server
-  ([Embedding graff](docs/embedding.md)). A
-  first-class sandbox backend (create/exec/read/write/destroy with provider
-  adapters) would remove the proxy you have to write yourself.
-- **Scaling the evolution loop.** The local half shipped in v0.0.219:
-  `graff learn init` runs privacy-bounded background trials and promotes the
-  winning genome into the root prompt. What remains is fleet scale: grounded
-  judging and trajectory sync-back across many installs.
-- **Shell completions + man page, and a config file** for default flags/model.
-
----
 
 ## Working on codegraff
 
-Install the tracked git hooks once:
-
 ```bash
-scripts/install-hooks.sh
+scripts/install-hooks.sh          # once
+scripts/eval-tier1.sh             # offline, ~20s warm
+python3 scripts/eval-tier2.py     # model-backed, opt-in
 ```
 
-From then on, every push runs **tier 1** of the internal eval set. It is
-deterministic and offline (no provider calls, no network, no spend) and takes
-about 20 seconds warm:
-
-| check | what it holds |
-| --- | --- |
-| `fmt` | `zig fmt --check src build.zig` |
-| `lines` | the 600-line ceiling on hand-written Zig |
-| `reach` | every file that declares tests is reachable from the test root |
-| `build` | `zig build` |
-| `tests` | `zig build test`, and a suite count that may grow but never shrink |
-| `invariants` | the named goal/loop/todo tests actually ran, not just compiled |
-| `sdk` | the committed SDKs still match `graff --schema` |
-
-A push that only touches docs skips the whole thing. When a check fails it names
-the invariant, says which regression it guards, and prints the one-liner that
-reruns only it:
-
-```bash
-scripts/eval-tier1.sh                 # everything
-scripts/eval-tier1.sh --only sdk      # one check
-scripts/eval-tier1.sh --list          # the check names
-```
-
-If you need to push past it, `git push --no-verify` (or `GRAFF_SKIP_PREPUSH=1
-git push`). CI runs the same checks and more, so the hook is a fast local
-opinion, not the last word.
-
-**Tier 2** is the model-backed half, and it is not in the hook because it runs
-the harness for real. The cases live in `evals/harness_behavior.jsonl`, one line
-each, carrying the regression it guards: a goal writes a checklist and finishes
-it, an empty `todo_write` changes nothing, a compaction keeps the items already
-completed, `--max-tool-calls` actually stops the run. The model is scripted, so
-the default run is offline and free:
-
-```bash
-python3 scripts/eval-tier2.py                 # every case, scripted model
-python3 scripts/eval-tier2.py --list          # the cases and what they guard
-python3 scripts/eval-tier2.py --dump <id>     # everything one case did
-python3 scripts/eval-tier2.py --provider anthropic --model claude-sonnet-4-6
-```
-
-Two checks exist because the unit suite could not see the failure. `reach` walks
-the `@import` graph: Zig only runs tests in files the root pulls in, so a
-split-out module nobody references compiles to nothing and the suite still
-reports green. `invariants` goes further, rerunning the suite under
-`-Dtest-filter` to prove the named tests executed, because a test can sit in the
-source and never run. Both are configured as data in
-`scripts/eval/tier1-manifest.json`.
-
-Both read the count off the compiled test binary rather than off the build
-summary, because a fully cached `zig build test` prints no `N/N tests passed`
-line, and they pick that binary by the test names it carries rather than by
-mtime, so a `-Dtest-filter` build left in `.zig-cache/o` is never mistaken for
-the whole suite. `test_count_baseline` is a floor nothing raises on its own:
-bump it at each release cut, and tier 1 warns once the suite runs more than
-`test_count_slack` tests ahead of it.
-
----
+Tier 1 is `zig fmt`, the 600-line ceiling, test reachability, `zig build test`
+(suite count never shrinks), named goal/loop/todo invariants, and SDK drift.
+Docs-only pushes skip it. In-house PR fixtures: `graff-evals/`
+(`--suite inhouse`).
 
 ## License
 
-codegraff is licensed under a **modified GNU AGPL-3.0** (see [`LICENSE`](LICENSE)).
-The public receives it under the AGPL-3.0, so network use triggers the Section 13
-obligation to make Corresponding Source available to remote users. The authors
-**Rach Pradhan (justrach)** and **Yu Xi Lim (yxlyx)** reserve full rights to use,
-distribute, and offer it (and modified versions) as a private, proprietary, or
-hosted/cloud product, free of those obligations.
+**Modified GNU AGPL-3.0** ([`LICENSE`](LICENSE)). Network use triggers
+Section 13. Authors **Rach Pradhan (justrach)** and **Yu Xi Lim (yxlyx)**
+reserve the right to offer proprietary or hosted versions. A recipient's AGPL
+licence is perpetual unless they breach it. Commercial permission without
+copyleft exists only if **both authors grant it jointly in writing**, and is
+revocable.
 
-A recipient's AGPL-3.0 licence is **perpetual and irrevocable unless they breach
-it**: it can't be withdrawn at will, which is what makes open use safe to rely on.
-Any **proprietary or commercial permission** to use codegraff *without* the AGPL's
-copyleft is a separate thing, and exists only if **both authors grant it jointly in
-writing**. Such a permission is **revocable at the authors' discretion at any
-time**, and neither the provision of consultancy or other services nor any side
-agreement grants it or makes it irrevocable. If it is revoked, the user falls back
-to full AGPL compliance or must stop using codegraff. For commercial or proprietary
-licensing, contact the authors.
-
----
-
-<p align="center"><sub>Built in Zig 0.17 dev · <a href="LICENSE">AGPL-3.0 (modified)</a> · <a href="architecture.md">architecture.md</a> · <a href="uxlog.md">uxlog.md</a></sub></p>
+<p align="center"><sub>Built in Zig 0.17 dev · <a href="LICENSE">AGPL-3.0 (modified)</a> · <a href="architecture.md">architecture.md</a> · <a href="CHANGELOG.md">CHANGELOG</a> · <a href="uxlog.md">uxlog.md</a></sub></p>

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,7 +1,7 @@
 # Benchmarks
 
 Reproducible head-to-head of **graff** vs **Claude Code** vs **Codex**, behind the
-numbers in the main README's [How it compares](../README.md#how-it-compares).
+numbers in the main README's [same-model table](../README.md#same-model-fewer-tokens).
 
 These are small, honest benchmarks (a few read-only code questions on one
 machine), not a leaderboard. Run them yourself. Your numbers will vary with the

--- a/docs/acp-registry.md
+++ b/docs/acp-registry.md
@@ -7,7 +7,7 @@ and is what Zed's "Install from Registry" (and other ACP clients) reads.
 This page is the submit recipe. There is no registry client in graff, and
 `graff acp` does not grow one.
 
-Hand-written Zed setup stays in the [README](../README.md#zed-external-agents--acp)
+Hand-written Zed setup is `graff acp` (see the [README](../README.md#install))
 and the host recipe stays [embedding.md](embedding.md). Replace those with
 "Install from Registry" only after a listing lands.
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -121,8 +121,7 @@ A hosted product that must not exec on the host machine already has a gate:
 `read_file` / `edit_file` / `write_file`, and `codedb` for the process
 (advertised off, dispatch refuses a hallucination). MCP tools are untouched,
 so a trusted host maps exec/read/write onto its own sandbox. Works with both
-`graff acp` and `graff --json`. `--yolo` does not lift the gate. Full
-write-up: [README — Embedder mode](../README.md#embedder-mode-run-the-harness-outside-the-sandbox).
+`graff acp` and `graff --json`. `--yolo` does not lift the gate.
 
 ```bash
 graff acp --yolo --no-local-tools --model gpt-5.5

--- a/graff-evals/README.md
+++ b/graff-evals/README.md
@@ -21,7 +21,7 @@ harness under test spends model calls.
 | `rlm` | scatter-gather / multi-file reads (where default rlm can overlap) |
 | `swe` | DeepSWE-shaped multi-file bugfixes, distilled from [deepswe.datacurve.ai/run](https://deepswe.datacurve.ai/run) (no Harbor/Docker) |
 | `mcp` | Linear-shaped fixture MCP (Blacksmith code-mode + muscle memory). Always `--no-lean` (`graff-dev-nolean`): lean is a different catalog and is not on the front. |
-| `inhouse` | Bug shapes distilled from shipped CodeGraff PRs (symlink write, oneshot chrome, cache git-root, stall widen/warn, empty catalog). Self-contained fixtures — not the live repo. Opt-in like `mcp`. |
+| `inhouse` | Bug shapes distilled from shipped CodeGraff PRs (first six: symlink write, oneshot chrome, cache git-root, stall widen/warn, empty catalog; plus hardlink pin, x_search splice, MCP first-turn, rlm showcase gate, codedb menu, peer resume). Self-contained fixtures — not the live repo. Opt-in like `mcp`. |
 
 ```sh
 ./run.py --suite swe --harness graff-dev-old,graff-dev --model grok-4.6 -j 12

--- a/graff-evals/fixtures/codedb-menu/SPEC.md
+++ b/graff-evals/fixtures/codedb-menu/SPEC.md
@@ -1,0 +1,14 @@
+# Advertise five codedb one-shots (CodeGraff #597 / ADR 0019, distilled)
+
+`menu.py` must expose:
+
+- `ADVERTISED` — `["context", "around", "callpath", "list_dir", "status"]`
+- `HOPS` — hop verbs that stay **callable** but off the menu:
+  `search`, `symbol`, `callers`, `find`, `outline`, `read`
+- `menu() -> list` — exactly `ADVERTISED`, in that order
+- `allowed(sub) -> bool` — true for advertised **and** hops
+- `usage() -> str` — names only the advertised five
+  (`context`, `around`, `callpath`, `list_dir`, `status`)
+
+`update` is never allowed. Hop verbs must not appear in `menu()` or
+`usage()`.

--- a/graff-evals/fixtures/codedb-menu/menu.py
+++ b/graff-evals/fixtures/codedb-menu/menu.py
@@ -1,0 +1,17 @@
+"""codedb advertised surface — incomplete. Fix the SPEC.md contract."""
+
+ADVERTISED = ["context", "around", "callpath", "list_dir", "status"]
+HOPS = ["search", "symbol", "callers", "find", "outline", "read"]
+
+
+def menu():
+    # BUG: hop verbs ride the catalog listing (ADR 0019).
+    return ADVERTISED + HOPS
+
+
+def allowed(sub):
+    return sub in ADVERTISED
+
+
+def usage():
+    return "codedb <command> — " + " · ".join(ADVERTISED + HOPS)

--- a/graff-evals/fixtures/codedb-menu/test_menu.py
+++ b/graff-evals/fixtures/codedb-menu/test_menu.py
@@ -1,0 +1,22 @@
+from menu import ADVERTISED, allowed, menu, usage
+
+
+def test_menu_is_five_oneshots():
+    assert menu() == ADVERTISED
+    assert menu() == ["context", "around", "callpath", "list_dir", "status"]
+    text = usage()
+    assert "context" in text and "list_dir" in text
+    assert "search" not in text and "symbol" not in text
+
+
+def test_hops_callable_update_not():
+    assert allowed("callpath")
+    assert allowed("search")
+    assert allowed("symbol")
+    assert not allowed("update")
+
+
+if __name__ == "__main__":
+    test_menu_is_five_oneshots()
+    test_hops_callable_update_not()
+    print("OK")

--- a/graff-evals/fixtures/hardlink-pin/SPEC.md
+++ b/graff-evals/fixtures/hardlink-pin/SPEC.md
@@ -1,0 +1,15 @@
+# Hardlink the learn pin (CodeGraff #687, distilled)
+
+`pin.py` must expose `pin_executable(source_path, dest_dir, name) -> str`.
+
+It places `name` inside `dest_dir` and returns that path.
+
+- Prefer `os.link(source, dest)` so the pin and the live exe share an inode
+  (`nlink >= 2`). A 127M byte-copy is the wall tax this contract kills.
+- If `dest` already exists, remove it first, then link.
+- Do **not** `chmod` the dest. After a hardlink that would also chmod the
+  live exe.
+- Copy only when `os.link` raises `OSError` (cross-device). The copy must
+  still not chmod the dest.
+- `source_path` must remain a regular file at the same mode it had before
+  the pin.

--- a/graff-evals/fixtures/hardlink-pin/pin.py
+++ b/graff-evals/fixtures/hardlink-pin/pin.py
@@ -1,0 +1,13 @@
+"""Learn-kit pin — incomplete. Fix the SPEC.md contract."""
+import os
+import shutil
+
+
+def pin_executable(source_path, dest_dir, name):
+    dest = os.path.join(dest_dir, name)
+    if os.path.exists(dest):
+        os.remove(dest)
+    # BUG: always byte-copy, then chmod the dest (would also chmod a hardlink).
+    shutil.copy2(source_path, dest)
+    os.chmod(dest, 0o755)
+    return dest

--- a/graff-evals/fixtures/hardlink-pin/test_pin.py
+++ b/graff-evals/fixtures/hardlink-pin/test_pin.py
@@ -1,0 +1,25 @@
+import os
+import stat
+import tempfile
+
+from pin import pin_executable
+
+
+def test_same_inode_on_one_fs():
+    with tempfile.TemporaryDirectory() as td:
+        src = os.path.join(td, "graff")
+        kit = os.path.join(td, "kit")
+        os.mkdir(kit)
+        with open(src, "wb") as f:
+            f.write(b"exe")
+        os.chmod(src, 0o700)
+        dest = pin_executable(src, kit, "graff-pinned")
+        assert os.path.isfile(dest)
+        assert os.stat(src).st_ino == os.stat(dest).st_ino
+        assert os.stat(dest).st_nlink >= 2
+        assert stat.S_IMODE(os.stat(src).st_mode) == 0o700
+
+
+if __name__ == "__main__":
+    test_same_inode_on_one_fs()
+    print("OK")

--- a/graff-evals/fixtures/mcp-first-turn/SPEC.md
+++ b/graff-evals/fixtures/mcp-first-turn/SPEC.md
@@ -1,0 +1,18 @@
+# First model call skips the deferred MCP join (CodeGraff ADR 0035, distilled)
+
+`join.py` must expose:
+
+- `defer_mcp_join(yolo, json_mode) -> bool` — `--yolo` (including `-p`)
+  starts MCP in the background. `--json` keeps a blocking connect.
+- `oneshot_skips_imported(oneshot, lean, project_servers) -> bool` — lean
+  `-p` skips imported global/plugin servers only when the project
+  `.mcp.json` is empty (ADR 0029: a project file still connects).
+- `first_request_join(pending_len, already_skipped) -> str` — one of
+  `"none"`, `"skip"`, `"join"`. `already_skipped` is a one-element list
+  used as a mutable flag (`[False]` → `[True]` on the first skip).
+
+`first_request_join` contract:
+
+- `pending_len == 0` → `"none"` (do not flip the flag).
+- First call with pending work → `"skip"` and set the flag.
+- Later calls with pending work → `"join"`.

--- a/graff-evals/fixtures/mcp-first-turn/join.py
+++ b/graff-evals/fixtures/mcp-first-turn/join.py
@@ -1,0 +1,17 @@
+"""MCP first-turn join — incomplete. Fix the SPEC.md contract."""
+
+
+def defer_mcp_join(yolo, json_mode):
+    return yolo
+
+
+def oneshot_skips_imported(oneshot, lean, project_servers):
+    # BUG: lean -p always skips, even with a project .mcp.json (ADR 0029).
+    return oneshot and lean
+
+
+def first_request_join(pending_len, already_skipped):
+    # BUG: always join, so the first -p turn waits on the handshake.
+    if pending_len == 0:
+        return "none"
+    return "join"

--- a/graff-evals/fixtures/mcp-first-turn/test_join.py
+++ b/graff-evals/fixtures/mcp-first-turn/test_join.py
@@ -1,0 +1,26 @@
+from join import defer_mcp_join, first_request_join, oneshot_skips_imported
+
+
+def test_defer_and_imported():
+    assert defer_mcp_join(True, False) is True
+    assert defer_mcp_join(True, True) is False
+    assert defer_mcp_join(False, False) is False
+    assert oneshot_skips_imported(True, True, 0) is True
+    assert oneshot_skips_imported(True, True, 1) is False
+    assert oneshot_skips_imported(True, False, 0) is False
+    assert oneshot_skips_imported(False, True, 0) is False
+
+
+def test_first_request_skips_once():
+    skipped = [False]
+    assert first_request_join(0, skipped) == "none"
+    assert skipped == [False]
+    assert first_request_join(2, skipped) == "skip"
+    assert skipped == [True]
+    assert first_request_join(2, skipped) == "join"
+
+
+if __name__ == "__main__":
+    test_defer_and_imported()
+    test_first_request_skips_once()
+    print("OK")

--- a/graff-evals/fixtures/peer-resume/SPEC.md
+++ b/graff-evals/fixtures/peer-resume/SPEC.md
@@ -1,0 +1,12 @@
+# Resume restores cursor and inbox, not the room (CodeGraff #584 / ADR 0014)
+
+`resume.py` must expose:
+
+- `snapshot(cursor, inbox) -> dict` — `{"cursor": int, "inbox": list}`
+  (a copy of `inbox`)
+- `resume(snap) -> dict` — `{"cursor", "inbox", "history"}`
+
+`/resume` restores the peer-channel **byte cursor** and **inbox**. It does
+**not** replay the room into history. `history` is always `[]`.
+`ROOM` in the file is leftover transcript — do not copy it into the
+restored session.

--- a/graff-evals/fixtures/peer-resume/resume.py
+++ b/graff-evals/fixtures/peer-resume/resume.py
@@ -1,0 +1,16 @@
+"""Peer-channel resume — incomplete. Fix the SPEC.md contract."""
+
+ROOM = ["[peer] alice: leftover", "[peer] bob: also leftover"]
+
+
+def snapshot(cursor, inbox):
+    return {"cursor": cursor, "inbox": list(inbox)}
+
+
+def resume(snap):
+    # BUG: replays the room into history (ADR 0014).
+    return {
+        "cursor": 0,
+        "inbox": [],
+        "history": list(ROOM),
+    }

--- a/graff-evals/fixtures/peer-resume/test_resume.py
+++ b/graff-evals/fixtures/peer-resume/test_resume.py
@@ -1,0 +1,14 @@
+from resume import resume, snapshot
+
+
+def test_restore_cursor_and_inbox():
+    snap = snapshot(42, ["wake-1", "wake-2"])
+    got = resume(snap)
+    assert got["cursor"] == 42
+    assert got["inbox"] == ["wake-1", "wake-2"]
+    assert got["history"] == []
+
+
+if __name__ == "__main__":
+    test_restore_cursor_and_inbox()
+    print("OK")

--- a/graff-evals/fixtures/rlm-showcase-gate/SPEC.md
+++ b/graff-evals/fixtures/rlm-showcase-gate/SPEC.md
@@ -1,0 +1,15 @@
+# Late rlm showcase (CodeGraff #633 / ADR 0030, distilled)
+
+`gate.py` must expose `should_showcase(*, cli=False, native_batch=None,
+mcp_batch=None, context=0, compact_at=8000) -> bool`.
+
+Showcase `rlm` when **any** of:
+
+- `cli=True` (`--rlm`)
+- `native_batch` has **≥ 4** native tool names (wide native batch)
+- `context >= compact_at // 2` (50% of compactAt)
+
+Never showcase on MCP fan-out: a 4-wide `mcp_batch` is not a native
+batch. `native_batch` / `mcp_batch` default to empty.
+
+`compact_at=8000` → threshold 4000. `context=3999` is still hidden.

--- a/graff-evals/fixtures/rlm-showcase-gate/gate.py
+++ b/graff-evals/fixtures/rlm-showcase-gate/gate.py
@@ -1,0 +1,7 @@
+"""rlm showcase gate — incomplete. Fix the SPEC.md contract."""
+
+
+def should_showcase(*, cli=False, native_batch=None, mcp_batch=None, context=0, compact_at=8000):
+    # BUG: any 4-wide batch showcases, including MCP fan-out; no 50% gate.
+    batch = list(native_batch or []) + list(mcp_batch or [])
+    return cli or len(batch) >= 4 or context > 0

--- a/graff-evals/fixtures/rlm-showcase-gate/test_gate.py
+++ b/graff-evals/fixtures/rlm-showcase-gate/test_gate.py
@@ -1,0 +1,20 @@
+from gate import should_showcase
+
+
+def test_cli_and_wide_native():
+    assert should_showcase(cli=True) is True
+    assert should_showcase(native_batch=["read_file", "codedb", "bash"]) is False
+    assert should_showcase(native_batch=["read_file", "codedb", "bash", "webfetch"]) is True
+
+
+def test_mcp_fanout_and_context():
+    mcp = ["mcp__linear__list_comments"] * 4
+    assert should_showcase(mcp_batch=mcp) is False
+    assert should_showcase(context=3999, compact_at=8000) is False
+    assert should_showcase(context=4000, compact_at=8000) is True
+
+
+if __name__ == "__main__":
+    test_cli_and_wide_native()
+    test_mcp_fanout_and_context()
+    print("OK")

--- a/graff-evals/fixtures/x-search-splice/SPEC.md
+++ b/graff-evals/fixtures/x-search-splice/SPEC.md
@@ -1,0 +1,13 @@
+# Hosted x_search is a splice, not a catalog tool (CodeGraff #632 / ADR 0031)
+
+`splice.py` must expose `splice(tools, provider, kind, enabled=True) -> list`.
+
+`tools` is a list of dicts (the Responses `tools` array). Return a new list.
+
+- When `enabled` and `provider == "xai"` and `kind == "responses"`: append
+  `{"type": "x_search"}` if that type is not already present.
+- Chat-completions (`kind == "chat"`) and every other provider: return
+  `tools` unchanged (copy ok). Never add a catalog function named `x_search`.
+- `enabled=False` (GRAFF_XAI_X_SEARCH=0): never splice.
+- Do not local-exec a resulting `x_search_call`. This fixture only covers
+  the splice.

--- a/graff-evals/fixtures/x-search-splice/splice.py
+++ b/graff-evals/fixtures/x-search-splice/splice.py
@@ -1,0 +1,8 @@
+"""x_search splice — incomplete. Fix the SPEC.md contract."""
+
+
+def splice(tools, provider, kind, enabled=True):
+    out = list(tools)
+    # BUG: always appends a catalog-style function, including chat / off.
+    out.append({"type": "function", "name": "x_search"})
+    return out

--- a/graff-evals/fixtures/x-search-splice/test_splice.py
+++ b/graff-evals/fixtures/x-search-splice/test_splice.py
@@ -1,0 +1,21 @@
+from splice import splice
+
+
+def test_xai_responses_splices_hosted():
+    tools = [{"type": "function", "name": "bash"}]
+    got = splice(tools, "xai", "responses", enabled=True)
+    assert any(t.get("type") == "x_search" for t in got)
+    assert not any(t.get("name") == "x_search" for t in got)
+
+
+def test_opt_out_and_chat_leave_tools():
+    tools = [{"type": "function", "name": "bash"}]
+    assert splice(tools, "xai", "responses", enabled=False) == tools
+    assert splice(tools, "xai", "chat", enabled=True) == tools
+    assert splice(tools, "openai", "responses", enabled=True) == tools
+
+
+if __name__ == "__main__":
+    test_xai_responses_splices_hosted()
+    test_opt_out_and_chat_leave_tools()
+    print("OK")

--- a/graff-evals/hidden/codedb-menu.py
+++ b/graff-evals/hidden/codedb-menu.py
@@ -1,0 +1,21 @@
+"""Held-out checks for codedb-menu."""
+import os
+import sys
+
+sys.path.insert(0, os.getcwd())
+from menu import HOPS, allowed, menu, usage  # noqa: E402
+
+
+def main():
+    assert "callers" not in menu()
+    assert "outline" not in usage()
+    for hop in HOPS:
+        assert allowed(hop), hop
+        assert hop not in menu()
+    assert allowed("read")
+    assert not allowed("delete")
+    print("hidden OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/graff-evals/hidden/hardlink-pin.py
+++ b/graff-evals/hidden/hardlink-pin.py
@@ -1,0 +1,30 @@
+"""Held-out checks for hardlink-pin (not copied into the sandbox)."""
+import os
+import stat
+import sys
+import tempfile
+
+sys.path.insert(0, os.getcwd())
+from pin import pin_executable  # noqa: E402
+
+
+def main():
+    with tempfile.TemporaryDirectory() as td:
+        src = os.path.join(td, "live")
+        kit = os.path.join(td, "kit")
+        os.mkdir(kit)
+        with open(src, "wb") as f:
+            f.write(b"x" * 64)
+        os.chmod(src, 0o640)
+        first = pin_executable(src, kit, "graff-pinned")
+        again = pin_executable(src, kit, "graff-pinned")
+        assert first == again
+        assert os.stat(src).st_ino == os.stat(again).st_ino
+        assert os.stat(again).st_nlink >= 2
+        assert stat.S_IMODE(os.stat(src).st_mode) == 0o640
+        assert os.path.getsize(src) == 64
+    print("hidden OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/graff-evals/hidden/mcp-first-turn.py
+++ b/graff-evals/hidden/mcp-first-turn.py
@@ -1,0 +1,21 @@
+"""Held-out checks for mcp-first-turn."""
+import os
+import sys
+
+sys.path.insert(0, os.getcwd())
+from join import defer_mcp_join, first_request_join, oneshot_skips_imported  # noqa: E402
+
+
+def main():
+    assert defer_mcp_join(False, True) is False
+    assert oneshot_skips_imported(True, True, 3) is False
+    skipped = [False]
+    assert first_request_join(1, skipped) == "skip"
+    assert first_request_join(0, skipped) == "none"
+    assert skipped == [True]
+    assert first_request_join(4, skipped) == "join"
+    print("hidden OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/graff-evals/hidden/peer-resume.py
+++ b/graff-evals/hidden/peer-resume.py
@@ -1,0 +1,23 @@
+"""Held-out checks for peer-resume."""
+import os
+import sys
+
+sys.path.insert(0, os.getcwd())
+from resume import ROOM, resume, snapshot  # noqa: E402
+
+
+def main():
+    snap = snapshot(7, [{"from": "peer", "text": "hi"}])
+    got = resume(snap)
+    assert got["cursor"] == 7
+    assert got["inbox"] == [{"from": "peer", "text": "hi"}]
+    assert got["history"] == []
+    for line in ROOM:
+        assert line not in got["history"]
+    empty = resume(snapshot(0, []))
+    assert empty["cursor"] == 0 and empty["inbox"] == [] and empty["history"] == []
+    print("hidden OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/graff-evals/hidden/rlm-showcase-gate.py
+++ b/graff-evals/hidden/rlm-showcase-gate.py
@@ -1,0 +1,18 @@
+"""Held-out checks for rlm-showcase-gate."""
+import os
+import sys
+
+sys.path.insert(0, os.getcwd())
+from gate import should_showcase  # noqa: E402
+
+
+def main():
+    assert should_showcase() is False
+    assert should_showcase(context=800, compact_at=160_000) is False
+    assert should_showcase(native_batch=["a", "b", "c", "d", "e"]) is True
+    assert should_showcase(mcp_batch=["m"] * 8, context=0) is False
+    print("hidden OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/graff-evals/hidden/x-search-splice.py
+++ b/graff-evals/hidden/x-search-splice.py
@@ -1,0 +1,20 @@
+"""Held-out checks for x-search-splice."""
+import os
+import sys
+
+sys.path.insert(0, os.getcwd())
+from splice import splice  # noqa: E402
+
+
+def main():
+    already = [{"type": "x_search"}]
+    got = splice(already, "xai", "responses", enabled=True)
+    assert sum(1 for t in got if t.get("type") == "x_search") == 1
+    empty = splice([], "xai", "responses", enabled=True)
+    assert empty == [{"type": "x_search"}]
+    assert splice([], "anthropic", "responses", enabled=True) == []
+    print("hidden OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/graff-evals/hillclimb/baseline.md
+++ b/graff-evals/hillclimb/baseline.md
@@ -26,6 +26,30 @@ In-house 6 PR fixtures:
 | grok | 5/6 | 396s | 2.4s | 30 | 535344 | $0.4285 | 157.7M |
 | opencode | **6/6** | 182.1s | 2.8s | 37 | 340074 | $0.3835 | 1103.9M |
 
+## 12-task in-house remasure (`run-20260830-141658`)
+
+Same SuperGrok seat, jobs=1, grok-4.6, `x_search` on, the six original
+fixtures plus #690 (`hardlink-pin`, `x-search-splice`, `mcp-first-turn`,
+`rlm-showcase-gate`, `codedb-menu`, `peer-resume`). All three harnesses
+**12/12**.
+
+| harness | pass | wall | first | calls | tokens | list$ | RSS |
+|---|---:|---:|---:|---:|---:|---:|
+| graff-dev | **12/12** | **192.1s** | 0.02s† | **52** | **227856** | **$0.3504** | **91.7M** |
+| grok | 12/12 | 461.8s | 3.8s | 63 | 1177050 | $1.1152 | 169.6M |
+| opencode | 12/12 | 235.8s | 2.7s | 74 | 674794 | $0.7916 | 1099.6M |
+
+† Graff `first_out_s` is 0.02s on **every** task — the first stderr line
+(`›` / boot), not first model SSE. Do not score it as TTFT. OpenCode 2.7s
+and grok 3.8s are real first bytes. Unique frontier on pass / wall /
+calls / tokens / list$ / RSS. First-token is **not** a named win on this
+run.
+
+OpenCode was faster on one task (`mcp-first-turn` 17.1s vs graff 18.3s).
+Suite totals still graff.
+
+![12-task in-house frontier](frontier-inhouse-12-20260830-141658.svg)
+
 ## Latest climb — PARETO (`run-20260830-122731` in-house, `run-20260830-124315` spine)
 
 Same SuperGrok seat, jobs=1, `x_search` on, ReleaseSafe `-p`. Graff is
@@ -130,9 +154,9 @@ grok-4.6 list price.
 In-house suite (`--suite inhouse`): twelve bug shapes distilled from shipped
 CodeGraff PRs. First six: #685/#405 symlink write, oneshot stdout chrome,
 cache-affinity git root, #681 stall widen, rlm-empty-tools catalog,
-stall-bus-silent warn. Next six (verifiers in, not yet remeasured):
-#687 hardlink pin, #632 x_search splice, ADR 0035 MCP first-turn,
-#633 rlm showcase gate, #597 codedb menu, #584 peer resume. Fixtures live
+stall-bus-silent warn. Next six (#690): #687 hardlink pin, #632 x_search splice, ADR 0035 MCP
+first-turn, #633 rlm showcase gate, #597 codedb menu, #584 peer resume.
+Remeasured `run-20260830-141658` (12/12 all harnesses). Fixtures live
 under `graff-evals/tasks/` + `fixtures/`; they are not the live repo.
 
 Axes: wall, first-token latency, tool calls, tokens (uncached + cached + out),

--- a/graff-evals/hillclimb/baseline.md
+++ b/graff-evals/hillclimb/baseline.md
@@ -127,11 +127,13 @@ Same-model series is grok-4.6. Native-default series (`opencode-zen`,
 `dsh-deepseek`) is a **different chart** — do not read those points as
 grok-4.6 list price.
 
-In-house suite (`--suite inhouse`): six bug shapes distilled from shipped
-CodeGraff PRs (#685/#405 symlink write, oneshot stdout chrome,
+In-house suite (`--suite inhouse`): twelve bug shapes distilled from shipped
+CodeGraff PRs. First six: #685/#405 symlink write, oneshot stdout chrome,
 cache-affinity git root, #681 stall widen, rlm-empty-tools catalog,
-stall-bus-silent warn). Fixtures live under `graff-evals/tasks/` +
-`fixtures/`; they are not the live repo.
+stall-bus-silent warn. Next six (verifiers in, not yet remeasured):
+#687 hardlink pin, #632 x_search splice, ADR 0035 MCP first-turn,
+#633 rlm showcase gate, #597 codedb menu, #584 peer resume. Fixtures live
+under `graff-evals/tasks/` + `fixtures/`; they are not the live repo.
 
 Axes: wall, first-token latency, tool calls, tokens (uncached + cached + out),
 xAI list-price USD (`$2/$0.50/$6` per 1M under 200k prompt tokens; `$4/$1/$12`

--- a/graff-evals/hillclimb/frontier-inhouse-12-20260830-141658.svg
+++ b/graff-evals/hillclimb/frontier-inhouse-12-20260830-141658.svg
@@ -1,0 +1,106 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 490" width="880" height="490" role="img">
+<title>In-house 12 · grok-4.6 · run-20260830-141658</title>
+<rect width="880" height="490" fill="#ffffff"/>
+<text x="20" y="22" font-size="16" font-weight="700" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">In-house 12 · grok-4.6 · run-20260830-141658</text>
+<text x="20" y="40" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">12/12 all harnesses. Lower-left better. Graff first-token is stderr › at boot (0.02s) — not plotted as TTFT.</text>
+<rect x="72" y="62" width="340" height="280" fill="#fafcfb" stroke="#d1d5db"/>
+<rect x="500" y="62" width="340" height="280" fill="#fafcfb" stroke="#d1d5db"/>
+<text x="72" y="56" font-size="13" font-weight="600" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">wall vs list$</text>
+<text x="500" y="56" font-size="13" font-weight="600" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">calls vs list$</text>
+<text x="242" y="376" text-anchor="middle" font-size="12" fill="#334155" font-family="ui-sans-serif, system-ui, sans-serif">wall (s) →</text>
+<text x="670" y="376" text-anchor="middle" font-size="12" fill="#334155" font-family="ui-sans-serif, system-ui, sans-serif">tool calls →</text>
+<line x1="72" y1="342.0" x2="412" y2="342.0" stroke="#e5e7eb"/>
+<line x1="500" y1="342.0" x2="840" y2="342.0" stroke="#e5e7eb"/>
+<text x="64" y="346.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.000</text>
+<text x="492" y="346.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.000</text>
+<line x1="72" y1="278.0" x2="412" y2="278.0" stroke="#e5e7eb"/>
+<line x1="500" y1="278.0" x2="840" y2="278.0" stroke="#e5e7eb"/>
+<text x="64" y="282.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.321</text>
+<text x="492" y="282.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.321</text>
+<line x1="72" y1="214.0" x2="412" y2="214.0" stroke="#e5e7eb"/>
+<line x1="500" y1="214.0" x2="840" y2="214.0" stroke="#e5e7eb"/>
+<text x="64" y="218.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.641</text>
+<text x="492" y="218.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.641</text>
+<line x1="72" y1="150.0" x2="412" y2="150.0" stroke="#e5e7eb"/>
+<line x1="500" y1="150.0" x2="840" y2="150.0" stroke="#e5e7eb"/>
+<text x="64" y="154.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.962</text>
+<text x="492" y="154.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.962</text>
+<line x1="72" y1="86.0" x2="412" y2="86.0" stroke="#e5e7eb"/>
+<line x1="500" y1="86.0" x2="840" y2="86.0" stroke="#e5e7eb"/>
+<text x="64" y="90.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$1.283</text>
+<text x="492" y="90.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$1.283</text>
+<line x1="72.0" y1="62" x2="72.0" y2="342" stroke="#e5e7eb"/>
+<text x="72.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">163s</text>
+<line x1="157.0" y1="62" x2="157.0" y2="342" stroke="#e5e7eb"/>
+<text x="157.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">252s</text>
+<line x1="242.0" y1="62" x2="242.0" y2="342" stroke="#e5e7eb"/>
+<text x="242.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">340s</text>
+<line x1="327.0" y1="62" x2="327.0" y2="342" stroke="#e5e7eb"/>
+<text x="327.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">429s</text>
+<line x1="412.0" y1="62" x2="412.0" y2="342" stroke="#e5e7eb"/>
+<text x="412.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">517s</text>
+<line x1="516.7" y1="62" x2="516.7" y2="342" stroke="#e5e7eb"/>
+<text x="516.7" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">52</text>
+<line x1="530.7" y1="62" x2="530.7" y2="342" stroke="#e5e7eb"/>
+<text x="530.7" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">53</text>
+<line x1="544.6" y1="62" x2="544.6" y2="342" stroke="#e5e7eb"/>
+<text x="544.6" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">54</text>
+<line x1="558.5" y1="62" x2="558.5" y2="342" stroke="#e5e7eb"/>
+<text x="558.5" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">55</text>
+<line x1="572.5" y1="62" x2="572.5" y2="342" stroke="#e5e7eb"/>
+<text x="572.5" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">56</text>
+<line x1="586.4" y1="62" x2="586.4" y2="342" stroke="#e5e7eb"/>
+<text x="586.4" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">57</text>
+<line x1="600.3" y1="62" x2="600.3" y2="342" stroke="#e5e7eb"/>
+<text x="600.3" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">58</text>
+<line x1="614.3" y1="62" x2="614.3" y2="342" stroke="#e5e7eb"/>
+<text x="614.3" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">59</text>
+<line x1="628.2" y1="62" x2="628.2" y2="342" stroke="#e5e7eb"/>
+<text x="628.2" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">60</text>
+<line x1="642.1" y1="62" x2="642.1" y2="342" stroke="#e5e7eb"/>
+<text x="642.1" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">61</text>
+<line x1="656.1" y1="62" x2="656.1" y2="342" stroke="#e5e7eb"/>
+<text x="656.1" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">62</text>
+<line x1="670.0" y1="62" x2="670.0" y2="342" stroke="#e5e7eb"/>
+<text x="670.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">63</text>
+<line x1="683.9" y1="62" x2="683.9" y2="342" stroke="#e5e7eb"/>
+<text x="683.9" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">64</text>
+<line x1="697.9" y1="62" x2="697.9" y2="342" stroke="#e5e7eb"/>
+<text x="697.9" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">65</text>
+<line x1="711.8" y1="62" x2="711.8" y2="342" stroke="#e5e7eb"/>
+<text x="711.8" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">66</text>
+<line x1="725.7" y1="62" x2="725.7" y2="342" stroke="#e5e7eb"/>
+<text x="725.7" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">67</text>
+<line x1="739.7" y1="62" x2="739.7" y2="342" stroke="#e5e7eb"/>
+<text x="739.7" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">68</text>
+<line x1="753.6" y1="62" x2="753.6" y2="342" stroke="#e5e7eb"/>
+<text x="753.6" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">69</text>
+<line x1="767.5" y1="62" x2="767.5" y2="342" stroke="#e5e7eb"/>
+<text x="767.5" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">70</text>
+<line x1="781.5" y1="62" x2="781.5" y2="342" stroke="#e5e7eb"/>
+<text x="781.5" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">71</text>
+<line x1="795.4" y1="62" x2="795.4" y2="342" stroke="#e5e7eb"/>
+<text x="795.4" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">72</text>
+<line x1="809.3" y1="62" x2="809.3" y2="342" stroke="#e5e7eb"/>
+<text x="809.3" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">73</text>
+<line x1="823.3" y1="62" x2="823.3" y2="342" stroke="#e5e7eb"/>
+<text x="823.3" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">74</text>
+<circle cx="99.7" cy="272.1" r="6.5" fill="#059669" stroke="#047857" stroke-width="1.4"/>
+<text x="109.7" y="264.1" font-size="11" font-weight="600" fill="#047857" font-family="ui-sans-serif, system-ui, sans-serif">graff-dev  192.1s · $0.3504</text>
+<circle cx="516.7" cy="272.1" r="6.5" fill="#059669" stroke="#047857" stroke-width="1.4"/>
+<text x="526.7" y="264.1" font-size="11" font-weight="600" fill="#047857" font-family="ui-sans-serif, system-ui, sans-serif">graff-dev  52 · $0.3504</text>
+<circle cx="28" cy="410" r="6.5" fill="#059669" stroke="#047857" stroke-width="1.4"/>
+<text x="40" y="414" font-size="12" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">graff-dev — 12/12 · on wall/$ + calls/$</text>
+<circle cx="358.8" cy="119.4" r="6.5" fill="#334155" stroke="#1e293b" stroke-width="1.4"/>
+<text x="368.8" y="111.4" font-size="11" font-weight="600" fill="#1e293b" font-family="ui-sans-serif, system-ui, sans-serif">grok  461.8s · $1.1152</text>
+<circle cx="670.0" cy="119.4" r="6.5" fill="#334155" stroke="#1e293b" stroke-width="1.4"/>
+<text x="680.0" y="111.4" font-size="11" font-weight="600" fill="#1e293b" font-family="ui-sans-serif, system-ui, sans-serif">grok  63 · $1.1152</text>
+<circle cx="28" cy="430" r="6.5" fill="#334155" stroke="#1e293b" stroke-width="1.4"/>
+<text x="40" y="434" font-size="12" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">grok — 12/12 · interior</text>
+<circle cx="141.6" cy="184.0" r="6.5" fill="#2563eb" stroke="#1d4ed8" stroke-width="1.4"/>
+<text x="151.6" y="176.0" font-size="11" font-weight="600" fill="#1d4ed8" font-family="ui-sans-serif, system-ui, sans-serif">opencode  235.8s · $0.7916</text>
+<circle cx="823.3" cy="184.0" r="6.5" fill="#2563eb" stroke="#1d4ed8" stroke-width="1.4"/>
+<text x="833.3" y="176.0" font-size="11" font-weight="600" fill="#1d4ed8" font-family="ui-sans-serif, system-ui, sans-serif">opencode  74 · $0.7916</text>
+<circle cx="28" cy="450" r="6.5" fill="#2563eb" stroke="#1d4ed8" stroke-width="1.4"/>
+<text x="40" y="454" font-size="12" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">opencode — 12/12 · interior</text>
+</svg>

--- a/graff-evals/tasks/40-hardlink-pin.json
+++ b/graff-evals/tasks/40-hardlink-pin.json
@@ -1,0 +1,10 @@
+{
+  "id": "hardlink-pin",
+  "suite": "inhouse",
+  "category": "inhouse",
+  "source": "codegraff #687 — hardlink graff-pinned instead of a 127M copy (distilled, not the live repo)",
+  "files_dir": "fixtures/hardlink-pin",
+  "prompt": "pin.py:pin_executable byte-copies the exe and chmods the dest. Read SPEC.md and pin.py, then edit pin.py so `python3 test_pin.py` prints OK. Do not only describe the fix. Do not edit the tests. Prefer os.link so the pin and the live path share an inode; never chmod the dest.",
+  "check": "python3 test_pin.py && python3 \"$TASK_ROOT/hidden/hardlink-pin.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/41-x-search-splice.json
+++ b/graff-evals/tasks/41-x-search-splice.json
@@ -1,0 +1,10 @@
+{
+  "id": "x-search-splice",
+  "suite": "inhouse",
+  "category": "inhouse",
+  "source": "codegraff #632 / ADR 0031 — hosted x_search on xAI Responses, not a catalog function (distilled)",
+  "files_dir": "fixtures/x-search-splice",
+  "prompt": "splice.py:splice always appends a catalog function named x_search. Read SPEC.md and splice.py, then edit splice.py so `python3 test_splice.py` prints OK. Do not only describe the fix. Do not edit the tests. Hosted x_search is {\"type\":\"x_search\"} on xai+responses when enabled; chat and other providers stay unchanged.",
+  "check": "python3 test_splice.py && python3 \"$TASK_ROOT/hidden/x-search-splice.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/42-mcp-first-turn.json
+++ b/graff-evals/tasks/42-mcp-first-turn.json
@@ -1,0 +1,10 @@
+{
+  "id": "mcp-first-turn",
+  "suite": "inhouse",
+  "category": "inhouse",
+  "source": "codegraff ADR 0035 / 0029 — first -p turn skips the MCP handshake wait (distilled)",
+  "files_dir": "fixtures/mcp-first-turn",
+  "prompt": "join.py always waits on MCP before the first model call. Read SPEC.md and join.py, then edit join.py so `python3 test_join.py` prints OK. Do not only describe the fix. Do not edit the tests. First request with pending handshakes is skip; --json still blocks; lean -p still connects a project .mcp.json.",
+  "check": "python3 test_join.py && python3 \"$TASK_ROOT/hidden/mcp-first-turn.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/43-rlm-showcase-gate.json
+++ b/graff-evals/tasks/43-rlm-showcase-gate.json
@@ -1,0 +1,10 @@
+{
+  "id": "rlm-showcase-gate",
+  "suite": "inhouse",
+  "category": "inhouse",
+  "source": "codegraff #633 / ADR 0030 — showcase rlm on --rlm, 4-wide native, or 50% compactAt; never MCP fan-out (distilled)",
+  "files_dir": "fixtures/rlm-showcase-gate",
+  "prompt": "gate.py:should_showcase treats MCP fan-out like a wide native batch and showcases on any context>0. Read SPEC.md and gate.py, then edit gate.py so `python3 test_gate.py` prints OK. Do not only describe the fix. Do not edit the tests. Showcase on --rlm, ≥4 native names, or context ≥ compactAt/2.",
+  "check": "python3 test_gate.py && python3 \"$TASK_ROOT/hidden/rlm-showcase-gate.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/44-codedb-menu.json
+++ b/graff-evals/tasks/44-codedb-menu.json
@@ -1,0 +1,10 @@
+{
+  "id": "codedb-menu",
+  "suite": "inhouse",
+  "category": "inhouse",
+  "source": "codegraff #597 / ADR 0019 — advertise five codedb one-shots; hop verbs stay callable (distilled)",
+  "files_dir": "fixtures/codedb-menu",
+  "prompt": "menu.py puts hop verbs on the catalog listing and rejects them as calls. Read SPEC.md and menu.py, then edit menu.py so `python3 test_menu.py` prints OK. Do not only describe the fix. Do not edit the tests. menu() is context/around/callpath/list_dir/status; search/symbol stay allowed.",
+  "check": "python3 test_menu.py && python3 \"$TASK_ROOT/hidden/codedb-menu.py\"",
+  "timeout_s": 240
+}

--- a/graff-evals/tasks/45-peer-resume.json
+++ b/graff-evals/tasks/45-peer-resume.json
@@ -1,0 +1,10 @@
+{
+  "id": "peer-resume",
+  "suite": "inhouse",
+  "category": "inhouse",
+  "source": "codegraff #584 / ADR 0014 — resume restores peer cursor and inbox, does not replay the room (distilled)",
+  "files_dir": "fixtures/peer-resume",
+  "prompt": "resume.py:resume drops the cursor/inbox and replays ROOM into history. Read SPEC.md and resume.py, then edit resume.py so `python3 test_resume.py` prints OK. Do not only describe the fix. Do not edit the tests. Restore cursor and inbox; history stays empty.",
+  "check": "python3 test_resume.py && python3 \"$TASK_ROOT/hidden/peer-resume.py\"",
+  "timeout_s": 240
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Doubles `--suite inhouse` and shortens the root README. Landed on `release/v0.0.281` (`831272d`). No tag. No merge to main.

## README

Visible page is **~200 lines** (was ~1700). Same-model 12-task table is on it. CLI / slash / providers live in one `<details>`. The retracted oneshot-learn-skip blurb is gone.

## Same-session remasure (`run-20260830-141658`)

| harness | pass | wall | calls | tokens | list$ | RSS |
|---|---:|---:|---:|---:|---:|---:|
| graff-dev | **12/12** | **192.1s** | **52** | **227856** | **$0.3504** | **91.7M** |
| grok | 12/12 | 461.8s | 63 | 1177050 | $1.1152 | 169.6M |
| opencode | 12/12 | 235.8s | 74 | 674794 | $0.7916 | 1099.6M |

Unique frontier on pass / wall / calls / tokens / list$ / RSS. Graff first-token 0.02s is boot stderr — not scored.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

