### PR TITLE
Release v0.0.285 — #717 Codex WS error hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
+## v0.0.285 (2026-09-03)
+
+- Native transcript follow-tail only while the reader is at the bottom.
+  Scrolling up mid-stream no longer yanks the thread (#724).
+- Follow-ups typed while a turn is running queue and drain in order when
+  it ends. The composer stays usable; stop stays on an empty draft.
+- Native tools interleave with the answer instead of stacking above it;
+  settled tool batches fold; ACP patches paint once per frame.
+- `#721`: `workspace` switch stars and reports the process cwd.
+- TUI streams the live answer instead of a Thinking placeholder while
+  tokens arrive.
+- 284 stays published as-is. This is not a retag.
+
 ## v0.0.284 (2026-09-01)
 
 - ACP turns stage GUI `@[image]` attachments as native vision blocks so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The release workflow uses a tag's section here as its release notes (a
 hand-written `docs/releases/<tag>.md` wins if present), so keeping this file
 current is part of cutting a release.
 
+## v0.0.285 (2026-09-01)
+
+- Next cut after tagged [v0.0.284](docs/releases/v0.0.284.md). No tag
+  until asked.
+- `#717` (yxlyx): Codex WS `type:error` retires the socket immediately
+  and keeps a one-request marker for the bounded diagnostic. Re-anchor
+  only when the rejected body actually sent `previous_response_id`.
+  Unparseable Responses envelopes no longer copy raw bytes into
+  `last_api_error`. Follow-up hardening for `#692` / `#693`.
+
 ## v0.0.284 (2026-09-01)
 
 - ACP turns stage GUI `@[image]` attachments as native vision blocks so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ current is part of cutting a release.
 - TUI mid-turn steer / `/btw` now bakes composer `[Image #N]` chips into
   the queued payload as `@[path]`. Previously only the typed text was
   queued, so the follow-up turn dropped the pixels.
+- Native + TUI: tools stream with the answer instead of landing as a
+  wall on top. Native pins the scroller (no WKWebView jitter),
+  interleaves chips at the text cursor, and collapses a settled batch
+  to “Explored N”. TUI drops the Thinking row once tokens arrive and
+  paints the live stream as the reply; codedb folds as “Looked up N
+  items”. `scrollback.zig` stays under 600 via `TUI/livetail.zig`.
 
 ## v0.0.284 (2026-09-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ current is part of cutting a release.
   only when the rejected body actually sent `previous_response_id`.
   Unparseable Responses envelopes no longer copy raw bytes into
   `last_api_error`. Follow-up hardening for `#692` / `#693`.
+- TUI mid-turn steer / `/btw` now bakes composer `[Image #N]` chips into
+  the queued payload as `@[path]`. Previously only the typed text was
+  queued, so the follow-up turn dropped the pixels.
 
 ## v0.0.284 (2026-09-01)
 

--- a/TUI/dispatch.zig
+++ b/TUI/dispatch.zig
@@ -41,9 +41,7 @@ pub fn applyLine(self: *Model, raw: []const u8) Effect {
         self.push(.system, busy_note) catch {};
         return .stay;
     }
