### PR TITLE
fix: Meta tool_choice, error-only SSE, selected-tree edits, resize-anchor flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ current is part of cutting a release.
   width change instead of asserting on the first (possibly stale) repaint.
 - `#748`: an error-only SSE event is reported as that error, not retried
   as a truncated gateway body.
-- `#747`: `edit_file` writes and verifies the selected worktree (absolute
-  path from the session cwd), so a switch cannot report success on the
-  previous tree.
+- `#747`: `edit_file` / `write_file` / `read_file` share one absolute path
+  from the posix session cwd (not a stale Io cwd or a disagreeing display
+  cwd), so a worktree switch cannot report success on the previous tree.
 - Prompt-cache affinity is the git root, or one scratch seed when there is
   no `.git`. Eval sandboxes and worktrees can reuse a warm system+tools
   prefix instead of paying it on every leaf cwd. An offline test fails if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ current is part of cutting a release.
 
 ## Unreleased
 
+- `#751`: Meta / Muse Spark requests send `tool_choice: auto` only, and
+  fold `reasoning_effort: max` to `xhigh`. The gateway rewrite stays a
+  safety net. ADR 0070.
+- `#750`: the resize-anchor PTY probe waits for a stable frame after a
+  width change instead of asserting on the first (possibly stale) repaint.
+- `#748`: an error-only SSE event is reported as that error, not retried
+  as a truncated gateway body.
+- `#747`: `edit_file` writes and verifies the selected worktree (absolute
+  path from the session cwd), so a switch cannot report success on the
+  previous tree.
 - Prompt-cache affinity is the git root, or one scratch seed when there is
   no `.git`. Eval sandboxes and worktrees can reuse a warm system+tools
   prefix instead of paying it on every leaf cwd. An offline test fails if

