### PR TITLE
Honor local-only policy in native codedb context retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ current is part of cutting a release.
 
 ## Unreleased
 
+- `#765`: native `codedb context` honors local-only repository policy.
+  Project instructions and `.graff` policy files that forbid transmitting
+  working data, or a per-call `local_only` argument, dispatch
+  `codedb context --local` (on-device BM25/symbol/graph) and never invoke
+  remote advisory rerank. If local-only cannot be guaranteed — including
+  an explicit `--hybrid`/`--semantic` under that policy — the call is
+  refused before spawn. Ordinary reads stay native codedb (ADR 0040).
+  ADR 0083.
 - Prompt-cache affinity is the git root, or one scratch seed when there is
   no `.git`. Eval sandboxes and worktrees can reuse a warm system+tools
   prefix instead of paying it on every leaf cwd. An offline test fails if

--- a/docs/adr/0083-codedb-context-honors-local-only.md
+++ b/docs/adr/0083-codedb-context-honors-local-only.md
@@ -1,0 +1,31 @@
+# 0083. Native codedb context honors local-only retrieval
+
+Status: accepted 2026-09-07
+
+## Context
+
+codedb's default `context` composer may send relative paths and bounded
+snippets to a hosted embeddings lane for advisory rerank. The tool result
+then reports retrieval-privacy metadata and a remote-retention policy
+(`none_by_codedb_policy`). #765: that is not equivalent to no network
+egress. Project instructions that prohibit transmitting working data had
+no effect, and the native schema had no per-call local-only control.
+
+## Decision
+
+When repository policy (AGENTS.md / HARNESS.md / CLAUDE.md phrases, or
+`.graff/policy.json` / `.graff/retrieval-policy`) or `local_only=true`
+requires on-device retrieval, native `codedb context` dispatches
+`codedb context --local` and never hybrid/semantic rerank. If that
+boundary cannot be guaranteed (caller asked for `--hybrid`/`--semantic`
+under the policy), refuse before spawn and explain. Do not redirect
+ordinary reads to codedb-pro (ADR 0040).
+
+## Consequences
+
+- Repos that forbid transmitting working data stay on local BM25/symbol/graph.
+- Callers can enforce the boundary with `local_only` even when policy files
+  are silent.
+- Hybrid remains the default where policy does not require local-only.
+- Revisit only if codedb grows a stronger in-process local composer that
+  graff should prefer over `--local`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -93,6 +93,7 @@ record only when you need the evidence or the edge cases.
 | [0080](0080-desktop-projects-are-folders.md) | Desktop projects are folders; preferences survive local UI origin changes, and new chats inherit the focused project's folder. |
 | [0081](0081-desktop-split-focus-and-layout.md) | Split positions remain stable as focus changes; shared controls and draggable separators keep navigation usable. |
 | [0082](0082-subagent-activity-through-acp.md) | Sub-agents publish bounded, independent activity snapshots for read-only ACP inspection without mixing parent transcripts. |
+| [0083](0083-codedb-context-honors-local-only.md) | Native `codedb context` is `--local` (or refused before spawn) when repository policy or `local_only` forbids transmitting working data; no-retention hybrid is not no egress. |
 
 ## When to write one
 

--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -15,7 +15,7 @@
     "src/repl.zig",
     "TUI/root.zig"
   ],
