### PR TITLE
fix(tui): preserve legacy Alt navigation

### DIFF
--- a/TUI/issue_524_tests.zig
+++ b/TUI/issue_524_tests.zig
@@ -1,0 +1,239 @@
+//! Reachable fullscreen TUI regressions for legacy ESC ESC CSI navigation.
+
+const std = @import("std");
+
+const app = @import("app.zig");
+const engine = @import("engine.zig");
+const key = @import("key.zig");
+const recover = @import("key_recover.zig");
+const stall = @import("run_stall.zig");
+const Term = @import("sim.zig").Term;
+
+const Trajectory = enum { idle, live_turn, compact, bash, files };
+const trajectories = [_]Trajectory{ .idle, .live_turn, .compact, .bash, .files };
+
+const Fixture = struct {
+    term: Term,
+    bg: ?*engine.BgOp = null,
+
+    fn init(trajectory: Trajectory) !Fixture {
+        var fixture: Fixture = undefined;
+        fixture.bg = null;
+        fixture.term.init(std.testing.allocator, 80, 24);
+        errdefer fixture.term.deinit();
+        try fixture.term.model.push(.user, "existing turn");
+        switch (trajectory) {
+            .idle => {},
+            .live_turn => {
+                const job = try std.testing.allocator.create(engine.Job);
+                job.* = .{ .gpa = std.testing.allocator, .history = &.{}, .params = .{}, .stream = .{}, .threaded = false };
+                try fixture.term.model.push(.pending, "");
+                fixture.term.model.pending = job;
+            },
+            .compact, .bash, .files => {
+                const op = try std.testing.allocator.create(engine.BgOp);
+                op.* = .{ .kind = switch (trajectory) {
+                    .compact => .compact,
+                    .bash => .bash,
+                    .files => .files,
+                    else => unreachable,
+                }, .gpa = std.testing.allocator, .threaded = false };
+                try fixture.term.model.push(.pending, "background operation");
+                fixture.term.model.bg = op;
+                fixture.bg = op;
+            },
+        }
+        return fixture;
+    }
+
+    fn deinit(self: *Fixture) void {
+        if (self.bg) |op| {
+            self.term.model.bg = null;
+            std.testing.allocator.destroy(op);
+        }
+        if (self.term.model.pending) |job| {
+            self.term.model.pending = null;
+            std.testing.allocator.destroy(job);
+        }
+        self.term.deinit();
+    }
+};
+
+fn expectAlive(fixture: *Fixture, trajectory: Trajectory) !void {
+    try std.testing.expect(!fixture.term.model.cancel_requested);
+    try std.testing.expect(fixture.term.last_effect == .stay);
+    if (trajectory == .live_turn) try std.testing.expect(fixture.term.model.pending != null);
+    if (trajectory != .idle and trajectory != .live_turn)
+        try std.testing.expect(fixture.bg != null and !fixture.bg.?.cancelled);
+}
+
+test "legacy Alt CSI decodes to the underlying navigation keys" {
+    const cases = [_]struct { bytes: []const u8, expected: key.Key }{
+        .{ .bytes = "\x1b\x1b[D", .expected = .left },
+        .{ .bytes = "\x1b\x1b[C", .expected = .right },
+        .{ .bytes = "\x1b\x1b[A", .expected = .up },
+        .{ .bytes = "\x1b\x1b[1;3A", .expected = .up },
+        .{ .bytes = "\x1b\x1b[1;3C", .expected = .word_right },
+        .{ .bytes = "\x1b\x1b[1;3D", .expected = .word_left },
+    };
+    key.resetInputState();
+    defer key.resetInputState();
+    for (cases) |case| {
+        var i: usize = 0;
+        try std.testing.expectEqual(case.expected, key.next(case.bytes, &i).?);
+        try std.testing.expectEqual(case.bytes.len, i);
+        try std.testing.expect(key.next(case.bytes, &i) == null);
+    }
+}
+
+test "legacy Alt CSI navigation accepts a coalesced printable key" {
+    const sequences = [_][]const u8{
+        "\x1b\x1b[Ax",
+        "\x1b\x1b[Cx",
+        "\x1b\x1b[Dx",
+        "\x1b\x1b[1;3Ax",
+        "\x1b\x1b[1;3Cx",
+        "\x1b\x1b[1;3Dx",
+    };
+    for (trajectories) |trajectory| for (sequences) |sequence| {
+        var fixture = try Fixture.init(trajectory);
+        defer fixture.deinit();
+        _ = fixture.term.feed(sequence);
+        try std.testing.expectEqualStrings("x", fixture.term.model.input.getValue());
+        try expectAlive(&fixture, trajectory);
+    };
+}
+
+test "legacy Alt CSI boundary preserves printable prose on every TUI trajectory" {
+    const prose = [_]struct { sequence: []const u8, expected: []const u8 }{
+        .{ .sequence = "\x1b\x1b[Alice]", .expected = "seed:[Alice]" },
+        .{ .sequence = "\x1b\x1b[1;3Alice]", .expected = "seed:[1;3Alice]" },
+    };
+    for (trajectories) |trajectory| for (prose) |case| {
+        var fixture = try Fixture.init(trajectory);
+        defer fixture.deinit();
+        try fixture.term.model.input.setValue("seed:");
+        fixture.term.model.scroll = 7;
+        fixture.term.model.follow = false;
+        _ = fixture.term.feed(case.sequence);
+        try std.testing.expectEqualStrings(case.expected, fixture.term.model.input.getValue());
+        try std.testing.expectEqual(@as(usize, 7), fixture.term.model.scroll);
+        try std.testing.expectEqual(app.Overlay.none, fixture.term.model.overlay);
+    };
+}
+
+test "legacy Alt CSI navigation never emits Escape on any TUI trajectory" {
+    const sequences = [_][]const u8{
+        "\x1b\x1b[D",
+        "\x1b\x1b[C",
+        "\x1b\x1b[A",
+        "\x1b\x1b[1;3A",
+        "\x1b\x1b[1;3C",
+        "\x1b\x1b[1;3D",
+    };
+    for (trajectories) |trajectory| {
+        for (sequences) |sequence| {
+            for (0..sequence.len + 1) |cut| {
+                var fixture = try Fixture.init(trajectory);
+                defer fixture.deinit();
+                _ = fixture.term.feed(sequence[0..cut]);
+                _ = fixture.term.feed(sequence[cut..]);
+                try std.testing.expectEqual(@as(usize, 0), fixture.term.pending);
+                try expectAlive(&fixture, trajectory);
+            }
+        }
+    }
+}
+
+test "legacy Alt CSI stays safe across the bounded stall window" {
+    const sequences = [_][]const u8{
+        "\x1b\x1b[A",
+        "\x1b\x1b[C",
+        "\x1b\x1b[D",
+        "\x1b\x1b[1;3A",
+        "\x1b\x1b[1;3C",
+        "\x1b\x1b[1;3D",
+    };
+    for (trajectories) |trajectory| for (sequences) |sequence| {
+        const grace: u8 = if (trajectory == .idle) 12 else stall.live_escape_stalls;
+        for (0..sequence.len) |cut| {
+            var fixture = try Fixture.init(trajectory);
+            defer fixture.deinit();
+            _ = fixture.term.feed(sequence[0..cut]);
+            for (0..grace - 1) |_| try std.testing.expectEqual(stall.StallVerdict.wait, fixture.term.stallTimeout());
+            _ = fixture.term.feed(sequence[cut..]);
+            try std.testing.expectEqual(@as(usize, 0), fixture.term.pending);
+            try expectAlive(&fixture, trajectory);
+        }
+    };
+}
+
+test "legacy Alt CSI rejoins after a dropped head and a full read" {
+    const cases = [_]struct { tail: []const u8, expected: key.Key }{
+        .{ .tail = "A", .expected = .up },
+        .{ .tail = "C", .expected = .right },
+        .{ .tail = "D", .expected = .left },
+        .{ .tail = "1;3A", .expected = .up },
+        .{ .tail = "1;3C", .expected = .word_right },
+        .{ .tail = "1;3D", .expected = .word_left },
+    };
+    for (cases) |case| {
+        key.resetInputState();
+        key.abandonSequence("\x1b\x1b[", .dropped);
+        var buf: [16 * 1024]u8 = @splat('x');
+        @memcpy(buf[0..case.tail.len], case.tail);
+        const n = key.joinOrphanHead(&buf, buf.len);
+        var i: usize = 0;
+        try std.testing.expectEqual(case.expected, key.next(buf[0..n], &i).?);
+        try std.testing.expectEqual(key.Key{ .char = 'x' }, key.next(buf[0..n], &i).?);
+    }
+    key.resetInputState();
+    key.abandonSequence("\x1b\x1b[", .dropped);
+    var prose: [16]u8 = @splat(0);
+    @memcpy(prose[0..6], "Alice]");
+    try std.testing.expectEqual(@as(?usize, 1), recover.legacyCsiProse("\x1b\x1b[", "Alice]", 9));
+    const prose_n = key.joinOrphanHead(&prose, 6);
+    try std.testing.expectEqual(@as(usize, 7), prose_n);
+    var prose_i: usize = 0;
+    for ("[Alice]") |expected| try std.testing.expectEqual(key.Key{ .char = expected }, key.next(prose[0..prose_n], &prose_i).?);
+    try std.testing.expectEqual(prose_n, prose_i);
+    key.resetInputState();
+}
+
+test "legacy Alt CSI survives the runtime dropped-head seam" {
+    var fixture = try Fixture.init(.live_turn);
+    defer fixture.deinit();
+    _ = fixture.term.feed("\x1b\x1b[");
+    fixture.term.stallDropPending();
+    _ = fixture.term.feed("1;3D");
+    try std.testing.expectEqual(@as(usize, 0), fixture.term.pending);
+    try expectAlive(&fixture, .live_turn);
+}
+
+test "genuine double Escape still arms rewind after legacy Alt ambiguity expires" {
+    var fixture = try Fixture.init(.idle);
+    defer fixture.deinit();
+    _ = fixture.term.feed("\x1b\x1b");
+    for (0..11) |_| try std.testing.expectEqual(stall.StallVerdict.wait, fixture.term.stallTimeout());
+    try std.testing.expectEqual(stall.StallVerdict.escape_pair, fixture.term.stallTimeout());
+    try std.testing.expectEqual(app.Overlay.rewind, fixture.term.model.overlay);
+}
+
+test "legacy Alt CSI does not close a paste or move through an overlay" {
+    var paste = try Fixture.init(.idle);
+    defer paste.deinit();
+    _ = paste.term.feed("\x1b[200~");
+    _ = paste.term.feed("\x1b\x1b[1;3D");
+    try std.testing.expect(key.inPaste());
+    try std.testing.expectEqualStrings("", paste.term.model.input.getValue());
+    _ = paste.term.feed("\x1b[201~");
+    try std.testing.expect(!key.inPaste());
+
+    var overlay = try Fixture.init(.idle);
+    defer overlay.deinit();
+    overlay.term.model.openOverlay(.palette);
+    overlay.term.model.overlay_sel = 1;
+    _ = overlay.term.feed("\x1b\x1b[A");
+    try std.testing.expectEqual(app.Overlay.palette, overlay.term.model.overlay);
+    try std.testing.expectEqual(@as(usize, 0), overlay.term.model.overlay_sel);
+}

