### PR TITLE
docs(evals): remasure latest 289 in-house 12/12 at 167s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ current is part of cutting a release.
 
 ## Unreleased
 
+- In-house remasure on this tip (`run-20260906-125222`): graff-dev
+  **12/12 · 167s · 55 calls · $0.34 · 10.1M**. Wall beats the 284 pin
+  (220s) and the pre-affinity 289 table (180s). list$ is down from the
+  $0.42 leaf-cwd miss (ADR 0069) toward the 284 pin ($0.32). Graff-only;
+  not a three-harness Pareto claim.
 - Prompt-cache affinity is the git root, or one scratch seed when there is
   no `.git`. Eval sandboxes and worktrees can reuse a warm system+tools
   prefix instead of paying it on every leaf cwd. An offline test fails if

--- a/docs/adr/0069-cache-affinity-is-the-git-root.md
+++ b/docs/adr/0069-cache-affinity-is-the-git-root.md
@@ -31,3 +31,8 @@ The offline guard is `affinity: two scratch sandboxes share one project
 cache id` (tier 1 `cache-affinity-scratch`): two `/tmp` leaves must mint
 the same UUID `projectRootId` would send. Hashing the leaf cwd is a
 forced miss, asserted separately. No provider call.
+
+Confirm on latest 289 (`46f13c6`, `run-20260906-125222`): graff-dev
+**12/12 · 167.2s · 55 · $0.3392 · 10.1M**. Ordinary input returned to
+95k (cached 190k) vs the leaf-cwd miss of 150k / $0.4205. Wall is
+under the 284 pin. Graff-only; not a three-harness table.

--- a/graff-evals/hillclimb/baseline.md
+++ b/graff-evals/hillclimb/baseline.md
@@ -7,6 +7,23 @@ Graff must be ≤ every named axis vs both rivals and strictly better on
 at least one. Do not claim Pareto until a new same-session table says so.
 Do not regress $, RSS, calls, or tokens to close wall / first-token / pass.
 
+## 12-task in-house remasure on latest 289 (`run-20260906-125222`)
+
+Same SuperGrok seat, jobs=1, grok-4.6, `x_search` on, ReleaseSafe
+`graff-dev` from `release/v0.0.289` (`46f13c6`). Graff-only — not a
+three-harness Pareto claim.
+
+| harness | pass | wall | first | calls | tokens | list$ | RSS |
+|---|---:|---:|---:|---:|---:|---:|
+| graff-dev | **12/12** | **167.2s** | 0.0s† | 55 | 294231 | **$0.3392** | **10.1M** |
+
+† Graff `first_out_s` is boot/`›`, not TTFT. Wall beats the 284 pin
+(219.6s) and the pre-affinity 289 table (179.6s). list$ is down from
+the leaf-cwd miss ($0.4205, 150k ordinary) after ADR 0069: ordinary
+input is 95k and cached is 190k. Calls are 55 (284 pin 53). RSS is
+ReleaseSafe process peak. Do not read this as unique frontier vs grok
+or OpenCode.
+
 ## 12-task in-house remasure on 284 (`run-20260901-121759-composite`)
 
 Same SuperGrok seat, jobs=1, grok-4.6, `x_search` on, ReleaseSafe


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Graff-only remasure of current `release/v0.0.289` (`46f13c6`), not a three-harness Pareto claim.

Same SuperGrok seat, grok-4.6, jobs=1, `x_search` on, ReleaseSafe `graff-dev`.

| tip | pass | wall | calls | tokens | list$ | RSS |
|---|---:|---:|---:|---:|---:|---:|
| latest 289 (`run-20260906-125222`) | **12/12** | **167.2s** | 55 | 294k | **$0.3392** | **10.1M** |
| 289 pre-affinity (ADR 0069) | 12/12 | 179.6s | 52 | 284k | $0.4205 | 11.2M |
| 284 pin | 12/12 | 219.6s | 53 | 234k | $0.3169 | 8.7M |

Wall beats both earlier pins. list$ is down from the leaf-cwd miss after ADR 0069 (ordinary input 95k, cached 190k). Calls are 55 vs the 284 pin of 53. README still carries the 284 three-harness table.

The open issue-fix PR (#756) is a separate tip and was not in this binary.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