-  "test_count_baseline": 2009,
+  "test_count_baseline": 2018,
   "test_count_slack": 25,
   "required_invariants": [
     {

--- a/src/codedb_exec.zig
+++ b/src/codedb_exec.zig
@@ -16,6 +16,7 @@ const harness_policy = @import("harness_policy.zig");
 const list_dir = @import("list_dir.zig");
 const codedb_health = @import("codedb_health.zig");
 const codedb_around = @import("codedb_around.zig");
+const codedb_local = @import("codedb_local.zig");
 const jobs = @import("jobs.zig");
 const main_mod = @import("main.zig");
 const hooks = @import("hooks.zig");
@@ -90,6 +91,8 @@ pub fn exec(ctx: ToolCtx, input: std.json.Value) !ToolOutput {
         .is_error = true,
     };
 
+    if (std.mem.eql(u8, sub, "context")) return execContext(ctx, it.rest(), input);
+
     if (isPathSub(sub)) {
         if (firstPathArg(it.rest())) |path| {
             if (!harness_policy.confinedPath(path) or !harness_policy.noSymlinkEscape(io, path, ctx.agent_cwd))
@@ -122,6 +125,53 @@ pub fn exec(ctx: ToolCtx, input: std.json.Value) !ToolOutput {
         defer gpa.free(text);
         return .{
             .text = try std.fmt.allocPrint(gpa, "codedb {s} timed out after {d}s and was killed — narrow the query, or run it through bash if it really needs that long", .{ sub, deadline_ms / 1000 }),
+            .is_error = true,
+        };
+    }
+    if (text.len == 0) {
+        defer gpa.free(text);
+        return .{ .text = try gpa.dupe(u8, "(codedb returned nothing — try `codedb status` or `codedb tree` to confirm the repo is indexed, or refine the query)") };
+    }
+    return .{ .text = text };
+}
+
+fn requiredLocal(ctx: ToolCtx, input: std.json.Value) bool {
+    if (codedb_local.inputRequiresLocal(input)) return true;
+    if (ctx.agent_cwd) |root| {
+        var dir = Io.Dir.cwd().openDir(ctx.io, root, .{}) catch
+            return codedb_local.dirRequiresLocal(ctx.io, ctx.gpa, Io.Dir.cwd());
+        defer dir.close(ctx.io);
+        return codedb_local.dirRequiresLocal(ctx.io, ctx.gpa, dir);
+    }
+    return codedb_local.dirRequiresLocal(ctx.io, ctx.gpa, Io.Dir.cwd());
+}
+
+fn execContext(ctx: ToolCtx, rest: []const u8, input: std.json.Value) !ToolOutput {
+    const gpa = ctx.gpa;
+    const plan = codedb_local.planContext(requiredLocal(ctx, input), rest);
+    if (plan.kind == .refuse) {
+        return .{ .text = try gpa.dupe(u8, plan.refuse_reason), .is_error = true };
+    }
+
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(gpa);
+    try argv.append(gpa, "codedb");
+    try argv.append(gpa, "context");
+    try codedb_local.appendContextArgs(gpa, &argv, plan, rest);
+
+    const run = jobs.runCappedWithOptions(gpa, ctx.io, argv.items, 512 * 1024, 4096, deadline_ms, jobs.toolRunOptions(ctx.agent_cwd)) catch |e| switch (e) {
+        error.FileNotFound => return .{
+            .text = try gpa.dupe(u8, "codedb isn't installed — it's open source at github.com/justrach/codedb; install it, then run `codedb` once in the repo to index it. Folder listing still works: codedb list_dir ."),
+            .is_error = true,
+        },
+        else => return tools.failure(gpa, e),
+    };
+    gpa.free(run.stderr);
+    const text = run.stdout;
+    if (run.timed_out) {
+        defer gpa.free(text);
+        return .{
+            .text = try std.fmt.allocPrint(gpa, "codedb context timed out after {d}s and was killed — narrow the query, or run it through bash if it really needs that long", .{deadline_ms / 1000}),
             .is_error = true,
         };
     }
@@ -203,4 +253,25 @@ test "advertised surface is the one-shots, hop verbs stay callable" {
         try std.testing.expect(!std.mem.eql(u8, s, "outline"));
         try std.testing.expect(!std.mem.eql(u8, s, "read"));
     }
+}
+
+test "execContext refuses remote rerank under local_only before spawn" {
+    const gpa = std.testing.allocator;
+    const parsed = try std.json.parseFromSlice(std.json.Value, gpa, "{\"command\":\"context --hybrid auth\",\"local_only\":true}", .{});
+    defer parsed.deinit();
+    var client: std.http.Client = undefined;
+    const ctx = ToolCtx{
+        .gpa = gpa,
+        .io = std.testing.io,
+        .client = &client,
+        .provider = undefined,
+        .from_sub = false,
+        .approvals = null,
+        .tracer = null,
+    };
+    const out = try execContext(ctx, "--hybrid auth", parsed.value);
+    defer gpa.free(out.text);
+    try std.testing.expect(out.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, out.text, "not dispatched") != null);
+    try std.testing.expect(!codedb_local.wouldInvokeRemoteRerank(codedb_local.planContext(true, "--hybrid auth")));
 }

--- a/src/codedb_exec.zig
+++ b/src/codedb_exec.zig
@@ -265,6 +265,7 @@ test "execContext refuses remote rerank under local_only before spawn" {
         .io = std.testing.io,
         .client = &client,
         .provider = undefined,
+        .registry = null,
         .from_sub = false,
         .approvals = null,
         .tracer = null,

--- a/src/codedb_local.zig
+++ b/src/codedb_local.zig
@@ -1,0 +1,283 @@
+//! Local-only retrieval policy for native `codedb context` (#765).
+//!
+//! codedb's default composer may send relative paths and bounded snippets to a
+//! hosted embeddings lane for advisory rerank. "No remote retention" is not no
+//! egress. When repository policy or the per-call `local_only` argument
+//! requires on-device retrieval, graff injects `context --local` before spawn
+//! and never dispatches hybrid/semantic rerank. If that boundary cannot be
+//! guaranteed, dispatch is refused. Ordinary reads stay native codedb
+//! (ADR 0040) — this is not a codedb-pro redirect.
+
+const std = @import("std");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+
+const json_args = @import("json_args.zig");
+const util = @import("util.zig");
+
+pub const instruction_names = [_][]const u8{ "AGENTS.md", "HARNESS.md", "CLAUDE.md" };
+pub const policy_json_path = ".graff/policy.json";
+pub const retrieval_policy_path = ".graff/retrieval-policy";
+
+const phrases = [_][]const u8{
+    "local-only retrieval",
+    "local only retrieval",
+    "local-only search",
+    "local only search",
+    "no transmission of working data",
+    "do not transmit working data",
+    "don't transmit working data",
+    "never transmit working data",
+    "prohibit transmission of working",
+    "prohibiting transmission of working",
+    "working data must not leave",
+    "no remote rerank",
+    "no remote ranking",
+    "do not send working data",
+    "never send working data",
+    "do not transmit repository",
+};
+
+pub const Kind = enum { local, remote, refuse };
+
+pub const Plan = struct {
+    kind: Kind,
+    inject_local: bool,
+    refuse_reason: []const u8 = "",
+};
+
+pub const refuse_remote =
+    "codedb context: repository policy requires local-only retrieval. Remote reranking sends relative paths and snippets over the network even when the provider claims no remote retention, so the call was not dispatched. Omit --hybrid/--semantic (graff will run `codedb context --local`) or pass local_only=true.";
+
+const remote_flags = [_][]const u8{ "--hybrid", "--semantic" };
+const local_flags = [_][]const u8{ "--local", "--no-semantic" };
+
+pub fn textRequiresLocal(text: []const u8) bool {
+    for (phrases) |p| {
+        if (util.indexOfIgnoreCase(text, p) != null) return true;
+    }
+    return false;
+}
+
+pub fn policyJsonRequiresLocal(body: []const u8) bool {
+    var parsed = std.json.parseFromSlice(std.json.Value, std.heap.page_allocator, std.mem.trim(u8, body, " \t\r\n"), .{}) catch return false;
+    defer parsed.deinit();
+    if (parsed.value != .object) return false;
+    if (stringIsLocal(parsed.value.object.get("retrieval"))) return true;
+    if (boolIsTrue(parsed.value.object.get("local_only"))) return true;
+    const codedb = parsed.value.object.get("codedb") orelse return false;
+    if (codedb != .object) return false;
+    return stringIsLocal(codedb.object.get("retrieval")) or boolIsTrue(codedb.object.get("local_only"));
+}
+
+fn stringIsLocal(v: ?std.json.Value) bool {
+    const val = v orelse return false;
+    if (val != .string) return false;
+    return std.ascii.eqlIgnoreCase(val.string, "local-only") or
+        std.ascii.eqlIgnoreCase(val.string, "local_only") or
+        std.ascii.eqlIgnoreCase(val.string, "local");
+}
+
+fn boolIsTrue(v: ?std.json.Value) bool {
+    const val = v orelse return false;
+    return val == .bool and val.bool;
+}
+
+pub fn retrievalPolicyRequiresLocal(body: []const u8) bool {
+    const trimmed = std.mem.trim(u8, body, " \t\r\n");
+    if (trimmed.len == 0) return false;
+    if (std.ascii.eqlIgnoreCase(trimmed, "local")) return true;
+    return util.indexOfIgnoreCase(trimmed, "local-only") != null or
+        util.indexOfIgnoreCase(trimmed, "local_only") != null;
+}
+
+pub fn dirRequiresLocal(io: Io, gpa: Allocator, dir: Io.Dir) bool {
+    for (instruction_names) |name| {
+        const body = dir.readFileAlloc(io, name, gpa, .limited(64 * 1024)) catch continue;
+        defer gpa.free(body);
+        if (textRequiresLocal(body)) return true;
+    }
+    if (dir.readFileAlloc(io, policy_json_path, gpa, .limited(16 * 1024))) |body| {
+        defer gpa.free(body);
+        if (policyJsonRequiresLocal(body)) return true;
+    } else |_| {}
+    if (dir.readFileAlloc(io, retrieval_policy_path, gpa, .limited(4 * 1024))) |body| {
+        defer gpa.free(body);
+        if (retrievalPolicyRequiresLocal(body)) return true;
+    } else |_| {}
+    return false;
+}
+
+pub fn inputRequiresLocal(input: std.json.Value) bool {
+    return json_args.flag(input, "local_only");
+}
+
+pub fn tokenIsRemoteFlag(tok: []const u8) bool {
+    for (remote_flags) |f| if (std.mem.eql(u8, tok, f)) return true;
+    return false;
+}
+
+pub fn tokenIsLocalFlag(tok: []const u8) bool {
+    for (local_flags) |f| if (std.mem.eql(u8, tok, f)) return true;
+    return false;
+}
+
+pub fn restHasFlag(rest: []const u8, check: *const fn ([]const u8) bool) bool {
+    var it = std.mem.tokenizeAny(u8, rest, " \t");
+    while (it.next()) |tok| {
+        if (check(tok)) return true;
+    }
+    return false;
+}
+
+/// Default `context` is hybrid (remote advisory rerank) unless `--local`.
+pub fn defaultWouldRemoteRerank(rest: []const u8) bool {
+    return !restHasFlag(rest, tokenIsLocalFlag);
+}
+
+pub fn planContext(required_local: bool, rest: []const u8) Plan {
+    if (!required_local) {
+        if (restHasFlag(rest, tokenIsLocalFlag)) return .{ .kind = .local, .inject_local = false };
+        return .{ .kind = .remote, .inject_local = false };
+    }
+    if (restHasFlag(rest, tokenIsRemoteFlag)) {
+        return .{ .kind = .refuse, .inject_local = false, .refuse_reason = refuse_remote };
+    }
+    return .{ .kind = .local, .inject_local = !restHasFlag(rest, tokenIsLocalFlag) };
+}
+
+pub fn wouldInvokeRemoteRerank(plan: Plan) bool {
+    return plan.kind == .remote;
+}
+
+/// Caller has already pushed `codedb` and `context`.
+pub fn appendContextArgs(gpa: Allocator, argv: *std.ArrayList([]const u8), plan: Plan, rest: []const u8) !void {
+    if (plan.inject_local) try argv.append(gpa, "--local");
+    var it = std.mem.tokenizeAny(u8, rest, " \t");
+    while (it.next()) |tok| {
+        if (tokenIsRemoteFlag(tok)) continue;
+        try argv.append(gpa, tok);
+    }
+}
+
+pub fn contextArgv(gpa: Allocator, plan: Plan, rest: []const u8) ![]const []const u8 {
+    var argv: std.ArrayList([]const u8) = .empty;
+    errdefer argv.deinit(gpa);
+    try argv.append(gpa, "codedb");
+    try argv.append(gpa, "context");
+    try appendContextArgs(gpa, &argv, plan, rest);
+    return argv.toOwnedSlice(gpa);
+}
+
+test "project-instruction phrases require local-only; generic offline notes do not" {
+    try std.testing.expect(textRequiresLocal("Do not transmit working data to any network service."));
+    try std.testing.expect(textRequiresLocal("Repository policy: local-only retrieval for codedb."));
+    try std.testing.expect(textRequiresLocal("explicit project instructions prohibiting transmission of working data"));
+    try std.testing.expect(textRequiresLocal("Use no remote rerank on context queries."));
+    try std.testing.expect(!textRequiresLocal("tier 1 is deterministic and offline (no provider calls, no network, no spend)"));
+    try std.testing.expect(!textRequiresLocal("Invalid remote compaction falls back locally"));
+}
+
+test "policy files honor local-only retrieval" {
+    try std.testing.expect(policyJsonRequiresLocal("{\"retrieval\":\"local-only\"}"));
+    try std.testing.expect(policyJsonRequiresLocal("{\"local_only\":true}"));
+    try std.testing.expect(policyJsonRequiresLocal("{\"codedb\":{\"retrieval\":\"local\"}}"));
+    try std.testing.expect(!policyJsonRequiresLocal("{\"retrieval\":\"hybrid\"}"));
+    try std.testing.expect(!policyJsonRequiresLocal("{\"local_only\":false}"));
+    try std.testing.expect(!policyJsonRequiresLocal("not json"));
+    try std.testing.expect(retrievalPolicyRequiresLocal("local-only\n"));
+    try std.testing.expect(retrievalPolicyRequiresLocal("local"));
+    try std.testing.expect(!retrievalPolicyRequiresLocal("hybrid"));
+}
+
+test "dirRequiresLocal reads instructions and .graff policy files" {
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try std.testing.expect(!dirRequiresLocal(io, gpa, tmp.dir));
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "README.md", .data = "no remote rerank\n" });
+    try std.testing.expect(!dirRequiresLocal(io, gpa, tmp.dir));
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "AGENTS.md", .data = "Do not transmit working data.\n" });
+    try std.testing.expect(dirRequiresLocal(io, gpa, tmp.dir));
+    try tmp.dir.writeFile(io, .{ .sub_path = "AGENTS.md", .data = "be helpful\n" });
+    try std.testing.expect(!dirRequiresLocal(io, gpa, tmp.dir));
+
+    try tmp.dir.createDirPath(io, ".graff");
+    try tmp.dir.writeFile(io, .{ .sub_path = policy_json_path, .data = "{\"retrieval\":\"local-only\"}\n" });
+    try std.testing.expect(dirRequiresLocal(io, gpa, tmp.dir));
+}
+
+test "local-only context never selects remote rerank" {
+    const gpa = std.testing.allocator;
+    const task = "find the request authentication path";
+    const plan = planContext(true, task);
+    try std.testing.expectEqual(Kind.local, plan.kind);
+    try std.testing.expect(plan.inject_local);
+    try std.testing.expect(!wouldInvokeRemoteRerank(plan));
+    try std.testing.expect(defaultWouldRemoteRerank(task));
+
+    const argv = try contextArgv(gpa, plan, task);
+    defer gpa.free(argv);
+    try std.testing.expectEqualStrings("codedb", argv[0]);
+    try std.testing.expectEqualStrings("context", argv[1]);
+    try std.testing.expectEqualStrings("--local", argv[2]);
+    try std.testing.expectEqualStrings(task[0..4], argv[3][0..4]);
+    for (argv) |tok| {
+        try std.testing.expect(!tokenIsRemoteFlag(tok));
+        try std.testing.expect(!std.mem.eql(u8, tok, "--hybrid"));
+        try std.testing.expect(!std.mem.eql(u8, tok, "--semantic"));
+    }
+}
+
+test "local-only refuses hybrid flags before dispatch" {
+    const plan = planContext(true, "--hybrid find auth");
+    try std.testing.expectEqual(Kind.refuse, plan.kind);
+    try std.testing.expect(!wouldInvokeRemoteRerank(plan));
+    try std.testing.expect(std.mem.indexOf(u8, plan.refuse_reason, "not dispatched") != null);
+    try std.testing.expect(std.mem.indexOf(u8, plan.refuse_reason, "local-only") != null);
+
+    const semantic = planContext(true, "--semantic how does auth work");
+    try std.testing.expectEqual(Kind.refuse, semantic.kind);
+    try std.testing.expect(!wouldInvokeRemoteRerank(semantic));
+}
+
+test "per-call local_only and existing --local stay on-device" {
+    const gpa = std.testing.allocator;
+    {
+        const parsed = try std.json.parseFromSlice(std.json.Value, gpa, "{\"command\":\"context auth\",\"local_only\":true}", .{});
+        defer parsed.deinit();
+        try std.testing.expect(inputRequiresLocal(parsed.value));
+        const plan = planContext(inputRequiresLocal(parsed.value), "auth");
+        try std.testing.expect(!wouldInvokeRemoteRerank(plan));
+    }
+    {
+        const parsed = try std.json.parseFromSlice(std.json.Value, gpa, "{\"command\":\"context auth\"}", .{});
+        defer parsed.deinit();
+        try std.testing.expect(!inputRequiresLocal(parsed.value));
+    }
+    const already = planContext(true, "--local auth");
+    try std.testing.expectEqual(Kind.local, already.kind);
+    try std.testing.expect(!already.inject_local);
+    try std.testing.expect(!wouldInvokeRemoteRerank(already));
+    const argv = try contextArgv(gpa, already, "--local auth");
+    defer gpa.free(argv);
+    var locals: usize = 0;
+    for (argv) |tok| {
+        if (std.mem.eql(u8, tok, "--local")) locals += 1;
+        try std.testing.expect(!tokenIsRemoteFlag(tok));
+    }
+    try std.testing.expectEqual(@as(usize, 1), locals);
+}
+
+test "without local-only policy default context still allows remote rerank" {
+    const plan = planContext(false, "find auth");
+    try std.testing.expectEqual(Kind.remote, plan.kind);
+    try std.testing.expect(wouldInvokeRemoteRerank(plan));
+    try std.testing.expect(defaultWouldRemoteRerank("find auth"));
+    try std.testing.expect(!defaultWouldRemoteRerank("--local find auth"));
+    try std.testing.expect(!defaultWouldRemoteRerank("--no-semantic find auth"));
+}

