### PR TITLE
fix: keep main.zig at 600 after Codex tool_search

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -586,7 +586,6 @@ test { // pull in tests from imported modules (mcp.zig)
     _ = @import("test_hooks.zig"); // unreached modules; their tests were silently skipped
     _ = @import("agent_overflow_tests.zig"); // #414: and, through it, agent_overflow.zig's table tests
     _ = @import("agent_server_compact.zig"); // server-side autocompact (codex Responses)
-    _ = @import("codex_tool_search.zig"); // hosted tool_search on gpt-5.4+ Codex
     _ = @import("acp_preauth.zig"); // credential-free ACP loop must stay in the test root
     _ = @import("task_outcome.zig"); // goal-outcome telemetry events
     _ = @import("learn_delete.zig"); // #303: its tests were dead until listed here

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -353,4 +353,5 @@ test {
     _ = @import("turn_dedup.zig"); // #714: identical user turns do not replay
     _ = @import("tui_goal.zig"); // #716: typed TUI /goal is retirable, not standing
     _ = @import("net_efficiency_test.zig");
+    _ = @import("codex_tool_search.zig"); // hosted tool_search on gpt-5.4+ Codex
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The xAI compact / SuperGrok `web_search` / Codex `tool_search` commit added `_ = @import("codex_tool_search.zig")` to `src/main.zig`'s test root. That file was already at the 600-line ceiling; CI's **zig** job failed on `Zig source exceeds 600 lines: src/main.zig (601)` before `zig build test` ran.

`413a002` (Codex hosted `web_search`) stacked on that tip and failed for the same reason — it does not touch `main.zig`.

`test_hooks.zig` exists for exactly this: unreached modules whose tests must stay compiled in. The import moves there. `main.zig` is 600 again; reachability still sees the Codex tool_search tests.

Rebased onto `413a002`. Local tier 1 is green (hover tuiguard flaked once, passed on rerun).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

