### PR TITLE
fix: key prompt-cache affinity on the git root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ current is part of cutting a release.
 
 - Prompt-cache affinity is the git root, or one scratch seed when there is
   no `.git`. Eval sandboxes and worktrees can reuse a warm system+tools
-  prefix instead of paying it on every leaf cwd. ADR 0069.
+  prefix instead of paying it on every leaf cwd. An offline test fails if
+  two scratch trees mint different `prompt_cache_key`s. ADR 0069.
 - `#753`: a background-agent handle survives a recoverable API interruption.
   `agent_output` replays a finished report, or says the launch ended with the
   parent turn, instead of "it may never have started". The ids ride in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ current is part of cutting a release.
 
 ## Unreleased
 
+- Prompt-cache affinity is the git root, or one scratch seed when there is
+  no `.git`. Eval sandboxes and worktrees can reuse a warm system+tools
+  prefix instead of paying it on every leaf cwd. ADR 0069.
 - `#753`: a background-agent handle survives a recoverable API interruption.
   `agent_output` replays a finished report, or says the launch ended with the
   parent turn, instead of "it may never have started". The ids ride in the

--- a/docs/adr/0069-cache-affinity-is-the-git-root.md
+++ b/docs/adr/0069-cache-affinity-is-the-git-root.md
@@ -1,0 +1,28 @@
+# 0069. Prompt-cache affinity is the git root, not the leaf cwd
+
+Status: accepted 2026-09-06
+
+## Context
+
+The in-house 12-task remasure on 289 held 12/12 and beat the 284 wall pin
+(179.6s vs 219.6s) but list$ rose $0.3169 → $0.4205. Uncached input went
+95k → 150k. `projectRootId` hashed the real cwd, so every eval sandbox
+and worktree was its own xAI cache partition and paid the system+tools
+prefix at `$2/M` instead of a cache read at `$0.50/M`. The
+`cache-gitroot` fixture already named this: a temp dir with no `.git`
+must not seed on its leaf cwd.
+
+## Decision
+
+The durable project cache id hashes the git root when one exists, otherwise
+the constant scratch seed `graff-scratch`. Nested dirs in one repo share a
+key. Scratch trees share one key. Do not hash the leaf cwd. Do not turn
+`x_search` off or shrink the catalog to close list$ (ADR 0024 / 0031).
+
+## Consequences
+
+First request after the seed change is a one-time miss, then sibling
+`-p` evals and worktrees can reuse the warm prefix. Unrelated scratch
+jobs share a routing id and may evict each other's tails; the prefix
+still hits when the bytes match. Revisit only if a same-session table
+shows pass or wall regressing to buy the cache.

--- a/docs/adr/0069-cache-affinity-is-the-git-root.md
+++ b/docs/adr/0069-cache-affinity-is-the-git-root.md
@@ -26,3 +26,8 @@ First request after the seed change is a one-time miss, then sibling
 jobs share a routing id and may evict each other's tails; the prefix
 still hits when the bytes match. Revisit only if a same-session table
 shows pass or wall regressing to buy the cache.
+
+The offline guard is `affinity: two scratch sandboxes share one project
+cache id` (tier 1 `cache-affinity-scratch`): two `/tmp` leaves must mint
+the same UUID `projectRootId` would send. Hashing the leaf cwd is a
+forced miss, asserted separately. No provider call.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,6 +79,7 @@ record only when you need the evidence or the edge cases.
 | [0066](0066-publication-policy-and-ledger-authority.md) | Publication safeguards survive custom prompts; recaps cannot change ledger authority, and constraint writes refresh active prompts atomically. |
 | [0067](0067-recorded-constraints-are-ledger-state.md) | Recorded constraints are live ledger JSON in the root prefix; recap prose is not authority, and a write refreshes instructions in the same turn. |
 | [0068](0068-background-agent-handles-survive-interrupt.md) | Background-agent ids are a session ledger; an interrupted parent turn must not report them as never started (#753). |
+| [0069](0069-cache-affinity-is-the-git-root.md) | Prompt-cache affinity is the git root (or a shared scratch seed), not the leaf cwd. |
 
 ## When to write one
 

--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -15,7 +15,7 @@
     "src/repl.zig",
     "TUI/root.zig"
   ],