--- a/TUI/key.zig
+++ b/TUI/key.zig
@@ -2,6 +2,7 @@
 
 const std = @import("std");
 const orphan = @import("key_orphan.zig");
+const recover = @import("key_recover.zig");
 const paste = @import("key_paste.zig");
 
 /// Super/alt currently held, from kitty modifier-key events (Ghostty Cmd+Delete
@@ -187,16 +188,27 @@ fn escapeSeq(bytes: []const u8, i: *usize) ?Key {
         i.* += 1;
         return .shift_enter;
     }
-    if (c0 == 0x1b) return .escape; // ESC ESC — deliver one, reparse the rest
-    if (c0 == 'O') return ss3(bytes, i);
-    if (c0 == ']' or c0 == 'P' or c0 == '_' or c0 == '^' or c0 == 'X') return stringSeq(bytes, i);
-    if (c0 != '[') {
-        // Unbound Alt+<char> chord: swallow both bytes so the char is not
-        // typed into the composer behind a phantom Escape.
+    const double_esc = c0 == 0x1b;
+    if (double_esc) {
+        // Legacy Alt arrows are ESC ESC CSI. Keep both ESC bytes ambiguous
+        // until the CSI is complete, otherwise the first one cancels work.
+        if (i.* + 1 >= bytes.len) {
+            i.* -= 1;
+            return null;
+        }
+        if (bytes[i.* + 1] != '[') return .escape;
+        i.* += 2;
+    } else {
+        if (c0 == 'O') return ss3(bytes, i);
+        if (c0 == ']' or c0 == 'P' or c0 == '_' or c0 == '^' or c0 == 'X') return stringSeq(bytes, i);
+        if (c0 != '[') {
+            // Unbound Alt+<char> chord: swallow both bytes so the char is not
+            // typed into the composer behind a phantom Escape.
+            i.* += 1;
+            return .ignore;
+        }
         i.* += 1;
-        return .ignore;
     }
-    i.* += 1;
     const start = i.*;
     while (i.* < bytes.len) : (i.* += 1) {
         const c = bytes[i.*];
@@ -209,11 +221,12 @@ fn escapeSeq(bytes: []const u8, i: *usize) ?Key {
             const params = bytes[start..i.*];
             i.* += 1;
             if (final == 'M' and params.len == 0) return x10Mouse(bytes, i, start);
+            if (double_esc and !recover.legacyCsiBoundary(params, final, bytes, i.*)) return recover.legacyDoubleEscape(i, start);
             return decodeCsi(params, final);
         }
     }
     // Incomplete CSI (split paste / arrow) — rewind so the next read can finish it.
-    i.* = start - 2;
+    i.* = start - @as(usize, if (double_esc) 3 else 2);
     return null;
 }
 

