### PR TITLE
Native folder picker: trailing slash and fuzzy rank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ current is part of cutting a release.
 
 ## Unreleased
 
+- `#776`: the native Open a folder picker keeps listing candidates while you
+  type, ranks them like `/model` (closest name first), and shows a resolved
+  directory with a trailing `/` (never `//`). Exact-path Go / Open folder
+  and row selection are unchanged.
 - Prompt-cache affinity is the git root, or one scratch seed when there is
   no `.git`. Eval sandboxes and worktrees can reuse a warm system+tools
   prefix instead of paying it on every leaf cwd. An offline test fails if

--- a/apps/native/README.md
+++ b/apps/native/README.md
@@ -92,8 +92,9 @@ server only validates a root it is handed) with the active one checked:
 
 - **Open a folder…** (also the caret beside the tab bar's folder chip)
   opens a folder picker (`/api/workspaces` walks one level at a time,
-  marks git roots, takes a typed or pasted path) and switches to the
-  folder you pick.
+  marks git roots, takes a typed or pasted path, ranks fuzzy name matches
+  like `/model`) and switches to the folder you pick. Resolved directories
+  show a trailing `/`.
 - **Workspace settings…** edits the active workspace: display name, the
   model new tabs spawn with, whether tools are auto-approved
   (`graff acp --yolo`), and whether each tab's agent starts the MCP

--- a/apps/native/app/api/workspaces/route.ts
+++ b/apps/native/app/api/workspaces/route.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { NextRequest } from "next/server";
+import { displayDirPath, joinDir } from "@/lib/folder-picker";
 import { defaultRoot, expandHome } from "@/lib/server-root";
 
 export const runtime = "nodejs";