-  "test_count_baseline": 1989,
+  "test_count_baseline": 1992,
   "test_count_slack": 25,
   "required_invariants": [
     {

--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -15,7 +15,7 @@
     "src/repl.zig",
     "TUI/root.zig"
   ],
-  "test_count_baseline": 1992,
+  "test_count_baseline": 1997,
   "test_count_slack": 25,
   "required_invariants": [
     {
@@ -62,6 +62,11 @@
       "id": "child-deadline",
       "test": "childTaskPrompt: the same absolute deadline reaches every child, minus a margin",
       "why": "d33c4a4: a timed /loop must hand its deadline down, or children outlive the run."
+    },
+    {
+      "id": "cache-affinity-scratch",
+      "test": "affinity: two scratch sandboxes share one project cache id",
+      "why": "289 remasure: hashing the leaf cwd minted a unique xAI partition per eval sandbox and paid the system+tools prefix at $2/M."
     }
   ],
   "docs_only_paths": [

--- a/src/cache_affinity.zig
+++ b/src/cache_affinity.zig
@@ -1,0 +1,103 @@
+//! Prompt-cache affinity seed (ADR 0069).
+//!
+//! xAI routes `prompt_cache_key` / `x-grok-conv-id` per server. Hashing the
+//! leaf cwd made every eval sandbox and worktree a unique partition, so the
+//! expensive system+tools prefix never warmed. The seed is the git root when
+//! one exists, otherwise the constant scratch token — never the leaf of a
+//! throwaway tree (the in-house `cache-gitroot` fixture).
+
+const std = @import("std");
+const Io = std.Io;
+
+pub const scratch_seed = "graff-scratch";
+
+/// Directory that owns `.git` (file or dir), walking parents of `cwd_abs`.
+/// `buf` holds the returned path. Null if the walk hits the filesystem root.
+pub fn gitRootOf(io: Io, cwd_abs: []const u8, buf: []u8) ?[]const u8 {
+    if (cwd_abs.len == 0 or cwd_abs.len >= buf.len) return null;
+    @memcpy(buf[0..cwd_abs.len], cwd_abs);
+    var cur: []const u8 = buf[0..cwd_abs.len];
+    while (cur.len > 1 and (cur[cur.len - 1] == '/' or cur[cur.len - 1] == '\\'))
+        cur = cur[0 .. cur.len - 1];
+
+    var git_buf: [4096]u8 = undefined;
+    while (true) {
+        const git_path = std.fmt.bufPrint(&git_buf, "{s}/.git", .{cur}) catch return null;
+        if (Io.Dir.cwd().access(io, git_path, .{})) |_| {
+            if (cur.ptr != buf.ptr) {
+                if (cur.len > buf.len) return null;
+                @memcpy(buf[0..cur.len], cur);
+                return buf[0..cur.len];
+            }
+            return cur;
+        } else |_| {}
+        const parent = std.fs.path.dirname(cur) orelse return null;
+        if (parent.len == 0 or std.mem.eql(u8, parent, cur)) return null;
+        cur = parent;
+    }
+}
+
+/// Seed hashed into the durable project cache id. Repo trees share the git
+/// root; a temp dir with no `.git` uses `scratch_seed`.
+pub fn affinitySeed(io: Io, cwd_abs: []const u8, buf: []u8) []const u8 {
+    return gitRootOf(io, cwd_abs, buf) orelse scratch_seed;
+}
+
+test "affinity: nested dirs under one repo share the git root" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, ".git");
+    try tmp.dir.createDirPath(io, "a/b");
+
+    var root_buf: [4096]u8 = undefined;
+    const root = root_buf[0..try tmp.dir.realPath(io, &root_buf)];
+    var child_buf: [4096]u8 = undefined;
+    const child = try std.fmt.bufPrint(&child_buf, "{s}/a/b", .{root});
+
+    var a_buf: [4096]u8 = undefined;
+    var b_buf: [4096]u8 = undefined;
+    try std.testing.expectEqualStrings(root, gitRootOf(io, root, &a_buf).?);
+    try std.testing.expectEqualStrings(root, gitRootOf(io, child, &b_buf).?);
+    try std.testing.expectEqualStrings(
+        affinitySeed(io, root, &a_buf),
+        affinitySeed(io, child, &b_buf),
+    );
+}
+
+test "affinity: a .git file counts as a repo root (worktree)" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = ".git", .data = "gitdir: /tmp/main.git\n" });
+    var root_buf: [4096]u8 = undefined;
+    const root = root_buf[0..try tmp.dir.realPath(io, &root_buf)];
+    var seed_buf: [4096]u8 = undefined;
+    try std.testing.expectEqualStrings(root, gitRootOf(io, root, &seed_buf).?);
+}
+
+test "affinity: scratch trees without .git share one seed, not the leaf cwd" {
+    if (@import("builtin").os.tag == .windows) return;
+    const io = std.testing.io;
+    // std.testing.tmpDir lives under the repo `.zig-cache`, so a parent walk
+    // would find /workspace/.git. Use /tmp so the walk is a real scratch.
+    const a_base = "/tmp/graff-aff-scratch-a";
+    const b_base = "/tmp/graff-aff-scratch-b";
+    Io.Dir.cwd().createDirPath(io, a_base ++ "/leaf") catch return error.SkipZigTest;
+    defer Io.Dir.cwd().deleteTree(io, a_base) catch {};
+    Io.Dir.cwd().createDirPath(io, b_base ++ "/other") catch return error.SkipZigTest;
+    defer Io.Dir.cwd().deleteTree(io, b_base) catch {};
+
+    var a_path: [160]u8 = undefined;
+    var b_path: [160]u8 = undefined;
+    const a = try std.fmt.bufPrint(&a_path, "{s}/leaf", .{a_base});
+    const b = try std.fmt.bufPrint(&b_path, "{s}/other", .{b_base});
+
+    var a_buf: [4096]u8 = undefined;
+    var b_buf: [4096]u8 = undefined;
+    try std.testing.expect(gitRootOf(io, a, &a_buf) == null);
+    try std.testing.expect(gitRootOf(io, b, &b_buf) == null);
+    try std.testing.expectEqualStrings(scratch_seed, affinitySeed(io, a, &a_buf));
+    try std.testing.expectEqualStrings(scratch_seed, affinitySeed(io, b, &b_buf));
+    try std.testing.expect(!std.mem.eql(u8, a, scratch_seed));
+}