--- a/docs/adr/0070-meta-tool-choice-is-auto-only.md
+++ b/docs/adr/0070-meta-tool-choice-is-auto-only.md
@@ -1,0 +1,25 @@
+# 0070. Meta tool_choice is auto-only at the source
+
+Status: accepted 2026-09-06
+
+## Context
+
+`muse-spark-1.3` via the Codegraff gateway 400'd on any non-`auto`
+`tool_choice`. Meta's error: only `"auto"` is supported; `"none"`,
+`"required"`, and named choices are not. The gateway already translates
+those (zigrepper `34a4882`): `none` drops tools+choice, `required`/named
+become `auto`. A silent rewrite means the harness asked for a forced call
+and got a maybe. `reasoning_effort: max` has the same shape (1.3
+non-contributor; gateway folds to `xhigh`).
+
+## Decision
+
+Normalise at the source for Meta and any `muse-spark*` model, including
+when the seat is the Codegraff gateway. `tool_choice` is always `auto`.
+`max`/`ultra` effort becomes `xhigh`. The gateway stays a safety net for
+unknown seats. Do not send `required` and hope the gateway rewrites it.
+
+## Consequences
+
+A forced-tool turn on Muse Spark is a request, not a guarantee — the
+model may answer in prose. Revisit if Meta adds `required`. #751.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -80,6 +80,7 @@ record only when you need the evidence or the edge cases.
 | [0067](0067-recorded-constraints-are-ledger-state.md) | Recorded constraints are live ledger JSON in the root prefix; recap prose is not authority, and a write refreshes instructions in the same turn. |
 | [0068](0068-background-agent-handles-survive-interrupt.md) | Background-agent ids are a session ledger; an interrupted parent turn must not report them as never started (#753). |
 | [0069](0069-cache-affinity-is-the-git-root.md) | Prompt-cache affinity is the git root (or a shared scratch seed), not the leaf cwd. |
+| [0070](0070-meta-tool-choice-is-auto-only.md) | Meta / Muse Spark `tool_choice` is `auto` at the source; `max` effort folds to `xhigh` (#751). |
 
 ## When to write one
 

--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -15,7 +15,7 @@
     "src/repl.zig",
     "TUI/root.zig"
   ],
-  "test_count_baseline": 2005,
+  "test_count_baseline": 2006,
   "test_count_slack": 25,
   "required_invariants": [
     {

--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -15,7 +15,7 @@
     "src/repl.zig",
     "TUI/root.zig"
   ],
-  "test_count_baseline": 1997,
+  "test_count_baseline": 2005,
   "test_count_slack": 25,
   "required_invariants": [
     {
@@ -67,6 +67,16 @@
       "id": "cache-affinity-scratch",
       "test": "affinity: two scratch sandboxes share one project cache id",
       "why": "289 remasure: hashing the leaf cwd minted a unique xAI partition per eval sandbox and paid the system+tools prefix at $2/M."
+    },
+    {
+      "id": "sse-error-not-truncated",
+      "test": "#748: error-only OpenAI SSE is an error envelope, not a missing stream",
+      "why": "#748: an explicit streamed error was retried as a truncated gateway body."
+    },
+    {
+      "id": "edit-selected-worktree",
+      "test": "#747: editing the same relative name after a tree switch lands on the selected root",
+      "why": "#747: an edit could report success while the selected worktree stayed unchanged."
     }
   ],
   "docs_only_paths": [

--- a/scripts/test-tui-resize-anchor.py
+++ b/scripts/test-tui-resize-anchor.py
@@ -135,14 +135,20 @@ def parse(stream):
 
 
 def frame_at(fd, rows, cols, settle=1.2):
-    # #750: the parallel probe suite can miss the first full repaint after
-    # TIOCSWINSZ. Wait for a frame that exists and is stable across a second
-    # read. Do not relax DRIFT — a late frame is timing, a slide is a bug.
+    resize(fd, rows, cols)
+    return parse(drain(fd, settle))
+
+
+def stable_frame(fd, rows, cols, budget=1.5):
+    # #750: a width change can emit two full frames (old wrap, then anchored).
+    # The first parse is a real frame — it just is not the settled one — so
+    # the parallel suite saw a marker jump. Wait for two identical parses
+    # inside the original settle budget. Do not relax DRIFT.
     resize(fd, rows, cols)
     last = None
-    deadline = time.time() + max(settle, 1.2) + 2.4
+    deadline = time.time() + budget
     while time.time() < deadline:
-        now = parse(drain(fd, 0.45))
+        now = parse(drain(fd, 0.12))
         if now is None:
             continue
         if last is not None and now == last:
@@ -202,7 +208,7 @@ def run():
         # Every step must CHANGE the height: an identical winsize is not a
         # resize, so no full repaint follows it and there is nothing to read.
         for h in (18, 34, 22, ROWS):
-            rows = frame_at(fd, h, COLS)
+            rows = stable_frame(fd, h, COLS)
             if rows is None:
                 return f"no full repaint at height {h}"
             if find(rows, TAIL) is None:
@@ -228,14 +234,14 @@ def run():
         # --- the width sweep --------------------------------------------------
         seen = [(COLS, top)]
         for w in (76, 58, 44, 92, COLS):
-            rows = frame_at(fd, ROWS, w)
+            rows = stable_frame(fd, ROWS, w)
             if rows is None:
                 return f"no full repaint at width {w}"
             at = find(rows, MARK)
             if at is None:
                 return f"width {w} scrolled {MARK} off screen (anchor lost); seen={seen}"
             if abs(at - top) > DRIFT:
-                again = frame_at(fd, ROWS, w, settle=1.8)
+                again = stable_frame(fd, ROWS, w, budget=1.8)
                 at2 = find(again, MARK) if again else None
                 if at2 is None or abs(at2 - top) > DRIFT:
                     return f"width {w} moved {MARK} from row {top} to {at2 if at2 is not None else at}; seen={seen}"

--- a/scripts/test-tui-resize-anchor.py
+++ b/scripts/test-tui-resize-anchor.py
@@ -135,8 +135,20 @@ def parse(stream):
 
 
 def frame_at(fd, rows, cols, settle=1.2):
+    # #750: the parallel probe suite can miss the first full repaint after
+    # TIOCSWINSZ. Wait for a frame that exists and is stable across a second
+    # read. Do not relax DRIFT — a late frame is timing, a slide is a bug.
     resize(fd, rows, cols)
-    return parse(drain(fd, settle))
+    last = None
+    deadline = time.time() + max(settle, 1.2) + 2.4
+    while time.time() < deadline:
+        now = parse(drain(fd, 0.45))
+        if now is None:
+            continue
+        if last is not None and now == last:
+            return now
+        last = now
+    return last
 
 
 def reread(fd):
@@ -223,7 +235,11 @@ def run():
             if at is None:
                 return f"width {w} scrolled {MARK} off screen (anchor lost); seen={seen}"
             if abs(at - top) > DRIFT:
-                return f"width {w} moved {MARK} from row {top} to {at}; seen={seen}"
+                again = frame_at(fd, ROWS, w, settle=1.8)
+                at2 = find(again, MARK) if again else None
+                if at2 is None or abs(at2 - top) > DRIFT:
+                    return f"width {w} moved {MARK} from row {top} to {at2 if at2 is not None else at}; seen={seen}"
+                at = at2
             seen.append((w, at))
         print(f"    widths/rows: {seen}")
         return None

--- a/src/agent_gateway_retry.zig
+++ b/src/agent_gateway_retry.zig
@@ -113,10 +113,22 @@ pub fn isShortGatewayFlake(etype: []const u8, code: ?[]const u8, msg: []const u8
     return generic and std.mem.trim(u8, msg, " \t\r\n").len == 0;
 }
 
+/// An explicit streamed error (not a truncated JSON body). Must not be
+/// classified as a gateway flake — invalid_request is deterministic (#748).
+pub fn sseLooksLikeError(body: []const u8) bool {
+    if (std.mem.indexOf(u8, body, "event: error") != null) return true;
+    if (std.mem.indexOf(u8, body, "event:error") != null) return true;
+    if (std.mem.indexOf(u8, body, "\"error\"") != null and
+        std.mem.indexOf(u8, body, "\"choices\"") == null)
+        return true;
+    return false;
+}
+
 /// Unparseable body that is keep-alive comments or a tiny truncated
 /// payload (the 110-byte follow-up). Bounded. Real JSON error envelopes
 /// do not reach this — they go through `afterServerErrorOrParseReject`.
 pub fn retryDegenerateBody(self: *Agent, body: []const u8, retries: *usize) !bool {
+    if (sseLooksLikeError(body)) return false;
     const tiny = body.len > 0 and body.len <= 256;
     if (!policy.sseKeepAliveOnly(body) and !tiny) return false;
     if (retries.* >= max_short_flake_retries) return false;
@@ -194,4 +206,12 @@ test "isShortGatewayFlake: internal/empty api_error retry; invalid/auth/quota do
     try std.testing.expect(isShortGatewayFlake("invalid_request_error", null, "Body must be valid JSON"));
     try std.testing.expect(isShortGatewayFlake("api_error", null, "Malformed JSON in request body"));
     try std.testing.expect(!isShortGatewayFlake("invalid_request_error", null, "invalid prompt"));
+}
+
+test "#748: error-only SSE is not a truncated gateway body" {
+    const err_sse = "event: error\ndata: {\"error\":{\"type\":\"invalid_request_error\",\"message\":\"bad\"}}\n";
+    try std.testing.expect(sseLooksLikeError(err_sse));
+    try std.testing.expect(sseLooksLikeError("data: {\"error\":{\"message\":\"only auto\"}}\n"));
+    try std.testing.expect(!sseLooksLikeError(": OPENROUTER PROCESSING\n"));
+    try std.testing.expect(!sseLooksLikeError("data: {\"choices\":[{\"delta\":{}}]}\n"));
 }

--- a/src/agent_request_body.zig
+++ b/src/agent_request_body.zig
@@ -137,9 +137,9 @@ pub fn buildBody(self: *Agent, tools_in: ?[]const u8, force_tool: bool, stream: 
                     try writeKimiTools(&s, self.scratchAlloc(), t)
                 else
                     try serde.writeOpenAITools(&s, self.scratchAlloc(), t);
-                if (force_tool) {
-                    try s.objectField("tool_choice");
-                    try s.write("required");
+                if (force_tool or @import("meta_wire.zig").restricted(self.provider.id, self.provider.model)) {
+                    try s.objectField("tool_choice"); // #751: Meta is auto-only
+                    try s.write(@import("meta_wire.zig").toolChoice(force_tool, self.provider.id, self.provider.model));
                 }
             }
             try s.objectField("messages");
@@ -255,14 +255,10 @@ test "Kimi request body follows live native or Anthropic protocol metadata" {
     try std.testing.expect(std.mem.indexOf(u8, anthropic, "\"prompt_cache_key\"") == null); // native-transport field only
 }
 
-// ── Retained-reasoning wire-format regressions ──────────────────────────────
-// OpenAI's ARC-AGI-3 result showed that keeping a model's reasoning across
-// turns (rather than dropping it once a turn ends) is worth a large capability
-// jump. graff already retains it on all three wire formats, but only as a side
-// effect of echoing provider output verbatim into history — nothing pinned that
-// behavior down, so a future normalization pass could silently drop it and no
-// test would fail. These three tests assert the retention at the point it
-// matters: the bytes that go on the wire.
+// Retained-reasoning wire-format regressions. OpenAI's ARC-AGI-3 result
+// showed keeping reasoning across turns is a capability jump. graff retains
+// it by echoing provider output into history — these three tests pin the
+// bytes on the wire so a later normalization pass cannot silently drop it.
 
 fn testUserMessage(arena: std.mem.Allocator, text: []const u8) !Value {
     var m: std.json.ObjectMap = .empty;

--- a/src/agent_steps.zig
+++ b/src/agent_steps.zig
@@ -465,6 +465,18 @@ pub fn assembleOpenAI(self: *Agent, body: []const u8) !?std.json.ObjectMap {
         const payload = ssePayload(raw_line) orelse continue;
         const v = std.json.parseFromSliceLeaky(Value, self.scratchAlloc(), payload, .{ .allocate = .alloc_always }) catch continue; // #124: per-event parse tree is transient (deltas are appendSlice'd into session accumulators)
         if (v != .object) continue;
+        // Error-only SSE (`event: error` / `data: {"error":…}`) has no
+        // choices chunk. Hand the envelope back so request() reports it
+        // instead of falling through to the truncated-body retry (#748).
+        if (v.object.get("error")) |err| if (err != .null) {
+            var env: std.json.ObjectMap = .empty;
+            try env.put(result_arena, "type", .{ .string = "error" });
+            try env.put(result_arena, "error", try util.dupeJsonValue(result_arena, err));
+            return env;
+        };
+        if (v.object.get("type")) |t| if (t == .string and std.mem.eql(u8, t.string, "error")) {
+            return (try util.dupeJsonValue(result_arena, v)).object;
+        };
         // The final usage chunk (stream_options.include_usage) may have
         // an empty choices array.
         if (v.object.get("usage")) |u| if (u == .object) {

--- a/src/agent_steps_tests.zig
+++ b/src/agent_steps_tests.zig
@@ -53,3 +53,27 @@ test "assembleOpenAI preserves streamed reasoning and Gemini echo fields" {
     try std.testing.expectEqualStrings("stop", gchoice.get("finish_reason").?.string);
     try std.testing.expectEqualStrings("GSIG", gcall.get("extra_content").?.object.get("google").?.object.get("thought_signature").?.string);
 }
+
+test "#748: error-only OpenAI SSE is an error envelope, not a missing stream" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var agent: Agent = .{
+        .gpa = std.testing.allocator,
+        .arena = arena,
+        .io = undefined,
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = null,
+    };
+    const root = (try agent.assembleOpenAI(
+        "event: error\n" ++
+            "data: {\"error\":{\"type\":\"invalid_request_error\",\"message\":\"only auto is supported\"}}\n\n",
+    )).?;
+    try std.testing.expectEqualStrings("error", root.get("type").?.string);
+    try std.testing.expectEqualStrings("invalid_request_error", root.get("error").?.object.get("type").?.string);
+    try std.testing.expectEqualStrings("only auto is supported", root.get("error").?.object.get("message").?.string);
+}

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -24,6 +24,8 @@ pub const changelog_text =
     \\0.0.289
     \\  • background-agent handles survive an interrupted API turn (#753)
     \\  • prompt-cache affinity is the git root, not the leaf cwd
+    \\  • Meta tool_choice is auto-only; error-only SSE is not a truncate-retry (#751 #748)
+    \\  • worktree edits land on the selected root (#747)
     \\
     \\0.0.288
     \\  • Gemini is a first-class provider on Google's Interactions API

--- a/src/codedbpro_paths.zig
+++ b/src/codedbpro_paths.zig
@@ -67,6 +67,23 @@ pub fn callerError(text: []const u8) bool {
     return false;
 }
 
+/// Absolute path for a model-supplied relative file, against the selected
+/// worktree. Prefer `agent_cwd`, then the session display cwd (updated by
+/// workspace switch), then the posix process cwd. Never `Io.Dir.cwd()`:
+/// Threaded Io can stay on the previous tree after `chdir` (#721 / #747).
+pub fn sessionAbs(gpa: Allocator, io: Io, agent_cwd: ?[]const u8, path: []const u8) ![]u8 {
+    if (std.fs.path.isAbsolute(path)) return gpa.dupe(u8, path);
+    if (agent_cwd) |worktree| return std.fs.path.resolve(gpa, &.{ worktree, path });
+    const display = @import("main.zig").g_cwd_display;
+    if (display.len > 0 and std.fs.path.isAbsolute(display))
+        return std.fs.path.resolve(gpa, &.{ display, path });
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    if (std.process.currentPath(io, &buf)) |n|
+        return std.fs.path.resolve(gpa, &.{ buf[0..n], path })
+    else |_|
+        return std.fs.path.resolve(gpa, &.{path});
+}
+
 /// CodeDB Pro's resident daemon has one launch cwd that can outlive and differ
 /// from the Graff session using it. Normalize path-bearing calls at the client
 /// boundary so relative model arguments keep their documented session-cwd
@@ -101,14 +118,7 @@ pub fn prepareInput(gpa: Allocator, io: Io, agent_cwd: ?[]const u8, tool: []cons
         return .{ .value = working, .owned_object = owned_object };
     }
 
-    var cwd_buf: [4096]u8 = undefined;
-    const base = if (agent_cwd) |worktree|
-        worktree
-    else blk: {
-        const n = try Io.Dir.cwd().realPathFile(io, ".", &cwd_buf);
-        break :blk cwd_buf[0..n];
-    };
-    const absolute = try std.fs.path.resolve(gpa, &.{ base, path_value.string });
+    const absolute = try sessionAbs(gpa, io, agent_cwd, path_value.string);
     errdefer gpa.free(absolute);
 
     var object: std.json.ObjectMap = .empty;

--- a/src/codedbpro_paths.zig
+++ b/src/codedbpro_paths.zig
@@ -68,20 +68,24 @@ pub fn callerError(text: []const u8) bool {
 }
 
 /// Absolute path for a model-supplied relative file, against the selected
-/// worktree. Prefer `agent_cwd`, then the session display cwd (updated by
-/// workspace switch), then the posix process cwd. Never `Io.Dir.cwd()`:
+/// worktree. Prefer `agent_cwd`, then the posix process cwd (`/workspace use`
+/// chdirs this), then the session display cwd. Never `Io.Dir.cwd()`:
 /// Threaded Io can stay on the previous tree after `chdir` (#721 / #747).
+/// Prefer posix over `g_cwd_display`: display can be a stale `realPath` of
+/// Io cwd while the child was launched with a different posix cwd (tier-2
+/// `cwd=` vs inherited `PWD`).
 pub fn sessionAbs(gpa: Allocator, io: Io, agent_cwd: ?[]const u8, path: []const u8) ![]u8 {
     if (std.fs.path.isAbsolute(path)) return gpa.dupe(u8, path);
     if (agent_cwd) |worktree| return std.fs.path.resolve(gpa, &.{ worktree, path });
-    const display = @import("main.zig").g_cwd_display;
-    if (display.len > 0 and std.fs.path.isAbsolute(display))
-        return std.fs.path.resolve(gpa, &.{ display, path });
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    if (std.process.currentPath(io, &buf)) |n|
-        return std.fs.path.resolve(gpa, &.{ buf[0..n], path })
-    else |_|
+    if (std.process.currentPath(io, &buf)) |n| {
+        return std.fs.path.resolve(gpa, &.{ buf[0..n], path });
+    } else |_| {
+        const display = @import("main.zig").g_cwd_display;
+        if (display.len > 0 and std.fs.path.isAbsolute(display))
+            return std.fs.path.resolve(gpa, &.{ display, path });
         return std.fs.path.resolve(gpa, &.{path});
+    }
 }
 
 /// CodeDB Pro's resident daemon has one launch cwd that can outlive and differ

--- a/src/edit_batch.zig
+++ b/src/edit_batch.zig
@@ -30,9 +30,9 @@ pub fn execBatch(ctx: ToolCtx, input: Value) !ToolOutput {
     const list = input.object.get("edits").?.array;
     if (list.items.len == 0) return .{ .text = try gpa.dupe(u8, "edits must contain at least one span"), .is_error = true };
 
-    // #276 P0-1, same as execEdit: resolve under the agent's worktree.
-    const resolved: []const u8 = if (ctx.agent_cwd) |base| try std.fmt.allocPrint(gpa, "{s}/{s}", .{ base, path }) else path;
-    defer if (ctx.agent_cwd != null) gpa.free(resolved);
+    // #747: same absolute selected-tree path as execEdit (write + verify).
+    const resolved = try @import("codedbpro_paths.zig").sessionAbs(gpa, ctx.io, ctx.agent_cwd, path);
+    defer gpa.free(resolved);
 
     var applied: usize = 0;
     for (list.items, 0..) |item, i| {

--- a/src/edit_verify.zig
+++ b/src/edit_verify.zig
@@ -187,9 +187,9 @@ pub fn execEdit(ctx: ToolCtx, input: Value) !ToolOutput {
     const all = tools.json_args.flag(input, "replace_all");
     if (old.len == 0) return .{ .text = try gpa.dupe(u8, "old_string must not be empty"), .is_error = true };
 
-    // #276 P0-1: resolve under the agent's isolated worktree when set.
-    const resolved: []const u8 = if (ctx.agent_cwd) |base| try std.fmt.allocPrint(gpa, "{s}/{s}", .{ base, path }) else path;
-    defer if (ctx.agent_cwd != null) gpa.free(resolved);
+    // #747: write and verify share one absolute path (selected tree).
+    const resolved = try @import("codedbpro_paths.zig").sessionAbs(gpa, ctx.io, ctx.agent_cwd, path);
+    defer gpa.free(resolved);
     return applyEdit(ctx, path, resolved, old, new, all);
 }
 

--- a/src/edit_worktree_tests.zig
+++ b/src/edit_worktree_tests.zig
@@ -1,9 +1,8 @@
 //! #747: after a workspace switch, edit_file must write the selected tree.
 //!
-//! The persistence check already refuses a false success. The miss was the
-//! write resolving a different root than the verify (relative path + a
-//! stale Threaded-Io cwd after `chdir`, #721). Both paths now go through
-//! `sessionAbs`, which follows the session display cwd — not `Io.Dir.cwd()`.
+//! `/workspace use` posix-chdirs. Write and verify must share one absolute
+//! path from that cwd (`sessionAbs`), not a stale Threaded-Io cwd (#721)
+//! and not a `g_cwd_display` that can disagree with posix (tier-2 `cwd=`).
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -19,10 +18,22 @@ fn tmpAbs(io: Io, dir: anytype) ![]u8 {
     return std.testing.allocator.dupe(u8, buf[0..n]);
 }
 
+fn chdirAbs(path: []const u8) !void {
+    const z = try std.testing.allocator.dupeSentinel(u8, path, 0);
+    defer std.testing.allocator.free(z);
+    if (std.posix.system.chdir(z.ptr) != 0) return error.ChdirFailed;
+}
+
 test "#747: editing the same relative name after a tree switch lands on the selected root" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
     const gpa = std.testing.allocator;
     const io = std.testing.io;
+
+    var here_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const here_n = std.process.currentPath(io, &here_buf) catch return error.SkipZigTest;
+    const here = try gpa.dupe(u8, here_buf[0..here_n]);
+    defer gpa.free(here);
+    defer chdirAbs(here) catch {};
 
     var dir_a = std.testing.tmpDir(.{});
     defer dir_a.cleanup();
@@ -35,9 +46,6 @@ test "#747: editing the same relative name after a tree switch lands on the sele
     const path_b = try tmpAbs(io, &dir_b);
     defer gpa.free(path_b);
 
-    const saved = main_mod.g_cwd_display;
-    defer main_mod.g_cwd_display = saved;
-
     var client: std.http.Client = undefined;
     const ctx = edit_verify.testCtx(&client);
 
@@ -47,7 +55,7 @@ test "#747: editing the same relative name after a tree switch lands on the sele
     try a_obj.put(gpa, "old_string", .{ .string = "alpha\n" });
     try a_obj.put(gpa, "new_string", .{ .string = "ALPHA\n" });
 
-    main_mod.g_cwd_display = path_a;
+    try chdirAbs(path_a);
     const out_a = try edit_verify.execEdit(ctx, .{ .object = a_obj });
     defer gpa.free(out_a.text);
     try std.testing.expect(!out_a.is_error);
@@ -58,17 +66,59 @@ test "#747: editing the same relative name after a tree switch lands on the sele
     try b_obj.put(gpa, "old_string", .{ .string = "beta\n" });
     try b_obj.put(gpa, "new_string", .{ .string = "BETA\n" });
 
-    main_mod.g_cwd_display = path_b;
+    try chdirAbs(path_b);
     const out_b = try edit_verify.execEdit(ctx, .{ .object = b_obj });
     defer gpa.free(out_b.text);
     try std.testing.expect(!out_b.is_error);
 
+    try chdirAbs(here);
     const on_a = try dir_a.dir.readFileAlloc(io, "note.txt", gpa, .limited(64));
     defer gpa.free(on_a);
     const on_b = try dir_b.dir.readFileAlloc(io, "note.txt", gpa, .limited(64));
     defer gpa.free(on_b);
     try std.testing.expectEqualStrings("ALPHA\n", on_a);
     try std.testing.expectEqualStrings("BETA\n", on_b);
+}
+
+test "#747: writeFile+readFileAlloc of sessionAbs agree after a posix chdir" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var here_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const here_n = std.process.currentPath(io, &here_buf) catch return error.SkipZigTest;
+    const here = try gpa.dupe(u8, here_buf[0..here_n]);
+    defer gpa.free(here);
+    defer chdirAbs(here) catch {};
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmpAbs(io, &tmp);
+    defer gpa.free(root);
+    try chdirAbs(root);
+
+    const abs = try codedbpro_paths.sessionAbs(gpa, io, null, "settings.py");
+    defer gpa.free(abs);
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = abs, .data = "TIMEOUT = 30\n" });
+    const via_abs = Io.Dir.cwd().readFileAlloc(io, abs, gpa, .limited(64)) catch |err| {
+        std.debug.print("readFileAlloc({s}) failed: {t}\n", .{ abs, err });
+        return err;
+    };
+    defer gpa.free(via_abs);
+    try std.testing.expectEqualStrings("TIMEOUT = 30\n", via_abs);
+    const via_rel = try Io.Dir.cwd().readFileAlloc(io, "settings.py", gpa, .limited(64));
+    defer gpa.free(via_rel);
+    try std.testing.expectEqualStrings("TIMEOUT = 30\n", via_rel);
+
+    var client: std.http.Client = undefined;
+    const ctx = edit_verify.testCtx(&client);
+    var obj: std.json.ObjectMap = .empty;
+    defer obj.deinit(gpa);
+    try obj.put(gpa, "path", .{ .string = "settings.py" });
+    try obj.put(gpa, "old_string", .{ .string = "TIMEOUT = 30" });
+    try obj.put(gpa, "new_string", .{ .string = "TIMEOUT = 60" });
+    const out = try edit_verify.execEdit(ctx, .{ .object = obj });
+    defer gpa.free(out.text);
+    try std.testing.expect(!out.is_error);
 }
 
 test "#747: sessionAbs of a relative name follows the selected cwd, not a sibling tree" {
@@ -83,11 +133,11 @@ test "#747: sessionAbs of a relative name follows the selected cwd, not a siblin
     try std.testing.expect(std.mem.endsWith(u8, a, "note.txt"));
     try std.testing.expect(std.mem.endsWith(u8, b, "note.txt"));
 
+    // A stale display cwd must not beat posix cwd (tier-2 HOME/PWD split).
     const saved = main_mod.g_cwd_display;
     defer main_mod.g_cwd_display = saved;
     main_mod.g_cwd_display = "/tmp/graff-747-tree-a";
-    const via_display = try codedbpro_paths.sessionAbs(gpa, io, null, "note.txt");
-    defer gpa.free(via_display);
-    try std.testing.expect(std.mem.indexOf(u8, via_display, "graff-747-tree-a") != null);
-    try std.testing.expect(std.mem.indexOf(u8, via_display, "graff-747-tree-b") == null);
+    const via_posix = try codedbpro_paths.sessionAbs(gpa, io, null, "note.txt");
+    defer gpa.free(via_posix);
+    try std.testing.expect(std.mem.indexOf(u8, via_posix, "graff-747-tree-a") == null);
 }

--- a/src/edit_worktree_tests.zig
+++ b/src/edit_worktree_tests.zig
@@ -1,0 +1,93 @@
+//! #747: after a workspace switch, edit_file must write the selected tree.
+//!
+//! The persistence check already refuses a false success. The miss was the
+//! write resolving a different root than the verify (relative path + a
+//! stale Threaded-Io cwd after `chdir`, #721). Both paths now go through
+//! `sessionAbs`, which follows the session display cwd — not `Io.Dir.cwd()`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Io = std.Io;
+
+const edit_verify = @import("edit_verify.zig");
+const codedbpro_paths = @import("codedbpro_paths.zig");
+const main_mod = @import("main.zig");
+
+fn tmpAbs(io: Io, dir: anytype) ![]u8 {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = dir.dir.realPath(io, &buf) catch return error.SkipZigTest;
+    return std.testing.allocator.dupe(u8, buf[0..n]);
+}
+
+test "#747: editing the same relative name after a tree switch lands on the selected root" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+
+    var dir_a = std.testing.tmpDir(.{});
+    defer dir_a.cleanup();
+    var dir_b = std.testing.tmpDir(.{});
+    defer dir_b.cleanup();
+    try dir_a.dir.writeFile(io, .{ .sub_path = "note.txt", .data = "alpha\n" });
+    try dir_b.dir.writeFile(io, .{ .sub_path = "note.txt", .data = "beta\n" });
+    const path_a = try tmpAbs(io, &dir_a);
+    defer gpa.free(path_a);
+    const path_b = try tmpAbs(io, &dir_b);
+    defer gpa.free(path_b);
+
+    const saved = main_mod.g_cwd_display;
+    defer main_mod.g_cwd_display = saved;
+
+    var client: std.http.Client = undefined;
+    const ctx = edit_verify.testCtx(&client);
+
+    var a_obj: std.json.ObjectMap = .empty;
+    defer a_obj.deinit(gpa);
+    try a_obj.put(gpa, "path", .{ .string = "note.txt" });
+    try a_obj.put(gpa, "old_string", .{ .string = "alpha\n" });
+    try a_obj.put(gpa, "new_string", .{ .string = "ALPHA\n" });
+
+    main_mod.g_cwd_display = path_a;
+    const out_a = try edit_verify.execEdit(ctx, .{ .object = a_obj });
+    defer gpa.free(out_a.text);
+    try std.testing.expect(!out_a.is_error);
+
+    var b_obj: std.json.ObjectMap = .empty;
+    defer b_obj.deinit(gpa);
+    try b_obj.put(gpa, "path", .{ .string = "note.txt" });
+    try b_obj.put(gpa, "old_string", .{ .string = "beta\n" });
+    try b_obj.put(gpa, "new_string", .{ .string = "BETA\n" });
+
+    main_mod.g_cwd_display = path_b;
+    const out_b = try edit_verify.execEdit(ctx, .{ .object = b_obj });
+    defer gpa.free(out_b.text);
+    try std.testing.expect(!out_b.is_error);
+
+    const on_a = try dir_a.dir.readFileAlloc(io, "note.txt", gpa, .limited(64));
+    defer gpa.free(on_a);
+    const on_b = try dir_b.dir.readFileAlloc(io, "note.txt", gpa, .limited(64));
+    defer gpa.free(on_b);
+    try std.testing.expectEqualStrings("ALPHA\n", on_a);
+    try std.testing.expectEqualStrings("BETA\n", on_b);
+}
+
+test "#747: sessionAbs of a relative name follows the selected cwd, not a sibling tree" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    const a = try codedbpro_paths.sessionAbs(gpa, io, "/tmp/graff-747-tree-a", "note.txt");
+    defer gpa.free(a);
+    const b = try codedbpro_paths.sessionAbs(gpa, io, "/tmp/graff-747-tree-b", "note.txt");
+    defer gpa.free(b);
+    try std.testing.expect(!std.mem.eql(u8, a, b));
+    try std.testing.expect(std.mem.endsWith(u8, a, "note.txt"));
+    try std.testing.expect(std.mem.endsWith(u8, b, "note.txt"));
+
+    const saved = main_mod.g_cwd_display;
+    defer main_mod.g_cwd_display = saved;
+    main_mod.g_cwd_display = "/tmp/graff-747-tree-a";
+    const via_display = try codedbpro_paths.sessionAbs(gpa, io, null, "note.txt");
+    defer gpa.free(via_display);
+    try std.testing.expect(std.mem.indexOf(u8, via_display, "graff-747-tree-a") != null);
+    try std.testing.expect(std.mem.indexOf(u8, via_display, "graff-747-tree-b") == null);
+}

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -325,12 +325,9 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
         if (want_compact) {
             if (try codedb_exec.maybeCompactRead(ctx, path, start_line, end_line)) |out| return out;
         }
-        // #276 P0-1: resolve under the agent's isolated worktree when set —
-        // path itself stays relative (that's the agent's own view, used in
-        // every message below); only the actual syscall targets the resolved
-        // absolute path.
-        const resolved: []const u8 = if (ctx.agent_cwd) |base| try std.fmt.allocPrint(gpa, "{s}/{s}", .{ base, path }) else path;
-        defer if (ctx.agent_cwd != null) gpa.free(resolved);
+        // #747: same selected-tree absolute path as edit_file (sessionAbs).
+        const resolved = try codedbpro_paths.sessionAbs(gpa, io, ctx.agent_cwd, path);
+        defer gpa.free(resolved);
         const outcome = read_file.read(io, gpa, .cwd(), resolved, start_line, end_line, contains) catch |err| {
             if (fsErrorText(gpa, .read, path, err)) |t| return .{ .text = t, .is_error = true };
             return err;
@@ -376,11 +373,10 @@ fn execToolInner(ctx: ToolCtx, call: ToolCall) !ToolOutput {
         const path = strField(input, "path") orelse return missingArg(gpa, "path");
         const content = strField(input, "content") orelse return missingArg(gpa, "content");
         if (!confinedPath(path) or !noSymlinkEscape(io, path, ctx.agent_cwd)) return outsideCwd(gpa, path);
-        // #276 P0-1: resolve under the agent's isolated worktree when set.
-        // (snapshots are root-only — `ctx.agent_cwd` is only ever set for a
-        // subagent, so the branch below never runs together with isolation.)
-        const resolved: []const u8 = if (ctx.agent_cwd) |base| try std.fmt.allocPrint(gpa, "{s}/{s}", .{ base, path }) else path;
-        defer if (ctx.agent_cwd != null) gpa.free(resolved);
+        // #747: share sessionAbs with edit_file so a write cannot land in
+        // posix cwd while the next edit looks at a stale display cwd.
+        const resolved = try codedbpro_paths.sessionAbs(gpa, io, ctx.agent_cwd, path);
+        defer gpa.free(resolved);
         // #337: a write_file racing an edit_file on the same path in the same
         // assistant turn (agent_tools.zig runs them concurrently) would drop
         // one of the two. Same stripe as edit_file, so they take turns.

--- a/src/meta_wire.zig
+++ b/src/meta_wire.zig
@@ -1,0 +1,105 @@
+//! Meta / Muse Spark request-body policy (#751).
+//!
+//! Meta's chat API only accepts `tool_choice: "auto"`. `none`, `required`,
+//! and named function choices 400 as `request_rejected`. The Codegraff
+//! gateway already translates those (zigrepper `34a4882`); the harness still
+//! must not emit them for a known-restricted model — a silent `required`→
+//! `auto` rewrite at the gateway is a semantic gap. ADR 0070.
+
+const std = @import("std");
+
+/// Native Meta seat, or a Muse Spark id on any provider (Codegraff gateway).
+pub fn restricted(provider_id: []const u8, model: []const u8) bool {
+    if (std.mem.eql(u8, provider_id, "meta")) return true;
+    return std.mem.startsWith(u8, model, "muse-spark");
+}
+
+/// Value written as OpenAI-chat `tool_choice`. Restricted models always
+/// get `auto`, even when the harness wanted a forced call.
+pub fn toolChoice(force_tool: bool, provider_id: []const u8, model: []const u8) []const u8 {
+    if (restricted(provider_id, model)) return "auto";
+    return if (force_tool) "required" else "auto";
+}
+
+/// Chat `reasoning_effort` after Z.AI's own map. Meta 1.3 rejects `max`
+/// for non-contributor seats; fold `max`/`ultra` to `xhigh` (gateway
+/// `0051310`). Everyone else: `ultra` → `max`, otherwise the tag as-is.
+pub fn chatEffort(requested: []const u8, provider_id: []const u8, model: []const u8) []const u8 {
+    if (restricted(provider_id, model)) {
+        if (std.mem.eql(u8, requested, "max") or std.mem.eql(u8, requested, "ultra"))
+            return "xhigh";
+        return requested;
+    }
+    if (std.mem.eql(u8, requested, "ultra")) return "max";
+    return requested;
+}
+
+test "meta: restricted is the meta seat or any muse-spark id" {
+    try std.testing.expect(restricted("meta", "muse-spark-1.3"));
+    try std.testing.expect(restricted("codegraff", "muse-spark-1.3"));
+    try std.testing.expect(restricted("meta", "something-else"));
+    try std.testing.expect(!restricted("openai", "gpt-5.6"));
+    try std.testing.expect(!restricted("codegraff", "grok-4.6"));
+}
+
+test "meta: tool_choice is auto even when the harness forces a call" {
+    try std.testing.expectEqualStrings("auto", toolChoice(true, "meta", "muse-spark-1.3"));
+    try std.testing.expectEqualStrings("auto", toolChoice(false, "meta", "muse-spark-1.3"));
+    try std.testing.expectEqualStrings("auto", toolChoice(true, "codegraff", "muse-spark-1.2"));
+    try std.testing.expectEqualStrings("required", toolChoice(true, "openai", "gpt-5.6"));
+    try std.testing.expectEqualStrings("auto", toolChoice(false, "openai", "gpt-5.6"));
+}
+
+test "meta: max/ultra effort folds to xhigh; other providers keep ultra→max" {
+    try std.testing.expectEqualStrings("xhigh", chatEffort("max", "meta", "muse-spark-1.3"));
+    try std.testing.expectEqualStrings("xhigh", chatEffort("ultra", "codegraff", "muse-spark-1.3"));
+    try std.testing.expectEqualStrings("high", chatEffort("high", "meta", "muse-spark-1.3"));
+    try std.testing.expectEqualStrings("max", chatEffort("ultra", "openai", "gpt-5.6"));
+    try std.testing.expectEqualStrings("high", chatEffort("high", "openai", "gpt-5.6"));
+}
+
+test "meta: forced chat body sends auto, never required; max effort is xhigh" {
+    const Agent = @import("agent.zig").Agent;
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var messages = std.json.Array.init(arena);
+    var user: std.json.ObjectMap = .empty;
+    try user.put(arena, "role", .{ .string = "user" });
+    try user.put(arena, "content", .{ .string = "hello" });
+    try messages.append(.{ .object = user });
+    var agent: Agent = .{
+        .gpa = std.testing.allocator,
+        .arena = arena,
+        .io = std.testing.io,
+        .client = undefined,
+        .provider = .{
+            .id = "meta",
+            .kind = .openai,
+            .auth = .bearer,
+            .url = "https://api.meta.ai/v1/chat/completions",
+            .api_key = "k",
+            .model = "muse-spark-1.3",
+            .context = 1_048_576,
+        },
+        .messages = messages,
+        .sub = false,
+        .label = "",
+        .out = null,
+        .sys_normal = "system",
+        .reasoning = .max,
+    };
+    const tools = "[{\"type\":\"function\",\"function\":{\"name\":\"ping\",\"description\":\"\",\"parameters\":{\"type\":\"object\"}}}]";
+    const forced = try agent.buildBody(tools, true, true, true);
+    defer std.testing.allocator.free(forced);
+    try std.testing.expect(std.mem.indexOf(u8, forced, "\"tool_choice\":\"required\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, forced, "\"tool_choice\":\"auto\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, forced, "\"reasoning_effort\":\"xhigh\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, forced, "\"reasoning_effort\":\"max\"") == null);
+
+    agent.provider.id = "codegraff";
+    const gw = try agent.buildBody(tools, true, true, true);
+    defer std.testing.allocator.free(gw);
+    try std.testing.expect(std.mem.indexOf(u8, gw, "\"tool_choice\":\"required\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, gw, "\"tool_choice\":\"auto\"") != null);
+}

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -358,4 +358,6 @@ test {
     _ = @import("codex_tool_search.zig"); // hosted tool_search on gpt-5.4+ Codex
     _ = @import("tool_call_args.zig"); // #752: truncated tool-call arguments must not poison history
     _ = @import("cache_affinity.zig"); // ADR 0069: git-root / scratch cache seed
+    _ = @import("meta_wire.zig"); // #751 / ADR 0070: Meta tool_choice is auto-only
+    _ = @import("edit_worktree_tests.zig"); // #747: edit lands on the selected worktree
 }

--- a/src/zai_wire.zig
+++ b/src/zai_wire.zig
@@ -67,7 +67,7 @@ pub fn writeChatExtras(s: *std.json.Stringify, provider_id: []const u8, model: [
     }
     if (!std.mem.eql(u8, provider_id, "kimi") and send_effort) {
         try s.objectField("reasoning_effort");
-        try s.write(if (is_zai) reasoningEffort(requested) else if (std.mem.eql(u8, requested, "ultra")) "max" else requested);
+        try s.write(if (is_zai) reasoningEffort(requested) else @import("meta_wire.zig").chatEffort(requested, provider_id, model));
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #751, #750, #748, #747.

Source-side harness fixes for the four open issues, targeting the 0.0.289 cut.

### #751 — Meta `tool_choice` is auto-only (ADR 0070)

Meta / Muse Spark reject non-`auto` choices. The harness now emits `tool_choice: "auto"` for provider `meta` or any `muse-spark*` id, and folds `max`/`ultra` effort to `xhigh`. The gateway rewrite stays a safety net.

### #748 — Error-only SSE is not a truncated-body retry

An `event: error` / `data: {"error":…}` stream is assembled as an error envelope. Deterministic `invalid_request` is not retried as a truncated body.

### #747 — Edits (and writes) land on the selected worktree

Write, read, and edit share `sessionAbs`: isolated `agent_cwd`, then posix process cwd, then display cwd. Never stale `Io.Dir.cwd()`. A follow-up commit stops `write_file` and `edit_file` from resolving different trees when display cwd and posix cwd disagree.

### #750 — Resize-anchor probe timing

Width/height assertions wait for two identical frames. Parking rereads stay a single settle. `DRIFT` is unchanged.

### Evals

In-house 12-task remasure (`graff-dev`, grok-4.6, jobs=1) held 12/12 on this tip, including after the write/edit cwd follow-up. Offline tier-2 `two-file-edit-lands-both` is green; remaining tier-2 reds are scripted-catalog cases unrelated to these four issues. Tier 1 suite floor is 2006.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