@@ -35,13 +36,13 @@ export async function GET(req: NextRequest) {
       if (entry.name.startsWith(".") || HIDDEN.has(entry.name)) continue;
       const full = path.join(target, entry.name);
       if (!(entry.isDirectory() || (entry.isSymbolicLink() && isDir(full)))) continue;
-      entries.push({ name: entry.name, path: full, git: existsSync(path.join(full, ".git")) });
+      entries.push({ name: entry.name, path: joinDir(target, entry.name), git: existsSync(path.join(full, ".git")) });
     }
     entries.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
     const parent = path.dirname(target);
     return Response.json({
       ok: true,
-      path: target,
+      path: displayDirPath(target),
       parent: parent === target ? null : parent,
       git: existsSync(path.join(target, ".git")),
       home,

--- a/apps/native/components/site/WorkspaceDialog.tsx
+++ b/apps/native/components/site/WorkspaceDialog.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { createPortal } from "react-dom";
 import { Switch } from "@/components/atoms/Switch";
 import type { PromptModel } from "@/components/primitives/PromptBar";
-import { displayDirPath, rankFolderEntries, sameDir, splitFolderQuery } from "@/lib/folder-picker";
+import { displayDirPath, rankFolderEntries, sameBrowse, sameDir, splitFolderQuery } from "@/lib/folder-picker";
 import { browseFolders, fsReveal, type FolderListing } from "@/lib/fs-client";
 import { IconCrossSmall, IconFolder } from "@/lib/icons";
 import { basename, type Workspace } from "@/lib/workspaces";
@@ -133,11 +133,12 @@ function FolderPicker({ startPath, onPick, onClose }: { startPath?: string; onPi
 
   const parsed = splitFolderQuery(typed, listing?.path);
   const listingPath = listing?.path ?? null;
+  const listingHome = listing?.home ?? null;
   useEffect(() => {
     if (!listingPath || !parsed.browse) return;
-    if (sameDir(parsed.browse, listingPath)) return;
+    if (sameBrowse(parsed.browse, listingPath, listingHome)) return;
     void go(parsed.browse, { refresh: true });
-  }, [go, listingPath, parsed.browse]);
+  }, [go, listingHome, listingPath, parsed.browse]);
   const shown = useMemo(
     () => (listing ? rankFolderEntries(listing.entries, parsed.needle) : []),
     [listing, parsed.needle],

--- a/apps/native/components/site/WorkspaceDialog.tsx
+++ b/apps/native/components/site/WorkspaceDialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { Switch } from "@/components/atoms/Switch";
 import type { PromptModel } from "@/components/primitives/PromptBar";
+import { displayDirPath, rankFolderEntries, sameDir, splitFolderQuery } from "@/lib/folder-picker";
 import { browseFolders, fsReveal, type FolderListing } from "@/lib/fs-client";
 import { IconCrossSmall, IconFolder } from "@/lib/icons";
 import { basename, type Workspace } from "@/lib/workspaces";
@@ -11,8 +12,9 @@ import { basename, type Workspace } from "@/lib/workspaces";
 /* ─────────────────────────────────────────────────────────
  * WORKSPACE DIALOG
  * The two faces of the sidebar's workspace menu. "New workspace" walks
- * the machine's folders one level at a time (or takes a typed path) and
- * hands back the folder graff should run in. "Workspace settings" edits
+ * the machine's folders one level at a time (typed paths stay listed and
+ * fuzzy-ranked like /model) and hands back the folder graff should run in.
+ * "Workspace settings" edits
  * how new tabs in a workspace spawn: its name, default model and whether
  * tools are auto-approved.
  * ───────────────────────────────────────────────────────── */
@@ -94,7 +96,7 @@ function GitBadge() {
 
 function FolderPicker({ startPath, onPick, onClose }: { startPath?: string; onPick: (path: string) => void; onClose: () => void }) {
   const [listing, setListing] = useState<FolderListing | null>(null);
-  const [typed, setTyped] = useState(startPath ?? "~");
+  const [typed, setTyped] = useState(displayDirPath(startPath ?? "~"));
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   // Only the newest navigation may land: a slow listing of a big folder
@@ -102,21 +104,24 @@ function FolderPicker({ startPath, onPick, onClose }: { startPath?: string; onPi
   const seq = useRef(0);
   const pickRef = useRef(onPick);
   pickRef.current = onPick;
-  const go = useCallback(async (target: string, pick = false) => {
+  const go = useCallback(async (target: string, opts: { pick?: boolean; refresh?: boolean } = {}) => {
     const n = (seq.current += 1);
-    setBusy(true);
-    setListing(null);
+    const refresh = opts.refresh === true;
+    if (!refresh) {
+      setBusy(true);
+      setListing(null);
+    }
     setError(null);
     try {
       const next = await browseFolders(target);
       if (n !== seq.current) return;
       setListing(next);
-      setTyped(next.path);
+      if (!refresh) setTyped(displayDirPath(next.path));
       setError(null);
-      if (pick) pickRef.current(next.path);
+      if (opts.pick) pickRef.current(next.path);
     } catch (err) {
       if (n !== seq.current) return;
-      setError(err instanceof Error ? err.message : String(err));
+      if (!refresh) setError(err instanceof Error ? err.message : String(err));
     } finally {
       if (n === seq.current) setBusy(false);
     }
@@ -125,6 +130,18 @@ function FolderPicker({ startPath, onPick, onClose }: { startPath?: string; onPi
     void go(startPath ?? "~");
     return () => { seq.current++; };
   }, [go, startPath]);
+
+  const parsed = splitFolderQuery(typed, listing?.path);
+  const listingPath = listing?.path ?? null;
+  useEffect(() => {
+    if (!listingPath || !parsed.browse) return;
+    if (sameDir(parsed.browse, listingPath)) return;
+    void go(parsed.browse, { refresh: true });
+  }, [go, listingPath, parsed.browse]);
+  const shown = useMemo(
+    () => (listing ? rankFolderEntries(listing.entries, parsed.needle) : []),
+    [listing, parsed.needle],
+  );
 
   const crumbs = listing ? listing.path.split("/").filter(Boolean) : [];
   const crumbPath = (i: number) => `/${crumbs.slice(0, i + 1).join("/")}`;
@@ -146,7 +163,7 @@ function FolderPicker({ startPath, onPick, onClose }: { startPath?: string; onPi
           </span>
           <input
             value={typed}
-            onChange={(event) => { seq.current++; setTyped(event.target.value); setBusy(false); setError(null); setListing(null); }}
+            onChange={(event) => { setTyped(event.target.value); setError(null); }}
             spellCheck={false}
             autoFocus
             aria-label="Folder path"
@@ -161,11 +178,11 @@ function FolderPicker({ startPath, onPick, onClose }: { startPath?: string; onPi
           </button>
         </form>
         <div className="flex items-center gap-1.5 text-[11.5px] text-ink-3">
-          <Chip onClick={() => void go("~")} active={listing?.path === home}>
+          <Chip onClick={() => void go("~")} active={sameDir(listing?.path, home)}>
             Home
           </Chip>
           {repo && (
-            <Chip onClick={() => void go(repo)} active={listing?.path === repo}>
+            <Chip onClick={() => void go(repo)} active={sameDir(listing?.path, repo)}>
               {basename(repo)}
             </Chip>
           )}
@@ -212,7 +229,7 @@ function FolderPicker({ startPath, onPick, onClose }: { startPath?: string; onPi
                 <span>Up one level</span>
               </button>
             )}
-            {listing.entries.map((entry) => (
+            {shown.map((entry) => (
               <div
                 key={entry.path}
                 className="group flex h-8 items-center gap-2 rounded-[7px] px-2 transition-colors duration-100 hover:bg-hover"
@@ -238,14 +255,16 @@ function FolderPicker({ startPath, onPick, onClose }: { startPath?: string; onPi
                 </button>
               </div>
             ))}
-            {listing.entries.length === 0 && <p className="px-2 py-2 text-[12.5px] text-ink-3">No folders here</p>}
+            {shown.length === 0 && (
+              <p className="px-2 py-2 text-[12.5px] text-ink-3">{parsed.needle ? "No folders match this name." : "No folders here"}</p>
+            )}
           </div>
         )}
       </div>
 
       <div className="flex shrink-0 items-center gap-2 border-t border-line px-4 py-3">
-        <span className="min-w-0 flex-1 truncate font-mono text-[11.5px] text-ink-3" title={listing?.path}>
-          {listing?.path ?? ""}
+        <span className="min-w-0 flex-1 truncate font-mono text-[11.5px] text-ink-3" title={listing ? displayDirPath(listing.path) : ""}>
+          {listing ? displayDirPath(listing.path) : ""}
         </span>
         <button
           type="button"
@@ -257,7 +276,7 @@ function FolderPicker({ startPath, onPick, onClose }: { startPath?: string; onPi
         <button
           type="button"
           disabled={!typed.trim() || busy}
-          onClick={() => void go(typed, true)}
+          onClick={() => void go(typed, { pick: true })}
           className="h-8 rounded-full bg-ink px-3.5 text-[12.5px] font-medium text-canvas transition-opacity hover:opacity-90 disabled:opacity-50"
         >
           Open folder

--- a/apps/native/electron/project-recovery-visual.cjs
+++ b/apps/native/electron/project-recovery-visual.cjs
@@ -20,9 +20,11 @@ async function runProjectRecovery({ win, origin, output }) {
       r.requests.push({url:String(input),body:options?.body});
       if(url.pathname==='/api/workspaces') {
         const folder=url.searchParams.get('path');
-        const listing={path:folder,parent:'/demo',home:'/demo',default:'/demo/field-notes',git:false,entries:[{name:'child',path:folder+'/child',git:false}]};
-        if(folder==='/demo/missing') return json({error:'Folder does not exist'},404);
-        if(folder==='/demo/slow') await new Promise(resolve=>r.holds.folder=resolve);
+        const root=String(folder||'').replace(/\/+$/,'')||'/';
+        const join=(name)=>root==='/'?'/'+name:root+'/'+name;
+        const listing={path:root==='/'?'/':root+'/',parent:'/demo',home:'/demo',default:'/demo/field-notes',git:false,entries:[{name:'alpha',path:join('alpha'),git:false},{name:'codegraff',path:join('codegraff'),git:false},{name:'child',path:join('child'),git:false}]};
+        if(root==='/demo/missing') return json({error:'Folder does not exist'},404);
+        if(root==='/demo/slow') await new Promise(resolve=>r.holds.folder=resolve);
         return json(listing);
       }
       if(url.pathname==='/api/sessions'&&url.searchParams.has('name')) {
@@ -100,6 +102,10 @@ async function runProjectRecovery({ win, origin, output }) {
 
   await js(`document.querySelector('button[aria-label="Open folder…"]').click()`);
   await wait(`!!document.querySelector('[role="dialog"] button[title$="/child"]')`);
+  assert.ok(await js(`document.querySelector('[aria-label="Folder path"]').value.endsWith('/')`),'Resolved folder paths show a trailing slash');
+  await input('Folder path','codeg');
+  await wait(`!!document.querySelector('[role="dialog"] button[title$="/codegraff"]')`);
+  assert.equal(await js(`document.querySelector('[role="dialog"] .group button[title]')?.title?.endsWith('/codegraff')`),true,'Closest fuzzy match is listed first');
   await input('Folder path','/demo/missing');
   await click('[role="dialog"] button','Open folder');
   await wait(`!!document.querySelector('[role="dialog"] [role="alert"]')`);

--- a/apps/native/electron/project-recovery-visual.cjs
+++ b/apps/native/electron/project-recovery-visual.cjs
@@ -3,13 +3,23 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 async function runProjectRecovery({ win, origin, output }) {
-  const wc = win.webContents, js = code => wc.executeJavaScript(code);
+  const wc = win.webContents;
+  const js = async code => {
+    let last;
+    for (let i = 0; i < 8; i++) {
+      try { return await wc.executeJavaScript(code); } catch (error) {
+        last = error;
+        await new Promise(r => setTimeout(r, 50));
+      }
+    }
+    throw last;
+  };
   const wait = async code => { for (let i = 0; i < 120; i++) { if (await js(code)) return; await new Promise(r => setTimeout(r, 50)); } throw Error(`Recovery check timed out: ${code}`); };
   const click = (selector, text) => js(`Array.from(document.querySelectorAll(${JSON.stringify(selector)})).find(e=>e.textContent.trim()===${JSON.stringify(text)}).click()`);
   const input = (label, value) => js(`(()=>{const e=document.querySelector('[aria-label="${label}"]');e.focus();Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value').set.call(e,${JSON.stringify(value)});e.dispatchEvent(new Event('input',{bubbles:true}));})()`);
   const library = '[data-conversation-library]';
   await wc.loadURL(origin);
-  await wait(`!!document.querySelector('[data-project-context]')`);
+  await wait(`document.readyState==='complete'&&!!document.querySelector('[data-project-context]')`);
   await js(`(() => {
     const previous = window.fetch;
     const json = (value, status=200) => new Response(JSON.stringify(value), {status,headers:{'content-type':'application/json'}});

--- a/apps/native/electron/projects-visual.cjs
+++ b/apps/native/electron/projects-visual.cjs
@@ -36,6 +36,10 @@ async function runProjectVisuals({ win, origin, output }) {
   assert.equal(await js(`document.querySelector('button[aria-label="Changes"]')?.getAttribute('aria-current')`), null);
   await js(`document.querySelector('button[aria-label="Open folder…"]').click()`);
   await wait(`!!document.querySelector('[role="dialog"]')`);
+  // Unmount the picker before navigating: an in-flight listing + loadURL
+  // left the renderer unable to run the next suite's scripts.
+  await js(`document.querySelector('[role="dialog"] button[aria-label="Close"]').click()`);
+  await wait(`!document.querySelector('[role="dialog"]')`);
   await wc.loadURL(origin);
   await wait(`!!document.querySelector('textarea[aria-label="Prompt"]')`);
   win.setSize(900, 680);

--- a/apps/native/lib/folder-picker.test.ts
+++ b/apps/native/lib/folder-picker.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { displayDirPath, joinDir, rankFolderEntries, sameDir, splitFolderQuery } from "./folder-picker.ts";
+import { displayDirPath, joinDir, rankFolderEntries, sameBrowse, sameDir, splitFolderQuery } from "./folder-picker.ts";
 
 describe("displayDirPath", () => {
   it("adds a single trailing separator and leaves root alone", () => {
@@ -23,6 +23,12 @@ describe("joinDir / sameDir", () => {
     assert.equal(sameDir("/", "/"), true);
     assert.equal(sameDir("/a", "/b"), false);
     assert.equal(sameDir("/a", null), false);
+  });
+  it("treats ~ as the listing home so the picker does not refetch", () => {
+    assert.equal(sameBrowse("~", "/Users/example", "/Users/example"), true);
+    assert.equal(sameBrowse("~/", "/Users/example/", "/Users/example"), true);
+    assert.equal(sameBrowse("~", "/demo", "/Users/example"), false);
+    assert.equal(sameBrowse("/Users/example/", "/Users/example", "/Users/example"), true);
   });
 });
 

--- a/apps/native/lib/folder-picker.test.ts
+++ b/apps/native/lib/folder-picker.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { displayDirPath, joinDir, rankFolderEntries, sameDir, splitFolderQuery } from "./folder-picker.ts";
+
+describe("displayDirPath", () => {
+  it("adds a single trailing separator and leaves root alone", () => {
+    assert.equal(displayDirPath("/Users/example"), "/Users/example/");
+    assert.equal(displayDirPath("/Users/example/"), "/Users/example/");
+    assert.equal(displayDirPath("/"), "/");
+    assert.equal(displayDirPath("~"), "~/");
+  });
+});
+
+describe("joinDir / sameDir", () => {
+  it("never emits a double slash", () => {
+    assert.equal(joinDir("/Users/example", "src"), "/Users/example/src");
+    assert.equal(joinDir("/Users/example/", "src"), "/Users/example/src");
+    assert.equal(joinDir("/", "Users"), "/Users");
+    assert.equal(joinDir("/", "/Users"), "/Users");
+  });
+  it("treats a trailing slash as the same directory", () => {
+    assert.equal(sameDir("/Users/example", "/Users/example/"), true);
+    assert.equal(sameDir("/", "/"), true);
+    assert.equal(sameDir("/a", "/b"), false);
+    assert.equal(sameDir("/a", null), false);
+  });
+});
+
+describe("splitFolderQuery", () => {
+  it("keeps a resolved current path as browse, not parent + name", () => {
+    assert.deepEqual(splitFolderQuery("/Users/example", "/Users/example"), {
+      browse: "/Users/example",
+      needle: "",
+    });
+    assert.deepEqual(splitFolderQuery("/Users/example/", "/Users/example"), {
+      browse: "/Users/example",
+      needle: "",
+    });
+  });
+  it("splits a partial child off the parent directory", () => {
+    assert.deepEqual(splitFolderQuery("/Users/example/cod", "/Users/example"), {
+      browse: "/Users/example/",
+      needle: "cod",
+    });
+    assert.deepEqual(splitFolderQuery("codegra", "/Users/example"), {
+      browse: null,
+      needle: "codegra",
+    });
+    assert.deepEqual(splitFolderQuery("~/proj"), { browse: "~/", needle: "proj" });
+  });
+});
+
+describe("rankFolderEntries", () => {
+  const entries = [
+    { name: "README-notes", path: "/demo/README-notes" },
+    { name: "codegraff", path: "/demo/codegraff" },
+    { name: "codex-scratch", path: "/demo/codex-scratch" },
+    { name: "lib", path: "/demo/lib" },
+  ];
+  it("keeps directory order when the needle is empty", () => {
+    assert.deepEqual(rankFolderEntries(entries, "").map((e) => e.name), [
+      "README-notes",
+      "codegraff",
+      "codex-scratch",
+      "lib",
+    ]);
+  });
+  it("ranks the closest folder name first, like /model", () => {
+    assert.deepEqual(rankFolderEntries(entries, "code").map((e) => e.name), [
+      "codegraff",
+      "codex-scratch",
+    ]);
+    assert.deepEqual(rankFolderEntries(entries, "lib").map((e) => e.name), ["lib"]);
+    assert.deepEqual(rankFolderEntries(entries, "zzz"), []);
+  });
+});

--- a/apps/native/lib/folder-picker.ts
+++ b/apps/native/lib/folder-picker.ts
@@ -19,6 +19,18 @@ export function sameDir(a: string | null | undefined, b: string | null | undefin
   return normalizeDir(a) === normalizeDir(b);
 }
 
+/** True when `browse` is the listing already on screen.
+ * `~` / `~/` is the listing's home, so typing it must not refetch. */
+export function sameBrowse(
+  browse: string | null | undefined,
+  listingPath: string | null | undefined,
+  home?: string | null,
+): boolean {
+  if (sameDir(browse, listingPath)) return true;
+  if (!browse || !home) return false;
+  return normalizeDir(browse) === "~" && sameDir(listingPath, home);
+}
+
 export function normalizeDir(p: string): string {
   const n = p.replace(/\\/g, "/").replace(/\/+$/, "");
   return n.length > 0 ? n : "/";

--- a/apps/native/lib/folder-picker.ts
+++ b/apps/native/lib/folder-picker.ts
@@ -1,0 +1,73 @@
+/** Path display and query-aware ranking for the Open a folder picker.
+ * Identity paths stay slash-stripped (`workspaces.normalizePath`); the field
+ * and footer show a directory with a trailing `/` so the next segment is
+ * obvious. Ranking is the `/model` fuzzy score. */
+
+import { fuzzyScore } from "./fuzzy.ts";
+
+/** POSIX directory form for display: `/Users/me` → `/Users/me/`; `/` stays `/`. */
+export function displayDirPath(p: string): string {
+  const n = p.replace(/\\/g, "/");
+  if (!n) return n;
+  if (n === "/") return "/";
+  return n.endsWith("/") ? n : `${n}/`;
+}
+
+/** Compare two directory strings, ignoring a trailing separator. */
+export function sameDir(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (a == null || b == null) return false;
+  return normalizeDir(a) === normalizeDir(b);
+}
+
+export function normalizeDir(p: string): string {
+  const n = p.replace(/\\/g, "/").replace(/\/+$/, "");
+  return n.length > 0 ? n : "/";
+}
+
+/** Join a parent directory and a child name without emitting `//`. */
+export function joinDir(parent: string, name: string): string {
+  const base = parent.replace(/\\/g, "/").replace(/\/+$/, "");
+  const child = name.replace(/^\/+/, "");
+  if (!base || base === "/") return `/${child}`;
+  return `${base}/${child}`;
+}
+
+export type FolderQuery = {
+  /** Directory to list, or `null` when the field is a bare name. */
+  browse: string | null;
+  /** Last path segment — the fuzzy needle. */
+  needle: string;
+};
+
+/** Split a typed path into the directory to list and the name to rank.
+ * `current` is the listing already on screen: typing that path without a
+ * trailing slash is still "this folder", not parent + last segment. */
+export function splitFolderQuery(typed: string, current?: string | null): FolderQuery {
+  const t = typed.trim();
+  if (!t) return { browse: null, needle: "" };
+  if (current && sameDir(t, current)) return { browse: current, needle: "" };
+  if (t === "~") return { browse: "~", needle: "" };
+  if (t.endsWith("/") || t.endsWith("\\")) return { browse: t, needle: "" };
+  const slash = Math.max(t.lastIndexOf("/"), t.lastIndexOf("\\"));
+  if (slash < 0) return { browse: null, needle: t };
+  const browse = t.slice(0, slash + 1);
+  return { browse: browse || "/", needle: t.slice(slash + 1) };
+}
+
+export type RankableFolder = { name: string; path: string };
+
+/** Keep alpha order when the needle is empty; otherwise closest `/model`
+ * match first. Non-matches drop out. */
+export function rankFolderEntries<T extends RankableFolder>(entries: readonly T[], needle: string): T[] {
+  const q = needle.trim();
+  if (!q) return [...entries];
+  const scored: { item: T; score: number; idx: number }[] = [];
+  for (let i = 0; i < entries.length; i += 1) {
+    const item = entries[i];
+    const score = fuzzyScore(item.name, q) ?? fuzzyScore(item.path, q);
+    if (score == null) continue;
+    scored.push({ item, score, idx: i });
+  }
+  scored.sort((a, b) => b.score - a.score || a.idx - b.idx);
+  return scored.map((row) => row.item);
+}

--- a/apps/native/lib/fuzzy.test.ts
+++ b/apps/native/lib/fuzzy.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { fuzzyScore, fuzzySubseq } from "./fuzzy.ts";
+
+describe("fuzzySubseq", () => {
+  it("matches across punctuation gaps", () => {
+    assert.equal(fuzzySubseq("gpt-5.5", "gpt5.5"), true);
+    assert.equal(fuzzySubseq("claude-opus-4-8", "opus"), true);
+    assert.equal(fuzzySubseq("anything", ""), true);
+    assert.equal(fuzzySubseq("gpt-5.5", "xyz"), false);
+    assert.equal(fuzzySubseq("abc", "abcd"), false);
+  });
+});
+
+describe("fuzzyScore", () => {
+  it("ranks basename prefix above substring above subsequence", () => {
+    const demo = fuzzyScore("sdk/py/demo.py", "dem");
+    const readme = fuzzyScore("README.md", "dem");
+    assert.ok(demo != null && readme != null && demo > readme);
+    const sub = fuzzyScore(".graff/traces/run.jsonl", "trace");
+    const seq = fuzzyScore("t-r-a-c-e.txt", "trace");
+    assert.ok(sub != null && seq != null && sub > seq);
+    const basePre = fuzzyScore("src/main.zig", "main");
+    const mid = fuzzyScore("domain.zig", "main");
+    assert.ok(basePre != null && mid != null && basePre > mid);
+    assert.ok((fuzzyScore("sdk/ts/harness.ts", "sdk") ?? 0) >= 300_000 - 200);
+    assert.ok((fuzzyScore("gpt-5.6-sol", "5.6 sol") ?? 0) > (fuzzyScore("gpt-5.6", "5.6") ?? 0));
+    assert.equal(fuzzyScore("abc", "xyz"), null);
+    assert.equal(fuzzyScore("abc", ""), 0);
+  });
+});

--- a/apps/native/lib/fuzzy.ts
+++ b/apps/native/lib/fuzzy.ts
@@ -1,0 +1,64 @@
+/** Same ranking the line-REPL `/model` picker uses (`src/pickers.zig`):
+ * prefix beats substring beats subsequence; separators fold so "5.6 sol"
+ * hits `gpt-5.6-sol`. Higher is better; `null` is no match. */
+
+const SEPS = new Set(["-", "_", " ", ".", "/"]);
+
+function foldSeps(s: string): string {
+  let out = "";
+  for (const ch of s) {
+    if (SEPS.has(ch)) continue;
+    out += ch.toLowerCase();
+  }
+  return out;
+}
+
+function indexOfIgnoreCase(hay: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  if (needle.length > hay.length) return -1;
+  const h = hay.toLowerCase();
+  const n = needle.toLowerCase();
+  return h.indexOf(n);
+}
+
+function startsWithIgnoreCase(hay: string, needle: string): boolean {
+  return hay.length >= needle.length && hay.slice(0, needle.length).toLowerCase() === needle.toLowerCase();
+}
+
+/** fzf-style: every char of `needle` appears in `hay` in order, gaps allowed. */
+export function fuzzySubseq(hay: string, needle: string): boolean {
+  if (needle.length === 0) return true;
+  const h = hay.toLowerCase();
+  const n = needle.toLowerCase();
+  let ni = 0;
+  for (let i = 0; i < h.length; i += 1) {
+    if (h[i] === n[ni]) {
+      ni += 1;
+      if (ni === n.length) return true;
+    }
+  }
+  return false;
+}
+
+function scoreFolded(hay: string, needle: string): number | null {
+  if (needle.length === 0) return 0;
+  if (needle.length > hay.length) return null;
+  const lenPen = Math.min(hay.length, 200);
+  const slash = hay.lastIndexOf("/");
+  const base = slash >= 0 ? slash + 1 : 0;
+  if (startsWithIgnoreCase(hay.slice(base), needle) || startsWithIgnoreCase(hay, needle)) {
+    return 300_000 - lenPen;
+  }
+  const pos = indexOfIgnoreCase(hay, needle);
+  if (pos >= 0) return 200_000 - Math.min(pos, 1000) * 10 - lenPen;
+  if (fuzzySubseq(hay, needle)) return 100_000 - lenPen;
+  return null;
+}
+
+/** Rank a fuzzy match. Prefix > substring > subsequence. Empty needle is 0. */
+export function fuzzyScore(hay: string, needle: string): number | null {
+  if (needle.length === 0) return 0;
+  const direct = scoreFolded(hay, needle);
+  if (direct != null) return direct;
+  return scoreFolded(foldSeps(hay), foldSeps(needle));
+}

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -10,7 +10,7 @@
     "start": "NEXT_TELEMETRY_DISABLED=1 next start --port 3000",
     "mock-serve": "node scripts/mock-serve.mjs",
     "lint": "next lint",
-    "test": "node --experimental-strip-types --test lib/graff-events.test.ts lib/acp.test.ts lib/sessions.test.ts lib/session-store.test.ts lib/follow-scroll.test.ts lib/prompt-queue.test.ts lib/prompt-history.test.ts lib/attachments.test.ts lib/workspaces.test.ts lib/browser/annotations.test.ts lib/browser/url.test.ts",
+    "test": "node --experimental-strip-types --test lib/graff-events.test.ts lib/acp.test.ts lib/sessions.test.ts lib/session-store.test.ts lib/follow-scroll.test.ts lib/prompt-queue.test.ts lib/prompt-history.test.ts lib/attachments.test.ts lib/workspaces.test.ts lib/fuzzy.test.ts lib/folder-picker.test.ts lib/browser/annotations.test.ts lib/browser/url.test.ts",
     "electron:build": "bash electron/build.sh",
     "test:electron": "bun test electron/policy.test.cjs",
     "test:desktop": "bun test lib ./electron/*.test.cjs",


### PR DESCRIPTION
Closes #776.

The Open a folder picker treated the path field as exact navigation only: editing it cleared the listing, children stayed alphabetical, and a resolved directory showed without a trailing `/`.

This keeps the current folder visible while you type a partial path or name, ranks candidates with the same fuzzy score as `/model` (closest first), and displays resolved directories with a single trailing `/` (root stays `/`). Go, Open folder, and row selection still require an exact path.

**Tested**
- `node --experimental-strip-types --test` on `lib/fuzzy.test.ts` and `lib/folder-picker.test.ts` (path display, `//` join, query split, ranking)
- Native package test script for the new files plus existing workspace helpers
- `scripts/eval-tier1.sh` via pre-push (green)
- Desktop visual fixture (`project-recovery-visual.cjs`) now asserts the trailing slash and that a typed name ranks the closest folder first; the existing invalid-path / late-listing checks stay in place. The Electron visual runner was not available in this environment.