--- a/src/cache_affinity.zig
+++ b/src/cache_affinity.zig
@@ -11,6 +11,42 @@ const Io = std.Io;
 
 pub const scratch_seed = "graff-scratch";
 
+/// Salt mixed into the durable project id. Keep in one place so a rename
+/// here moves `prompt_cache_key` / `x-grok-conv-id` together.
+pub const cache_salt = "graff-kimi-project-cache-v1";
+
+/// UUIDv5-shaped project cache id from an already-resolved seed. Same bytes
+/// `projectRootId` sends as `prompt_cache_key` / `x-grok-conv-id`.
+pub fn projectIdFromSeed(seed: []const u8, out: *[36]u8) []const u8 {
+    var raw: [16]u8 = undefined;
+    var digest: [32]u8 = undefined;
+    var h = std.crypto.hash.sha2.Sha256.init(.{});
+    h.update(cache_salt);
+    h.update(seed);
+    h.final(&digest);
+    @memcpy(&raw, digest[0..16]);
+    raw[6] = (raw[6] & 0x0f) | 0x50; // version 5: name-derived
+    raw[8] = (raw[8] & 0x3f) | 0x80; // variant 1
+    const hex = std.fmt.bytesToHex(raw, .lower);
+    @memcpy(out[0..8], hex[0..8]);
+    out[8] = '-';
+    @memcpy(out[9..13], hex[8..12]);
+    out[13] = '-';
+    @memcpy(out[14..18], hex[12..16]);
+    out[18] = '-';
+    @memcpy(out[19..23], hex[16..20]);
+    out[23] = '-';
+    @memcpy(out[24..36], hex[20..32]);
+    return out[0..36];
+}
+
+/// Project cache id for an absolute cwd: git root when one exists, otherwise
+/// the shared scratch seed. Never hashes the leaf of a throwaway tree.
+pub fn projectIdForCwd(io: Io, cwd_abs: []const u8, out: *[36]u8) []const u8 {
+    var seed_buf: [4096]u8 = undefined;
+    return projectIdFromSeed(affinitySeed(io, cwd_abs, &seed_buf), out);
+}
+
 /// Directory that owns `.git` (file or dir), walking parents of `cwd_abs`.
 /// `buf` holds the returned path. Null if the walk hits the filesystem root.
 pub fn gitRootOf(io: Io, cwd_abs: []const u8, buf: []u8) ?[]const u8 {
@@ -100,4 +136,61 @@ test "affinity: scratch trees without .git share one seed, not the leaf cwd" {
     try std.testing.expectEqualStrings(scratch_seed, affinitySeed(io, a, &a_buf));
     try std.testing.expectEqualStrings(scratch_seed, affinitySeed(io, b, &b_buf));
     try std.testing.expect(!std.mem.eql(u8, a, scratch_seed));
+}
+
+test "affinity: two scratch sandboxes share one project cache id" {
+    // 289 list$: hashing the leaf cwd minted a unique prompt_cache_key per
+    // eval sandbox, so the system+tools prefix never warmed. Offline — no
+    // provider, no model. Would have failed on the cwd-hash.
+    if (@import("builtin").os.tag == .windows) return;
+    const io = std.testing.io;
+    const a_base = "/tmp/graff-aff-id-a";
+    const b_base = "/tmp/graff-aff-id-b";
+    Io.Dir.cwd().createDirPath(io, a_base ++ "/leaf") catch return error.SkipZigTest;
+    defer Io.Dir.cwd().deleteTree(io, a_base) catch {};
+    Io.Dir.cwd().createDirPath(io, b_base ++ "/other") catch return error.SkipZigTest;
+    defer Io.Dir.cwd().deleteTree(io, b_base) catch {};
+
+    var a_path: [160]u8 = undefined;
+    var b_path: [160]u8 = undefined;
+    const a = try std.fmt.bufPrint(&a_path, "{s}/leaf", .{a_base});
+    const b = try std.fmt.bufPrint(&b_path, "{s}/other", .{b_base});
+
+    var id_a: [36]u8 = undefined;
+    var id_b: [36]u8 = undefined;
+    var id_seed: [36]u8 = undefined;
+    try std.testing.expectEqualStrings(projectIdForCwd(io, a, &id_a), projectIdForCwd(io, b, &id_b));
+    try std.testing.expectEqualStrings(projectIdFromSeed(scratch_seed, &id_seed), projectIdForCwd(io, a, &id_a));
+}
+
+test "affinity: hashing the leaf cwd is a forced miss" {
+    // The 289 bug, spelled as ids: two sibling sandbox paths hash to
+    // different UUIDs, and neither is the shared scratch id.
+    const a = "/tmp/graff-evals/.sandboxes/task-a-r1";
+    const b = "/tmp/graff-evals/.sandboxes/task-b-r1";
+    var id_a: [36]u8 = undefined;
+    var id_b: [36]u8 = undefined;
+    var id_scratch: [36]u8 = undefined;
+    try std.testing.expect(!std.mem.eql(u8, projectIdFromSeed(a, &id_a), projectIdFromSeed(b, &id_b)));
+    try std.testing.expect(!std.mem.eql(u8, projectIdFromSeed(a, &id_a), projectIdFromSeed(scratch_seed, &id_scratch)));
+}
+
+test "affinity: nested repo dirs share one project cache id" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, ".git");
+    try tmp.dir.createDirPath(io, "a/b");
+
+    var root_buf: [4096]u8 = undefined;
+    const root = root_buf[0..try tmp.dir.realPath(io, &root_buf)];
+    var child_buf: [4096]u8 = undefined;
+    const child = try std.fmt.bufPrint(&child_buf, "{s}/a/b", .{root});
+
+    var id_root: [36]u8 = undefined;
+    var id_child: [36]u8 = undefined;
+    var id_leaf: [36]u8 = undefined;
+    try std.testing.expectEqualStrings(projectIdForCwd(io, root, &id_root), projectIdForCwd(io, child, &id_child));
+    // Old hash of the leaf path would have missed the root's warm prefix.
+    try std.testing.expect(!std.mem.eql(u8, projectIdFromSeed(child, &id_leaf), projectIdForCwd(io, child, &id_child)));
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -23,6 +23,7 @@ pub const changelog_text =
     \\──────────
     \\0.0.289
     \\  • background-agent handles survive an interrupted API turn (#753)
+    \\  • prompt-cache affinity is the git root, not the leaf cwd
     \\
     \\0.0.288
     \\  • Gemini is a first-class provider on Google's Interactions API

--- a/src/http_headers.zig
+++ b/src/http_headers.zig
@@ -5,6 +5,7 @@ const Io = std.Io;
 const Provider = @import("provider.zig").Provider;
 const root = @import("main.zig");
 const kimi_catalog = @import("kimi_catalog.zig");
+const cache_affinity = @import("cache_affinity.zig"); // ADR 0069: git-root / scratch seed
 
 var session_id_buf: [36]u8 = undefined;
 var session_id_len: usize = 0;
@@ -95,7 +96,7 @@ var project_id_buf: [36]u8 = undefined;
 var project_id_len: usize = 0;
 var project_id_lock: std.atomic.Value(bool) = .init(false);
 
-/// Durable per-project id (cwd-derived UUIDv5, no state to persist). A new
+/// Durable per-project id (affinity-seed UUIDv5, no state to persist). A new
 /// session in the same repo reuses the bucket the last session wrote, so
 /// turn 1 can hit the warm system+tools prefix if the provider still has
 /// it. Different models do not share a cache (the server keys by model);
@@ -114,10 +115,12 @@ pub fn projectRootId(io: Io) []const u8 {
                 break :blk 1;
             };
             const cwd = cwd_buf[0..n];
+            var seed_buf: [4096]u8 = undefined;
+            const seed = cache_affinity.affinitySeed(io, cwd, &seed_buf);
             var digest: [32]u8 = undefined;
             var h = std.crypto.hash.sha2.Sha256.init(.{});
             h.update("graff-kimi-project-cache-v1");
-            h.update(cwd);
+            h.update(seed);
             h.final(&digest);
             @memcpy(&raw, digest[0..16]);
             raw[6] = (raw[6] & 0x0f) | 0x50; // version 5: name-derived

--- a/src/http_headers.zig
+++ b/src/http_headers.zig
@@ -107,35 +107,12 @@ pub fn projectRootId(io: Io) []const u8 {
     while (project_id_lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) std.atomic.spinLoopHint();
     defer project_id_lock.store(false, .release);
     if (project_id_len == 0) {
-        var raw: [16]u8 = undefined;
-        {
-            var cwd_buf: [4096]u8 = undefined;
-            const n = Io.Dir.cwd().realPathFile(io, ".", &cwd_buf) catch blk: {
-                @memcpy(cwd_buf[0..1], ".");
-                break :blk 1;
-            };
-            const cwd = cwd_buf[0..n];
-            var seed_buf: [4096]u8 = undefined;
-            const seed = cache_affinity.affinitySeed(io, cwd, &seed_buf);
-            var digest: [32]u8 = undefined;
-            var h = std.crypto.hash.sha2.Sha256.init(.{});
-            h.update("graff-kimi-project-cache-v1");
-            h.update(seed);
-            h.final(&digest);
-            @memcpy(&raw, digest[0..16]);
-            raw[6] = (raw[6] & 0x0f) | 0x50; // version 5: name-derived
-            raw[8] = (raw[8] & 0x3f) | 0x80; // variant 1
-        }
-        const hex = std.fmt.bytesToHex(raw, .lower);
-        @memcpy(project_id_buf[0..8], hex[0..8]);
-        project_id_buf[8] = '-';
-        @memcpy(project_id_buf[9..13], hex[8..12]);
-        project_id_buf[13] = '-';
-        @memcpy(project_id_buf[14..18], hex[12..16]);
-        project_id_buf[18] = '-';
-        @memcpy(project_id_buf[19..23], hex[16..20]);
-        project_id_buf[23] = '-';
-        @memcpy(project_id_buf[24..36], hex[20..32]);
+        var cwd_buf: [4096]u8 = undefined;
+        const n = Io.Dir.cwd().realPathFile(io, ".", &cwd_buf) catch blk: {
+            @memcpy(cwd_buf[0..1], ".");
+            break :blk 1;
+        };
+        _ = cache_affinity.projectIdForCwd(io, cwd_buf[0..n], &project_id_buf);
         project_id_len = 36;
     }
     return project_id_buf[0..project_id_len];
@@ -363,6 +340,20 @@ test "OpenRouter chat sends app attribution and no grok conv headers" {
     try std.testing.expect(saw_ref);
     try std.testing.expect(saw_title);
     try std.testing.expect(saw_categories);
+}
+
+test "projectRootId is minted from the affinity seed, not a second hash" {
+    // Locks the wire: a future change that hashes cwd again inside
+    // projectRootId would still pass the seed-string tests in
+    // cache_affinity.zig. Offline — no provider.
+    const io = std.testing.io;
+    var cwd_buf: [4096]u8 = undefined;
+    const n = Io.Dir.cwd().realPathFile(io, ".", &cwd_buf) catch blk: {
+        cwd_buf[0] = '.';
+        break :blk 1;
+    };
+    var want: [36]u8 = undefined;
+    try std.testing.expectEqualStrings(projectRootId(io), cache_affinity.projectIdForCwd(io, cwd_buf[0..n], &want));
 }
 
 test "project and prefix cache keys preserve conversation and sharing boundaries" {

--- a/src/prompt_lean_tests.zig
+++ b/src/prompt_lean_tests.zig
@@ -48,3 +48,21 @@ test "unattended one-shots are told the REAL approval map up front; attended ses
     try std.testing.expect(std.mem.indexOf(u8, unattended, "--yolo") != null);
     try std.testing.expect(std.mem.indexOf(u8, unattended, ".harness/settings.json") != null);
 }
+
+test "lean prefix hash is stable and does not name a sandbox path" {
+    // Second bust vector: even with a shared cache key, a prefix that
+    // interpolates the cwd is a miss on every eval sandbox. Offline.
+    const saved = no_local_tools.lean;
+    defer no_local_tools.lean = saved;
+    no_local_tools.lean = true;
+    const hud = @import("prompt_cache_hud.zig");
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+    const lean = prompts.detectCaps();
+    const first = try prompts.composeBase(a, lean);
+    const second = try prompts.composeBase(a, lean);
+    try std.testing.expectEqual(hud.prefixHash(first, ""), hud.prefixHash(second, ""));
+    try std.testing.expect(std.mem.indexOf(u8, first, ".sandboxes") == null);
+    try std.testing.expect(std.mem.indexOf(u8, first, "/tmp/") == null);
+}

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -357,4 +357,5 @@ test {
     _ = @import("net_efficiency_test.zig");
     _ = @import("codex_tool_search.zig"); // hosted tool_search on gpt-5.4+ Codex
     _ = @import("tool_call_args.zig"); // #752: truncated tool-call arguments must not poison history
+    _ = @import("cache_affinity.zig"); // ADR 0069: git-root / scratch cache seed
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The 289 in-house remasure was faster than the 284 pin (179.6s vs 219.6s) but list$ went $0.3169 → $0.4205 because uncached input jumped 95k → 150k.

`projectRootId` hashed the leaf cwd, so every eval sandbox was its own xAI partition and repaid the system+tools prefix at $2/M. This hashes the git root when one exists, otherwise a shared scratch seed. Nested dirs in one repo share a key. ADR 0069.

**Offline guard (no model call).** `projectRootId` now mints through `cache_affinity.projectIdForCwd`. Five unit tests lock it:

- two `/tmp` sandboxes share one project UUID (would have failed on the cwd-hash)
- hashing the leaf path is a forced miss (the 289 bug, spelled as ids)
- nested repo dirs share one UUID, and that UUID is not the leaf-path hash
- `projectRootId` equals `projectIdForCwd(cwd)` (wiring, not a second hash)
- lean `-p` prefix hash is stable and does not name `.sandboxes` / `/tmp/`

Tier 1 named invariant `cache-affinity-scratch`. Suite floor 1997. Rerun: `zig build test -Dtest-filter="two scratch sandboxes share one project cache id"`.

**Post-fix same-session remasure** (`graff-evals/results/run-20260906-041025.jsonl`, jobs=1, grok-4.6, ReleaseSafe, `x_search` on):

| | pass | wall | calls | tokens | list$ | cached / uncached |
|---|---|---|---|---|---|---|
| 284 pin | 12/12 | 219.6s | 53 | 234035 | $0.3169 | — |
| 289 pre-fix composite | 12/12 | 179.6s | 52 | 284374 | $0.4205 | ~124k / ~150k |
| 289 + git-root affinity | 12/12 | 249.6s | 55 | 308465 | **$0.3253** | **232k / 63k** |

Wall includes the known `atomic-symlink-write` stall (117s). list$ is back near the 284 pin; later tasks show cache reads (e.g. `empty-catalog` 23.5k cached / 1.7k ordinary). Not claiming Pareto: wall is worse on this draw, $ recovered.

Does not turn `x_search` off or shrink the catalog.

Updated grok-build 1.0.21 on this VM failed every in-house task in <0.5s with 0 tokens (CLI never reached a model). Not a same-session grok comparison.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