--- a/src/schema.zig
+++ b/src/schema.zig
@@ -105,9 +105,9 @@ pub const base_specs = [_]ToolSpec{
     .{ .name = skill_docs.tool_name, .desc = skill_docs.tool_desc, .schema = skill_docs.tool_schema },
     .{
         .name = "codedb",
-        .desc = "Indexed code nav (github.com/justrach/codedb). ONE command — not a hop chain: context <task> · around <name> · callpath A B · list_dir <path> · status. Prefer over bash grep/find/ls. list_dir is in-process (gitignore, PathConfine; no binary). status reports codedb.snapshot. Paths stay in the cwd.",
+        .desc = "Indexed code nav (github.com/justrach/codedb). ONE command — not a hop chain: context <task> · around <name> · callpath A B · list_dir <path> · status. Prefer over bash grep/find/ls. list_dir is in-process (gitignore, PathConfine; no binary). status reports codedb.snapshot. Paths stay in the cwd. context is local-only when local_only is set or repository policy forbids transmitting working data (no remote rerank).",
         .schema =
-        \\{"type": "object", "properties": {"command": {"type": "string", "description": "One of: \"context how does auth work\", \"around codedbGuard\", \"callpath exec codedbGuard\", \"list_dir src\", \"status\"."}}, "required": ["command"]}
+        \\{"type": "object", "properties": {"command": {"type": "string", "description": "One of: \"context how does auth work\", \"around codedbGuard\", \"callpath exec codedbGuard\", \"list_dir src\", \"status\"."}, "local_only": {"type": "boolean", "description": "Force on-device retrieval: dispatch `codedb context --local` with no remote rerank. Also applied automatically when repository policy requires local-only retrieval. If local-only cannot be guaranteed, the call is refused before spawn."}}, "required": ["command"]}
         ,
     },
     .{ .name = result_read.tool_name, .desc = result_read.tool_desc, .schema = result_read.tool_schema },

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -358,4 +358,5 @@ test {
     _ = @import("codex_tool_search.zig"); // hosted tool_search on gpt-5.4+ Codex
     _ = @import("tool_call_args.zig"); // #752: truncated tool-call arguments must not poison history
     _ = @import("cache_affinity.zig"); // ADR 0069: git-root / scratch cache seed
+    _ = @import("codedb_local.zig"); // #765: local-only codedb context (no remote rerank)
 }

--- a/src/tool_schema_tests.zig
+++ b/src/tool_schema_tests.zig
@@ -398,3 +398,14 @@ test "subagent desc: Codex sidecar rules, no routing essay on the catalog prefix
     };
     try std.testing.expect(found);
 }