-    const prefix = self.takeImagesPrefix(self.alloc);
-    const payload = if (prefix.len == 0) line else (std.fmt.allocPrint(self.alloc, "{s}{s}", .{ prefix, line }) catch line);
-    if (prefix.len > 0) self.alloc.free(prefix);
+    const payload = withImages(self, line);
     self.push(.user, payload) catch {};
     if (payload.ptr != line.ptr) self.alloc.free(payload);
     if (self.chat) {
@@ -57,6 +55,31 @@ pub fn applyLine(self: *Model, raw: []const u8) Effect {
 
 fn rememberPrompt(self: *Model, line: []const u8) void {
     @import("prompt_history.zig").remember(self, line);
+}
+
+/// Bake live composer chips onto `line` as `@[path]` markers (same shape
+/// applyLine sends). Clears the chips. Returns `line` when there are none.
+fn withImages(self: *Model, line: []const u8) []const u8 {
+    const prefix = self.takeImagesPrefix(self.alloc);
+    if (prefix.len == 0) return line;
+    defer self.alloc.free(prefix);
+    return std.fmt.allocPrint(self.alloc, "{s}{s}", .{ prefix, line }) catch line;
+}
+
+/// Queue a mid-turn follow-up, including any attached chips. Idle applyLine
+/// already prefixes `@[path]`; steer used to copy only the typed text, so the
+/// pixels never left the composer.
+pub fn queueSteerLine(self: *Model, text: []const u8) void {
+    const line = std.mem.trim(u8, text, " \t\r\n");
+    if (line.len == 0 and self.images.items.len == 0) return;
+    const payload = withImages(self, line);
+    const dup = if (payload.ptr == line.ptr) self.alloc.dupe(u8, line) catch return else payload;
+    self.steer_queue.append(dup) catch {
+        if (dup.ptr != line.ptr) self.alloc.free(dup);
+        return;
+    };
+    self.input.setValue("") catch {};
+    self.pushFmt(.system, "↳ queued ({d} waiting)", .{self.steer_queue.items.len}) catch {};
 }
 
 pub fn runCommand(self: *Model, line: []const u8) Effect {
@@ -217,10 +240,7 @@ pub fn runCommand(self: *Model, line: []const u8) Effect {
         if (arg.len == 0) {
             self.push(.system, "usage: /btw <aside> — queue a note without interrupting") catch {};
         } else if (self.pending != null) {
-            if (self.alloc.dupe(u8, arg)) |dup| {
-                self.steer_queue.append(dup) catch self.alloc.free(dup);
-                self.pushFmt(.system, "↳ aside queued ({d} waiting)", .{self.steer_queue.items.len}) catch {};
-            } else |_| {}
+            queueSteerLine(self, arg);
         } else {
             return applyLine(self, arg);
         }

--- a/TUI/dispatch_command_tests.zig
+++ b/TUI/dispatch_command_tests.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 const app = @import("app.zig");
 const dispatch = @import("dispatch.zig");
 const engine = @import("engine.zig");
+const turn = @import("turn.zig");
 const Effect = app.Effect;
 const Model = app.Model;
 const applyLine = dispatch.applyLine;
@@ -274,6 +275,56 @@ test "/btw queues an aside while a turn is pending" {
     _ = applyLine(&m, "/btw remember the tests");
     try std.testing.expectEqual(@as(usize, 1), m.steer_queue.items.len);
     try std.testing.expectEqualStrings("remember the tests", m.steer_queue.items[0]);
+}
+
+test "steer queues @[path] with the text so drain sends pixels" {
+    var m: Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    const job = try std.testing.allocator.create(engine.Job);
+    job.* = .{ .gpa = std.testing.allocator, .history = &.{}, .params = .{}, .stream = .{}, .threaded = false };
+    m.pending = job;
+    defer {
+        m.pending = null;
+        std.testing.allocator.destroy(job);
+    }
+    m.attachImage("/tmp/shot.png");
+    try m.input.setValue("look at this");
+    turn.steerEnter(&m);
+    try std.testing.expectEqual(@as(usize, 1), m.steer_queue.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, m.steer_queue.items[0], "@[/tmp/shot.png]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, m.steer_queue.items[0], "look at this") != null);
+    try std.testing.expectEqual(@as(usize, 0), m.images.items.len);
+    try std.testing.expectEqualStrings("", m.input.getValue());
+
+    m.pending = null;
+    _ = turn.drainSteer(&m);
+    var user_text: []const u8 = "";
+    for (m.history.items) |e| {
+        if (e.kind == .user) user_text = e.text;
+    }
+    try std.testing.expect(std.mem.indexOf(u8, user_text, "@[/tmp/shot.png]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, user_text, "look at this") != null);
+    try std.testing.expectEqual(@as(usize, 0), m.steer_queue.items.len);
+}
+
+test "image-only steer queues the chip, empty Enter does not cancel" {
+    var m: Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    const job = try std.testing.allocator.create(engine.Job);
+    job.* = .{ .gpa = std.testing.allocator, .history = &.{}, .params = .{}, .stream = .{}, .threaded = false };
+    m.pending = job;
+    defer {
+        m.pending = null;
+        std.testing.allocator.destroy(job);
+    }
+    m.attachImage("/tmp/only.png");
+    turn.steerEnter(&m);
+    try std.testing.expectEqual(@as(usize, 1), m.steer_queue.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, m.steer_queue.items[0], "@[/tmp/only.png]") != null);
+    try std.testing.expect(!m.cancel_requested);
+    try std.testing.expectEqual(@as(usize, 0), m.images.items.len);
 }
 
 var captured_op: engine.GoalOp = .none;

--- a/TUI/turn.zig
+++ b/TUI/turn.zig
@@ -146,12 +146,8 @@ pub fn drainSteer(self: *Model) Effect {
 
 pub fn steerEnter(self: *Model) void {
     const v = std.mem.trim(u8, self.input.getValue(), " \t\r\n");
-    if (v.len > 0) {
-        if (self.alloc.dupe(u8, v)) |dup| {
-            self.steer_queue.append(dup) catch self.alloc.free(dup);
-            self.input.setValue("") catch {};
-            self.pushFmt(.system, "↳ queued ({d} waiting)", .{self.steer_queue.items.len}) catch {};
-        } else |_| {}
+    if (v.len > 0 or self.images.items.len > 0) {
+        @import("dispatch.zig").queueSteerLine(self, v);
     } else if (self.steer_queue.items.len > 0) {
         cancelTurn(self);
         self.push(.system, "↳ force › interrupting…") catch {};

--- a/apps/native/components/primitives/PromptBar.tsx
+++ b/apps/native/components/primitives/PromptBar.tsx
@@ -439,6 +439,7 @@ export default function PromptBar({
   };
 
   const canSend = !disabled && (draft.trim().length > 0 || attachments.length > 0);
+  const showStop = busy && !canSend;
   const send = () => {
     if (!canSend) return;
     onSend?.(draft.trim());
@@ -770,18 +771,18 @@ export default function PromptBar({
               runs it morphs into the Codex-style stop control */}
           <button
             type="button"
-            aria-label={busy ? "Stop" : "Send"}
-            disabled={busy ? !onStop : !canSend}
-            onClick={busy ? onStop : send}
+            aria-label={showStop ? "Stop" : "Send"}
+            disabled={showStop ? !onStop : !canSend}
+            onClick={showStop ? onStop : send}
             className={`flex size-7 shrink-0 items-center justify-center transition-[background-color,color,transform] duration-200 enabled:active:scale-[0.94] ${
               pill ? "rounded-full" : "rounded-[8px]"
             } ${wide ? "col-start-5 row-start-2" : "col-start-5 row-start-1"}`}
             style={{
-              background: busy || canSend ? "var(--ink)" : "var(--line-strong)",
-              color: busy || canSend ? "var(--surface)" : "var(--ink-2)",
+              background: showStop || canSend ? "var(--ink)" : "var(--line-strong)",
+              color: showStop || canSend ? "var(--surface)" : "var(--ink-2)",
             }}
           >
-            {busy ? (
+            {showStop ? (
               <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
                 <rect x="5" y="5" width="14" height="14" rx="2.5" />
               </svg>

--- a/apps/native/components/site/ChatBubbles.tsx
+++ b/apps/native/components/site/ChatBubbles.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { memo, useEffect, useRef, useState, type RefObject } from "react";
+import Markdown from "@/components/primitives/Markdown";
+import ThinkingState from "@/components/primitives/ThinkingState";
+import ToolChips from "@/components/primitives/ToolChips";
+import { pinScrollerTail } from "@/lib/follow-scroll";
+import { turnBlocks, type AssistantTurn } from "@/lib/acp";
+
+/** Typewriter reveal over the ACP text. Catch-up lands on whitespace so
+ * markdown chips/lists don't reflow every mid-token character. */
+function useSmoothStream(target: string, live: boolean): string {
+  const [shown, setShown] = useState(target);
+  const shownRef = useRef(target);
+  useEffect(() => {
+    if (!live) {
+      shownRef.current = target;
+      setShown(target);
+      return;
+    }
+    if (!target.startsWith(shownRef.current)) {
+      shownRef.current = target;
+      setShown(target);
+      return;
+    }
+    if (target === shownRef.current) return;
+    let raf = 0;
+    let last = performance.now();
+    const tick = (now: number) => {
+      const dt = Math.min(now - last, 80);
+      last = now;
+      const have = shownRef.current.length;
+      const behind = target.length - have;
+      if (behind <= 0) return;
+      const rate = Math.min(180 + behind * 1.4, 2800);
+      let next = have + Math.max(1, Math.round((rate * dt) / 1000));
+      if (next < target.length) {
+        const rest = target.slice(next, next + 24);
+        const cut = rest.search(/[\s\n]/);
+        if (cut > 0) next += cut + 1;
+      } else {
+        next = target.length;
+      }
+      shownRef.current = target.slice(0, next);
+      setShown(shownRef.current);
+      if (shownRef.current.length < target.length) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [target, live]);
+  return live ? shown : target;
+}
+
+export const UserBubble = memo(function UserBubble({ text }: { text: string }) {
+  return (
+    <div className="flex justify-end pl-10 sm:pl-24" style={{ animation: "fade-up 300ms cubic-bezier(0.23,1,0.32,1) both" }}>
+      <div
+        className="rounded-xl px-3.5 py-2 text-[13px] leading-relaxed text-ink shadow-hairline"
+        style={{ background: "color-mix(in oklab, var(--accent) 12%, var(--surface))" }}
+      >
+        {text}
+      </div>
+    </div>
+  );
+});
+
+export const AssistantBody = memo(function AssistantBody({
+  turn,
+  onOpenPath,
+  onReview,
+  scroller,
+  following,
+}: {
+  turn: AssistantTurn;
+  onOpenPath?: (path: string) => void;
+  onReview?: () => void;
+  scroller?: RefObject<HTMLDivElement | null>;
+  following: boolean;
+}) {
+  const thinking = turn.status === "thinking";
+  const live = thinking || turn.status === "streaming";
+  const blocks = turnBlocks(turn.text, turn.tools);
+  const lastText = [...blocks].reverse().find((b) => b.kind === "text");
+  const lastTextBody = lastText?.kind === "text" ? lastText.text : "";
+  const smoothText = useSmoothStream(lastTextBody, live);
+  const draining = smoothText.length < lastTextBody.length;
+  useEffect(() => {
+    if (draining) pinScrollerTail(scroller?.current ?? null, following);
+  }, [smoothText, draining, scroller, following]);
+  const startRef = useRef(Date.now());
+  const [thoughtSecs, setThoughtSecs] = useState<number | null>(
+    turn.thoughtMs !== undefined ? Math.max(1, Math.round(turn.thoughtMs / 1000)) : null,
+  );
+  useEffect(() => {
+    if (thinking) return;
+    setThoughtSecs((current) => {
+      if (current !== null) return current;
+      const ms = turn.thoughtMs ?? Date.now() - startRef.current;
+      return Math.max(1, Math.round(ms / 1000));
+    });
+  }, [thinking, turn.thoughtMs]);
+  const reasoningRows = turn.reasoning
+    ? turn.reasoning
+        .split(/\n+/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((primary) => ({ primary }))
+    : [];
+  const toChipRows = (tools: typeof turn.tools) =>
+    tools.map((tool) => ({
+      id: tool.id,
+      icon: tool.icon,
+      label: tool.name,
+      chip: tool.chip,
+      mono: tool.icon === "run" || tool.icon === "write" || tool.icon === "read",
+      detailMono: tool.icon === "run" || tool.icon === "write",
+      detail: tool.detail,
+      path: tool.path,
+      status: tool.status,
+      startedAt: tool.startedAt,
+      elapsedMs: tool.elapsedMs,
+    }));
+
+  const lastTextIndex = blocks.reduce((acc, b, i) => (b.kind === "text" ? i : acc), -1);
+  const lastBlock = blocks[blocks.length - 1];
+  const waitingOnTools =
+    turn.status === "streaming" &&
+    !lastTextBody &&
+    (lastBlock?.kind === "tools" || blocks.length === 0);
+
+  return (
+    <article className="min-w-0" style={{ overflowAnchor: "none", animation: "fade-in 280ms ease both" }}>
+      {(thinking || reasoningRows.length > 0 || (turn.thoughtMs ?? 0) >= 1500) && (
+        <ThinkingState
+          variant="Reasoning"
+          rows={reasoningRows.length ? reasoningRows : [{ primary: "Waiting on the model…", shimmer: true }]}
+          activeLabel={turn.model ? `Thinking · ${turn.model}` : "Thinking"}
+          doneLabel={thoughtSecs ? `Thought for ${thoughtSecs}s` : "Thought"}
+          working={thinking}
+        />
+      )}
+      {blocks.map((block, i) =>
+        block.kind === "tools" ? (
+          <div key={`tools-${block.tools[0]?.id ?? i}`} className="mt-3">
+            <ToolChips
+              rows={toChipRows(block.tools)}
+              diffs={i === blocks.length - 1 || (i === blocks.length - 2 && lastBlock?.kind === "text") ? turn.diffs : []}
+              onOpenPath={onOpenPath}
+            />
+          </div>
+        ) : (
+          <div key={`text-${i}`} className="mt-3 max-w-[630px]">
+            <Markdown
+              text={i === lastTextIndex ? smoothText : block.text}
+              streaming={i === lastTextIndex && (draining || turn.status === "streaming" || turn.status === "thinking")}
+              onOpenPath={onOpenPath}
+            />
+          </div>
+        ),
+      )}
+      {waitingOnTools && (
+        <div className="mt-4">
+          <span
+            className="bg-clip-text text-[13px] font-medium whitespace-nowrap text-transparent"
+            style={{
+              backgroundImage: "linear-gradient(90deg, var(--ink-3) 35%, var(--ink) 50%, var(--ink-3) 65%)",
+              backgroundSize: "200% 100%",
+              animation: "shimmer-text 1.4s linear infinite",
+            }}
+          >
+            {turn.tools.some((tool) => tool.status === "running") ? "Running tools…" : "Writing…"}
+          </span>
+        </div>
+      )}
+      {turn.error && (
+        <p className="mt-4 max-w-[620px] text-[13.5px] leading-[1.65] text-red">{turn.error}</p>
+      )}
+      {turn.recap && turn.status === "done" && !draining && (
+        <p className="mt-3 text-[12px] text-ink-3">{turn.recap}</p>
+      )}
+      {turn.costUsd !== undefined && turn.status === "done" && !draining && (
+        <p className="mt-1 font-mono text-[11px] text-ink-3">${turn.costUsd.toFixed(4)}</p>
+      )}
+      {turn.status === "done" && !draining && turn.diffs.length > 0 && onReview && (
+        <button
+          type="button"
+          onClick={onReview}
+          className="mt-4 flex h-9 w-full max-w-[630px] items-center gap-2 rounded-[10px] bg-surface px-3 text-left shadow-btn transition-colors duration-100 hover:bg-hover"
+          style={{ animation: "fade-up 300ms cubic-bezier(0.23,1,0.32,1) both" }}
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-ink-3" aria-hidden>
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+            <path d="M14 2v6h6" />
+          </svg>
+          <span className="text-[12.5px] font-medium text-ink">
+            Changed {turn.diffs.length} file{turn.diffs.length === 1 ? "" : "s"}
+          </span>
+          <span className="font-mono text-[11.5px] tabular-nums">
+            <span className="text-green">+{turn.diffs.reduce((n, d) => n + d.add, 0)}</span>{" "}
+            <span className="text-red">−{turn.diffs.reduce((n, d) => n + d.del, 0)}</span>
+          </span>
+          <span className="ml-auto flex items-center gap-0.5 text-[12.5px] font-medium text-ink-2">
+            Review
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <path d="M9 18l6-6-6-6" />
+            </svg>
+          </span>
+        </button>
+      )}
+    </article>
+  );
+});

--- a/apps/native/components/site/ChatEmpty.tsx
+++ b/apps/native/components/site/ChatEmpty.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState, type CSSProperties } from "react";
+import PromptBar, { type PromptModel } from "@/components/primitives/PromptBar";
+import { STARTER_PROMPTS, type Health } from "@/lib/acp-client";
+
+function greeting(): string {
+  const hour = new Date().getHours();
+  if (hour < 5) return "Up late";
+  if (hour < 12) return "Good morning";
+  if (hour < 18) return "Good afternoon";
+  return "Good evening";
+}
+
+const HOME_REVEAL = {
+  offsetY: 23,
+  blur: 17,
+  duration: 800,
+  easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+};
+
+function homeRevealStyle(visible: boolean): CSSProperties {
+  return {
+    opacity: visible ? 1 : 0,
+    transform: visible ? "translate3d(0, 0, 0)" : `translate3d(0, ${HOME_REVEAL.offsetY}px, 0)`,
+    filter: visible ? "blur(0px)" : `blur(${HOME_REVEAL.blur}px)`,
+    transition: ["opacity", "transform", "filter"]
+      .map((property) => `${property} ${HOME_REVEAL.duration}ms ${HOME_REVEAL.easing}`)
+      .join(", "),
+  };
+}
+
+export default function EmptyState({
+  onSend,
+  health,
+  offset,
+  shuffle,
+  models,
+  modelKey,
+  onModelChange,
+}: {
+  onSend: (text: string) => void;
+  health: Health | null;
+  offset: number;
+  shuffle: () => void;
+  models: PromptModel[];
+  modelKey?: string;
+  onModelChange: (key: string) => void;
+}) {
+  const shown = [0, 1, 2].map((i) => STARTER_PROMPTS[(offset + i) % STARTER_PROMPTS.length]);
+  const [stage, setStage] = useState(0);
+  useEffect(() => {
+    const timers = [
+      setTimeout(() => setStage(1), 170),
+      setTimeout(() => setStage(2), 330),
+      setTimeout(() => setStage(3), 400),
+      setTimeout(() => setStage(4), 550),
+    ];
+    return () => timers.forEach(clearTimeout);
+  }, []);
+
+  return (
+    <div className="mx-auto flex min-h-full max-w-[720px] flex-col justify-center px-4 py-10 sm:px-8">
+      <h1 className="text-[26px] font-normal tracking-[-0.02em] text-ink">
+        <span className="home-reveal block text-ink-3" style={homeRevealStyle(stage >= 1)}>
+          {greeting()}
+        </span>
+        <span className="home-reveal block" style={homeRevealStyle(stage >= 2)}>
+          What should graff work on?
+        </span>
+      </h1>
+
+      <div className="home-reveal relative mt-7" style={homeRevealStyle(stage >= 3)}>
+        <PromptBar
+          demo={false}
+          tall
+          placeholder="Ask graff to read, edit, or review this workspace…"
+          models={models}
+          modelKey={modelKey}
+          onModelChange={onModelChange}
+          onSend={onSend}
+          disabled={health !== null && !health.ok}
+        />
+        {health && !health.ok && (
+          <p className="mt-3 text-[12.5px] text-orange">
+            graff acp is not reachable. From the repo root run{" "}
+            <span className="font-mono text-ink">zig build</span>
+            {health.detail ? ` — ${health.detail}` : ""}.
+          </p>
+        )}
+      </div>
+
+      <div className="home-reveal mt-6 flex flex-col" style={homeRevealStyle(stage >= 4)}>
+        {shown.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => onSend(item.prompt)}
+            className="-mx-2 flex items-center gap-3 rounded-control px-2 py-2.5 text-left text-[14px] text-ink transition-colors duration-150 hover:bg-hover"
+          >
+            <span className="text-ink-3">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                <path d="M8 6l-5 6 5 6M16 6l5 6-5 6" />
+              </svg>
+            </span>
+            <span className="min-w-0 truncate">{item.label}</span>
+          </button>
+        ))}
+        <div className="mt-1 flex items-center gap-5 pl-0.5 text-[13px] text-ink-3">
+          <span className="flex items-center gap-2 py-1" title={health?.cwd}>
+            <span className={`size-1.5 rounded-full ${health?.ok ? "bg-green" : "bg-orange"}`} />
+            {health?.ok
+              ? `Connected · ${health.cwd ? (health.cwd.split("/").pop() ?? health.cwd) : "over ACP"}`
+              : "Waiting for graff acp"}
+          </span>
+          <button type="button" onClick={shuffle} className="flex items-center gap-2 py-1 transition-colors duration-150 hover:text-ink">
+            Shuffle suggestions
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/native/components/site/GraffHarness.tsx
+++ b/apps/native/components/site/GraffHarness.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, type CSSProperties, type RefObject } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type RefObject } from "react";
 import Markdown from "@/components/primitives/Markdown";
 import PromptBar, { type PromptModel } from "@/components/primitives/PromptBar";
 import SidebarNav from "@/components/primitives/SidebarNav";
@@ -43,10 +43,15 @@ function greeting(): string {
  * Mounted mid-history it starts caught-up, so old messages never replay.
  * Catch-up lands on whitespace so markdown chips/lists don't reflow every
  * mid-token character — that wrap-jitter stacked with scrollIntoView. */
-function useSmoothStream(target: string): string {
+function useSmoothStream(target: string, live: boolean): string {
   const [shown, setShown] = useState(target);
   const shownRef = useRef(target);
   useEffect(() => {
+    if (!live) {
+      shownRef.current = target;
+      setShown(target);
+      return;
+    }
     if (!target.startsWith(shownRef.current)) {
       shownRef.current = target;
       setShown(target);
@@ -76,8 +81,8 @@ function useSmoothStream(target: string): string {
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [target]);
-  return shown;
+  }, [target, live]);
+  return live ? shown : target;
 }
 
 /** Pin the thread scroller to its tail without scrollIntoView. WKWebView
@@ -107,7 +112,7 @@ function homeRevealStyle(visible: boolean): CSSProperties {
   };
 }
 
-function UserBubble({ text }: { text: string }) {
+const UserBubble = memo(function UserBubble({ text }: { text: string }) {
   return (
     <div className="flex justify-end pl-10 sm:pl-24" style={{ animation: "fade-up 300ms cubic-bezier(0.23,1,0.32,1) both" }}>
       <div
@@ -118,9 +123,9 @@ function UserBubble({ text }: { text: string }) {
       </div>
     </div>
   );
-}
+});
 
-function AssistantBody({
+const AssistantBody = memo(function AssistantBody({
   turn,
   onOpenPath,
   onReview,
@@ -133,10 +138,11 @@ function AssistantBody({
   scroller?: RefObject<HTMLDivElement | null>;
 }) {
   const thinking = turn.status === "thinking";
+  const live = thinking || turn.status === "streaming";
   const blocks = turnBlocks(turn.text, turn.tools);
   const lastText = [...blocks].reverse().find((b) => b.kind === "text");
   const lastTextBody = lastText?.kind === "text" ? lastText.text : "";
-  const smoothText = useSmoothStream(lastTextBody);
+  const smoothText = useSmoothStream(lastTextBody, live);
   const draining = smoothText.length < lastTextBody.length;
   // Follow the typewriter tail — the parent's pin tracks the wire text,
   // which goes quiet while the reveal is still playing out. Pin the
@@ -271,7 +277,7 @@ function AssistantBody({
       )}
     </article>
   );
-}
+});
 
 type Msg =
   | { id: number; role: "user"; text: string }
@@ -504,15 +510,15 @@ export default function GraffHarness() {
     }
   };
 
-  const openPath = (path: string) => {
+  const openPath = useCallback((path: string) => {
     setFilesOpen(true);
     setFileRequest({ path, n: (fileReqRef.current += 1) });
-  };
+  }, []);
 
-  const openChanges = () => {
+  const openChanges = useCallback(() => {
     setFilesOpen(true);
     setFileRequest({ path: "", n: (fileReqRef.current += 1), changes: true });
-  };
+  }, []);
 
   const changeModel = (key: string) => {
     // New tabs inherit the pick; the active tab respawns its agent with it
@@ -565,11 +571,23 @@ export default function GraffHarness() {
     const startedAt = Date.now();
     try {
       const id = await requireSession(chatId);
+      // Paint at most once per frame. ACP text/tool events can arrive dozens
+      // of times per 16ms; each setChats used to re-parse every settled
+      // markdown block in the thread.
+      let paint = 0;
+      const turnRef = { current: turn };
       for await (const update of prompt(handleOf(chatId), id, trimmed)) {
         turn = applyAcpUpdate(turn, update);
         if (turn.thoughtMs === undefined && turn.status !== "thinking") turn = { ...turn, thoughtMs: Date.now() - startedAt };
-        patchAssistant(chatId, asstId, turn);
+        turnRef.current = turn;
+        if (!paint) {
+          paint = requestAnimationFrame(() => {
+            paint = 0;
+            patchAssistant(chatId, asstId, turnRef.current);
+          });
+        }
       }
+      if (paint) cancelAnimationFrame(paint);
       turn = finishAcpTurn(turn);
       patchAssistant(chatId, asstId, turn);
     } catch (err) {

--- a/apps/native/components/site/GraffHarness.tsx
+++ b/apps/native/components/site/GraffHarness.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type RefObject } from "react";
-import Markdown from "@/components/primitives/Markdown";
+import { useCallback, useEffect, useRef, useState } from "react";
 import PromptBar, { type PromptModel } from "@/components/primitives/PromptBar";
 import SidebarNav from "@/components/primitives/SidebarNav";
 import FilesPane from "@/components/site/FilesPane";
 import { IconFolder } from "@/lib/icons";
 import TaskRows from "@/components/primitives/TaskRows";
-import ThinkingState from "@/components/primitives/ThinkingState";
-import ToolChips from "@/components/primitives/ToolChips";
 import { ThemeToggle } from "@/components/site/ThemeToggle";
+import { AssistantBody, UserBubble } from "@/components/site/ChatBubbles";
+import EmptyState from "@/components/site/ChatEmpty";
 import {
   MODELS,
   STARTER_PROMPTS,
@@ -23,261 +22,10 @@ import {
   prompt,
   type Health,
 } from "@/lib/acp-client";
-import { applyAcpUpdate, emptyTurn, finishAcpTurn, turnBlocks, type AssistantTurn } from "@/lib/acp";
+import { applyAcpUpdate, emptyTurn, finishAcpTurn, type AssistantTurn } from "@/lib/acp";
+import { isFollowingTail, pinScrollerTail } from "@/lib/follow-scroll";
+import { dropQueuedPrompt, enqueuePrompt, shiftQueuedPrompt, type QueuedPrompt } from "@/lib/prompt-queue";
 import { dateGroup, listSessions, loadSession, relativeTime, type StoredSession } from "@/lib/sessions";
-
-const NAME = "there";
-
-function greeting(): string {
-  const hour = new Date().getHours();
-  if (hour < 5) return "Up late";
-  if (hour < 12) return "Good morning";
-  if (hour < 18) return "Good afternoon";
-  return "Good evening";
-}
-
-/** Typewriter reveal over the ACP text, the way every AI app streams: a
- * readable base rate with gentle backlog catch-up (capped so a one-shot
- * final answer still visibly types out), and the drain keeps playing after
- * the turn's result lands — done-state chrome waits for the last word.
- * Mounted mid-history it starts caught-up, so old messages never replay.
- * Catch-up lands on whitespace so markdown chips/lists don't reflow every
- * mid-token character — that wrap-jitter stacked with scrollIntoView. */
-function useSmoothStream(target: string, live: boolean): string {
-  const [shown, setShown] = useState(target);
-  const shownRef = useRef(target);
-  useEffect(() => {
-    if (!live) {
-      shownRef.current = target;
-      setShown(target);
-      return;
-    }
-    if (!target.startsWith(shownRef.current)) {
-      shownRef.current = target;
-      setShown(target);
-      return;
-    }
-    if (target === shownRef.current) return;
-    let raf = 0;
-    let last = performance.now();
-    const tick = (now: number) => {
-      const dt = Math.min(now - last, 80);
-      last = now;
-      const have = shownRef.current.length;
-      const behind = target.length - have;
-      if (behind <= 0) return;
-      const rate = Math.min(180 + behind * 1.4, 2800);
-      let next = have + Math.max(1, Math.round((rate * dt) / 1000));
-      if (next < target.length) {
-        const rest = target.slice(next, next + 24);
-        const cut = rest.search(/[\s\n]/);
-        if (cut > 0) next += cut + 1;
-      } else {
-        next = target.length;
-      }
-      shownRef.current = target.slice(0, next);
-      setShown(shownRef.current);
-      if (shownRef.current.length < target.length) raf = requestAnimationFrame(tick);
-    };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
-  }, [target, live]);
-  return live ? shown : target;
-}
-
-/** Pin the thread scroller to its tail without scrollIntoView. WKWebView
- * treats block:end on a tall article as a viewport realignment every frame
- * — the whole reply judders while the typewriter runs. */
-function pinScrollerTail(el: HTMLElement | null): void {
-  if (!el) return;
-  const fromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-  if (fromBottom < 240) el.scrollTop = el.scrollHeight;
-}
-
-const HOME_REVEAL = {
-  offsetY: 23,
-  blur: 17,
-  duration: 800,
-  easing: "cubic-bezier(0.16, 1, 0.3, 1)",
-};
-
-function homeRevealStyle(visible: boolean): CSSProperties {
-  return {
-    opacity: visible ? 1 : 0,
-    transform: visible ? "translate3d(0, 0, 0)" : `translate3d(0, ${HOME_REVEAL.offsetY}px, 0)`,
-    filter: visible ? "blur(0px)" : `blur(${HOME_REVEAL.blur}px)`,
-    transition: ["opacity", "transform", "filter"]
-      .map((property) => `${property} ${HOME_REVEAL.duration}ms ${HOME_REVEAL.easing}`)
-      .join(", "),
-  };
-}
-
-const UserBubble = memo(function UserBubble({ text }: { text: string }) {
-  return (
-    <div className="flex justify-end pl-10 sm:pl-24" style={{ animation: "fade-up 300ms cubic-bezier(0.23,1,0.32,1) both" }}>
-      <div
-        className="rounded-xl px-3.5 py-2 text-[13px] leading-relaxed text-ink shadow-hairline"
-        style={{ background: "color-mix(in oklab, var(--accent) 12%, var(--surface))" }}
-      >
-        {text}
-      </div>
-    </div>
-  );
-});
-
-const AssistantBody = memo(function AssistantBody({
-  turn,
-  onOpenPath,
-  onReview,
-  scroller,
-}: {
-  turn: AssistantTurn;
-  onOpenPath?: (path: string) => void;
-  /** Open the workspace changes review (the Codex "Changed N files" bar). */
-  onReview?: () => void;
-  scroller?: RefObject<HTMLDivElement | null>;
-}) {
-  const thinking = turn.status === "thinking";
-  const live = thinking || turn.status === "streaming";
-  const blocks = turnBlocks(turn.text, turn.tools);
-  const lastText = [...blocks].reverse().find((b) => b.kind === "text");
-  const lastTextBody = lastText?.kind === "text" ? lastText.text : "";
-  const smoothText = useSmoothStream(lastTextBody, live);
-  const draining = smoothText.length < lastTextBody.length;
-  // Follow the typewriter tail — the parent's pin tracks the wire text,
-  // which goes quiet while the reveal is still playing out. Pin the
-  // overflow scroller directly; do not scrollIntoView (WKWebView jitter).
-  useEffect(() => {
-    if (draining) pinScrollerTail(scroller?.current ?? null);
-  }, [smoothText, draining, scroller]);
-  // "Thought for Ns": the harness stamps `thoughtMs` on the turn as it streams
-  // (ACP updates carry no timestamps); a live turn without one yet is timed here.
-  const startRef = useRef(Date.now());
-  const [thoughtSecs, setThoughtSecs] = useState<number | null>(
-    turn.thoughtMs !== undefined ? Math.max(1, Math.round(turn.thoughtMs / 1000)) : null,
-  );
-  useEffect(() => {
-    if (thinking) return;
-    setThoughtSecs((current) => {
-      if (current !== null) return current;
-      const ms = turn.thoughtMs ?? Date.now() - startRef.current;
-      return Math.max(1, Math.round(ms / 1000));
-    });
-  }, [thinking, turn.thoughtMs]);
-  const reasoningRows = turn.reasoning
-    ? turn.reasoning
-        .split(/\n+/)
-        .map((line) => line.trim())
-        .filter(Boolean)
-        .map((primary) => ({ primary }))
-    : [];
-  const toChipRows = (tools: typeof turn.tools) =>
-    tools.map((tool) => ({
-      id: tool.id,
-      icon: tool.icon,
-      label: tool.name,
-      chip: tool.chip,
-      mono: tool.icon === "run" || tool.icon === "write" || tool.icon === "read",
-      detailMono: tool.icon === "run" || tool.icon === "write",
-      detail: tool.detail,
-      path: tool.path,
-      status: tool.status,
-      startedAt: tool.startedAt,
-      elapsedMs: tool.elapsedMs,
-    }));
-
-  const lastTextIndex = blocks.reduce((acc, b, i) => (b.kind === "text" ? i : acc), -1);
-  const lastBlock = blocks[blocks.length - 1];
-  const waitingOnTools =
-    turn.status === "streaming" &&
-    !lastTextBody &&
-    (lastBlock?.kind === "tools" || blocks.length === 0);
-
-  return (
-    <article className="min-w-0" style={{ overflowAnchor: "none", animation: "fade-in 280ms ease both" }}>
-      {/* Keep the header once the model has actually thought (streamed
-        * reasoning, or a think long enough to notice): unmounting it when the
-        * think ends made the answer jump up into the space it left. */}
-      {(thinking || reasoningRows.length > 0 || (turn.thoughtMs ?? 0) >= 1500) && (
-        <ThinkingState
-          variant="Reasoning"
-          rows={reasoningRows.length ? reasoningRows : [{ primary: "Waiting on the model…", shimmer: true }]}
-          activeLabel={turn.model ? `Thinking · ${turn.model}` : "Thinking"}
-          doneLabel={thoughtSecs ? `Thought for ${thoughtSecs}s` : "Thought"}
-          working={thinking}
-        />
-      )}
-      {blocks.map((block, i) =>
-        block.kind === "tools" ? (
-          <div key={`tools-${block.tools[0]?.id ?? i}`} className="mt-3">
-            <ToolChips
-              rows={toChipRows(block.tools)}
-              diffs={i === blocks.length - 1 || (i === blocks.length - 2 && lastBlock?.kind === "text") ? turn.diffs : []}
-              onOpenPath={onOpenPath}
-            />
-          </div>
-        ) : (
-          <div key={`text-${i}`} className="mt-3 max-w-[630px]">
-            <Markdown
-              text={i === lastTextIndex ? smoothText : block.text}
-              streaming={i === lastTextIndex && (draining || turn.status === "streaming" || turn.status === "thinking")}
-              onOpenPath={onOpenPath}
-            />
-          </div>
-        ),
-      )}
-      {waitingOnTools && (
-        <div className="mt-4">
-          <span
-            className="bg-clip-text text-[13px] font-medium whitespace-nowrap text-transparent"
-            style={{
-              backgroundImage: "linear-gradient(90deg, var(--ink-3) 35%, var(--ink) 50%, var(--ink-3) 65%)",
-              backgroundSize: "200% 100%",
-              animation: "shimmer-text 1.4s linear infinite",
-            }}
-          >
-            {turn.tools.some((tool) => tool.status === "running") ? "Running tools…" : "Writing…"}
-          </span>
-        </div>
-      )}
-      {turn.error && (
-        <p className="mt-4 max-w-[620px] text-[13.5px] leading-[1.65] text-red">{turn.error}</p>
-      )}
-      {turn.recap && turn.status === "done" && !draining && (
-        <p className="mt-3 text-[12px] text-ink-3">{turn.recap}</p>
-      )}
-      {turn.costUsd !== undefined && turn.status === "done" && !draining && (
-        <p className="mt-1 font-mono text-[11px] text-ink-3">${turn.costUsd.toFixed(4)}</p>
-      )}
-      {turn.status === "done" && !draining && turn.diffs.length > 0 && onReview && (
-        <button
-          type="button"
-          onClick={onReview}
-          className="mt-4 flex h-9 w-full max-w-[630px] items-center gap-2 rounded-[10px] bg-surface px-3 text-left shadow-btn transition-colors duration-100 hover:bg-hover"
-          style={{ animation: "fade-up 300ms cubic-bezier(0.23,1,0.32,1) both" }}
-        >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-ink-3" aria-hidden>
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-            <path d="M14 2v6h6" />
-          </svg>
-          <span className="text-[12.5px] font-medium text-ink">
-            Changed {turn.diffs.length} file{turn.diffs.length === 1 ? "" : "s"}
-          </span>
-          <span className="font-mono text-[11.5px] tabular-nums">
-            <span className="text-green">+{turn.diffs.reduce((n, d) => n + d.add, 0)}</span>{" "}
-            <span className="text-red">−{turn.diffs.reduce((n, d) => n + d.del, 0)}</span>
-          </span>
-          <span className="ml-auto flex items-center gap-0.5 text-[12.5px] font-medium text-ink-2">
-            Review
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-              <path d="M9 18l6-6-6-6" />
-            </svg>
-          </span>
-        </button>
-      )}
-    </article>
-  );
-});
 
 type Msg =
   | { id: number; role: "user"; text: string }
@@ -296,98 +44,6 @@ function newPageToken(): string {
  * sidebar row and the running agent keep pointing at the same file. */
 function newSessionName(): string {
   return `native-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-}
-
-function EmptyState({
-  onSend,
-  health,
-  offset,
-  shuffle,
-  models,
-  modelKey,
-  onModelChange,
-}: {
-  onSend: (text: string) => void;
-  health: Health | null;
-  offset: number;
-  shuffle: () => void;
-  models: PromptModel[];
-  modelKey?: string;
-  onModelChange: (key: string) => void;
-}) {
-  const shown = [0, 1, 2].map((i) => STARTER_PROMPTS[(offset + i) % STARTER_PROMPTS.length]);
-  const [stage, setStage] = useState(0);
-  useEffect(() => {
-    const timers = [
-      setTimeout(() => setStage(1), 170),
-      setTimeout(() => setStage(2), 330),
-      setTimeout(() => setStage(3), 400),
-      setTimeout(() => setStage(4), 550),
-    ];
-    return () => timers.forEach(clearTimeout);
-  }, []);
-
-  return (
-    <div className="mx-auto flex min-h-full max-w-[720px] flex-col justify-center px-4 py-10 sm:px-8">
-      <h1 className="text-[26px] font-normal tracking-[-0.02em] text-ink">
-        <span className="home-reveal block text-ink-3" style={homeRevealStyle(stage >= 1)}>
-          {greeting()}
-        </span>
-        <span className="home-reveal block" style={homeRevealStyle(stage >= 2)}>
-          What should graff work on?
-        </span>
-      </h1>
-
-      <div className="home-reveal relative mt-7" style={homeRevealStyle(stage >= 3)}>
-        <PromptBar
-          demo={false}
-          tall
-          placeholder="Ask graff to read, edit, or review this workspace…"
-          models={models}
-          modelKey={modelKey}
-          onModelChange={onModelChange}
-          onSend={onSend}
-          disabled={health !== null && !health.ok}
-        />
-        {health && !health.ok && (
-          <p className="mt-3 text-[12.5px] text-orange">
-            graff acp is not reachable. From the repo root run{" "}
-            <span className="font-mono text-ink">zig build</span>
-            {health.detail ? ` — ${health.detail}` : ""}.
-          </p>
-        )}
-      </div>
-
-      <div className="home-reveal mt-6 flex flex-col" style={homeRevealStyle(stage >= 4)}>
-        {shown.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            onClick={() => onSend(item.prompt)}
-            className="-mx-2 flex items-center gap-3 rounded-control px-2 py-2.5 text-left text-[14px] text-ink transition-colors duration-150 hover:bg-hover"
-          >
-            <span className="text-ink-3">
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                <path d="M8 6l-5 6 5 6M16 6l5 6-5 6" />
-              </svg>
-            </span>
-            <span className="min-w-0 truncate">{item.label}</span>
-          </button>
-        ))}
-        <div className="mt-1 flex items-center gap-5 pl-0.5 text-[13px] text-ink-3">
-          <span className="flex items-center gap-2 py-1" title={health?.cwd}>
-            <span className={`size-1.5 rounded-full ${health?.ok ? "bg-green" : "bg-orange"}`} />
-            {health?.ok
-              ? `Connected · ${health.cwd ? (health.cwd.split("/").pop() ?? health.cwd) : "over ACP"}`
-              : "Waiting for graff acp"}
-          </span>
-          <button type="button" onClick={shuffle} className="flex items-center gap-2 py-1 transition-colors duration-150 hover:text-ink">
-            Shuffle suggestions
-          </button>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 export default function GraffHarness() {
@@ -414,12 +70,20 @@ export default function GraffHarness() {
   const chatIdRef = useRef(1);
   const msgIdRef = useRef(0);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const chatsRef = useRef(chats);
+  chatsRef.current = chats;
+  const [following, setFollowing] = useState(true);
+  const queuesRef = useRef<Record<number, QueuedPrompt[]>>({});
+  const [queues, setQueues] = useState<Record<number, QueuedPrompt[]>>({});
+  const queueIdRef = useRef(0);
+  const runningRef = useRef(new Set<number>());
 
   const chatThread = chats.find((c) => c.id === activeId) ?? chats[0];
   const active = chatThread.messages.length > 0;
   const busy = busyIds.has(chatThread.id);
   const chatModel = chatThread.model ?? model ?? undefined;
   const sessionId = sessionIds[chatThread.id] ?? null;
+  const queued = queues[chatThread.id] ?? [];
   const handleOf = (chatId: number) => chatHandle(pageRef.current, chatId);
   const setBusyFor = (chatId: number, on: boolean) =>
     setBusyIds((current) => {
@@ -432,6 +96,10 @@ export default function GraffHarness() {
   const setChatModel = (chatId: number, key: string) =>
     setChats((current) => current.map((c) => (c.id === chatId ? { ...c, model: key } : c)));
   const lastAssistant = [...chatThread.messages].reverse().find((m): m is Extract<Msg, { role: "assistant" }> => m.role === "assistant");
+  const setQueue = (chatId: number, list: QueuedPrompt[]) => {
+    queuesRef.current = { ...queuesRef.current, [chatId]: list };
+    setQueues(queuesRef.current);
+  };
 
   const adoptCatalog = async (chatId: number) => {
     // What did the agent actually resolve? The picker should show graff's
@@ -544,13 +212,14 @@ export default function GraffHarness() {
     );
   };
 
-  const send = async (text: string) => {
-    const trimmed = text.trim();
-    const chatId = chatThread.id;
-    if (!trimmed || busyIds.has(chatId)) return;
+  const runPrompt = async (chatId: number, trimmed: string) => {
+    runningRef.current.add(chatId);
+    setFollowing(true);
+    const thread = chatsRef.current.find((c) => c.id === chatId);
+    const spawnModel = thread?.model ?? model ?? undefined;
     const userId = (msgIdRef.current += 1);
     const asstId = (msgIdRef.current += 1);
-    const title = chatThread.title ?? (trimmed.length > 30 ? `${trimmed.slice(0, 30).trimEnd()}…` : trimmed);
+    const title = thread?.title ?? (trimmed.length > 30 ? `${trimmed.slice(0, 30).trimEnd()}…` : trimmed);
     setChats((current) =>
       current.map((c) =>
         c.id !== chatId
@@ -561,13 +230,13 @@ export default function GraffHarness() {
               messages: [
                 ...c.messages,
                 { id: userId, role: "user", text: trimmed },
-                { id: asstId, role: "assistant", turn: { ...emptyTurn(), model: chatModel } },
+                { id: asstId, role: "assistant", turn: { ...emptyTurn(), model: spawnModel } },
               ],
             },
       ),
     );
     setBusyFor(chatId, true);
-    let turn: AssistantTurn = { ...emptyTurn(), model: chatModel };
+    let turn: AssistantTurn = { ...emptyTurn(), model: spawnModel };
     const startedAt = Date.now();
     try {
       const id = await requireSession(chatId);
@@ -594,12 +263,25 @@ export default function GraffHarness() {
       turn = { ...turn, error: err instanceof Error ? err.message : String(err), status: "error" };
       patchAssistant(chatId, asstId, turn);
     } finally {
+      runningRef.current.delete(chatId);
       setBusyFor(chatId, false);
-      // graff autosaves the turn in the background; look once now for the
-      // title, and again after the write has had time to land.
       void refreshStored();
       setTimeout(() => void refreshStored(), 2500);
+      const { next, rest } = shiftQueuedPrompt(queuesRef.current[chatId] ?? []);
+      setQueue(chatId, rest);
+      if (next) void runPrompt(chatId, next.text);
     }
+  };
+
+  const send = async (text: string) => {
+    const trimmed = text.trim();
+    const chatId = chatThread.id;
+    if (!trimmed) return;
+    if (runningRef.current.has(chatId) || busyIds.has(chatId)) {
+      setQueue(chatId, enqueuePrompt(queuesRef.current[chatId] ?? [], trimmed, (queueIdRef.current += 1)));
+      return;
+    }
+    await runPrompt(chatId, trimmed);
   };
 
   const openChat = (id: number) => {
@@ -608,6 +290,7 @@ export default function GraffHarness() {
     setChats((current) => [...current, { id, title: null, messages: [], model: model ?? undefined, session }]);
     setActiveId(id);
     setFilesOpen(false);
+    setFollowing(true);
     // Spawn eagerly so the first send is not stuck behind agent + MCP boot.
     void requireSession(id).catch(() => undefined);
   };
@@ -637,6 +320,7 @@ export default function GraffHarness() {
     ]);
     setActiveId(id);
     setFilesOpen(false);
+    setFollowing(true);
     void requireSession(id, false, loaded.meta.model ?? undefined).catch(() => undefined);
   };
 
@@ -645,6 +329,8 @@ export default function GraffHarness() {
   const dropChat = (id: number) => {
     sessionsRef.current.delete(id);
     sessionNamesRef.current.delete(id);
+    runningRef.current.delete(id);
+    setQueue(id, []);
     setSessionIds((current) => {
       const { [id]: _gone, ...rest } = current;
       return rest;
@@ -669,20 +355,23 @@ export default function GraffHarness() {
     void openStored(id);
   };
 
-  // A new message glides the thread to the bottom; streaming growth (reasoning,
-  // text, tool rows) follows instantly and only while the reader is already at
-  // the tail. Re-issuing a *smooth* scroll on every chunk restarted the scroll
-  // animation each token — the whole thread juddered while the model thought.
-  const messageCount = chatThread.messages.length;
   useEffect(() => {
-    if (!active) return;
     const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [messageCount, activeId, active]);
+    if (!el) return;
+    setFollowing(true);
+    el.scrollTop = el.scrollHeight;
+    const onScroll = () => {
+      const next = isFollowingTail(el);
+      setFollowing((current) => (current === next ? current : next));
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [activeId, active]);
+
   useEffect(() => {
     if (!active) return;
-    pinScrollerTail(scrollRef.current);
-  }, [active, lastAssistant?.turn.text, lastAssistant?.turn.reasoning, lastAssistant?.turn.tools.length]);
+    pinScrollerTail(scrollRef.current, following);
+  }, [active, following, lastAssistant?.turn.text, lastAssistant?.turn.reasoning, lastAssistant?.turn.tools.length]);
 
   // The sidebar is graff's session directory, newest first, bucketed by day.
   const now = Date.now();
@@ -778,28 +467,57 @@ export default function GraffHarness() {
             {tabBar}
             {active ? (
               <div className="flex min-h-0 flex-1 flex-col">
-                <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+                <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto overscroll-contain" style={{ overflowAnchor: "none" }}>
                   <div className="mx-auto flex w-full max-w-[720px] flex-col gap-8 px-4 py-8 sm:px-8">
-                    {chatThread.messages.map((message) =>
+                    {chatThread.messages.map((message, index) =>
                       message.role === "user" ? (
                         <UserBubble key={message.id} text={message.text} />
                       ) : (
-                        <AssistantBody key={message.id} turn={message.turn} onOpenPath={openPath} onReview={openChanges} scroller={scrollRef} />
+                        <AssistantBody
+                          key={message.id}
+                          turn={message.turn}
+                          onOpenPath={openPath}
+                          onReview={openChanges}
+                          scroller={scrollRef}
+                          following={following && index === chatThread.messages.length - 1}
+                        />
                       ),
                     )}
                   </div>
                 </div>
                 <div className="shrink-0 bg-page px-4 pt-3 pb-6 sm:px-8">
                   <div className="mx-auto max-w-[720px]">
+                    {queued.length > 0 && (
+                      <ul className="mb-2 flex flex-col gap-1">
+                        {queued.map((item) => (
+                          <li
+                            key={item.id}
+                            className="flex items-center gap-2 rounded-[8px] bg-surface px-2.5 py-1.5 text-[12.5px] text-ink-2 shadow-hairline"
+                          >
+                            <span className="shrink-0 text-[11px] font-medium tracking-wide text-ink-3 uppercase">Queued</span>
+                            <span className="min-w-0 flex-1 truncate text-ink">{item.text}</span>
+                            <button
+                              type="button"
+                              aria-label="Remove from queue"
+                              onClick={() => setQueue(chatThread.id, dropQueuedPrompt(queuesRef.current[chatThread.id] ?? [], item.id))}
+                              className="flex size-5 shrink-0 items-center justify-center rounded-[5px] text-ink-3 hover:bg-hover hover:text-ink"
+                            >
+                              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" aria-hidden>
+                                <path d="M18 6L6 18M6 6l12 12" />
+                              </svg>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                     <PromptBar
                       demo={false}
                       tall
-                      placeholder={busy ? "Agent is working…" : "Follow up"}
+                      placeholder={busy ? "Queue a follow-up…" : "Follow up"}
                       models={models}
                       modelKey={chatModel}
                       onModelChange={changeModel}
                       onSend={send}
-                      disabled={busy}
                       busy={busy}
                       onStop={() => {
                         const live = sessionsRef.current.get(chatThread.id);

--- a/apps/native/lib/follow-scroll.test.ts
+++ b/apps/native/lib/follow-scroll.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { distanceFromTail, isFollowingTail, pinScrollerTail, TAIL_SLACK_PX } from "./follow-scroll.ts";
+
+function box(scrollTop: number, scrollHeight = 1000, clientHeight = 400) {
+  return { scrollTop, scrollHeight, clientHeight };
+}
+
+describe("follow-scroll", () => {
+  it("treats the exact tail as following", () => {
+    assert.equal(distanceFromTail(box(600)), 0);
+    assert.equal(isFollowingTail(box(600)), true);
+  });
+
+  it("lets the reader leave once they scroll past the slack", () => {
+    assert.equal(isFollowingTail(box(600 - TAIL_SLACK_PX - 1)), false);
+    assert.equal(isFollowingTail(box(600 - TAIL_SLACK_PX)), true);
+  });
+
+  it("does not pin when the reader has scrolled away", () => {
+    const el = { scrollTop: 10, scrollHeight: 1000, clientHeight: 400 };
+    pinScrollerTail(el as HTMLElement, false);
+    assert.equal(el.scrollTop, 10);
+    pinScrollerTail(el as HTMLElement, true);
+    assert.equal(el.scrollTop, 1000);
+  });
+});

--- a/apps/native/lib/follow-scroll.ts
+++ b/apps/native/lib/follow-scroll.ts
@@ -1,0 +1,25 @@
+/** How close to the tail counts as "still following". A large slack (the old
+ * 240px magnet) made it impossible to scroll away while tokens arrived. */
+export const TAIL_SLACK_PX = 48;
+
+export function distanceFromTail(el: {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}): number {
+  return el.scrollHeight - el.scrollTop - el.clientHeight;
+}
+
+export function isFollowingTail(
+  el: { scrollHeight: number; scrollTop: number; clientHeight: number },
+  slack = TAIL_SLACK_PX,
+): boolean {
+  return distanceFromTail(el) <= slack;
+}
+
+/** Pin only while the reader is following. WKWebView treats scrollIntoView
+ * on a tall article as a viewport realignment every frame. */
+export function pinScrollerTail(el: HTMLElement | null, following: boolean): void {
+  if (!el || !following) return;
+  el.scrollTop = el.scrollHeight;
+}

--- a/apps/native/lib/prompt-queue.test.ts
+++ b/apps/native/lib/prompt-queue.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { dropQueuedPrompt, enqueuePrompt, shiftQueuedPrompt } from "./prompt-queue.ts";
+
+describe("prompt-queue", () => {
+  it("ignores blank lines", () => {
+    assert.deepEqual(enqueuePrompt([], "   \n", 1), []);
+  });
+
+  it("queues, drops, and drains in order", () => {
+    let list = enqueuePrompt([], " first ", 1);
+    list = enqueuePrompt(list, "second", 2);
+    assert.deepEqual(list, [
+      { id: 1, text: "first" },
+      { id: 2, text: "second" },
+    ]);
+    list = dropQueuedPrompt(list, 1);
+    const { next, rest } = shiftQueuedPrompt(list);
+    assert.deepEqual(next, { id: 2, text: "second" });
+    assert.deepEqual(rest, []);
+  });
+});

--- a/apps/native/lib/prompt-queue.ts
+++ b/apps/native/lib/prompt-queue.ts
@@ -1,0 +1,20 @@
+export type QueuedPrompt = { id: number; text: string };
+
+export function enqueuePrompt(list: QueuedPrompt[], text: string, id: number): QueuedPrompt[] {
+  const trimmed = text.trim();
+  if (!trimmed) return list;
+  return [...list, { id, text: trimmed }];
+}
+
+export function dropQueuedPrompt(list: QueuedPrompt[], id: number): QueuedPrompt[] {
+  return list.filter((item) => item.id !== id);
+}
+
+export function shiftQueuedPrompt(list: QueuedPrompt[]): {
+  next: QueuedPrompt | undefined;
+  rest: QueuedPrompt[];
+} {
+  if (list.length === 0) return { next: undefined, rest: list };
+  const [next, ...rest] = list;
+  return { next, rest };
+}

--- a/apps/native/next.config.ts
+++ b/apps/native/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: { unoptimized: true },
+  experimental: {
+    optimizePackageImports: ["iconoir-react"],
+  },
 };
 
 export default nextConfig;

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -10,7 +10,7 @@
     "start": "NEXT_TELEMETRY_DISABLED=1 next start --port 3000",
     "mock-serve": "node scripts/mock-serve.mjs",
     "lint": "next lint",
-    "test": "node --experimental-strip-types --test lib/graff-events.test.ts lib/acp.test.ts lib/sessions.test.ts"
+    "test": "node --experimental-strip-types --test lib/graff-events.test.ts lib/acp.test.ts lib/sessions.test.ts lib/follow-scroll.test.ts lib/prompt-queue.test.ts"
   },
   "dependencies": {
     "glimm": "^0.3.0",

--- a/docs/releases/v0.0.285.md
+++ b/docs/releases/v0.0.285.md
@@ -31,6 +31,15 @@ request that actually used the chain rebuilds.
 `agent.zig` stays at the 600-line ceiling: the new field replaces a
 tightened scratch-arena comment.
 
+## TUI steer carries image chips
+
+A follow-up typed while a turn is running (`Enter` to queue, or `/btw`)
+copied only `input.getValue()`. Composer chips live on `Model.images`,
+not in that string, so the queued line was text-only and the next turn
+never staged `@[path]` pixels. Queueing now prefixes the same `@[path]`
+markers a normal send uses, clears the chips, and an image-only Enter
+queues the chip instead of treating empty text as “force interrupt”.
+
 ## Tests
 
 This fold adds `shouldReanchorRequest requires a rejected

--- a/docs/releases/v0.0.285.md
+++ b/docs/releases/v0.0.285.md
@@ -1,0 +1,86 @@
+# v0.0.285 (2026-09-03)
+
+Next cut after [v0.0.284](v0.0.284.md). The headline is the native app
+behaving like a chat you can actually read: scrolling up while the
+agent is writing no longer yanks the transcript, follow-ups typed
+during a turn queue instead of vanishing, and tool rows land in the
+answer instead of as a wall on top.
+
+284 stays published as-is. This is not a retag.
+
+## What this cut is
+
+graff is still one static Zig binary that turns the AI subscriptions you
+already pay for into an agent on your machine — same `Agent` type on the
+line REPL, the fullscreen TUI, `graff acp`, and the native GUI. 285 is
+the native/TUI polish that landed after the 284 tag:
+
+- scrolling the native transcript during a stream was impossible — every
+  token pinned the viewport to the tail
+- sending a follow-up while a turn was running was a no-op
+- tool chips rendered as a stack above the answer
+- `workspace` switch could star the wrong tree and report a stale cwd
+- the TUI hid the live answer behind a Thinking placeholder
+
+Those are all closed.
+
+## Scroll away while it writes (#724)
+
+The native thread followed the tail with a large near-bottom magnet, so
+a short scroll never escaped — the next token jumped you back. Follow
+now pins only while the reader is actually at the tail. Scrolling up
+pauses it; returning to the bottom resumes. The pin uses the scroller
+offset, not `scrollIntoView` (that realigned the whole WKWebView every
+frame).
+
+## Queue a follow-up while a turn is running
+
+The composer stayed disabled for the whole turn, so the next prompt was
+dropped. It now stays open. Enter with text queues the line (shown above
+the bar, removable). Queued prompts drain in order when the turn ends.
+An empty draft still shows stop.
+
+## Tools in the answer, not a wall on top
+
+Tool chips and text now follow the wire order instead of dumping every
+tool first. Settled batches fold; the live row stays open. ACP patches
+coalesce to one paint per frame so a long thread does not re-parse
+every settled markdown block on each token.
+
+## Workspace switch reports the process cwd (#721)
+
+`workspace` could star a tree the process had not entered, and the
+status line could disagree with cwd. Switch now compares real paths and
+reports the process cwd after enter.
+
+## TUI live answer
+
+While tokens arrive, the TUI shows the live answer instead of a
+Thinking placeholder. `codedb` rows use the lookup family so they are
+not a blank Read chip.
+
+## Tests
+
+Suite floor stays the 284 ratchet. Native follow-tail and prompt-queue
+helpers are covered in the native unit suite.
+
+## Downloads
+
+All six CLI archives, the curl installer, and checksums:
+
+| File | Platform |
+|---|---|
+| [graff-aarch64-linux.tar.gz](https://github.com/justrach/codegraff/releases/download/v0.0.285/graff-aarch64-linux.tar.gz) | Linux arm64 |
+| [graff-aarch64-macos.tar.gz](https://github.com/justrach/codegraff/releases/download/v0.0.285/graff-aarch64-macos.tar.gz) | macOS Apple Silicon |
+| [graff-aarch64-windows.tar.gz](https://github.com/justrach/codegraff/releases/download/v0.0.285/graff-aarch64-windows.tar.gz) | Windows arm64 |
+| [graff-x86_64-linux.tar.gz](https://github.com/justrach/codegraff/releases/download/v0.0.285/graff-x86_64-linux.tar.gz) | Linux x86_64 |
+| [graff-x86_64-macos.tar.gz](https://github.com/justrach/codegraff/releases/download/v0.0.285/graff-x86_64-macos.tar.gz) | macOS Intel |
+| [graff-x86_64-windows.tar.gz](https://github.com/justrach/codegraff/releases/download/v0.0.285/graff-x86_64-windows.tar.gz) | Windows x86_64 |
+| [install.sh](https://github.com/justrach/codegraff/releases/download/v0.0.285/install.sh) | curl installer |
+| [SHA256SUMS](https://github.com/justrach/codegraff/releases/download/v0.0.285/SHA256SUMS) | checksums for the six archives |
+
+```bash
+curl -fsSL https://github.com/justrach/codegraff/releases/download/v0.0.285/install.sh | bash
+```
+
+GitHub also attaches the usual source zip/tarball for the tag.

--- a/docs/releases/v0.0.285.md
+++ b/docs/releases/v0.0.285.md
@@ -1,0 +1,40 @@
+# v0.0.285 (2026-09-01)
+
+Next cut after [v0.0.284](v0.0.284.md) merged to main. No GitHub tag
+until asked. Download / notarization ids land after the build.
+
+## Codex WS error-frame recovery (#717)
+
+yxlyx's [#717](https://github.com/justrach/codegraff/pull/717), replayed
+onto this tip (its original base was 283-era `main`). `#692` / `#693`
+already treat a generic WebSocket `type:error` as a terminal API
+response. Three edges were still loose:
+
+- The transport kept the dead socket until the Responses parser ran, so
+  a lower-level caller could reuse it.
+- Chain recovery keyed off retained `codex_prev_id`, even when the
+  serialized body had omitted `previous_response_id` (property change
+  or full-resend experiment).
+- An unparseable Responses envelope was copied into `last_api_error`,
+  which can echo request or authentication-adjacent bytes.
+
+A short-lived `ws_api_error_pending` marker separates transport cleanup
+from later formatting: the socket closes on the error frame, and the
+parser still traces a bounded diagnostic. Re-anchor now requires the
+rejected wire body to contain `previous_response_id` *and* a recognized
+chain error (`shouldReanchorRequest`). Unparseable bodies use the same
+`failureDiagnostic` path as structured provider failures.
+
+Generic errors stay terminal. Only a recognized chain error on a
+request that actually used the chain rebuilds.
+
+`agent.zig` stays at the 600-line ceiling: the new field replaces a
+tightened scratch-arena comment.
+
+## Tests
+
+This fold adds `shouldReanchorRequest requires a rejected
+previous_response_id request` and tightens the `#692` reuse case
+(socket is null, marker is set, transport ladder is untouched). The
+`#402` source pin now covers the redacted unparseable path. Suite
+floor stays **1896** until the next ratchet bump.

--- a/docs/releases/v0.0.285.md
+++ b/docs/releases/v0.0.285.md
@@ -40,6 +40,21 @@ never staged `@[path]` pixels. Queueing now prefixes the same `@[path]`
 markers a normal send uses, clears the chips, and an image-only Enter
 queues the chip instead of treating empty text as “force interrupt”.
 
+## Tools stream with the answer
+
+Folded from `main` after the 285 branch (`0fb41c0`, `1632b0d`).
+
+On the native app, tool chips used to stack as a wall above the
+reply, and `scrollIntoView` jittered WKWebView. The thread scroller
+is pinned; chips interleave at the text cursor they landed on; a
+settled batch collapses to “Explored N”; markdown list numbers stay
+with the source.
+
+On the TUI, once tokens arrive the pending Thinking row goes away and
+the live stream paints as the assistant reply. `codedb` folds as
+“Looked up N items”. Live-tail helpers moved to `TUI/livetail.zig` so
+`scrollback.zig` stays under the 600-line ceiling.
+
 ## Tests
 
 This fold adds `shouldReanchorRequest requires a rejected

--- a/docs/releases/v0.0.285.md
+++ b/docs/releases/v0.0.285.md
@@ -37,4 +37,4 @@ This fold adds `shouldReanchorRequest requires a rejected
 previous_response_id request` and tightens the `#692` reuse case
 (socket is null, marker is set, transport ladder is untouched). The
 `#402` source pin now covers the redacted unparseable path. Suite
-floor stays **1896** until the next ratchet bump.
+floor is **1909** (this cut's suite count).

--- a/graff-evals/gemini-cli.sh
+++ b/graff-evals/gemini-cli.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Drive Google Gemini CLI (@google/gemini-cli) with GEMINI_API_KEY.
+set -e
+export GEMINI_API_KEY="${GEMINI_API_KEY:-$(cat "$HOME/.gemini-api-key" 2>/dev/null || true)}"
+export GEMINI_CLI_TRUST_WORKSPACE=true
+if [ -z "${GEMINI_API_KEY}" ]; then
+	echo "gemini-cli: GEMINI_API_KEY is unset and ~/.gemini-api-key not found" >&2
+	exit 127
+fi
+exec gemini "$@"

--- a/graff-evals/harnesses.json
+++ b/graff-evals/harnesses.json
@@ -199,5 +199,21 @@
     "env": {"DSH_PERMISSION_MODE": "danger-full-access"},
     "default_model": "grok-4.5",
     "note": "deepseek-harness on grok-4.5 (nearest xAI id in its catalog). NOT grok-4.6. Mixed-model chart only. Needs Node >=22.15 (zstd). SuperGrok OAuth → XAI_API_KEY via attach-dsh-xai-oauth.py (local; see dsh-local-oauth.md). No usage footer."
+  },
+  "gemini-cli": {
+    "cmd": ["{repo}/graff-evals/gemini-cli.sh", "-p", "{prompt}", "-m", "{model}", "-y", "--skip-trust", "-o", "json", "--allowed-mcp-server-names", "none"],
+    "answer": "gemini-json",
+    "usage": "gemini-json",
+    "capabilities": [],
+    "default_model": "gemini-3.5-flash",
+    "note": "Official Google Gemini CLI (@google/gemini-cli) driven with GEMINI_API_KEY"
+  },
+  "pi-dev": {
+    "cmd": ["pi", "-p", "--mode", "json", "--provider", "codegraff", "--model", "{model}", "--no-session", "{prompt}"],
+    "answer": "pi-json",
+    "usage": "pi-json",
+    "capabilities": [],
+    "default_model": "gemini-3.8-flash",
+    "note": "Pi coding agent (pi.dev) on Codegraff gateway"
   }
 }

--- a/graff-evals/hillclimb/frontier-gemini-20260903.svg
+++ b/graff-evals/hillclimb/frontier-gemini-20260903.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 490" width="880" height="490" role="img">
+<title>Pareto Frontier: graff-dev vs gemini-cli</title>
+<rect width="880" height="490" fill="#ffffff"/>
+<text x="20" y="22" font-size="16" font-weight="700" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">Pareto Frontier: graff-dev vs gemini-cli</text>
+<text x="20" y="40" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">7 head-to-head tasks (Core + SWE) on Gemini Flash</text>
+<rect x="72" y="62" width="340" height="280" fill="#fafcfb" stroke="#d1d5db"/>
+<rect x="500" y="62" width="340" height="280" fill="#fafcfb" stroke="#d1d5db"/>
+<text x="72" y="56" font-size="13" font-weight="600" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">wall vs list$</text>
+<text x="500" y="56" font-size="13" font-weight="600" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">calls vs list$</text>
+<text x="242" y="376" text-anchor="middle" font-size="12" fill="#334155" font-family="ui-sans-serif, system-ui, sans-serif">wall (s) →</text>
+<text x="670" y="376" text-anchor="middle" font-size="12" fill="#334155" font-family="ui-sans-serif, system-ui, sans-serif">tool calls →</text>
+<line x1="72" y1="342.0" x2="412" y2="342.0" stroke="#e5e7eb"/>
+<line x1="500" y1="342.0" x2="840" y2="342.0" stroke="#e5e7eb"/>
+<text x="64" y="346.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.000</text>
+<text x="492" y="346.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.000</text>
+<line x1="72" y1="278.0" x2="412" y2="278.0" stroke="#e5e7eb"/>
+<line x1="500" y1="278.0" x2="840" y2="278.0" stroke="#e5e7eb"/>
+<text x="64" y="282.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.104</text>
+<text x="492" y="282.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.104</text>
+<line x1="72" y1="214.0" x2="412" y2="214.0" stroke="#e5e7eb"/>
+<line x1="500" y1="214.0" x2="840" y2="214.0" stroke="#e5e7eb"/>
+<text x="64" y="218.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.209</text>
+<text x="492" y="218.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.209</text>
+<line x1="72" y1="150.0" x2="412" y2="150.0" stroke="#e5e7eb"/>
+<line x1="500" y1="150.0" x2="840" y2="150.0" stroke="#e5e7eb"/>
+<text x="64" y="154.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.313</text>
+<text x="492" y="154.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.313</text>
+<line x1="72" y1="86.0" x2="412" y2="86.0" stroke="#e5e7eb"/>
+<line x1="500" y1="86.0" x2="840" y2="86.0" stroke="#e5e7eb"/>
+<text x="64" y="90.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.417</text>
+<text x="492" y="90.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.417</text>
+<line x1="72.0" y1="62" x2="72.0" y2="342" stroke="#e5e7eb"/>
+<text x="72.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">69s</text>
+<line x1="157.0" y1="62" x2="157.0" y2="342" stroke="#e5e7eb"/>
+<text x="157.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">147s</text>
+<line x1="242.0" y1="62" x2="242.0" y2="342" stroke="#e5e7eb"/>
+<text x="242.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">225s</text>
+<line x1="327.0" y1="62" x2="327.0" y2="342" stroke="#e5e7eb"/>
+<text x="327.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">303s</text>
+<line x1="412.0" y1="62" x2="412.0" y2="342" stroke="#e5e7eb"/>
+<text x="412.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">381s</text>
+<line x1="516.1" y1="62" x2="516.1" y2="342" stroke="#e5e7eb"/>
+<text x="516.1" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">30</text>
+<line x1="529.4" y1="62" x2="529.4" y2="342" stroke="#e5e7eb"/>
+<text x="529.4" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">31</text>
+<line x1="542.8" y1="62" x2="542.8" y2="342" stroke="#e5e7eb"/>
+<text x="542.8" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">32</text>
+<line x1="556.2" y1="62" x2="556.2" y2="342" stroke="#e5e7eb"/>
+<text x="556.2" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">33</text>
+<line x1="569.6" y1="62" x2="569.6" y2="342" stroke="#e5e7eb"/>
+<text x="569.6" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">34</text>
+<line x1="583.0" y1="62" x2="583.0" y2="342" stroke="#e5e7eb"/>
+<text x="583.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">35</text>
+<line x1="596.4" y1="62" x2="596.4" y2="342" stroke="#e5e7eb"/>
+<text x="596.4" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">36</text>
+<line x1="609.8" y1="62" x2="609.8" y2="342" stroke="#e5e7eb"/>
+<text x="609.8" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">37</text>
+<line x1="623.1" y1="62" x2="623.1" y2="342" stroke="#e5e7eb"/>
+<text x="623.1" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">38</text>
+<line x1="636.5" y1="62" x2="636.5" y2="342" stroke="#e5e7eb"/>
+<text x="636.5" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">39</text>
+<line x1="649.9" y1="62" x2="649.9" y2="342" stroke="#e5e7eb"/>
+<text x="649.9" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">40</text>
+<line x1="663.3" y1="62" x2="663.3" y2="342" stroke="#e5e7eb"/>
+<text x="663.3" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">41</text>
+<line x1="676.7" y1="62" x2="676.7" y2="342" stroke="#e5e7eb"/>
+<text x="676.7" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">42</text>
+<line x1="690.1" y1="62" x2="690.1" y2="342" stroke="#e5e7eb"/>
+<text x="690.1" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">43</text>
+<line x1="703.5" y1="62" x2="703.5" y2="342" stroke="#e5e7eb"/>
+<text x="703.5" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">44</text>
+<line x1="716.9" y1="62" x2="716.9" y2="342" stroke="#e5e7eb"/>
+<text x="716.9" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">45</text>
+<line x1="730.2" y1="62" x2="730.2" y2="342" stroke="#e5e7eb"/>
+<text x="730.2" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">46</text>
+<line x1="743.6" y1="62" x2="743.6" y2="342" stroke="#e5e7eb"/>
+<text x="743.6" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">47</text>
+<line x1="757.0" y1="62" x2="757.0" y2="342" stroke="#e5e7eb"/>
+<text x="757.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">48</text>
+<line x1="770.4" y1="62" x2="770.4" y2="342" stroke="#e5e7eb"/>
+<text x="770.4" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">49</text>
+<line x1="783.8" y1="62" x2="783.8" y2="342" stroke="#e5e7eb"/>
+<text x="783.8" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">50</text>
+<line x1="797.2" y1="62" x2="797.2" y2="342" stroke="#e5e7eb"/>
+<text x="797.2" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">51</text>
+<line x1="810.6" y1="62" x2="810.6" y2="342" stroke="#e5e7eb"/>
+<text x="810.6" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">52</text>
+<line x1="823.9" y1="62" x2="823.9" y2="342" stroke="#e5e7eb"/>
+<text x="823.9" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">53</text>
+<circle cx="85.4" cy="250.2" r="6.5" fill="#059669" stroke="#047857" stroke-width="1.4"/>
+<text x="95.4" y="242.2" font-size="11" font-weight="600" fill="#047857" font-family="ui-sans-serif, system-ui, sans-serif">graff-dev  81.7s · $0.1496</text>
+<circle cx="516.1" cy="250.2" r="6.5" fill="#059669" stroke="#047857" stroke-width="1.4"/>
+<text x="526.1" y="242.2" font-size="11" font-weight="600" fill="#047857" font-family="ui-sans-serif, system-ui, sans-serif">graff-dev  30 · $0.1496</text>
+<circle cx="28" cy="410" r="6.5" fill="#059669" stroke="#047857" stroke-width="1.4"/>
+<text x="40" y="414" font-size="12" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">graff-dev — 7/7 · on wall/$ + calls/$</text>
+<circle cx="367.4" cy="119.4" r="6.5" fill="#4285f4" stroke="#1a73e8" stroke-width="1.4"/>
+<text x="377.4" y="111.4" font-size="11" font-weight="600" fill="#1a73e8" font-family="ui-sans-serif, system-ui, sans-serif">gemini-cli  340.1s · $0.3628</text>
+<circle cx="823.9" cy="119.4" r="6.5" fill="#4285f4" stroke="#1a73e8" stroke-width="1.4"/>
+<text x="833.9" y="111.4" font-size="11" font-weight="600" fill="#1a73e8" font-family="ui-sans-serif, system-ui, sans-serif">gemini-cli  53 · $0.3628</text>
+<circle cx="28" cy="430" r="6.5" fill="#4285f4" stroke="#1a73e8" stroke-width="1.4"/>
+<text x="40" y="434" font-size="12" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">gemini-cli — 7/7 · interior</text>
+</svg>

--- a/graff-evals/hillclimb/frontier-tri-gemini-20260903.svg
+++ b/graff-evals/hillclimb/frontier-tri-gemini-20260903.svg
@@ -1,0 +1,138 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 490" width="880" height="490" role="img">
+<title>Pareto Frontier: graff-dev vs pi-dev vs gemini-cli</title>
+<rect width="880" height="490" fill="#ffffff"/>
+<text x="20" y="22" font-size="16" font-weight="700" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">Pareto Frontier: graff-dev vs pi-dev vs gemini-cli</text>
+<text x="20" y="40" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">7 head-to-head tasks (Core + SWE) on Gemini Flash</text>
+<rect x="72" y="62" width="340" height="280" fill="#fafcfb" stroke="#d1d5db"/>
+<rect x="500" y="62" width="340" height="280" fill="#fafcfb" stroke="#d1d5db"/>
+<text x="72" y="56" font-size="13" font-weight="600" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">wall vs list$</text>
+<text x="500" y="56" font-size="13" font-weight="600" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">calls vs list$</text>
+<text x="242" y="376" text-anchor="middle" font-size="12" fill="#334155" font-family="ui-sans-serif, system-ui, sans-serif">wall (s) →</text>
+<text x="670" y="376" text-anchor="middle" font-size="12" fill="#334155" font-family="ui-sans-serif, system-ui, sans-serif">tool calls →</text>
+<line x1="72" y1="342.0" x2="412" y2="342.0" stroke="#e5e7eb"/>
+<line x1="500" y1="342.0" x2="840" y2="342.0" stroke="#e5e7eb"/>
+<text x="64" y="346.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.000</text>
+<text x="492" y="346.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.000</text>
+<line x1="72" y1="278.0" x2="412" y2="278.0" stroke="#e5e7eb"/>
+<line x1="500" y1="278.0" x2="840" y2="278.0" stroke="#e5e7eb"/>
+<text x="64" y="282.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.130</text>
+<text x="492" y="282.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.130</text>
+<line x1="72" y1="214.0" x2="412" y2="214.0" stroke="#e5e7eb"/>
+<line x1="500" y1="214.0" x2="840" y2="214.0" stroke="#e5e7eb"/>
+<text x="64" y="218.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.261</text>
+<text x="492" y="218.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.261</text>
+<line x1="72" y1="150.0" x2="412" y2="150.0" stroke="#e5e7eb"/>
+<line x1="500" y1="150.0" x2="840" y2="150.0" stroke="#e5e7eb"/>
+<text x="64" y="154.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.391</text>
+<text x="492" y="154.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.391</text>
+<line x1="72" y1="86.0" x2="412" y2="86.0" stroke="#e5e7eb"/>
+<line x1="500" y1="86.0" x2="840" y2="86.0" stroke="#e5e7eb"/>
+<text x="64" y="90.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.521</text>
+<text x="492" y="90.0" text-anchor="end" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">$0.521</text>
+<line x1="72.0" y1="62" x2="72.0" y2="342" stroke="#e5e7eb"/>
+<text x="72.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">69s</text>
+<line x1="157.0" y1="62" x2="157.0" y2="342" stroke="#e5e7eb"/>
+<text x="157.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">147s</text>
+<line x1="242.0" y1="62" x2="242.0" y2="342" stroke="#e5e7eb"/>
+<text x="242.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">225s</text>
+<line x1="327.0" y1="62" x2="327.0" y2="342" stroke="#e5e7eb"/>
+<text x="327.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">303s</text>
+<line x1="412.0" y1="62" x2="412.0" y2="342" stroke="#e5e7eb"/>
+<text x="412.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">381s</text>
+<line x1="510.1" y1="62" x2="510.1" y2="342" stroke="#e5e7eb"/>
+<text x="510.1" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">30</text>
+<line x1="518.5" y1="62" x2="518.5" y2="342" stroke="#e5e7eb"/>
+<text x="518.5" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">31</text>
+<line x1="526.9" y1="62" x2="526.9" y2="342" stroke="#e5e7eb"/>
+<text x="526.9" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">32</text>
+<line x1="535.3" y1="62" x2="535.3" y2="342" stroke="#e5e7eb"/>
+<text x="535.3" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">33</text>
+<line x1="543.8" y1="62" x2="543.8" y2="342" stroke="#e5e7eb"/>
+<text x="543.8" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">34</text>
+<line x1="552.2" y1="62" x2="552.2" y2="342" stroke="#e5e7eb"/>
+<text x="552.2" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">35</text>
+<line x1="560.6" y1="62" x2="560.6" y2="342" stroke="#e5e7eb"/>
+<text x="560.6" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">36</text>
+<line x1="569.0" y1="62" x2="569.0" y2="342" stroke="#e5e7eb"/>
+<text x="569.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">37</text>
+<line x1="577.4" y1="62" x2="577.4" y2="342" stroke="#e5e7eb"/>
+<text x="577.4" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">38</text>
+<line x1="585.8" y1="62" x2="585.8" y2="342" stroke="#e5e7eb"/>
+<text x="585.8" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">39</text>
+<line x1="594.3" y1="62" x2="594.3" y2="342" stroke="#e5e7eb"/>
+<text x="594.3" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">40</text>
+<line x1="602.7" y1="62" x2="602.7" y2="342" stroke="#e5e7eb"/>
+<text x="602.7" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">41</text>
+<line x1="611.1" y1="62" x2="611.1" y2="342" stroke="#e5e7eb"/>
+<text x="611.1" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">42</text>
+<line x1="619.5" y1="62" x2="619.5" y2="342" stroke="#e5e7eb"/>
+<text x="619.5" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">43</text>
+<line x1="627.9" y1="62" x2="627.9" y2="342" stroke="#e5e7eb"/>
+<text x="627.9" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">44</text>
+<line x1="636.3" y1="62" x2="636.3" y2="342" stroke="#e5e7eb"/>
+<text x="636.3" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">45</text>
+<line x1="644.8" y1="62" x2="644.8" y2="342" stroke="#e5e7eb"/>
+<text x="644.8" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">46</text>
+<line x1="653.2" y1="62" x2="653.2" y2="342" stroke="#e5e7eb"/>
+<text x="653.2" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">47</text>
+<line x1="661.6" y1="62" x2="661.6" y2="342" stroke="#e5e7eb"/>
+<text x="661.6" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">48</text>
+<line x1="670.0" y1="62" x2="670.0" y2="342" stroke="#e5e7eb"/>
+<text x="670.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">49</text>
+<line x1="678.4" y1="62" x2="678.4" y2="342" stroke="#e5e7eb"/>
+<text x="678.4" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">50</text>
+<line x1="686.8" y1="62" x2="686.8" y2="342" stroke="#e5e7eb"/>
+<text x="686.8" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">51</text>
+<line x1="695.2" y1="62" x2="695.2" y2="342" stroke="#e5e7eb"/>
+<text x="695.2" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">52</text>
+<line x1="703.7" y1="62" x2="703.7" y2="342" stroke="#e5e7eb"/>
+<text x="703.7" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">53</text>
+<line x1="712.1" y1="62" x2="712.1" y2="342" stroke="#e5e7eb"/>
+<text x="712.1" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">54</text>
+<line x1="720.5" y1="62" x2="720.5" y2="342" stroke="#e5e7eb"/>
+<text x="720.5" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">55</text>
+<line x1="728.9" y1="62" x2="728.9" y2="342" stroke="#e5e7eb"/>
+<text x="728.9" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">56</text>
+<line x1="737.3" y1="62" x2="737.3" y2="342" stroke="#e5e7eb"/>
+<text x="737.3" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">57</text>
+<line x1="745.7" y1="62" x2="745.7" y2="342" stroke="#e5e7eb"/>
+<text x="745.7" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">58</text>
+<line x1="754.2" y1="62" x2="754.2" y2="342" stroke="#e5e7eb"/>
+<text x="754.2" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">59</text>
+<line x1="762.6" y1="62" x2="762.6" y2="342" stroke="#e5e7eb"/>
+<text x="762.6" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">60</text>
+<line x1="771.0" y1="62" x2="771.0" y2="342" stroke="#e5e7eb"/>
+<text x="771.0" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">61</text>
+<line x1="779.4" y1="62" x2="779.4" y2="342" stroke="#e5e7eb"/>
+<text x="779.4" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">62</text>
+<line x1="787.8" y1="62" x2="787.8" y2="342" stroke="#e5e7eb"/>
+<text x="787.8" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">63</text>
+<line x1="796.2" y1="62" x2="796.2" y2="342" stroke="#e5e7eb"/>
+<text x="796.2" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">64</text>
+<line x1="804.7" y1="62" x2="804.7" y2="342" stroke="#e5e7eb"/>
+<text x="804.7" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">65</text>
+<line x1="813.1" y1="62" x2="813.1" y2="342" stroke="#e5e7eb"/>
+<text x="813.1" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">66</text>
+<line x1="821.5" y1="62" x2="821.5" y2="342" stroke="#e5e7eb"/>
+<text x="821.5" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">67</text>
+<line x1="829.9" y1="62" x2="829.9" y2="342" stroke="#e5e7eb"/>
+<text x="829.9" y="358" text-anchor="middle" font-size="11" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif">68</text>
+<circle cx="85.4" cy="268.6" r="6.5" fill="#059669" stroke="#047857" stroke-width="1.4"/>
+<text x="95.4" y="260.6" font-size="11" font-weight="600" fill="#047857" font-family="ui-sans-serif, system-ui, sans-serif">graff-dev  81.7s · $0.1496</text>
+<circle cx="510.1" cy="268.6" r="6.5" fill="#059669" stroke="#047857" stroke-width="1.4"/>
+<text x="520.1" y="260.6" font-size="11" font-weight="600" fill="#047857" font-family="ui-sans-serif, system-ui, sans-serif">graff-dev  30 · $0.1496</text>
+<circle cx="28" cy="410" r="6.5" fill="#059669" stroke="#047857" stroke-width="1.4"/>
+<text x="40" y="414" font-size="12" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">graff-dev — 7/7 · on wall/$ + calls/$</text>
+<circle cx="367.4" cy="163.9" r="6.5" fill="#4285f4" stroke="#1a73e8" stroke-width="1.4"/>
+<text x="377.4" y="155.9" font-size="11" font-weight="600" fill="#1a73e8" font-family="ui-sans-serif, system-ui, sans-serif">gemini-cli  340.1s · $0.3628</text>
+<circle cx="703.7" cy="163.9" r="6.5" fill="#4285f4" stroke="#1a73e8" stroke-width="1.4"/>
+<text x="713.7" y="155.9" font-size="11" font-weight="600" fill="#1a73e8" font-family="ui-sans-serif, system-ui, sans-serif">gemini-cli  53 · $0.3628</text>
+<circle cx="28" cy="430" r="6.5" fill="#4285f4" stroke="#1a73e8" stroke-width="1.4"/>
+<text x="40" y="434" font-size="12" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">gemini-cli — 7/7 · interior</text>
+<circle cx="304.1" cy="119.4" r="6.5" fill="#f97316" stroke="#ea580c" stroke-width="1.4"/>
+<text x="314.1" y="111.4" font-size="11" font-weight="600" fill="#ea580c" font-family="ui-sans-serif, system-ui, sans-serif">pi-dev  282.1s · $0.4534</text>
+<circle cx="829.9" cy="119.4" r="6.5" fill="#f97316" stroke="#ea580c" stroke-width="1.4"/>
+<text x="839.9" y="111.4" font-size="11" font-weight="600" fill="#ea580c" font-family="ui-sans-serif, system-ui, sans-serif">pi-dev  68 · $0.4534</text>
+<circle cx="28" cy="450" r="6.5" fill="#f97316" stroke="#ea580c" stroke-width="1.4"/>
+<text x="40" y="454" font-size="12" fill="#0f172a" font-family="ui-sans-serif, system-ui, sans-serif">pi-dev — 7/7 · interior</text>
+</svg>

--- a/graff-evals/hillclimb/plot_frontier.py
+++ b/graff-evals/hillclimb/plot_frontier.py
@@ -23,6 +23,9 @@ COLORS = {
     "dsh": ("#7c3aed", "#5b21b6"),
     "dsh-deepseek": ("#ffffff", "#7c3aed"),
     "dsh-grok": ("#7c3aed", "#5b21b6"),
+    "gemini-cli": ("#4285f4", "#1a73e8"),
+    "pi-dev": ("#f97316", "#ea580c"),
+    "pi-codegraff": ("#f97316", "#ea580c"),
 }
 
 

--- a/graff-evals/list_price.py
+++ b/graff-evals/list_price.py
@@ -30,6 +30,24 @@ RATES = {
         "high_cache": 0.60,
         "high_out": 12.0,
     },
+    "muse-spark-1.2": {
+        "high_at": 0,
+        "in": 1.25,
+        "cache": 0.125,
+        "out": 4.25,
+        "high_in": 1.25,
+        "high_cache": 0.125,
+        "high_out": 4.25,
+    },
+    "muse-spark-1.2-contributor": {
+        "high_at": 0,
+        "in": 0.10,
+        "cache": 0.01,
+        "out": 0.20,
+        "high_in": 0.10,
+        "high_cache": 0.01,
+        "high_out": 0.20,
+    },
     "grok-build-0.1": {
         "high_at": 200_000,
         "in": 1.0,
@@ -38,6 +56,15 @@ RATES = {
         "high_in": 2.0,
         "high_cache": 0.40,
         "high_out": 4.0,
+    },
+    "gemini-3.8-flash": {
+        "high_at": 0,
+        "in": 0.75,
+        "cache": 0.075,
+        "out": 3.75,
+        "high_in": 0.75,
+        "high_cache": 0.075,
+        "high_out": 3.75,
     },
 }
 
@@ -64,6 +91,12 @@ def rates_for(model: str) -> dict | None:
         return RATES["grok-4.6"]
     if model.startswith("grok-build") or leaf.startswith("grok-build"):
         return RATES["grok-build-0.1"]
+    if model.startswith("muse-spark-1.2-contributor") or leaf.startswith("muse-spark-1.2-contributor"):
+        return RATES["muse-spark-1.2-contributor"]
+    if model.startswith("muse-spark-1.2") or leaf.startswith("muse-spark-1.2"):
+        return RATES["muse-spark-1.2"]
+    if model.startswith("gemini") or leaf.startswith("gemini"):
+        return RATES["gemini-3.8-flash"]
     return None
 
 
@@ -81,6 +114,8 @@ def convention_for(rec: dict) -> bool:
     if h == "grok":
         return False
     if h.startswith("graff"):
+        return True
+    if h in ("muse",) or h.startswith("muse"):
         return True
     if (rec.get("tok_cached") or 0) > (rec.get("tok_in") or 0):
         return False

--- a/graff-evals/run.py
+++ b/graff-evals/run.py
@@ -140,7 +140,42 @@ def _parse_opencode_json(stdout):
     return answer, usage
 
 
-def parse_answer_and_usage(harness, stdout, stderr):
+def _parse_gemini_json(stdout):
+    answer = ""
+    usage = {}
+    idx = stdout.find("{")
+    if idx != -1:
+        try:
+            data = json.loads(stdout[idx:])
+            answer = (data.get("response") or "").strip()
+            stats = data.get("stats") or {}
+            models = stats.get("models") or {}
+            tin, tread, tout, requests = 0, 0, 0, 0
+            for mdata in models.values():
+                tok = mdata.get("tokens") or {}
+                tin += int(tok.get("input") or 0)
+                tread += int(tok.get("cached") or 0)
+                tout += int(tok.get("candidates") or 0) + int(tok.get("thoughts") or 0)
+                api = mdata.get("api") or {}
+                requests += int(api.get("totalRequests") or 0)
+            tools = stats.get("tools") or {}
+            calls = int(tools.get("totalCalls") or 0)
+            if not calls and requests > 0:
+                calls = requests
+            usage = {
+                "calls": calls,
+                "in": tin + tread,
+                "cached": tread,
+                "out": tout,
+            }
+        except json.JSONDecodeError:
+            pass
+    if not answer:
+        answer = stdout.strip()
+    return answer, usage
+
+
+def parse_answer_and_usage(harness, stdout, stderr, sandbox=""):
     answer, usage = stdout.strip(), {}
     if harness["answer"] == "grok-stream":
         answer = ""
@@ -194,6 +229,44 @@ def parse_answer_and_usage(harness, stdout, stderr):
                  "out": tout, "cost_usd": round(cost, 6)}
     if harness["answer"] == "opencode-json":
         answer, usage = _parse_opencode_json(stdout)
+    if harness["answer"] == "gemini-json":
+        answer, usage = _parse_gemini_json(stdout)
+    if harness["answer"] == "muse" or harness.get("usage") == "muse":
+        answer = stdout.strip()
+        usage = {}
+        # Sidecar written by graff-evals/muse.sh: .muse-usage.json + template-hashed model task log
+        import glob, json as _json, os as _os, subprocess as _sp
+        side = _os.path.join(sandbox, ".muse-usage.json")
+        try:
+            u = _json.load(open(side))
+            usage = {"calls": 1, "in": int(u.get("input_tokens",0))
+                     + int(u.get("cached_tokens",0)),
+                     "cached": int(u.get("cached_tokens",0)),
+                     "out": int(u.get("output_tokens",0) or 0) + int(u.get("reasoning_tokens",0) or 0),
+                     "reasoning": int(u.get("reasoning_tokens",0) or 0)}
+        except Exception:
+            pass
+        # Calls = model turns, counted from the stashed exec stream.
+        # muse's tracer can't decode exec-stream payloads (schema drift), so count
+        # tool results directly: each tool result implies a preceding model turn, so
+        # turns = tool_results + 1 (final answer) is a hard LOWER bound — favorable
+        # to muse on the calls axis.
+        try:
+            raw = _os.path.join(sandbox, ".muse-raw.jsonl")
+            tools = 0
+            with open(raw) as fh:
+                for line in fh:
+                    try:
+                        if _json.loads(line).get("payload_type") == "tool.result":
+                            tools += 1
+                    except Exception:
+                        pass
+            if tools:
+                usage["calls"] = tools + 1
+        except Exception:
+            pass
+        if not usage.get("calls"):
+            usage["calls"] = 1
     if harness.get("usage") == "graff-stderr":
         m = GRAFF_USAGE_RE.search(stderr)
         if m:
@@ -359,7 +432,7 @@ def one_run(hname, harness, task, model, rep, live=False):
     ru1 = _rusage_children()
     stdout, stderr = "".join(stdout_parts), "".join(stderr_parts)
     wall = round(time.monotonic() - t0, 2)
-    answer, usage = parse_answer_and_usage(harness, stdout, stderr)
+    answer, usage = parse_answer_and_usage(harness, stdout, stderr, sandbox)
     with open(os.path.join(sandbox, ".eval-answer.txt"), "w") as f:
         f.write(answer)
     check_env = dict(os.environ, ANSWER_FILE=".eval-answer.txt", TASK_ROOT=ROOT)

--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -15,7 +15,7 @@
     "src/repl.zig",
     "TUI/root.zig"
   ],
-  "test_count_baseline": 1896,
+  "test_count_baseline": 1909,
   "test_count_slack": 25,
   "required_invariants": [
     {

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -73,10 +73,9 @@ pub const Goal = struct {
 pub const Agent = struct {
     gpa: Allocator,
     arena: Allocator,
-    /// #124: per-turn transient parse garbage (per-SSE-event envelope parses,
-    /// isStreamEnd) allocates here and is reset each request(), so the long-lived
-    /// ROOT agent's session arena stops growing unboundedly. Optional — null on
-    /// subagents/one-shots (scratchAlloc() then falls back to arena, unchanged).
+    /// #124: per-turn parse garbage (SSE envelopes, isStreamEnd) lives here and
+    /// is reset each request() so the root session arena stays bounded. Null on
+    /// subagents/one-shots (scratchAlloc() falls back to arena).
     scratch_arena: ?*std.heap.ArenaAllocator = null,
     /// Optional allocator for a temporary request transaction. compact() points
     /// this at its arena so failed summaries do not leak message rewrites or
@@ -214,6 +213,7 @@ pub const Agent = struct {
     named_work_settled: []const u8 = "", // mention already nudged or tooled
     precompact_note_gen: ?u32 = null, // #391: one pre-compaction note per history generation
     ws_off: bool = false, // codex ws transport disabled for this session after a handshake/transport fallback to SSE (#codex-ws)
+    ws_api_error_pending: bool = false, // terminal WS error awaits Responses parsing/tracing; socket is already retired
     ws_transport_failures: u8 = 0, // consecutive WS failures; retry once before latching persistent SSE
     streamed_text: bool = false, // the last request printed its text live
     stall: @import("http_stall.zig").State = .{}, // #680: reconnects made this request (each widens the between-lines budget) + the budget that last tripped

--- a/src/agent_request.zig
+++ b/src/agent_request.zig
@@ -368,10 +368,10 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
         // object — pull the final `response` out of it (or an error).
         if (self.provider.kind == .responses) {
             const r = self.parseResponses(resp_body) catch {
-                // #287/#299: sayApiError so the body snippet survives as
-                // last_api_error; with plain say a subagent's parent got only
-                // the literal "ApiError" for this failure.
-                try self.sayApiError("unparseable codex response: {s}", .{resp_body[0..@min(resp_body.len, 600)]});
+                // Preserve a useful last_api_error without copying an unparsed
+                // provider envelope: it may contain echoed request/auth data.
+                const diagnostic = try responses.failureDiagnostic(self.arena, self.provider.id, .{ .message = "unparseable codex response" });
+                try self.sayApiError("{s}", .{diagnostic});
                 if (self.tracer) |tr| tr.api(self.label, self.sub, self.provider.model, ms, body.len, resp_body.len, 0, 0, true);
                 return error.ApiError;
             };
@@ -392,14 +392,11 @@ pub fn request(self: *Agent, tools_in: ?[]const u8) !std.json.ObjectMap {
                 },
                 .err => |failure| {
                     const msg = failure.message;
-                    const had_chain = self.codex_prev_id != null;
-                    const ws_error_frame = if (self.codex_ws) |c| c.dead else false;
+                    const ws_error_frame = self.ws_api_error_pending;
+                    self.ws_api_error_pending = false;
                     const diagnostic = try responses.failureDiagnostic(self.arena, self.provider.id, failure);
-                    if (ws_error_frame) {
-                        self.closeCodexWs();
-                        if (self.tracer) |tr| tr.note("ws_api_error", diagnostic);
-                    }
-                    if (had_chain and codex_chain.shouldDropChain(msg, failure.code)) {
+                    if (ws_error_frame) if (self.tracer) |tr| tr.note("ws_api_error", diagnostic);
+                    if (codex_chain.shouldReanchorRequest(body, msg, failure.code)) {
                         self.closeCodexWs();
                         if (self.tracer) |tr| tr.note("ws", "server dropped previous_response_id — re-anchoring with full input");
                         continue :rebuild;

--- a/src/agent_ws.zig
+++ b/src/agent_ws.zig
@@ -88,15 +88,14 @@ fn nowAwakeMs(io: Io) i64 {
 }
 
 const ws_failures_before_fallback: u8 = 2;
-
 pub fn wsShouldFallback(consecutive_failures: u8) bool {
     return consecutive_failures >= ws_failures_before_fallback;
 }
 
-/// Transport selector: try ws for eligible codex turns, else persistent SSE.
-/// The first WS transport/handshake failure rebuilds full input and retries a
-/// fresh socket; the second — or any 426 — latches SSE. Esc/stall propagates.
+/// Transport selector: try WS for eligible turns; the first failure retries a
+/// fresh socket, while the second or any 426 latches SSE. Esc/stall propagates.
 pub fn postLive(self: *Agent, body: []const u8) ![]u8 {
+    self.ws_api_error_pending = false;
     // #134/#132 test seam: force a one-shot stall/drop on a live turn so the
     // end-to-end "[response ended early: …]" path (never "[response interrupted
     // by user]") can be exercised without a real provider. Consumed after one use.
@@ -579,10 +578,11 @@ pub fn postResponsesWs(self: *Agent, body: []const u8) ![]u8 {
         try full.writer.writeAll(fbuf.items);
         try full.writer.writeByte('\n');
         const line = try std.fmt.allocPrint(arena, "data: {s}", .{fbuf.items});
-        // Codex closes after `type:error`; return the accumulated API body
-        // instead of waiting for EOF and misclassifying it as transport loss.
+        // Codex closes after `type:error`; return its API body instead of misclassifying the expected EOF as transport loss.
         if (signal.errorFrameAction(gpa, fbuf.items) != .none) {
+            self.ws_api_error_pending = true;
             client.dead = true; // no courtesy close write to a closing peer
+            self.closeCodexWs();
             if (self.tracer) |tr| tr.note("ws", "terminal API error frame");
             break :stream;
         }

--- a/src/agent_ws_reuse_test.zig
+++ b/src/agent_ws_reuse_test.zig
@@ -269,6 +269,8 @@ test "#692: a generic error frame is returned as the terminal API body before pe
     try std.testing.expect(std.mem.indexOf(u8, out, mock.generic_error_event) != null);
     try std.testing.expect(traced(&tw, "\"detail\":\"terminal API error frame\""));
     try std.testing.expect(!traced(&tw, "transport error"));
-    try std.testing.expect(agent.codex_ws != null);
-    try std.testing.expect(agent.codex_ws.?.dead);
+    try std.testing.expect(agent.codex_ws == null); // closing peer is retired before returning
+    try std.testing.expect(agent.ws_api_error_pending); // request parser still traces the bounded diagnostic
+    try std.testing.expectEqual(@as(u8, 0), agent.ws_transport_failures);
+    try std.testing.expect(!agent.ws_off);
 }

--- a/src/agent_ws_test.zig
+++ b/src/agent_ws_test.zig
@@ -78,9 +78,11 @@ test "codexWsIdleExpired: fires only strictly past the idle limit (codex-ws)" {
 // RETRIED request's Authorization header carries the newly adopted bearer.
 test "the codex .responses arm refreshes auth and re-anchors before resending (#402)" {
     const src = @embedFile("agent_request.zig");
-    const arm_start = std.mem.indexOf(u8, src, "unparseable codex response").?;
-    const arm_end = std.mem.indexOf(u8, src, "try self.sayApiError(\"{s}\", .{diagnostic})").?;
+    const arm_start = std.mem.indexOf(u8, src, "if (self.provider.kind == .responses)").?;
+    const arm_end = std.mem.indexOf(u8, src[arm_start..], "// Streamed anthropic/openai bodies").? + arm_start;
     const arm = src[arm_start..arm_end];
+
+    try std.testing.expect(std.mem.indexOf(u8, arm, "responses.failureDiagnostic") != null and std.mem.indexOf(u8, arm, "resp_body[0..@min(resp_body.len, 600)]") == null);
 
     const call = std.mem.indexOf(u8, arm, "retryAfterAuthRefresh(self, msg, &auth_refreshed)") orelse
         return error.ResponsesPathHasNoAuthRecovery;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -21,6 +21,10 @@ const harness_version = root.harness_version;
 pub const changelog_text =
     \\What's new
     \\──────────
+    \\0.0.285
+    \\  • Codex WS type:error retires the socket immediately; last_api_error stays bounded (#717)
+    \\  • chain re-anchor only when the rejected body sent previous_response_id
+    \\
     \\0.0.284
     \\  • ACP turns stage GUI @[image] attachments as native vision blocks — pasted images reach the model
     \\  • peer inbox wake is advisory ("parked; read when relevant"), never a command that displaces the turn

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -21,6 +21,13 @@ const harness_version = root.harness_version;
 pub const changelog_text =
     \\What's new
     \\──────────
+    \\0.0.285
+    \\  • native transcript stays put when you scroll up mid-stream; return to the tail to follow again (#724)
+    \\  • follow-ups typed while a turn is running queue and send when it ends
+    \\  • native tools land in the answer, not as a wall on top; settled batches fold
+    \\  • workspace switch stars and reports the process cwd (#721)
+    \\  • TUI streams the live answer instead of a Thinking placeholder
+    \\
     \\0.0.284
     \\  • ACP turns stage GUI @[image] attachments as native vision blocks — pasted images reach the model
     \\  • peer inbox wake is advisory ("parked; read when relevant"), never a command that displaces the turn

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -25,6 +25,7 @@ pub const changelog_text =
     \\  • Codex WS type:error retires the socket immediately; last_api_error stays bounded (#717)
     \\  • chain re-anchor only when the rejected body sent previous_response_id
     \\  • TUI steer / /btw queues composer image chips with the text, not text alone
+    \\  • tools stream with the answer (native chips + TUI live reply; codedb “Looked up N”)
     \\
     \\0.0.284
     \\  • ACP turns stage GUI @[image] attachments as native vision blocks — pasted images reach the model

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -24,6 +24,7 @@ pub const changelog_text =
     \\0.0.285
     \\  • Codex WS type:error retires the socket immediately; last_api_error stays bounded (#717)
     \\  • chain re-anchor only when the rejected body sent previous_response_id
+    \\  • TUI steer / /btw queues composer image chips with the text, not text alone
     \\
     \\0.0.284
     \\  • ACP turns stage GUI @[image] attachments as native vision blocks — pasted images reach the model

--- a/src/codex_chain.zig
+++ b/src/codex_chain.zig
@@ -68,6 +68,13 @@ pub fn shouldDropChain(message: []const u8, code: ?[]const u8) bool {
     return false;
 }
 
+/// Re-anchor only when the rejected request actually used the server-side
+/// chain. A retained codex_prev_id is not enough: property changes and the
+/// full-resend experiment deliberately emit full input while keeping it held.
+pub fn shouldReanchorRequest(body: []const u8, message: []const u8, code: ?[]const u8) bool {
+    return std.mem.indexOf(u8, body, "\"previous_response_id\"") != null and shouldDropChain(message, code);
+}
+
 pub fn chainUsable(self: *const Agent) bool {
     if (g_force_full_resend) return false;
     const xai_chain = g_xai_ws_chain and std.mem.eql(u8, self.provider.id, "xai");
@@ -182,4 +189,13 @@ test "shouldDropChain: not-found and 25-minute cap evict the in-memory id" {
     try std.testing.expect(shouldDropChain("Responses websocket connection limit reached (25 minutes).", "websocket_connection_limit_reached"));
     try std.testing.expect(shouldDropChain("unsupported previous_response_id", null));
     try std.testing.expect(!shouldDropChain("rate limited", "rate_limit_exceeded"));
+}
+
+test "shouldReanchorRequest requires a rejected previous_response_id request" {
+    const chained = "{\"previous_response_id\":\"resp_1\",\"input\":[]}";
+    const full = "{\"input\":[]}";
+    try std.testing.expect(shouldReanchorRequest(chained, "missing", "previous_response_not_found"));
+    try std.testing.expect(shouldReanchorRequest(chained, "unsupported previous_response_id", "invalid_request_error"));
+    try std.testing.expect(!shouldReanchorRequest(full, "missing", "previous_response_not_found"));
+    try std.testing.expect(!shouldReanchorRequest(chained, "bad request", "invalid_request_error"));
 }

--- a/src/libgraff.zig
+++ b/src/libgraff.zig
@@ -76,7 +76,7 @@ export fn graff_acp_create(new_seed: u32) void {
     session_id = null;
     seed = if (new_seed == 0) 1 else new_seed;
     engine.cancel_flag.store(false, .release);
-    engine.implementation_version = "0.0.284-core";
+    engine.implementation_version = "0.0.285-core";
 }
 
 export fn graff_acp_feed(len: usize) i32 {

--- a/src/workspace_switch.zig
+++ b/src/workspace_switch.zig
@@ -110,10 +110,33 @@ pub fn parsePorcelain(arena: Allocator, text: []const u8) []Entry {
     return list.items;
 }
 
+fn zpath(path: []const u8, z: *[std.fs.max_path_bytes + 1]u8) ?[:0]const u8 {
+    if (path.len >= z.len) return null;
+    @memcpy(z[0..path.len], path);
+    z[path.len] = 0;
+    return z[0..path.len :0];
+}
+
+fn realpathOs(path: []const u8, out: []u8) ?[]const u8 {
+    var z: [std.fs.max_path_bytes + 1]u8 = undefined;
+    const src = zpath(path, &z) orelse return null;
+    const p = std.c.realpath(src, out.ptr) orelse return null;
+    return std.mem.sliceTo(p, 0);
+}
+
 fn samePath(a: []const u8, b: []const u8) bool {
     const left = std.mem.trimEnd(u8, a, "/");
     const right = std.mem.trimEnd(u8, b, "/");
-    return std.mem.eql(u8, left, right);
+    if (std.mem.eql(u8, left, right)) return true;
+    if (left.len == 0 or right.len == 0) return false;
+    // Porcelain paths and getcwd disagree on macOS (/tmp vs /private/tmp) and
+    // on any worktree added through a symlink. Star / already / enter must
+    // compare the resolved directories, not the strings git printed (#721).
+    var ab: [std.fs.max_path_bytes]u8 = undefined;
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const ar = realpathOs(left, &ab) orelse return false;
+    const br = realpathOs(right, &bb) orelse return false;
+    return std.mem.eql(u8, std.mem.trimEnd(u8, ar, "/"), std.mem.trimEnd(u8, br, "/"));
 }
 
 const Rank = enum(u8) { substring = 1, exact_branch, exact_base, exact_path };
@@ -164,9 +187,14 @@ pub fn formatList(arena: Allocator, entries: []const Entry, current: []const u8)
 }
 
 fn currentAbs(io: Io, arena: Allocator) []const u8 {
-    var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const n = Io.Dir.cwd().realPath(io, &cwd_buf) catch return main_mod.g_cwd_display;
-    return arena.dupe(u8, cwd_buf[0..n]) catch main_mod.g_cwd_display;
+    _ = io;
+    // OS getcwd, not Io.Dir.cwd().realPath: Threaded Io can keep a stale Dir
+    // across posix.chdir, so the listing starred one tree while bash still
+    // ran in another, and `use` of the starred tree returned .already
+    // without chdir'ing (#721).
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ptr = std.c.getcwd(&buf, buf.len) orelse return main_mod.g_cwd_display;
+    return arena.dupe(u8, std.mem.sliceTo(ptr, 0)) catch main_mod.g_cwd_display;
 }
 
 fn listEntries(gpa: Allocator, io: Io, arena: Allocator) []Entry {
@@ -184,6 +212,7 @@ fn enterPath(gpa: Allocator, io: Io, arena: Allocator, path: []const u8) ![]cons
     const z = try arena.dupeSentinel(u8, path, 0);
     if (std.posix.system.chdir(z.ptr) != 0) return error.ChdirFailed;
     const abs = currentAbs(io, arena);
+    if (!samePath(abs, path)) return error.ChdirFailed;
     adoptDisplay(gpa, abs);
     main_mod.g_worktree_branch = null;
     tool_spill.enable(.{ .io = io, .dir = .cwd(), .base_abs = main_mod.g_cwd_display });
@@ -456,6 +485,58 @@ test "enterPath: chdir then restore; display follows the new tree" {
         tool_spill.resetForTest();
     }
     const abs = try enterPath(gpa, io, a, dest);
-    try std.testing.expectEqualStrings(dest, abs);
-    try std.testing.expectEqualStrings(dest, main_mod.g_cwd_display);
+    try std.testing.expect(samePath(dest, abs));
+    try std.testing.expect(samePath(dest, main_mod.g_cwd_display));
+}
+
+test "#721: round-trip switch keeps posix cwd, display, and list star in lockstep" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    var dir_a = std.testing.tmpDir(.{});
+    defer dir_a.cleanup();
+    var dir_b = std.testing.tmpDir(.{});
+    defer dir_b.cleanup();
+    var orig = try Io.Dir.cwd().openDir(io, ".", .{});
+    defer orig.close(io);
+    defer _ = std.posix.system.fchdir(orig.handle);
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    if (std.posix.system.fchdir(dir_a.dir.handle) != 0) return error.ChdirFailed;
+    const path_a = try a.dupe(u8, std.mem.sliceTo(std.c.getcwd(&buf, buf.len) orelse return error.SkipZigTest, 0));
+    if (std.posix.system.fchdir(dir_b.dir.handle) != 0) return error.ChdirFailed;
+    const path_b = try a.dupe(u8, std.mem.sliceTo(std.c.getcwd(&buf, buf.len) orelse return error.SkipZigTest, 0));
+    _ = std.posix.system.fchdir(orig.handle);
+    const saved = main_mod.g_cwd_display;
+    const saved_branch = main_mod.g_worktree_branch;
+    defer {
+        main_mod.g_cwd_display = saved;
+        main_mod.g_worktree_branch = saved_branch;
+        deinitDisplay(gpa);
+        tool_spill.resetForTest();
+    }
+    _ = try enterPath(gpa, io, a, path_a);
+    try std.testing.expect(samePath(std.mem.sliceTo(std.c.getcwd(&buf, buf.len) orelse "", 0), path_a));
+    try std.testing.expect(samePath(main_mod.g_cwd_display, path_a));
+    _ = try enterPath(gpa, io, a, path_b);
+    try std.testing.expect(samePath(std.mem.sliceTo(std.c.getcwd(&buf, buf.len) orelse "", 0), path_b));
+    try std.testing.expect(samePath(main_mod.g_cwd_display, path_b));
+    const rows = [_]Entry{ .{ .path = path_a, .branch = "a" }, .{ .path = path_b, .branch = "b" } };
+    const listed = formatList(a, &rows, currentAbs(io, a));
+    try std.testing.expect(std.mem.indexOf(u8, listed, "* ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, listed, path_b) != null);
+    // The #721 failure: report primary, posix still secondary.
+    _ = try enterPath(gpa, io, a, path_a);
+    try std.testing.expect(samePath(std.mem.sliceTo(std.c.getcwd(&buf, buf.len) orelse "", 0), path_a));
+    try std.testing.expect(samePath(main_mod.g_cwd_display, path_a));
+    switch (resolve(a, &rows, path_a, currentAbs(io, a))) {
+        .already => {},
+        else => return error.TestExpectedAlready,
+    }
+    switch (resolve(a, &rows, path_b, currentAbs(io, a))) {
+        .one => {},
+        else => return error.TestExpectedSwitch,
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Draft cut of **v0.0.285** after [v0.0.284](https://github.com/justrach/codegraff/releases/tag/v0.0.284). No merge to `main` and no GitHub tag until asked.

## Folded from `main` after the branch cut

`main` moved two commits past the 285 branch (`7da4ff2`). Both are now on this line via merge `a01413a`:

- **`0fb41c0`** — tools stream with the answer, not as a wall on top. Native: pin the thread scroller (no WKWebView `scrollIntoView` jitter), interleave tool chips at the text cursor, collapse a settled batch to “Explored N”, keep markdown list numbers. TUI: drop the Thinking row once tokens arrive and paint the live stream as the assistant reply; `codedb` folds as “Looked up N items”.
- **`1632b0d`** — split live-stream helpers into `TUI/livetail.zig` so `scrollback.zig` stays under the 600-line ceiling. Behavior unchanged.

## Already on this cut

- **#717** Codex WS error-frame recovery (replayed; yxlyx’s original base was 283-era `main`). Immediate `closeCodexWs` on `type:error`, `shouldReanchorRequest` requires a rejected `previous_response_id`, unparseable bodies use `failureDiagnostic`.
- TUI steer / `/btw` now queue composer image chips (`@[path]`) with the text. Image-only Enter queues the chip instead of force-interrupt.

## Notes / tests

- [docs/releases/v0.0.285.md](docs/releases/v0.0.285.md)
- Suite floor **1909**. TUI suite **523**.

## Related

- [#717](https://github.com/justrach/codegraff/pull/717) still open on its original branch (replayed here, not merged as that PR).
- [#722](https://github.com/justrach/codegraff/issues/722) — account-scoped session control when logged into Codegraff (filed separately; not in this cut).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