--- a/TUI/key_orphan.zig
+++ b/TUI/key_orphan.zig
@@ -114,6 +114,7 @@ fn validPartial(h: []const u8, t: []const u8) bool {
     if (n == 0 or n > max_head or at(h, t, 0) != 0x1b) return false;
     if (n == 1) return true;
     switch (at(h, t, 1)) {
+        0x1b => return recover.legacyCsiPrefix(h, t, n),
         'O' => return n < 3,
         '[' => {
             var k: usize = 2;
@@ -157,6 +158,14 @@ pub fn joinHead(buf: []u8, n: usize) usize {
     const h = head_len;
     if (h == 0 or n == 0) return n;
     const dropped = armed;
+    if (recover.legacyCsiProse(head[0..h], buf[0..n], h + n)) |prefix_len| {
+        if (prefix_len + n <= buf.len) {
+            std.mem.copyBackwards(u8, buf[prefix_len .. prefix_len + n], buf[0..n]);
+            @memcpy(buf[0..prefix_len], head[2..h]);
+            disarm();
+            return prefix_len + n;
+        }
+    }
     const progress = if (dropped) pasteProgress(head[0..h], buf[0..n]) else null;
     if (completesWithEvidence(head[0..h], buf[0..n], dropped)) {
         if (h + n <= buf.len) {
@@ -227,8 +236,11 @@ pub fn completes(h: []const u8, t: []const u8) bool {
 fn completesWithEvidence(h: []const u8, t: []const u8, dropped: bool) bool {
     const n = h.len + t.len;
     if (h.len == 0 or t.len == 0 or h[0] != 0x1b or n < 2) return false;
+    // The first ESC was already delivered by the bounded genuine-Escape path;
+    // do not turn its late second ESC into a new double-Escape candidate.
+    if (!dropped and h.len == 1 and t[0] == 0x1b) return false;
     switch (at(h, t, 1)) {
-        0x1b => return true, // ESC ESC — a real Escape either way
+        0x1b => return if (n > 2 and at(h, t, 2) == '[') recover.legacyCsiComplete(h, t, n, dropped) else true,
         'O' => return n >= 3 and isSs3Final(at(h, t, 2)) and
             (n == 3 or at(h, t, 3) < 0x20 or at(h, t, 3) == 0x7f),
         '[' => {

--- a/TUI/key_recover.zig
+++ b/TUI/key_recover.zig
@@ -7,6 +7,84 @@ const Key = key.Key;
 pub const Event = struct { event: Key, tail_len: usize };
 const max_body = 128;
 
+pub fn legacyCsiPrefix(head: []const u8, tail: []const u8, n: usize) bool {
+    if (n == 2) return true;
+    if (n < 3 or at(head, tail, 2) != '[') return false;
+    for (3..n) |i| {
+        const c = at(head, tail, i);
+        if (c < 0x20 or c > 0x3f) return false;
+    }
+    return true;
+}
+
+pub fn legacyCsiNavigation(params: []const u8, final: u8) bool {
+    if (final < 'A' or final > 'D') return false;
+    if (params.len == 0) return true;
+    var semicolon = false;
+    var field: u32 = 0;
+    var need_digit = true;
+    for (params) |c| {
+        if (c >= '0' and c <= '9') {
+            field = field *| 10 +| (c - '0');
+            need_digit = false;
+        } else if (c == ';' and !need_digit) {
+            semicolon = true;
+            field = 0;
+            need_digit = true;
+        } else return false;
+    }
+    return !need_digit and (!semicolon or field == 3);
+}
+
+fn legacyNavigation(head: []const u8, tail: []const u8, start: usize, end: usize, final: u8) bool {
+    var params_buf: [max_body]u8 = undefined;
+    const params = combinedSlice(head, tail, start, end, &params_buf) orelse return false;
+    return legacyCsiNavigation(params, final);
+}
+
+pub fn legacyCsiBoundary(params: []const u8, final: u8, bytes: []const u8, after: usize) bool {
+    if (!legacyCsiNavigation(params, final)) return true;
+    // A complete navigation may share a read with the next printable key.
+    // Reject only recognizable bracketed prose, not every printable suffix.
+    var i = after;
+    while (i < bytes.len and bytes[i] >= 0x20 and bytes[i] <= 0x7e) : (i += 1) {
+        if (bytes[i] == ']') return false;
+    }
+    return true;
+}
+
+/// A recovered double-ESC prefix that was followed by bracketed prose. Return
+/// the literal CSI prefix so the recovery path can preserve the human text.
+pub fn legacyCsiProse(head: []const u8, tail: []const u8, n: usize) ?usize {
+    if (head.len < 3 or at(head, tail, 0) != 0x1b or at(head, tail, 1) != 0x1b or at(head, tail, 2) != '[') return null;
+    var i: usize = 3;
+    while (i < n and at(head, tail, i) >= 0x20 and at(head, tail, i) <= 0x3f) : (i += 1) {}
+    if (i >= n or !legacyNavigation(head, tail, 3, i, at(head, tail, i))) return null;
+    if (i + 1 >= n or at(head, tail, i + 1) < 0x20 or at(head, tail, i + 1) == 0x7f) return null;
+    while (i < n and at(head, tail, i) >= 0x20 and at(head, tail, i) <= 0x7e) : (i += 1) {
+        if (at(head, tail, i) == ']') return head.len - 2;
+    }
+    return null;
+}
+
+pub fn legacyDoubleEscape(i: *usize, start: usize) Key {
+    i.* = start - 1;
+    return .escape;
+}
+
+pub fn legacyCsiComplete(head: []const u8, tail: []const u8, n: usize, dropped: bool) bool {
+    var i: usize = 3;
+    while (i < n) : (i += 1) {
+        const c = at(head, tail, i);
+        if (c >= 0x20 and c <= 0x3f) continue;
+        if (!legacyNavigation(head, tail, 3, i, c)) return false;
+        if (legacyCsiProse(head, tail, n) != null) return false;
+        const control = i + 1 < n and (at(head, tail, i + 1) < 0x20 or at(head, tail, i + 1) == 0x7f);
+        return i + 1 == n or control or (dropped and legacyNavigation(head, tail, 3, i, c));
+    }
+    return false;
+}
+
 fn at(head: []const u8, tail: []const u8, i: usize) u8 {
     return if (i < head.len) head[i] else tail[i - head.len];
 }
@@ -23,7 +101,17 @@ fn combinedSlice(head: []const u8, tail: []const u8, start: usize, end: usize, o
 pub fn completed(head: []const u8, tail: []const u8) ?Event {
     const n = head.len + tail.len;
     switch (at(head, tail, 1)) {
-        0x1b => return .{ .event = .escape, .tail_len = 0 },
+        0x1b => {
+            if (n <= 2 or at(head, tail, 2) != '[') return .{ .event = .escape, .tail_len = 0 };
+            var final_at: usize = 3;
+            while (final_at < n and at(head, tail, final_at) >= 0x20 and at(head, tail, final_at) <= 0x3f) : (final_at += 1) {}
+            if (final_at >= n) return null;
+            var params_buf: [max_body]u8 = undefined;
+            const params = combinedSlice(head, tail, 3, final_at, &params_buf) orelse return null;
+            const event_end = final_at + 1;
+            if (event_end < head.len) return null;
+            return .{ .event = key.decodeCsi(params, at(head, tail, final_at)), .tail_len = event_end - head.len };
+        },
         'O' => {
             if (head.len > 3) return null;
             return .{ .event = key.decodeSs3(at(head, tail, 2)), .tail_len = 3 - head.len };

--- a/TUI/key_tests.zig
+++ b/TUI/key_tests.zig
@@ -70,12 +70,10 @@ test "lone trailing ESC stays pending, not an instant Escape" {
     try std.testing.expectEqual(@as(usize, 0), i);
 }
 
-test "ESC ESC delivers an Escape and leaves the second pending" {
+test "ESC ESC stays pending until its Alt-CSI ambiguity is bounded" {
     var i: usize = 0;
-    try std.testing.expectEqual(Key.escape, next("\x1b\x1b", &i).?);
-    try std.testing.expectEqual(@as(usize, 1), i);
     try std.testing.expect(next("\x1b\x1b", &i) == null);
-    try std.testing.expectEqual(@as(usize, 1), i);
+    try std.testing.expectEqual(@as(usize, 0), i);
 }
 
 test "kitty release events never fire keys" {

--- a/TUI/root.zig
+++ b/TUI/root.zig
@@ -82,6 +82,7 @@ test {
     _ = @import("spec_terminal_modes_conformance.zig");
     _ = @import("key_loop_tests.zig");
     _ = @import("issue_537_reviewer_tests.zig");
+    _ = @import("issue_524_tests.zig");
     _ = @import("input.zig");
     _ = @import("keys.zig");
     _ = @import("nav.zig");

--- a/TUI/run.zig
+++ b/TUI/run.zig
@@ -299,6 +299,15 @@ pub fn run(
                         esc_stall = 0;
                         if (keys.handle(&m, .escape) == .quit) m.running = false;
                     },
+                    .escape_pair => {
+                        // A genuine double Escape is still two Escape keys;
+                        // only an unfinished legacy Alt CSI reaches here.
+                        key_mod.abandonSequence(inbuf[0..pending_len], .none);
+                        pending_len = 0;
+                        esc_stall = 0;
+                        if (keys.handle(&m, .escape) == .quit) m.running = false;
+                        if (m.running and keys.handle(&m, .escape) == .quit) m.running = false;
+                    },
                     .drop => {
                         // A sequence the terminal never finished, waited out.
                         // Carry the head so a late tail can still rejoin it,
@@ -410,8 +419,9 @@ pub fn run(
             std.mem.copyForwards(u8, inbuf[0..rest], inbuf[i..n]);
             pending_len = rest;
         } else pending_len = 0;
-        // Capture before bgop/turn completion at the top of the next tick.
-        esc_live = stall.isLoneEscape(inbuf[0..pending_len]) and (m.pending != null or m.bg != null);
+        // Capture operation state before it can complete between polls. Keep
+        // that bounded grace when a lone ESC grows into a legacy Alt prefix.
+        if (pending_len == 0) esc_live = false else if (!esc_live and (m.pending != null or m.bg != null)) esc_live = true;
     }
     // Quitting with a turn still live: cancel FIRST — Ctrl+Q (nav.zig) and the
     // palette's /quit never did — then wait for the thread here, with the alt

--- a/TUI/run_stall.zig
+++ b/TUI/run_stall.zig
@@ -9,7 +9,7 @@
 
 const std = @import("std");
 
-pub const StallVerdict = enum { wait, escape_key, drop };
+pub const StallVerdict = enum { wait, escape_key, escape_pair, drop };
 
 pub const StallCtx = struct {
     /// A model turn or background operation was live when this ESC head
@@ -48,13 +48,18 @@ const escape_carry_window_ms: u64 = 400;
 const arm_window_ms: u64 = 1000;
 
 /// What to do with input bytes stuck mid-sequence after quiet polls (~25ms
-/// each). Exactly one pending ESC byte is the Escape key after the #94 grace.
-/// A longer prefix is a truncated CSI/OSC split by link latency (ssh/tmux):
+/// each). A lone ESC is the Escape key after the #94 grace; a legacy Alt
+/// prefix resolves as a genuine pair. A longer prefix is a truncated CSI/OSC
+/// split by link latency (ssh/tmux):
 /// delivering Escape cancelled live turns and typing the late tail sprayed
 /// "2;39M"-style debris into the transcript — wait for the tail instead, and
 /// only silently drop once it is clearly never coming.
 pub fn stallVerdict(pending: []const u8, stalls: u8, ctx: StallCtx) StallVerdict {
     if (pending.len == 0) return .wait;
+    if (isLegacyAltPrefix(pending)) {
+        const grace = if (ctx.operation_live) live_escape_stalls else esc_grace_idle;
+        return if (stalls >= grace) .escape_pair else .wait;
+    }
     const lone_esc = isLoneEscape(pending);
     if (ctx.in_paste and isPasteMarkerPrefix(pending)) {
         // ESC is a proper prefix of `CSI 201~`, so the marker budget also
@@ -77,6 +82,15 @@ pub fn stallVerdict(pending: []const u8, stalls: u8, ctx: StallCtx) StallVerdict
 
 pub fn isLoneEscape(pending: []const u8) bool {
     return pending.len == 1 and pending[0] == 0x1b;
+}
+
+/// A legacy Alt navigation prefix: ESC ESC followed by an incomplete CSI.
+pub fn isLegacyAltPrefix(pending: []const u8) bool {
+    if (pending.len < 2 or pending[0] != 0x1b or pending[1] != 0x1b) return false;
+    if (pending.len == 2) return true;
+    if (pending[2] != '[') return false;
+    for (pending[3..]) |c| if (c < 0x20 or c > 0x3f) return false;
+    return true;
 }
 
 /// A proper prefix of either bracketed-paste marker.

--- a/TUI/sim.zig
+++ b/TUI/sim.zig
@@ -103,7 +103,7 @@ pub const Term = struct {
             break :blk rest;
         } else 0;
         // Latch before a fast operation can complete on a later quiet tick.
-        self.esc_live = stall.isLoneEscape(self.inbuf[0..self.pending]) and (self.model.pending != null or self.model.bg != null);
+        if (self.pending == 0) self.esc_live = false else if (!self.esc_live and (self.model.pending != null or self.model.bg != null)) self.esc_live = true;
         self.last_effect = last;
     }
 
@@ -119,6 +119,11 @@ pub const Term = struct {
             .escape_key => {
                 self.abandonPending(.escape);
                 self.last_effect = keys.handle(&self.model, .escape);
+            },
+            .escape_pair => {
+                self.abandonPending(.none);
+                self.last_effect = keys.handle(&self.model, .escape);
+                if (self.last_effect == .stay) self.last_effect = keys.handle(&self.model, .escape);
             },
             .drop => self.stallDropPending(),
         }


### PR DESCRIPTION
Closes #524. This PR is intentionally stacked on #699 and contains one additional commit; once #699 merges, this PR can be retargeted to `main` without changing its diff.

## What changed

- Decode legacy `ESC ESC <CSI>` Alt+Left/Right/Up as one navigation event instead of Escape followed by navigation.
- Preserve framing across every read split, bounded delayed delivery, full-buffer recovery, and dropped-head recovery.
- Keep genuine lone/double Escape behavior after the ambiguity window and preserve recognizable bracketed prose instead of guessing it is navigation.
- Add reachable fullscreen-TUI regressions for idle, live turn, background compact/bash/files, overlay, and bracketed-paste trajectories.

## Why

### Problem / failure mode

Some terminals encode legacy Alt+Arrow as `ESC ESC` plus CSI. The parser previously emitted the first Escape immediately, so the shared TUI dispatcher could cancel a model turn or background operation, close an overlay, end paste, or arm rewind before processing the arrow. Split and delayed terminal reads made this destructive behavior timing-dependent.

### Reason for this approach

The incorrect event originates in the shared input framing path, so the fix keeps the complete legacy sequence ambiguous until it can be decoded once. The bounded stall/recovery state from #699 already tracks live operations and late terminal tails; building on it protects every fullscreen TUI trajectory without adding downstream guards or duplicating #537's broader recovery machinery.

### Constraints and trade-offs

The terminal byte stream cannot perfectly distinguish `ESC ESC [Ax]` as Alt+Up then `x]` from genuine double Escape followed by literal `[Ax]`. The implementation uses narrow evidence: exact navigation, split input, and navigation followed by ordinary coalesced text win as navigation; recognizable bracketed prose wins as text; an incomplete sequence beyond the existing ~300 ms idle / ~1 s live window resolves as genuine Escape. This preserves cancellation responsiveness while covering the reported 50–250 ms delivery range.

### Rejected alternatives

- Suppressing Escape only in live-turn code was rejected because the same phantom event affects background operations, overlays, paste, rewind, and idle navigation.
- Copying the old #524 draft was rejected because it mixed paste normalization, stale modifiers, SS3/orphan recovery, and other #537 concerns.
- Basing directly on `main` was rejected because the delayed runtime seam needs #699's operation-aware stall/recovery behavior; restating that work would create overlapping PRs.

## Verification

- `GRAFF_TUIGUARD_JOBS=1 scripts/eval-tier1.sh` — green in 562s.
- Unit suite: `1860` passed + 1 platform skip (`1861` total).
- TUI suite: `514/514`.
- PTY/tuiguard: `18/18`.
- Formatting, 600-line ceiling, test reachability, build, invariants, and SDK drift checks all passed.
- Independent implementation, adversarial-test, and final-review agents exercised split/delayed input, coalesced printable keys, `[Alice]` prose, unmodified and `1;3` CSI forms, all background operation kinds, overlay movement, paste, full-buffer recovery, and genuine Escape behavior. Final review reported no blockers.