+
+test "codedb schema exposes per-call local_only (#765)" {
+    var found = false;
+    for (schema.root_specs) |t| if (std.mem.eql(u8, t.name, "codedb")) {
+        found = true;
+        try std.testing.expect(std.mem.indexOf(u8, t.schema, "\"local_only\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, t.schema, "no remote rerank") != null);
+        try std.testing.expect(std.mem.indexOf(u8, t.desc, "local_only") != null);
+    };
+    try std.testing.expect(found);
+}


### PR DESCRIPTION
## Summary

Native `codedb context` defaulted to hybrid retrieval, which can send relative paths and bounded snippets to a hosted embeddings lane for advisory rerank. The tool then reported retrieval-privacy metadata and a remote-retention policy. **No remote retention is not no network egress**, and the schema had no per-call local-only control (#765).

When repository policy requires local-only retrieval — project instructions (`AGENTS.md` / `HARNESS.md` / `CLAUDE.md` phrases that prohibit transmitting working data), `.graff/policy.json` / `.graff/retrieval-policy`, or `local_only=true` — graff now dispatches `codedb context --local` (on-device BM25/symbol/graph) and never invokes remote rerank. If that boundary cannot be guaranteed (explicit `--hybrid` / `--semantic` under the policy), the call is **refused before spawn** with an explanation.

Ordinary reads stay native `codedb` / `read_file` (ADR 0040 / 0013 / 0019). This is not a codedb-pro redirect.

Closes #765.

## Decision

ADR 0083: local-only policy forces `--local` or a pre-dispatch refuse. Hybrid remains the default where policy does not require local-only.

## Tests

- Phrase / policy-file detection (and a negative control so generic “offline / no network” docs do not trip it)
- Local-only argv is `codedb context --local …` with no `--hybrid` / `--semantic`
- `--hybrid` / `--semantic` under local-only refuse before spawn (`wouldInvokeRemoteRerank` is false)
- Per-call `local_only` schema field is advertised and honored
- Default (no policy) still allows remote rerank

`zig build test` ran 2024 tests. Tier 1 green on push.