### PR TITLE
Add /update to install a release for the next launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ current is part of cutting a release.
 
 ## Unreleased
 
+- `#773`: `/update` checks a GitHub release and, after an explicit human
+  confirm, installs it for the next launch. The live process, conversation,
+  and permissions stay on the original version; `/new` and `/resume` do not
+  activate it. The in-session service pins the tag, verifies SHA256SUMS, and
+  writes atomically — it does not run `install.sh` or restart. `graff update
+  --check` shares the same running/latest comparison.
 - Prompt-cache affinity is the git root, or one scratch seed when there is
   no `.git`. Eval sandboxes and worktrees can reuse a warm system+tools
   prefix instead of paying it on every leaf cwd. An offline test fails if

--- a/TUI/bgop.zig
+++ b/TUI/bgop.zig
@@ -72,11 +72,13 @@ pub fn finish(self: *Model) void {
             .compact => "compaction failed to start",
             .bash => "command failed to start",
             .files => "file list failed to start",
+            .update => "update failed to start",
         }) catch {};
     } else switch (op.kind) {
         .compact => applyCompact(self, op),
         .bash => applyBash(self, op),
         .files => applyFiles(self, op),
+        .update => applyUpdate(self, op),
     }
     release(self, op);
     self.scroll = 0;
@@ -159,6 +161,16 @@ fn applyFiles(self: *Model, op: *Op) void {
     if (self.files_cache != null) return;
     const t = op.text orelse return;
     self.files_cache = self.alloc.dupe(u8, t) catch null;
+}
+
+fn applyUpdate(self: *Model, op: *Op) void {
+    if (op.text) |text| {
+        self.push(.system, text) catch {};
+    } else if (op.cancelled) {
+        self.push(.system, "update cancelled — the existing install is unchanged") catch {};
+    } else {
+        self.push(.err, "update check unavailable") catch {};
+    }
 }
 
 const testing = std.testing;
@@ -284,20 +296,27 @@ test "thread spawn failure completes through finish without inline engine work (
             calls += 1;
             return null;
         }
+        fn update(_: ?*anyopaque, _: std.mem.Allocator, _: []const u8) ?[]const u8 {
+            calls += 1;
+            return null;
+        }
     };
     Fake.calls = 0;
     engine.g_compact_fn = Fake.compact;
     engine.g_bash_fn = Fake.bash;
     engine.g_files_fn = Fake.files;
+    engine.g_update_fn = Fake.update;
     defer {
         engine.g_compact_fn = null;
         engine.g_bash_fn = null;
         engine.g_files_fn = null;
+        engine.g_update_fn = null;
     }
     const cases = [_]struct { kind: Op.Kind, message: []const u8 }{
         .{ .kind = .compact, .message = "compaction failed to start" },
         .{ .kind = .bash, .message = "command failed to start" },
         .{ .kind = .files, .message = "file list failed to start" },
+        .{ .kind = .update, .message = "update failed to start" },
     };
     for (cases) |case| {
         var m: Model = undefined;

--- a/TUI/catalog.zig
+++ b/TUI/catalog.zig
@@ -17,6 +17,7 @@ pub const items = [_]Item{
     .{ .name = "/context", .desc = "Show context-window use" },
     .{ .name = "/session-info", .desc = "Session details", .aliases = &.{ "/status", "/info" } },
     .{ .name = "/usage", .desc = "Token usage and cost", .aliases = &.{"/cost"} },
+    .{ .name = "/update", .desc = "Install a release for the next launch (this session keeps running)" },
     .{ .name = "/debug", .desc = "Live observability HUD" },
     .{ .name = "/cache", .desc = "Prompt-cache posture and remaining max levers" },
     .{ .name = "/rewind", .desc = "Undo the last turn", .aliases = &.{"/undo"} },
@@ -104,6 +105,7 @@ test "filter: slash prefix and alias" {
     try std.testing.expect(lookup("/debug") != null);
     try std.testing.expect(lookup("/cache") != null);
     try std.testing.expect(lookup("/cost") != null);
+    try std.testing.expect(lookup("/update") != null);
     try std.testing.expect(lookup("/tell") != null);
     try std.testing.expect(lookup("/peek") != null);
     try std.testing.expect(lookup("/not-a-cmd") == null);

--- a/TUI/dispatch.zig
+++ b/TUI/dispatch.zig
@@ -205,6 +205,8 @@ pub fn runCommand(self: *Model, line: []const u8) Effect {
         meters.sessionInfo(self);
     } else if (std.mem.eql(u8, canon, "/debug") or std.mem.eql(u8, canon, "/cache")) {
         self.openOverlay(.debug);
+    } else if (std.mem.eql(u8, canon, "/update")) {
+        startUpdate(self, arg);
     } else if (std.mem.eql(u8, canon, "/usage")) {
         var buf: [512]u8 = undefined;
         if (engine.g_hud_fn) |f| {
@@ -447,6 +449,22 @@ pub fn looksLikeImagePath(s: []const u8) bool {
         return t[0] == '/' or t[0] == '~' or t[0] == '.';
     }
     return true;
+}
+
+fn startUpdate(self: *Model, arg: []const u8) void {
+    const action = if (std.mem.eql(u8, arg, "install")) "install" else "check";
+    if (engine.g_update_fn == null) {
+        self.push(.system, "check for a release with /update; install it for the next launch only after you confirm. This session keeps running.") catch {};
+        return;
+    }
+    const cmd = self.alloc.dupe(u8, action) catch {
+        self.push(.err, "update check unavailable") catch {};
+        return;
+    };
+    if (!bgop.start(self, .update, &.{}, cmd, if (std.mem.eql(u8, action, "install")) "installing update" else "checking for update")) {
+        self.alloc.free(cmd);
+        self.push(.system, busy_note) catch {};
+    }
 }
 
 fn onOff(v: bool) []const u8 {

--- a/TUI/dispatch_command_tests.zig
+++ b/TUI/dispatch_command_tests.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 
 const app = @import("app.zig");
 const dispatch = @import("dispatch.zig");
+const bgop = @import("bgop.zig");
 const engine = @import("engine.zig");
 const turn = @import("turn.zig");
 const Effect = app.Effect;
@@ -31,6 +32,37 @@ test "/debug opens the observability overlay" {
     defer m.deinit();
     _ = applyLine(&m, "/debug");
     try std.testing.expectEqual(app.Overlay.debug, m.overlay);
+}
+
+test "/update checks in the background and does not activate via /new" {
+    engine.g_update_fn = struct {
+        fn f(_: ?*anyopaque, gpa: std.mem.Allocator, action: []const u8) ?[]const u8 {
+            return std.fmt.allocPrint(gpa, "running: v0.0.289 (this process)\ninstalled: v0.0.292\nlatest: v0.0.292\n{s}\n/new and /resume keep this process and do not activate the update.\n", .{action}) catch null;
+        }
+    }.f;
+    defer engine.g_update_fn = null;
+    var m: Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    try m.push(.user, "keep talking");
+    _ = applyLine(&m, "/update");
+    try std.testing.expect(m.bg != null);
+    try std.testing.expectEqual(engine.BgOp.Kind.update, m.bg.?.kind);
+    var spins: usize = 0;
+    while (!m.bg.?.done.load(.acquire)) : (spins += 1) {
+        if (spins > 1_000_000) return error.UpdateCheckNeverFinished;
+        std.Thread.yield() catch {};
+    }
+    bgop.finish(&m);
+    const text = m.history.items[m.history.items.len - 1].text;
+    try std.testing.expect(std.mem.indexOf(u8, text, "running:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "do not activate") != null);
+    const before = m.history.items.len;
+    _ = applyLine(&m, "/new");
+    const new_text = m.history.items[m.history.items.len - 1].text;
+    try std.testing.expect(std.mem.indexOf(u8, new_text, "update") == null);
+    try std.testing.expect(std.mem.indexOf(u8, new_text, "activate") == null);
+    try std.testing.expect(m.history.items.len < before + 3);
 }
 
 test "/cache opens the same observability overlay" {

--- a/TUI/engine.zig
+++ b/TUI/engine.zig
@@ -71,13 +71,15 @@ pub var g_idle_wake_fn: ?IdleWakeFn = null;
 /// mailbox (`tellCommand` / `peekCommand`). Caller frees the returned text.
 pub const PeerFn = *const fn (turn_ctx: ?*anyopaque, gpa: std.mem.Allocator, line: []const u8) ?[]const u8;
 pub var g_peer_fn: ?PeerFn = null;
+pub const UpdateFn = *const fn (turn_ctx: ?*anyopaque, gpa: std.mem.Allocator, action: []const u8) ?[]const u8;
+pub var g_update_fn: ?UpdateFn = null;
 
 /// A background engine op: `/compact`, `!cmd`, or the @-file list. Same
 /// thread + done-flag contract as Job, so the render+input loop keeps painting
 /// and Esc keeps reaching keys.handle while the engine works (#533). Every
 /// field the worker writes is read only after `done`.
 pub const BgOp = struct {
-    pub const Kind = enum { compact, bash, files };
+    pub const Kind = enum { compact, bash, files, update };
 
     kind: Kind,
     gpa: std.mem.Allocator,
@@ -112,6 +114,9 @@ pub fn bgRun(op: *BgOp) void {
         },
         .files => if (g_files_fn) |f| {
             op.text = f(g_turn_ctx, op.gpa);
+        },
+        .update => if (g_update_fn) |f| {
+            op.text = f(g_turn_ctx, op.gpa, op.cmd);
         },
     }
     op.done.store(true, .release);
@@ -152,6 +157,7 @@ pub const RunOpts = struct {
     emergency_fn: ?*const fn (turn_ctx: ?*anyopaque) void = null,
     idle_wake_fn: ?IdleWakeFn = null,
     peer_fn: ?PeerFn = null,
+    update_fn: ?UpdateFn = null,
 };
 
 pub var g_turn_fn: ?TurnFn = null;

--- a/TUI/overlaypane.zig
+++ b/TUI/overlaypane.zig
@@ -253,6 +253,7 @@ const help_body =
     \\  /effort           reasoning depth (type to filter)
     \\  /settings         model · effort · mode · theme
     \\  /usage /cost      live token/cost line
+    \\  /update           install a release for the next launch
     \\  /debug            observability HUD
     \\  /cache            prompt-cache posture
     \\  /plan             toggle plan mode

--- a/TUI/root.zig
+++ b/TUI/root.zig
@@ -41,6 +41,7 @@ pub const SessionState = engine.SessionState;
 pub const GoalOp = engine.GoalOp;
 pub const StateFn = engine.StateFn;
 pub const PeerFn = engine.PeerFn;
+pub const UpdateFn = engine.UpdateFn;
 pub const RunOpts = run_mod.RunOpts;
 pub const run = run_mod.run;
 pub fn setCurrentModel(name: []const u8, provider: []const u8) void {

--- a/TUI/run.zig
+++ b/TUI/run.zig
@@ -61,6 +61,7 @@ pub fn run(
     engine.g_state_fn = opts.state_fn;
     engine.g_idle_wake_fn = opts.idle_wake_fn;
     engine.g_peer_fn = opts.peer_fn;
+    engine.g_update_fn = opts.update_fn;
     engine.g_model_name = opts.model_name;
     engine.g_model_provider = opts.model_provider;
     engine.g_model_entries = opts.model_entries;

--- a/docs/adr/0083-in-session-update-is-next-launch.md
+++ b/docs/adr/0083-in-session-update-is-next-launch.md
@@ -1,0 +1,33 @@
+# 0083. In-session `/update` installs for the next launch
+
+Status: accepted 2026-09-07
+
+## Context
+
+Updating from a live terminal session must not require a second terminal, and
+must not interrupt the conversation. Automatic restart and launch-flag replay
+(#770) would activate new code in a way that looks like `/new` or `/resume`
+had switched binaries. The existing `graff update` CLI is process-fatal and
+delegates to `curl | install.sh`, which inherits a TTY and is not safe to
+call from the pager.
+
+## Decision
+
+`/update` (line REPL and TUI) uses a nonfatal in-process service: pin a
+GitHub release tag, download that tag's tarball and `SHA256SUMS`, verify,
+and atomically replace the resolved user install. Installation requires an
+explicit human confirm in this process (TTY picker or `/update install`
+after a human `/update` check). Model output, tool calls, saved
+conversations, and yolo/always-approve are not authorization.
+
+The live process, conversation, and permissions stay on the original binary.
+`/new` and `/resume` only change conversation state. A later normal launch
+uses the installed executable. Package-managed and zig-out paths are
+explained, not overwritten. Fail closed if verification is missing.
+
+## Consequences
+
+Activating new code without a restart stays out of scope (same boundary as
+ADR 0079). `graff update --check` shares the running/latest comparison in
+`version_status.zig`. Isolated fixtures cover install, already-installed,
+offline/malformed, verify, permission, cancel, and concurrent requests.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -93,6 +93,7 @@ record only when you need the evidence or the edge cases.
 | [0080](0080-desktop-projects-are-folders.md) | Desktop projects are folders; preferences survive local UI origin changes, and new chats inherit the focused project's folder. |
 | [0081](0081-desktop-split-focus-and-layout.md) | Split positions remain stable as focus changes; shared controls and draggable separators keep navigation usable. |
 | [0082](0082-subagent-activity-through-acp.md) | Sub-agents publish bounded, independent activity snapshots for read-only ACP inspection without mixing parent transcripts. |
+| [0083](0083-in-session-update-is-next-launch.md) | `/update` installs a verified release for the next launch; this session keeps its original binary. |
 
 ## When to write one
 

--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -15,7 +15,7 @@
     "src/repl.zig",
     "TUI/root.zig"
   ],
-  "test_count_baseline": 2009,
+  "test_count_baseline": 2037,
   "test_count_slack": 25,
   "required_invariants": [
     {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -10,11 +10,11 @@
 
 const std = @import("std");
 const Io = std.Io;
-const Value = std.json.Value;
 const Allocator = std.mem.Allocator;
 
 const root = @import("main.zig");
 const harness_version = root.harness_version;
+const version_status = @import("version_status.zig");
 
 /// Shown under `graff --version` — a terse "what's new" for recent releases.
 /// Keep it short and current; bump alongside the version each release.
@@ -384,89 +384,13 @@ pub const usage_text =
     \\
 ;
 
-const Version = struct {
-    major: u32,
-    minor: u32,
-    patch: u32,
-
-    fn eql(self: Version, other: Version) bool {
-        return self.major == other.major and self.minor == other.minor and self.patch == other.patch;
-    }
-
-    fn order(self: Version, other: Version) std.math.Order {
-        if (self.major != other.major) return std.math.order(self.major, other.major);
-        if (self.minor != other.minor) return std.math.order(self.minor, other.minor);
-        return std.math.order(self.patch, other.patch);
-    }
-};
-
-/// Parse a leading `MAJOR.MINOR.PATCH` from `s` (after any leading 'v' is
-/// stripped by the caller). Returns null if the numeric triple isn't present.
-fn parseVersion(s: []const u8) ?Version {
-    var it = std.mem.splitScalar(u8, s, '.');
-    const major_s = it.next() orelse return null;
-    const minor_s = it.next() orelse return null;
-    const patch_s = it.next() orelse return null;
-    // Each component must be all digits up to the next '.' (or end). `patch`
-    // may trail a pre-release suffix ("-3-gabc", "-dev"); take only the leading
-    // digits so "0.0.14-3-gabc" parses as 0.0.14.
-    const major = std.fmt.parseInt(u32, major_s, 10) catch return null;
-    const minor = std.fmt.parseInt(u32, minor_s, 10) catch return null;
-    const patch_digits = std.mem.indexOfAny(u8, patch_s, "-+") orelse patch_s.len;
-    const patch = std.fmt.parseInt(u32, patch_s[0..patch_digits], 10) catch return null;
-    return .{ .major = major, .minor = minor, .patch = patch };
-}
-
-/// True when `s` is a bare release version with no `git describe` suffix — i.e.
-/// exactly `MAJOR.MINOR.PATCH` (optionally 'v'-prefixed), no "-N-gHASH",
-/// "-dirty", "-dev", or "+build". A dev/dirty/commit-ahead build is not a clean
-/// release and shouldn't be silently "updated" (downgraded) to an older tag.
-fn isCleanReleaseVersion(s: []const u8) bool {
-    if (s.len == 0) return false;
-    var dots: u8 = 0;
-    for (s) |c| {
-        switch (c) {
-            '0'...'9' => {},
-            '.' => dots += 1,
-            else => return false, // any '-','+','g',... means it's not a bare tag
-        }
-    }
-    return dots == 2;
-}
-
-fn fetchLatestReleaseTag(io: Io, gpa: Allocator, arena: Allocator, repo_api: []const u8) ?[]const u8 {
-    var client: std.http.Client = .{ .allocator = gpa, .io = io };
-    defer client.deinit();
-    var aw: Io.Writer.Allocating = .init(arena);
-    defer aw.deinit();
-    const extra = [_]std.http.Header{.{ .name = "Accept", .value = "application/vnd.github+json" }};
-    const res = client.fetch(.{
-        .location = .{ .url = repo_api },
-        .method = .GET,
-        .response_writer = &aw.writer,
-        .headers = .{ .user_agent = .{ .override = "simple-harness/" ++ harness_version } },
-        .extra_headers = &extra,
-    }) catch return null;
-    if (@intFromEnum(res.status) != 200) return null;
-    if (aw.writer.buffered().len > 64 * 1024) return null;
-    const v = std.json.parseFromSliceLeaky(Value, arena, aw.writer.buffered(), .{ .allocate = .alloc_always }) catch return null;
-    if (v != .object) return null;
-    const t = v.object.get("tag_name") orelse return null;
-    return if (t == .string) t.string else null;
-}
-
 /// Dim REPL/TUI line when GitHub has a newer release. Null if current, newer,
 /// offline, or GRAFF_NO_UPDATE_CHECK is set.
 pub fn updateAvailableLine(io: Io, gpa: Allocator, arena: Allocator, skip: bool) ?[]const u8 {
     if (skip) return null;
-    const repo_api = "https://api.github.com/repos/justrach/codegraff/releases/latest";
-    const latest_tag = fetchLatestReleaseTag(io, gpa, arena, repo_api) orelse return null;
-    const cur_raw = if (std.mem.startsWith(u8, harness_version, "v")) harness_version[1..] else harness_version;
-    const latest_raw = if (std.mem.startsWith(u8, latest_tag, "v")) latest_tag[1..] else latest_tag;
-    const cur = parseVersion(cur_raw) orelse return null;
-    const latest = parseVersion(latest_raw) orelse return null;
-    if (cur.order(latest) != .lt) return null;
-    return std.fmt.allocPrint(arena, "graff v{s} is available (you have {s}) — graff update", .{ latest_raw, cur_raw }) catch null;
+    const check = version_status.checkLatest(io, gpa, arena, harness_version);
+    if (check.order != .lt) return null;
+    return std.fmt.allocPrint(arena, "graff v{s} is available (you have {s}) — graff update", .{ check.latest.?, check.running }) catch null;
 }
 
 /// `graff update [--force|--check]` — bring the installed binary up to the
@@ -484,7 +408,6 @@ pub fn updateCommand(
     force: bool,
     check_only: bool,
 ) !void {
-    const repo_api = "https://api.github.com/repos/justrach/codegraff/releases/latest";
     const install_url = environ.get("GRAFF_INSTALL_URL") orelse environ.get("HARNESS_INSTALL_URL") orelse
         "https://github.com/justrach/codegraff/releases/latest/download/install.sh";
 
@@ -492,34 +415,20 @@ pub fn updateCommand(
     var ow = Io.File.stdout().writer(io, &obuf);
     const out = &ow.interface;
 
-    // current version, leading 'v' stripped so the comparison ignores tag style.
-    const cur_raw = if (std.mem.startsWith(u8, harness_version, "v")) harness_version[1..] else harness_version;
+    const check = version_status.checkLatest(io, gpa, arena, harness_version);
+    const cur_raw = check.running;
+    const latest_tag = check.latest_tag;
+    const latest_raw = check.latest;
 
-    // A release tag is a bare "MAJOR.MINOR.PATCH". A dev/dirty/commit-ahead
-    // build (from `git describe --tags --always --dirty`) carries a suffix
-    // ("-3-gabc", "-dirty", "-dev+hash", "0.1.0-dev") and is NOT a clean
-    // release version. Comparing such a string against a release tag with exact
-    // equality always mismatched, so `graff update` would "update" (downgrade)
-    // a newer dev build to an older release, and `--check` always reported an
-    // update available. Parse the leading numeric triple instead, and refuse to
-    // act on a non-release local build rather than silently downgrading it.
-    const cur = parseVersion(cur_raw);
-    const cur_is_release = cur != null and isCleanReleaseVersion(cur_raw);
-
-    const latest_tag = fetchLatestReleaseTag(io, gpa, arena, repo_api);
-
-    // `latest` is a release tag from GitHub, so it parses to a clean triple.
-    const latest_raw = if (latest_tag) |tag| (if (std.mem.startsWith(u8, tag, "v")) tag[1..] else tag) else null;
-    const latest = if (latest_raw) |r| parseVersion(r) else null;
-
-    if (latest_tag != null and latest == null) {
+    if (check.failure == .latest_tag) {
         // The release endpoint returned a tag we couldn't parse — treat like a
         // failed check rather than guessing.
         if (check_only) std.process.fatal("update check failed — unparseable release tag '{s}'", .{latest_tag.?});
         try out.print("could not parse latest release tag '{s}'; running installer anyway…\n", .{latest_tag.?});
-    } else if (latest != null) {
-        const up_to_date = cur != null and cur.?.eql(latest.?);
-        const cur_newer = cur != null and cur.?.order(latest.?) == .gt;
+    } else if (latest_raw != null) {
+        const up_to_date = check.order == .eq;
+        const cur_newer = check.order == .gt;
+        const cur_is_release = check.clean_release;
 
         if (check_only) {
             if (cur_is_release and up_to_date) {

--- a/src/command_catalog.zig
+++ b/src/command_catalog.zig
@@ -84,6 +84,7 @@ pub const commands = [_]Item{
     .{ .name = "/jobs", .usage = "/jobs [keep|unkeep|stop|restart <id>]", .desc = "list background jobs (age, port, idle stop); keep pins a server, restart reruns one" },
     .{ .name = "/cost", .desc = "session token usage and cost" },
     .{ .name = "/usage", .desc = "alias for /cost" },
+    .{ .name = "/update", .usage = "/update [install]", .desc = "check for a release and install it for the next launch (this session keeps running)" },
     .{ .name = "/debug", .desc = "live content-free observability HUD (turns, tokens, tools, last events)" },
     .{ .name = "/cache", .desc = "prompt-cache posture: prefix hash, hit rate, last bust, remaining max levers" },
     .{ .name = "/tools", .desc = "session tool balance: codedb-pro vs zigrep vs native usage, gate refusals, skew" },

--- a/src/commands_misc.zig
+++ b/src/commands_misc.zig
@@ -165,6 +165,7 @@ pub fn tryHandle(root: *Agent, keys: *Keys, arena: Allocator, line: []const u8, 
     if (std.mem.startsWith(u8, line, "/schedule") and (line.len == 9 or line[9] == ' ' or line[9] == '\t')) return @import("schedule.zig").slashCommand(root, arena, line, out);
     if (std.mem.startsWith(u8, line, "/adapter") and (line.len == 8 or line[8] == ' ' or line[8] == '\t')) return @import("channel_worker.zig").slashCommand(root, arena, line, out);
     if (try side_question.command(root, arena, line, out)) return true; // #415 /btw
+    if (try @import("update_cmd.zig").tryHandle(root, arena, line, out)) return true; // #773 /update
     // #321: doctor.zig shipped with a catalog entry but no dispatch, so /doctor
     // was advertised in /help and the `/` menu while answering "unknown command".
     if (std.mem.eql(u8, line, "/doctor")) {

--- a/src/help.zig
+++ b/src/help.zig
@@ -32,7 +32,7 @@ pub const sections = [_]Section{
     .{ .title = "the model", .names = &.{ "/model", "/models", "/effort", "/reasoning", "/fast", "/thinking", "/keepcontext", "/fallback", "/routes" } },
     .{ .title = "working autonomously", .names = &.{ "/goal", "/loop", "/schedule", "/review", "/plan", "/todo", "/jobs", "/ultracode", "/strict", "/yolo", "/never" } },
     .{ .title = "talking to other graffs", .names = &.{ "/tell", "/peek", "/adapter" }, .blurb = peers_blurb },
-    .{ .title = "your setup", .names = &.{ "/login", "/key", "/cost", "/usage", "/privacy", "/mcp", "/import-claude", "/skills", "/plugins", "/agents", "/hooks", "/tools", "/fleet" } },
+    .{ .title = "your setup", .names = &.{ "/login", "/key", "/cost", "/usage", "/update", "/privacy", "/mcp", "/import-claude", "/skills", "/plugins", "/agents", "/hooks", "/tools", "/fleet" } },
     .{ .title = "context & history", .names = &.{ "/compact", "/btw", "/doctor", "/debug", "/cache", "/trace", "/trajectory" } },
     .{ .title = "shell & images", .names = &.{ "/bash", "/image", "/images", "/paste" } },
     .{ .title = "look & feel", .names = &.{ "/theme", "/animation", "/title" } },

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -73,6 +73,8 @@ pub var g_models: []const u8 = ""; // comma-joined model names (for /models)
 pub var g_model_fn: ?ModelFn = null; // switch the active model by name
 pub const CancelFn = *const fn (turn_ctx: ?*anyopaque) void;
 pub var g_cancel_fn: ?CancelFn = null; // force-interrupt the running turn (steer drain)
+pub const UpdateFn = *const fn (turn_ctx: ?*anyopaque, gpa: std.mem.Allocator, action: []const u8) ?[]const u8;
+pub var g_update_fn: ?UpdateFn = null;
 pub var g_debug: bool = false; // GRAFF_REPL_DEBUG / `/debug` → dump raw stream + frames to stderr
 
 // ---------------------------------------------------------------------------
@@ -356,6 +358,7 @@ pub const HELP_CALC =
     \\Commands:
     \\  /help     this help
     \\  /clear    clear the conversation
+    \\  /update   install a release for the next launch (this session keeps running)
     \\  /animation enso|braille|dragon   spinner style
     \\  /quit     exit  (also /q, ctrl-c)
     \\

--- a/src/repl_model_commands.zig
+++ b/src/repl_model_commands.zig
@@ -41,6 +41,8 @@ pub fn runCommand(self: *Model, line: []const u8) void {
         self.compact();
     } else if (std.mem.eql(u8, cmd, "/help")) {
         self.push(.info, if (self.chat) HELP_CHAT else repl.HELP_CALC) catch {};
+    } else if (std.mem.eql(u8, cmd, "/update")) {
+        showUpdate(self, arg);
     } else if (std.mem.eql(u8, cmd, "/model")) {
         if (arg.len == 0) {
             if (repl.g_model_name.len > 0) self.pushFmt(.info, "model: {s}", .{repl.g_model_name}) catch {} else self.push(.info, "no model configured") catch {};
@@ -126,6 +128,29 @@ pub fn runCommand(self: *Model, line: []const u8) void {
     } else {
         self.pushFmt(.err, "unknown command: {s} — try /help", .{cmd}) catch {};
     }
+}
+
+fn showUpdate(self: *Model, action: []const u8) void {
+    if (repl.g_update_fn) |f| if (f(repl.g_turn_ctx, self.alloc, if (action.len == 0) "check" else action)) |text| {
+        self.pushOwned(.info, text) catch self.alloc.free(text);
+        return;
+    };
+    self.push(.info, "check for a release with /update; install it for the next launch only after you confirm. This session keeps running.") catch {};
+}
+
+test "/update does not claim /new activates a binary" {
+    repl.g_update_fn = null;
+    var m: Model = undefined;
+    m.setup(std.testing.allocator);
+    defer m.deinit();
+    runCommand(&m, "/update");
+    const text = m.history.items[m.history.items.len - 1].text;
+    try std.testing.expect(std.mem.indexOf(u8, text, "next launch") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "keeps running") != null);
+    runCommand(&m, "/new");
+    const new_text = m.history.items[m.history.items.len - 1].text;
+    try std.testing.expect(std.mem.indexOf(u8, new_text, "update") == null);
+    try std.testing.expect(std.mem.indexOf(u8, new_text, "activate") == null);
 }
 
 /// Remove the last user turn and everything after it (its reply).

--- a/src/repl_util.zig
+++ b/src/repl_util.zig
@@ -11,7 +11,7 @@ pub const accent = zz.Color.fromRgb(0x05, 0x96, 0x69); // codegraff.com emerald 
 pub const HELP_CHAT =
     \\Commands (mirrors the graff session):
     \\  /help /clear /new /quit          conversation
-    \\  /rewind /compact /cost           history
+    \\  /rewind /compact /cost /update   history and next-launch install
     \\  /model [name] /models            model (switch / list)
     \\  /effort low|med|high|xhigh|max|ultra   reasoning depth
     \\  /fast /thinking /ultracode       thinking controls (toggles)

--- a/src/session_run.zig
+++ b/src/session_run.zig
@@ -45,6 +45,7 @@ const engine_events = @import("engine_events.zig");
 const harness_policy = @import("harness_policy.zig");
 const title_mod = @import("title.zig");
 const repl = @import("repl.zig");
+const update_cmd = @import("update_cmd.zig");
 const tui_launch = @import("tui_launch.zig");
 const shapes = @import("shapes.zig"); // applyUltracodeSteering lives here (#326)
 const repl_glue = @import("repl_glue.zig");
@@ -114,12 +115,19 @@ pub fn runReplCommand(gpa: Allocator, io: Io, environ_map: anytype, root: *agent
         if (models_buf.items.len != 0) models_buf.appendSlice(", ") catch {};
         models_buf.appendSlice(mi.name) catch {};
     }
+    repl.g_update_fn = replUpdateCb;
+    defer repl.g_update_fn = null;
     try repl.runScripted(gpa, io, environ_map, in, out, &repl_ctx, repl_glue.replTurnCb, repl_glue.replModelCb, repl_glue.replCancelCb, root.provider.model, models_buf.items);
     // Same stderr footer as `-p`, so evals can score the scripted REPL the
     // same way. TTY `graff repl` is the TUI and keeps the restore tail clean.
     pricing.printUsageFooter(io);
     root.messages = try convo.cloneInto(root.arena);
     return true;
+}
+
+fn replUpdateCb(ctx: ?*anyopaque, gpa: Allocator, action: []const u8) ?[]const u8 {
+    const c: *repl_glue.ReplCtx = @ptrCast(@alignCast(ctx orelse return null));
+    return update_cmd.hostAction(c.io, gpa, c.home, action);
 }
 
 pub fn runFrontendCommands(gpa: Allocator, io: Io, environ_map: anytype, root: *agent_mod.Agent, keys: *provider_mod.Keys, client: *std.http.Client, in: *Io.Reader, out: *Io.Writer, arena: Allocator, flags: args.Flags, json_mode: bool, cwd: []const u8, final_io: Io) !bool {

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -358,4 +358,10 @@ test {
     _ = @import("codex_tool_search.zig"); // hosted tool_search on gpt-5.4+ Codex
     _ = @import("tool_call_args.zig"); // #752: truncated tool-call arguments must not poison history
     _ = @import("cache_affinity.zig"); // ADR 0069: git-root / scratch cache seed
+    _ = @import("version_status.zig");
+    _ = @import("update_target.zig");
+    _ = @import("update_archive.zig");
+    _ = @import("update_service.zig");
+    _ = @import("update_cmd.zig");
+    _ = @import("update_tests.zig");
 }

--- a/src/tui_launch.zig
+++ b/src/tui_launch.zig
@@ -13,6 +13,7 @@ const pricing = @import("pricing.zig");
 const providers = @import("providers.zig");
 const process_runner = @import("process_runner.zig");
 const repl = @import("repl.zig");
+const update_cmd = @import("update_cmd.zig");
 const repl_bash = @import("repl_bash.zig");
 const repl_glue = @import("repl_glue.zig");
 const session = @import("session.zig");
@@ -149,6 +150,7 @@ pub fn run(
         .emergency_fn = emergencyCb,
         .idle_wake_fn = idleWakeCb,
         .peer_fn = tui_peer.peerCb,
+        .update_fn = updateCb,
     });
     try tui_session.syncRoot(&convo, root);
 }
@@ -192,6 +194,11 @@ fn historyCb(ctx: ?*anyopaque, op: tui.HistoryOp) void {
         },
         .rewind => convo.rewind(),
     }
+}
+
+fn updateCb(ctx: ?*anyopaque, gpa: Allocator, action: []const u8) ?[]const u8 {
+    const c: *repl_glue.ReplCtx = @ptrCast(@alignCast(ctx orelse return null));
+    return update_cmd.hostAction(c.io, gpa, c.home, action);
 }
 
 fn idleWakeCb(ctx: ?*anyopaque, buf: []u8) ?[]const u8 {

--- a/src/update_archive.zig
+++ b/src/update_archive.zig
@@ -1,0 +1,200 @@
+//! Pin a release artifact, verify it against that release's SHA256SUMS, and
+//! extract the `graff` binary. Fail closed if the sums file is missing,
+//! malformed, or does not match. No remote scripts.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const Error = error{ VerifyFailed, Malformed, OutOfMemory };
+
+pub fn sha256Hex(bytes: []const u8, out: *[64]u8) []const u8 {
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    const digits = "0123456789abcdef";
+    for (digest, 0..) |b, i| {
+        out[i * 2] = digits[b >> 4];
+        out[i * 2 + 1] = digits[b & 0x0f];
+    }
+    return out;
+}
+
+/// Find the lowercase hex digest for `asset` in GNU `sha256sum` text.
+/// Fail closed on a missing or malformed line.
+pub fn digestFor(sums: []const u8, asset: []const u8) ?[]const u8 {
+    var lines = std.mem.splitScalar(u8, sums, '\n');
+    while (lines.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \t\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        if (line.len < 66) return null;
+        const hex = line[0..64];
+        for (hex) |c| {
+            const ok = (c >= '0' and c <= '9') or (c >= 'a' and c <= 'f') or (c >= 'A' and c <= 'F');
+            if (!ok) return null;
+        }
+        var rest = std.mem.trim(u8, line[64..], " \t");
+        if (rest.len > 0 and (rest[0] == '*' or rest[0] == ' ')) rest = std.mem.trim(u8, rest, " *");
+        if (std.mem.eql(u8, rest, asset) or std.mem.endsWith(u8, rest, asset)) return hex;
+    }
+    return null;
+}
+
+pub fn verifyAsset(sums: []const u8, asset: []const u8, bytes: []const u8) Error!void {
+    const want = digestFor(sums, asset) orelse return error.VerifyFailed;
+    var hex: [64]u8 = undefined;
+    const got = sha256Hex(bytes, &hex);
+    if (!eqlHex(want, got)) return error.VerifyFailed;
+}
+
+fn eqlHex(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    var same: u8 = 0;
+    for (a, b) |x, y| same |= std.ascii.toLower(x) ^ std.ascii.toLower(y);
+    return same == 0;
+}
+
+fn isZeroBlock(hdr: []const u8) bool {
+    for (hdr) |b| if (b != 0) return false;
+    return true;
+}
+
+fn tarName(hdr: []const u8) []const u8 {
+    const prefix = memCstr(hdr[345..500]);
+    const name = memCstr(hdr[0..100]);
+    if (prefix.len == 0) return name;
+    return name; // we only match a basename of graff
+}
+
+fn memCstr(s: []const u8) []const u8 {
+    return s[0 .. std.mem.indexOfScalar(u8, s, 0) orelse s.len];
+}
+
+fn tarSize(hdr: []const u8) ?u64 {
+    const field = memCstr(hdr[124..136]);
+    const trimmed = std.mem.trim(u8, field, " \t");
+    if (trimmed.len == 0) return 0;
+    return std.fmt.parseInt(u64, trimmed, 8) catch null;
+}
+
+fn isGraffMember(name: []const u8) bool {
+    const base = std.fs.path.basename(name);
+    return std.mem.eql(u8, base, "graff") or std.mem.eql(u8, base, "graff.exe");
+}
+
+pub fn extractGraff(gpa: Allocator, tar_bytes: []const u8) Error![]u8 {
+    if (tar_bytes.len < 512) return error.Malformed;
+    var off: usize = 0;
+    while (off + 512 <= tar_bytes.len) {
+        const hdr = tar_bytes[off .. off + 512];
+        if (isZeroBlock(hdr)) break;
+        const size = tarSize(hdr) orelse return error.Malformed;
+        const typeflag = hdr[156];
+        off += 512;
+        if (off + size > tar_bytes.len) return error.Malformed;
+        const payload = tar_bytes[off .. off + @as(usize, @intCast(size))];
+        off += std.mem.alignForward(usize, @as(usize, @intCast(size)), 512);
+        if ((typeflag == 0 or typeflag == '0') and isGraffMember(tarName(hdr)))
+            return gpa.dupe(u8, payload);
+    }
+    return error.Malformed;
+}
+
+pub fn gunzip(gpa: Allocator, gz: []const u8) Error![]u8 {
+    var in_reader: std.Io.Reader = .fixed(gz);
+    const window = gpa.alloc(u8, std.compress.flate.max_window_len) catch return error.OutOfMemory;
+    defer gpa.free(window);
+    var dec = std.compress.flate.Decompress.init(&in_reader, .gzip, window);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    errdefer out.deinit();
+    _ = dec.reader.streamRemaining(&out.writer) catch return error.Malformed;
+    return out.toOwnedSlice() catch return error.OutOfMemory;
+}
+
+pub fn extractVerified(gpa: Allocator, sums: []const u8, asset: []const u8, archive: []const u8) Error![]u8 {
+    try verifyAsset(sums, asset, archive);
+    const tar = gunzip(gpa, archive) catch |err| switch (err) {
+        error.Malformed, error.OutOfMemory => return err,
+        else => return error.Malformed,
+    };
+    defer gpa.free(tar);
+    return extractGraff(gpa, tar);
+}
+
+fn checksumField(hdr: []u8) void {
+    @memset(hdr[148..156], ' ');
+    var sum: u32 = 0;
+    for (hdr[0..512]) |b| sum += b;
+    _ = std.fmt.bufPrint(hdr[148..155], "{o:0>6}", .{sum}) catch {};
+    hdr[155] = 0;
+}
+
+/// Build a one-file ustar + gzip for isolated fixtures. Never used as a
+/// production download path.
+pub fn fixtureArchive(gpa: Allocator, member_name: []const u8, payload: []const u8) ![]u8 {
+    const data_pad = std.mem.alignForward(usize, payload.len, 512);
+    const tar = try gpa.alloc(u8, 512 + data_pad + 1024);
+    errdefer gpa.free(tar);
+    @memset(tar, 0);
+    const hdr = tar[0..512];
+    const name_len = @min(member_name.len, 99);
+    @memcpy(hdr[0..name_len], member_name[0..name_len]);
+    _ = try std.fmt.bufPrint(hdr[100..107], "{o:0>7}", .{@as(u32, 0o0755)});
+    _ = try std.fmt.bufPrint(hdr[124..135], "{o:0>11}", .{payload.len});
+    hdr[156] = '0';
+    @memcpy(hdr[257..262], "ustar");
+    hdr[263] = '0';
+    checksumField(hdr);
+    @memcpy(tar[512 .. 512 + payload.len], payload);
+    const gz = try gzipAlloc(gpa, tar);
+    gpa.free(tar);
+    return gz;
+}
+
+pub fn gzipAlloc(gpa: Allocator, plain: []const u8) ![]u8 {
+    var out_buf: [1 << 16]u8 = undefined;
+    var out: std.Io.Writer = .fixed(&out_buf);
+    const window = try gpa.alloc(u8, std.compress.flate.max_window_len);
+    defer gpa.free(window);
+    const c = try gpa.create(std.compress.flate.Compress);
+    defer gpa.destroy(c);
+    c.* = try std.compress.flate.Compress.init(&out, window, .gzip, .default);
+    try c.writer.writeAll(plain);
+    try c.finish();
+    return gpa.dupe(u8, out.buffered());
+}
+
+pub fn sumsLine(gpa: Allocator, asset: []const u8, bytes: []const u8) ![]u8 {
+    var hex: [64]u8 = undefined;
+    _ = sha256Hex(bytes, &hex);
+    return std.fmt.allocPrint(gpa, "{s}  {s}\n", .{ hex, asset });
+}
+
+test "digestFor reads GNU sha256sum lines and rejects junk" {
+    const body = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  graff-x86_64-linux.tar.gz\n";
+    try std.testing.expectEqualStrings(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        digestFor(body, "graff-x86_64-linux.tar.gz").?,
+    );
+    try std.testing.expect(digestFor("not-a-sum\n", "graff-x86_64-linux.tar.gz") == null);
+    try std.testing.expect(digestFor(body, "graff-aarch64-macos.tar.gz") == null);
+}
+
+test "verify + extract a fixture archive" {
+    const gpa = std.testing.allocator;
+    const archive = try fixtureArchive(gpa, "graff-x86_64-linux/graff", "NEWBIN");
+    defer gpa.free(archive);
+    const sums = try sumsLine(gpa, "graff-x86_64-linux.tar.gz", archive);
+    defer gpa.free(sums);
+    const bin = try extractVerified(gpa, sums, "graff-x86_64-linux.tar.gz", archive);
+    defer gpa.free(bin);
+    try std.testing.expectEqualStrings("NEWBIN", bin);
+}
+
+test "verification fails closed on a wrong digest" {
+    const gpa = std.testing.allocator;
+    const archive = try fixtureArchive(gpa, "graff", "NEWBIN");
+    defer gpa.free(archive);
+    try std.testing.expectError(
+        error.VerifyFailed,
+        extractVerified(gpa, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  graff-x86_64-linux.tar.gz\n", "graff-x86_64-linux.tar.gz", archive),
+    );
+}

--- a/src/update_cmd.zig
+++ b/src/update_cmd.zig
@@ -1,0 +1,288 @@
+//! `/update` for the line REPL: check a release, ask a human, install for
+//! the next launch. Yolo, tools, model text, and saved conversations never
+//! authorize an install. ACP / pipes have no TTY picker, so they only check.
+
+const std = @import("std");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+
+const Agent = @import("agent.zig").Agent;
+const pickers = @import("pickers.zig");
+const version_status = @import("version_status.zig");
+const update_target = @import("update_target.zig");
+const update_service = @import("update_service.zig");
+
+pub const installed_for_next_launch = update_target.install_note;
+pub const no_activate_note = update_target.no_activate_note;
+
+var pending_tag: [64]u8 = undefined;
+var pending_tag_len: usize = 0;
+var pending_target: [std.fs.max_path_bytes]u8 = undefined;
+var pending_target_len: usize = 0;
+var test_running: ?[]const u8 = null;
+var test_target: ?[]const u8 = null;
+var test_fetch: ?update_service.Fetch = null;
+var test_asset: ?[]const u8 = null;
+var test_cancel: ?*const std.atomic.Value(bool) = null;
+var test_auto_consent: bool = false;
+var suppress_picker: bool = false;
+
+pub fn resetPending() void {
+    pending_tag_len = 0;
+    pending_target_len = 0;
+}
+
+pub fn setTestHooks(
+    running: ?[]const u8,
+    target: ?[]const u8,
+    fetch: ?update_service.Fetch,
+    asset: ?[]const u8,
+    cancel: ?*const std.atomic.Value(bool),
+    auto_consent: bool,
+) void {
+    test_running = running;
+    test_target = target;
+    test_fetch = fetch;
+    test_asset = asset;
+    test_cancel = cancel;
+    test_auto_consent = auto_consent;
+    if (target == null) resetPending();
+}
+
+fn rememberOffer(tag: []const u8, target: []const u8) void {
+    pending_tag_len = @min(tag.len, pending_tag.len);
+    @memcpy(pending_tag[0..pending_tag_len], tag[0..pending_tag_len]);
+    pending_target_len = @min(target.len, pending_target.len);
+    @memcpy(pending_target[0..pending_target_len], target[0..pending_target_len]);
+}
+
+/// Human `/update install` after a prior `/update` check in this process.
+pub fn consumePending() ?update_service.Consent {
+    if (pending_tag_len == 0) return null;
+    pending_tag_len = 0;
+    pending_target_len = 0;
+    return .human;
+}
+
+pub fn hasPending() bool {
+    return pending_tag_len != 0;
+}
+
+pub fn renderReport(out: *Io.Writer, report: update_service.Report) !void {
+    try out.print("running:   v{s} (this process)\n", .{report.running()});
+    if (report.installed()) |inst|
+        try out.print("installed: v{s} ({s})\n", .{ inst, report.target })
+    else if (report.target.len > 0)
+        try out.print("installed: unknown ({s})\n", .{report.target});
+    if (report.latest()) |latest|
+        try out.print("latest:    v{s}\n", .{latest})
+    else
+        try out.writeAll("latest:    unable to check\n");
+    switch (report.kind) {
+        .available => {
+            try out.print("An update is available. Install v{s} for the next launch? This session stays on v{s}.\n", .{
+                report.latest() orelse "?",
+                report.running(),
+            });
+            try out.writeAll("Type /update install after reviewing, or confirm the picker. ");
+            try out.writeAll(no_activate_note);
+            try out.writeByte('\n');
+        },
+        .already_installed => {
+            try out.writeAll("That release is already installed for the next launch. This session is still running its original version.\n");
+            try out.writeAll(no_activate_note);
+            try out.writeByte('\n');
+        },
+        .current => try out.print("graff is up to date (v{s})\n", .{report.running()}),
+        .newer => try out.print("running v{s} is newer than latest v{s} — not downgrading\n", .{
+            report.running(),
+            report.latest() orelse "?",
+        }),
+        .installed => {
+            try out.writeAll(installed_for_next_launch);
+            try out.writeByte('\n');
+            try out.writeAll(no_activate_note);
+            try out.writeByte('\n');
+        },
+        .offline => try out.writeAll("update check failed — offline or the release feed did not respond\n"),
+        .malformed => try out.writeAll("update check failed — malformed release response (not guessing)\n"),
+        .verify_failed => try out.writeAll("update refused — the artifact did not match the release SHA256SUMS\n"),
+        .permission => try out.writeAll("update refused — the install target is not writable (not escalating privileges)\n"),
+        .cancelled => try out.writeAll("update cancelled — the existing install is unchanged\n"),
+        .busy => try out.writeAll("an update is already installing — this session is unchanged\n"),
+        .unsupported, .package_managed, .development => {
+            try out.writeAll(report.detail);
+            try out.writeByte('\n');
+        },
+        .no_consent => try out.writeAll("update not installed — a human has to confirm in this terminal\n"),
+    }
+}
+
+pub fn renderText(gpa: Allocator, report: update_service.Report) Allocator.Error![]u8 {
+    var aw: Io.Writer.Allocating = .init(gpa);
+    errdefer aw.deinit();
+    renderReport(&aw.writer, report) catch return error.OutOfMemory;
+    return aw.toOwnedSlice();
+}
+
+fn makeOpts(root: *Agent, target: []const u8, fetch: update_service.Fetch, asset: []const u8) update_service.Opts {
+    return .{
+        .io = root.io,
+        .gpa = root.gpa,
+        .running_version = test_running orelse @import("main.zig").harness_version,
+        .target_path = target,
+        .asset_name = asset,
+        .fetch = fetch,
+        .cancel = test_cancel,
+    };
+}
+
+fn productionFetch(root: *Agent, store: *update_service.HttpFetch) update_service.Fetch {
+    store.* = .{
+        .io = root.io,
+        .gpa = root.gpa,
+        .user_agent = "simple-harness/" ++ @import("main.zig").harness_version,
+    };
+    return store.fetch();
+}
+
+fn resolveTarget(root: *Agent, buf: []u8) update_target.Target {
+    if (test_target) |t| return .{ .kind = .supported, .path = t, .detail = "test fixture" };
+    const exe = std.process.executablePathAlloc(root.io, root.gpa) catch
+        return .{ .kind = .unsupported, .path = "", .detail = update_target.explain(.unsupported) };
+    defer root.gpa.free(exe);
+    const resolved = update_target.resolve(exe, root.home, buf);
+    if (resolved.path.ptr == buf.ptr) return resolved;
+    const n = @min(resolved.path.len, buf.len);
+    @memcpy(buf[0..n], resolved.path[0..n]);
+    return .{ .kind = resolved.kind, .path = buf[0..n], .detail = resolved.detail };
+}
+
+fn offerChoices() []const pickers.PickItem {
+    return &.{
+        .{ .name = "Install for the next launch", .desc = "keep this session on the original version" },
+        .{ .name = "Not now", .desc = "leave the install unchanged" },
+    };
+}
+
+fn confirmInstall(root: *Agent, out: *Io.Writer) bool {
+    if (suppress_picker) return false;
+    if (test_auto_consent) return true;
+    const yolo = if (root.approvals) |a| a.yolo else false;
+    _ = yolo; // yolo is not authorization
+    const idx = pickers.listPicker(root, root.arena, out, "Update ›", offerChoices()) orelse return false;
+    return idx == 0;
+}
+
+pub fn tryHandle(root: *Agent, arena: Allocator, line: []const u8, out: *Io.Writer) !bool {
+    _ = arena;
+    const t = std.mem.trim(u8, line, " \t\r\n");
+    if (!std.mem.eql(u8, t, "/update") and !std.mem.startsWith(u8, t, "/update ")) return false;
+    const arg = std.mem.trim(u8, t["/update".len..], " \t");
+
+    var target_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target = resolveTarget(root, &target_buf);
+    if (target.kind != .supported) {
+        var r: update_service.Report = .{
+            .kind = switch (target.kind) {
+                .package_managed => .package_managed,
+                .development => .development,
+                else => .unsupported,
+            },
+            .target = target.path,
+            .detail = target.detail,
+        };
+        const run = version_status.stripV(test_running orelse @import("main.zig").harness_version);
+        const n = @min(run.len, r.running_buf.len);
+        @memcpy(r.running_buf[0..n], run[0..n]);
+        r.running_len = n;
+        try renderReport(out, r);
+        try out.flush();
+        return true;
+    }
+    if (update_target.assetName() == null and test_asset == null) {
+        try out.writeAll(update_target.explain(.unsupported));
+        try out.writeByte('\n');
+        try out.flush();
+        return true;
+    }
+
+    var http_store: update_service.HttpFetch = undefined;
+    const fetch = test_fetch orelse productionFetch(root, &http_store);
+    const asset = test_asset orelse update_target.assetName().?;
+    const opts = makeOpts(root, target.path, fetch, asset);
+
+    if (std.mem.eql(u8, arg, "install")) {
+        const consent = consumePending() orelse {
+            try out.writeAll("Run /update first and confirm the release. Model output, tools, and yolo do not authorize an install.\n");
+            try out.flush();
+            return true;
+        };
+        const report = update_service.install(opts, consent);
+        try renderReport(out, report);
+        try out.flush();
+        return true;
+    }
+
+    const report = update_service.inspect(opts);
+    if (report.kind == .available) {
+        if (report.latest_tag()) |tag| rememberOffer(tag, target.path);
+        if (confirmInstall(root, out)) {
+            _ = consumePending();
+            const installed = update_service.install(opts, .human);
+            try renderReport(out, installed);
+            try out.flush();
+            return true;
+        }
+    }
+    try renderReport(out, report);
+    try out.flush();
+    return true;
+}
+
+/// Host callback for the TUI / zigzag repl: `check` or `install`.
+pub fn hostAction(io: Io, gpa: Allocator, home: []const u8, action: []const u8) ?[]const u8 {
+    suppress_picker = true;
+    defer suppress_picker = false;
+    var dummy: Agent = .{
+        .gpa = gpa,
+        .arena = gpa,
+        .io = io,
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "update",
+        .out = null,
+        .home = home,
+    };
+    var aw: Io.Writer.Allocating = .init(gpa);
+    const line: []const u8 = if (std.mem.eql(u8, action, "install")) "/update install" else "/update";
+    _ = tryHandle(&dummy, gpa, line, &aw.writer) catch {
+        aw.deinit();
+        return null;
+    };
+    return aw.toOwnedSlice() catch {
+        aw.deinit();
+        return null;
+    };
+}
+
+test "yolo and a missing pending offer are not authorization" {
+    resetPending();
+    try std.testing.expect(consumePending() == null);
+    rememberOffer("v0.0.292", "/tmp/fixture/graff");
+    try std.testing.expect(hasPending());
+    try std.testing.expect(consumePending() == .human);
+    try std.testing.expect(!hasPending());
+}
+
+test "success copy names the next launch and refuses /new activation" {
+    try std.testing.expectEqualStrings(
+        "Update installed for the next launch. This session is still running its original version; you can keep working.",
+        installed_for_next_launch,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, no_activate_note, "/new") != null);
+    try std.testing.expect(std.mem.indexOf(u8, no_activate_note, "/resume") != null);
+    try std.testing.expect(std.mem.indexOf(u8, no_activate_note, "do not activate") != null);
+}

--- a/src/update_service.zig
+++ b/src/update_service.zig
@@ -1,0 +1,295 @@
+//! Nonfatal, noninteractive in-session update service.
+//!
+//! Pins a GitHub release tag, downloads that tag's tarball + SHA256SUMS,
+//! verifies, and atomically replaces a caller-supplied install path. Never
+//! calls `graff update`, never runs install.sh, never inherits a TTY, never
+//! execs or relaunches this process. Concurrent installs serialize; a
+//! failure or cancel before commit leaves the existing file in place.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+
+const version_status = @import("version_status.zig");
+const update_target = @import("update_target.zig");
+const archive = @import("update_archive.zig");
+const credential_store = @import("credential_store.zig");
+
+pub const FetchError = error{ Offline, Malformed, Permission, OutOfMemory };
+
+pub const Fetch = struct {
+    ctx: ?*anyopaque = null,
+    get: *const fn (ctx: ?*anyopaque, gpa: Allocator, url: []const u8) FetchError![]u8,
+};
+
+pub const Consent = enum { human };
+
+pub const Kind = enum {
+    available,
+    already_installed,
+    current,
+    newer,
+    unsupported,
+    package_managed,
+    development,
+    offline,
+    malformed,
+    verify_failed,
+    permission,
+    cancelled,
+    busy,
+    installed,
+    no_consent,
+};
+
+pub const Report = struct {
+    kind: Kind,
+    target: []const u8 = "",
+    detail: []const u8 = "",
+    running_buf: [64]u8 = undefined,
+    running_len: usize = 0,
+    installed_buf: [64]u8 = undefined,
+    installed_len: usize = 0,
+    latest_buf: [64]u8 = undefined,
+    latest_len: usize = 0,
+    tag_buf: [64]u8 = undefined,
+    tag_len: usize = 0,
+
+    pub fn running(self: *const Report) []const u8 {
+        return self.running_buf[0..self.running_len];
+    }
+    pub fn installed(self: *const Report) ?[]const u8 {
+        return if (self.installed_len == 0) null else self.installed_buf[0..self.installed_len];
+    }
+    pub fn latest(self: *const Report) ?[]const u8 {
+        return if (self.latest_len == 0) null else self.latest_buf[0..self.latest_len];
+    }
+    pub fn latest_tag(self: *const Report) ?[]const u8 {
+        return if (self.tag_len == 0) null else self.tag_buf[0..self.tag_len];
+    }
+};
+
+fn hold(buf: *[64]u8, src: []const u8) usize {
+    const n = @min(src.len, buf.len);
+    @memcpy(buf[0..n], src[0..n]);
+    return n;
+}
+
+pub const Opts = struct {
+    io: Io,
+    gpa: Allocator,
+    running_version: []const u8,
+    target_path: []const u8,
+    asset_name: []const u8,
+    fetch: Fetch,
+    cancel: ?*const std.atomic.Value(bool) = null,
+};
+
+var install_busy = std.atomic.Value(bool).init(false);
+
+pub fn resetBusyForTest() void {
+    install_busy.store(false, .release);
+}
+
+fn cancelled(opts: Opts) bool {
+    const flag = opts.cancel orelse return false;
+    return flag.load(.acquire);
+}
+
+fn tryLock() bool {
+    return install_busy.cmpxchgStrong(false, true, .acq_rel, .acquire) == null;
+}
+
+fn unlock() void {
+    install_busy.store(false, .release);
+}
+
+pub fn readInstalledVersion(io: Io, gpa: Allocator, target_path: []const u8) ?[]u8 {
+    var side_buf: [std.fs.max_path_bytes + 8]u8 = undefined;
+    const side = update_target.versionSidecar(target_path, &side_buf) orelse return null;
+    return Io.Dir.cwd().readFileAlloc(io, side, gpa, .limited(128)) catch return null;
+}
+
+pub fn writeInstalledVersion(io: Io, target_path: []const u8, version: []const u8) void {
+    var side_buf: [std.fs.max_path_bytes + 8]u8 = undefined;
+    const side = update_target.versionSidecar(target_path, &side_buf) orelse return;
+    const parent = std.fs.path.dirname(side) orelse return;
+    var dir = Io.Dir.cwd().openDir(io, parent, .{}) catch return;
+    defer dir.close(io);
+    credential_store.replaceFile(io, dir, std.fs.path.basename(side), version, .default_file) catch {};
+}
+
+fn fetchOwned(opts: Opts, url: []const u8) FetchError![]u8 {
+    return opts.fetch.get(opts.fetch.ctx, opts.gpa, url);
+}
+
+fn latestFromFetch(opts: Opts) FetchError![]u8 {
+    const body = fetchOwned(opts, version_status.repo_api) catch |err| return err;
+    defer opts.gpa.free(body);
+    var tag_buf: [64]u8 = undefined;
+    const tag = version_status.copyTagName(body, &tag_buf) orelse return error.Malformed;
+    return opts.gpa.dupe(u8, tag);
+}
+
+fn snapshot(opts: Opts, kind: Kind, latest_tag: ?[]const u8, installed: ?[]const u8, detail: []const u8) Report {
+    var r: Report = .{ .kind = kind, .target = opts.target_path, .detail = detail };
+    r.running_len = hold(&r.running_buf, version_status.stripV(opts.running_version));
+    if (installed) |v| r.installed_len = hold(&r.installed_buf, version_status.stripV(v));
+    if (latest_tag) |t| {
+        r.tag_len = hold(&r.tag_buf, t);
+        r.latest_len = hold(&r.latest_buf, version_status.stripV(t));
+    }
+    return r;
+}
+
+pub fn inspect(opts: Opts) Report {
+    const installed = readInstalledVersion(opts.io, opts.gpa, opts.target_path);
+    defer if (installed) |v| opts.gpa.free(v);
+    const tag = latestFromFetch(opts) catch |err| return snapshot(opts, switch (err) {
+        error.Offline => .offline,
+        error.Malformed => .malformed,
+        error.Permission => .permission,
+        error.OutOfMemory => .offline,
+    }, null, installed, "could not reach the release feed");
+    defer opts.gpa.free(tag);
+
+    const run = version_status.compare(opts.running_version, tag);
+    if (run.failure == .latest_tag) return snapshot(opts, .malformed, tag, installed, "unparseable release tag");
+
+    if (installed) |inst| {
+        if (version_status.alreadyHasRelease(inst, tag))
+            return snapshot(opts, .already_installed, tag, inst, "the install target is already at this release");
+    }
+
+    return snapshot(opts, switch (run.state) {
+        .current => .current,
+        .older, .dev => if (run.order == .gt) .newer else .available,
+        .newer => .newer,
+        .unable => .malformed,
+    }, tag, installed, "");
+}
+
+fn pinnedUrls(opts: Opts, tag: []const u8, asset_buf: *[512]u8, sums_buf: *[512]u8) error{Malformed}!struct { asset: []const u8, sums: []const u8 } {
+    const asset = std.fmt.bufPrint(asset_buf, "{s}/{s}/{s}", .{
+        version_status.repo_download_base, tag, opts.asset_name,
+    }) catch return error.Malformed;
+    const sums = std.fmt.bufPrint(sums_buf, "{s}/{s}/SHA256SUMS", .{
+        version_status.repo_download_base, tag,
+    }) catch return error.Malformed;
+    return .{ .asset = asset, .sums = sums };
+}
+
+const exe_mode: Io.File.Permissions = if (Io.File.Permissions.has_executable_bit)
+    Io.File.Permissions.fromMode(0o755)
+else
+    .default_file;
+
+fn atomicPlace(io: Io, target_path: []const u8, bytes: []const u8) error{Permission}!void {
+    const parent = std.fs.path.dirname(target_path) orelse return error.Permission;
+    var dir = Io.Dir.cwd().openDir(io, parent, .{}) catch return error.Permission;
+    defer dir.close(io);
+    credential_store.replaceFile(io, dir, std.fs.path.basename(target_path), bytes, exe_mode) catch return error.Permission;
+}
+
+fn existingMatches(io: Io, gpa: Allocator, path: []const u8, bytes: []const u8) bool {
+    const cur = Io.Dir.cwd().readFileAlloc(io, path, gpa, .limited(80 * 1024 * 1024)) catch return false;
+    defer gpa.free(cur);
+    return std.mem.eql(u8, cur, bytes);
+}
+
+/// Install the pinned latest release into `opts.target_path`. Requires an
+/// explicit `Consent.human` minted by the TTY picker or `/update install`
+/// after a human `/update` check — yolo, tools, and saved transcripts never
+/// call this.
+pub fn install(opts: Opts, consent: Consent) Report {
+    _ = consent;
+    if (!tryLock()) return snapshot(opts, .busy, null, null, "an update is already installing");
+    defer unlock();
+    if (cancelled(opts)) return snapshot(opts, .cancelled, null, null, "update cancelled");
+
+    const viewed = inspect(opts);
+    switch (viewed.kind) {
+        .available => {},
+        .already_installed, .current, .newer, .offline, .malformed, .permission => return viewed,
+        else => return viewed,
+    }
+    const tag = viewed.latest_tag() orelse return snapshot(opts, .malformed, null, viewed.installed(), "release tag missing");
+    var tag_owned: [64]u8 = undefined;
+    if (tag.len > tag_owned.len) return snapshot(opts, .malformed, null, viewed.installed(), "release tag missing");
+    @memcpy(tag_owned[0..tag.len], tag);
+    const tag_copy = tag_owned[0..tag.len];
+
+    if (cancelled(opts)) return snapshot(opts, .cancelled, tag_copy, viewed.installed(), "update cancelled");
+
+    var asset_url_buf: [512]u8 = undefined;
+    var sums_url_buf: [512]u8 = undefined;
+    const urls = pinnedUrls(opts, tag_copy, &asset_url_buf, &sums_url_buf) catch
+        return snapshot(opts, .malformed, tag_copy, viewed.installed(), "could not pin release URLs");
+
+    const sums = fetchOwned(opts, urls.sums) catch |err| return snapshot(opts, switch (err) {
+        error.Offline => .offline,
+        error.Malformed => .malformed,
+        error.Permission => .permission,
+        error.OutOfMemory => .offline,
+    }, tag_copy, viewed.installed(), "SHA256SUMS unavailable — refusing to install");
+    defer opts.gpa.free(sums);
+    if (cancelled(opts)) return snapshot(opts, .cancelled, tag_copy, viewed.installed(), "update cancelled");
+
+    const tarball = fetchOwned(opts, urls.asset) catch |err| return snapshot(opts, switch (err) {
+        error.Offline => .offline,
+        error.Malformed => .malformed,
+        error.Permission => .permission,
+        error.OutOfMemory => .offline,
+    }, tag_copy, viewed.installed(), "release artifact unavailable");
+    defer opts.gpa.free(tarball);
+    if (cancelled(opts)) return snapshot(opts, .cancelled, tag_copy, viewed.installed(), "update cancelled");
+
+    const bin = archive.extractVerified(opts.gpa, sums, opts.asset_name, tarball) catch |err| return snapshot(opts, switch (err) {
+        error.VerifyFailed => .verify_failed,
+        error.Malformed => .malformed,
+        error.OutOfMemory => .offline,
+    }, tag_copy, viewed.installed(), "artifact verification failed");
+    defer opts.gpa.free(bin);
+    if (cancelled(opts)) return snapshot(opts, .cancelled, tag_copy, viewed.installed(), "update cancelled");
+
+    if (existingMatches(opts.io, opts.gpa, opts.target_path, bin)) {
+        writeInstalledVersion(opts.io, opts.target_path, version_status.stripV(tag_copy));
+        return snapshot(opts, .already_installed, tag_copy, version_status.stripV(tag_copy), "the install target already has these bytes");
+    }
+
+    atomicPlace(opts.io, opts.target_path, bin) catch
+        return snapshot(opts, .permission, tag_copy, viewed.installed(), "install target is not writable — not escalating privileges");
+    writeInstalledVersion(opts.io, opts.target_path, version_status.stripV(tag_copy));
+    return snapshot(opts, .installed, tag_copy, version_status.stripV(tag_copy), update_target.install_note);
+}
+
+pub const HttpFetch = struct {
+    io: Io,
+    gpa: Allocator,
+    user_agent: []const u8,
+    max_bytes: usize = 80 * 1024 * 1024,
+
+    pub fn get(ctx: ?*anyopaque, gpa: Allocator, url: []const u8) FetchError![]u8 {
+        const self: *HttpFetch = @ptrCast(@alignCast(ctx orelse return error.Offline));
+        var client: std.http.Client = .{ .allocator = self.gpa, .io = self.io };
+        defer client.deinit();
+        var aw: Io.Writer.Allocating = .init(gpa);
+        errdefer aw.deinit();
+        const extra = [_]std.http.Header{.{ .name = "Accept", .value = "application/octet-stream" }};
+        const res = client.fetch(.{
+            .location = .{ .url = url },
+            .method = .GET,
+            .response_writer = &aw.writer,
+            .headers = .{ .user_agent = .{ .override = self.user_agent } },
+            .extra_headers = &extra,
+        }) catch return error.Offline;
+        if (@intFromEnum(res.status) != 200) return error.Offline;
+        if (aw.writer.buffered().len > self.max_bytes) return error.Malformed;
+        return aw.toOwnedSlice() catch return error.OutOfMemory;
+    }
+
+    pub fn fetch(self: *HttpFetch) Fetch {
+        return .{ .ctx = self, .get = get };
+    }
+};

--- a/src/update_target.zig
+++ b/src/update_target.zig
@@ -1,0 +1,169 @@
+//! Resolve the on-disk graff the in-session updater may replace.
+//!
+//! Never PATH-lookup `graff` or `install.sh`. A project-local zig-out binary,
+//! a Homebrew/Nix/apt prefix, or an unwritable system path is explained
+//! rather than guessed or escalated.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+
+pub const Kind = enum { supported, package_managed, development, unsupported };
+
+pub const Target = struct {
+    kind: Kind,
+    path: []const u8,
+    detail: []const u8,
+};
+
+pub const install_note =
+    \\Update installed for the next launch. This session is still running its original version; you can keep working.
+;
+
+pub const no_activate_note =
+    \\/new and /resume keep this process and do not activate the update.
+;
+
+pub fn assetTriple() ?[]const u8 {
+    const os = builtin.os.tag;
+    const arch = builtin.cpu.arch;
+    return switch (os) {
+        .macos => switch (arch) {
+            .aarch64 => "aarch64-macos",
+            .x86_64 => "x86_64-macos",
+            else => null,
+        },
+        .linux => switch (arch) {
+            .aarch64 => "aarch64-linux",
+            .x86_64 => "x86_64-linux",
+            else => null,
+        },
+        else => null,
+    };
+}
+
+pub fn assetName() ?[]const u8 {
+    const triple = assetTriple() orelse return null;
+    return switch (builtin.os.tag) {
+        .macos => if (std.mem.eql(u8, triple, "aarch64-macos"))
+            "graff-aarch64-macos.tar.gz"
+        else
+            "graff-x86_64-macos.tar.gz",
+        .linux => if (std.mem.eql(u8, triple, "aarch64-linux"))
+            "graff-aarch64-linux.tar.gz"
+        else
+            "graff-x86_64-linux.tar.gz",
+        else => null,
+    };
+}
+
+pub fn versionSidecar(path: []const u8, buf: []u8) ?[]const u8 {
+    const n = std.fmt.bufPrint(buf, "{s}.version", .{path}) catch return null;
+    return n;
+}
+
+fn contains(hay: []const u8, needle: []const u8) bool {
+    return std.mem.indexOf(u8, hay, needle) != null;
+}
+
+fn basenameIs(path: []const u8, name: []const u8) bool {
+    return std.mem.eql(u8, std.fs.path.basename(path), name);
+}
+
+/// Classify an absolute (or user-supplied) executable path. `home` may be
+/// empty; then `$HOME/bin` is not treated as the install.sh target.
+pub fn classify(path: []const u8, home: []const u8) Kind {
+    if (path.len == 0) return .unsupported;
+    if (contains(path, "/Cellar/") or contains(path, "/linuxbrew/") or
+        contains(path, "/Homebrew/") or contains(path, "/homebrew/"))
+        return .package_managed;
+    if (contains(path, "/nix/store/") or contains(path, "/.nix-profile/") or
+        contains(path, "/nix-profile/"))
+        return .package_managed;
+    if (contains(path, "/snap/") or contains(path, "/flatpak/") or
+        contains(path, "/var/lib/flatpak/"))
+        return .package_managed;
+    if (contains(path, "/opt/local/")) return .package_managed;
+    if (std.mem.startsWith(u8, path, "/usr/bin/") or
+        std.mem.startsWith(u8, path, "/bin/") or
+        std.mem.startsWith(u8, path, "/usr/sbin/"))
+        return .package_managed;
+    if (contains(path, "/zig-out/bin/") or contains(path, "/.zig-cache/") or
+        contains(path, "/zig-cache/"))
+        return .development;
+    if (home.len > 0) {
+        if (underHomeBin(path, home, "bin") or underHomeBin(path, home, ".local/bin"))
+            return .supported;
+    }
+    // A writable user prefix that is not a package tree. `/usr/local/bin`
+    // is often Homebrew on Intel Macs — treat it as package-managed when
+    // the basename is graff and it is not under $HOME.
+    if (std.mem.startsWith(u8, path, "/usr/local/") or std.mem.startsWith(u8, path, "/opt/homebrew/"))
+        return .package_managed;
+    if (basenameIs(path, "graff") or basenameIs(path, "graff.exe")) return .supported;
+    return .unsupported;
+}
+
+fn underHomeBin(path: []const u8, home: []const u8, rel: []const u8) bool {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = std.fmt.bufPrint(&buf, "{s}/{s}/", .{ home, rel }) catch return false;
+    return std.mem.startsWith(u8, path, prefix);
+}
+
+pub fn explain(kind: Kind) []const u8 {
+    return switch (kind) {
+        .supported => "writable user install (install.sh location)",
+        .package_managed => "this install is package-managed — update it with the package manager, not /update",
+        .development => "this process is a development build (zig-out); /update will not overwrite the checkout",
+        .unsupported => "this platform or install location is not supported for in-session updates",
+    };
+}
+
+/// Prefer the running executable when it is a supported user install.
+/// A development process may still name `$HOME/bin/graff` as the future-launch
+/// target when that path is classified supported — never zig-out, never PATH.
+pub fn resolve(running_exe: []const u8, home: []const u8, buf: []u8) Target {
+    const running_kind = classify(running_exe, home);
+    if (running_kind == .supported) {
+        return .{ .kind = .supported, .path = running_exe, .detail = explain(.supported) };
+    }
+    if (running_kind == .package_managed) {
+        return .{ .kind = .package_managed, .path = running_exe, .detail = explain(.package_managed) };
+    }
+    if (home.len > 0) {
+        const home_bin = std.fmt.bufPrint(buf, "{s}/bin/graff", .{home}) catch
+            return .{ .kind = running_kind, .path = running_exe, .detail = explain(running_kind) };
+        if (classify(home_bin, home) == .supported) {
+            return .{
+                .kind = .supported,
+                .path = home_bin,
+                .detail = "install.sh default ($HOME/bin/graff) — this process stays on its original binary",
+            };
+        }
+    }
+    return .{ .kind = running_kind, .path = running_exe, .detail = explain(running_kind) };
+}
+
+test "classify: package trees and zig-out never look supported" {
+    try std.testing.expectEqual(Kind.package_managed, classify("/opt/homebrew/bin/graff", "/Users/me"));
+    try std.testing.expectEqual(Kind.package_managed, classify("/usr/local/Cellar/graff/0.1/bin/graff", "/Users/me"));
+    try std.testing.expectEqual(Kind.package_managed, classify("/nix/store/aaa/bin/graff", "/home/me"));
+    try std.testing.expectEqual(Kind.package_managed, classify("/usr/bin/graff", "/home/me"));
+    try std.testing.expectEqual(Kind.development, classify("/work/codegraff/zig-out/bin/graff", "/home/me"));
+    try std.testing.expectEqual(Kind.supported, classify("/home/me/bin/graff", "/home/me"));
+    try std.testing.expectEqual(Kind.supported, classify("/home/me/.local/bin/graff", "/home/me"));
+}
+
+test "resolve: a zig-out process names $HOME/bin, never the checkout" {
+    var buf: [256]u8 = undefined;
+    const t = resolve("/repo/zig-out/bin/graff", "/home/me", &buf);
+    try std.testing.expectEqual(Kind.supported, t.kind);
+    try std.testing.expectEqualStrings("/home/me/bin/graff", t.path);
+}
+
+test "resolve: Homebrew stays package-managed" {
+    var buf: [256]u8 = undefined;
+    const t = resolve("/opt/homebrew/bin/graff", "/Users/me", &buf);
+    try std.testing.expectEqual(Kind.package_managed, t.kind);
+    try std.testing.expect(std.mem.indexOf(u8, t.detail, "package-managed") != null);
+}

--- a/src/update_tests.zig
+++ b/src/update_tests.zig
@@ -1,0 +1,360 @@
+//! Isolated-fixture acceptance for the in-session updater. Never touches the
+//! developer's live graff executable.
+
+const std = @import("std");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+
+const Agent = @import("agent.zig").Agent;
+const Approvals = @import("approvals.zig").Approvals;
+const archive = @import("update_archive.zig");
+const update_cmd = @import("update_cmd.zig");
+const update_service = @import("update_service.zig");
+const update_target = @import("update_target.zig");
+
+const asset = "graff-x86_64-linux.tar.gz";
+const latest_json = "{\"tag_name\":\"v0.0.292\"}";
+
+const Fixture = struct {
+    archive: []const u8,
+    sums: []const u8,
+    fail: enum { none, offline, malformed, no_sums, bad_sums } = .none,
+    seen_latest_download: std.atomic.Value(bool) = .init(false),
+    fetches: std.atomic.Value(usize) = .init(0),
+    cancel_on_tarball: ?*std.atomic.Value(bool) = null,
+    hold: ?*std.atomic.Value(bool) = null,
+
+    fn get(ctx: ?*anyopaque, gpa: Allocator, url: []const u8) update_service.FetchError![]u8 {
+        const self: *Fixture = @ptrCast(@alignCast(ctx orelse return error.Offline));
+        _ = self.fetches.fetchAdd(1, .monotonic);
+        if (self.hold) |h| {
+            while (h.load(.acquire)) std.Thread.yield() catch {};
+        }
+        if (self.fail == .offline) return error.Offline;
+        if (std.mem.indexOf(u8, url, "/releases/latest") != null) {
+            if (self.fail == .malformed) return gpa.dupe(u8, "{nope") catch return error.OutOfMemory;
+            return gpa.dupe(u8, latest_json) catch return error.OutOfMemory;
+        }
+        if (std.mem.indexOf(u8, url, "/latest/download/") != null) {
+            self.seen_latest_download.store(true, .release);
+            return error.Malformed;
+        }
+        if (std.mem.endsWith(u8, url, "SHA256SUMS")) {
+            if (self.fail == .no_sums) return error.Offline;
+            if (self.fail == .bad_sums)
+                return gpa.dupe(u8, "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  graff-x86_64-linux.tar.gz\n") catch return error.OutOfMemory;
+            return gpa.dupe(u8, self.sums) catch return error.OutOfMemory;
+        }
+        if (self.cancel_on_tarball) |c| c.store(true, .release);
+        return gpa.dupe(u8, self.archive) catch return error.OutOfMemory;
+    }
+
+    fn fetch(self: *Fixture) update_service.Fetch {
+        return .{ .ctx = self, .get = get };
+    }
+};
+
+fn setupArchive(gpa: Allocator) !struct { bytes: []u8, sums: []u8 } {
+    const bytes = try archive.fixtureArchive(gpa, "graff-x86_64-linux/graff", "NEW-GRAFF");
+    errdefer gpa.free(bytes);
+    return .{ .bytes = bytes, .sums = try archive.sumsLine(gpa, asset, bytes) };
+}
+
+fn fixturePath(tmp: *std.testing.TmpDir, io: Io, gpa: Allocator, name: []const u8) ![]u8 {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &buf);
+    return std.fmt.allocPrint(gpa, "{s}/{s}", .{ buf[0..n], name });
+}
+
+fn opts(io: Io, gpa: Allocator, target: []const u8, fetch: update_service.Fetch, cancel: ?*const std.atomic.Value(bool)) update_service.Opts {
+    return .{
+        .io = io,
+        .gpa = gpa,
+        .running_version = "0.0.289",
+        .target_path = target,
+        .asset_name = asset,
+        .fetch = fetch,
+        .cancel = cancel,
+    };
+}
+
+fn stub(out: *Io.Writer, yolo: bool, approvals: *Approvals) Agent {
+    approvals.* = .{ .yolo = yolo };
+    return .{
+        .gpa = std.testing.allocator,
+        .arena = std.testing.allocator,
+        .io = std.testing.io,
+        .client = undefined,
+        .provider = undefined,
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = out,
+        .approvals = approvals,
+        .session_name = "live",
+        .home = "/tmp/issue-773-home-must-not-be-used",
+    };
+}
+
+test "successful install replaces only the fixture and keeps the session" {
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    update_service.resetBusyForTest();
+    update_cmd.resetPending();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "graff", .data = "OLD-GRAFF" });
+    const target = try fixturePath(&tmp, io, gpa, "graff");
+    defer gpa.free(target);
+    update_service.writeInstalledVersion(io, target, "0.0.289");
+
+    const pack = try setupArchive(gpa);
+    defer gpa.free(pack.bytes);
+    defer gpa.free(pack.sums);
+    var fx: Fixture = .{ .archive = pack.bytes, .sums = pack.sums };
+    const before = try Io.Dir.cwd().readFileAlloc(io, target, gpa, .limited(64));
+    defer gpa.free(before);
+    try std.testing.expectEqualStrings("OLD-GRAFF", before);
+
+    var approvals: Approvals = .{ .yolo = true };
+    var aw: Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    var root = stub(&aw.writer, true, &approvals);
+    const yolo_before = root.approvals.?.yolo;
+    const session_before = root.session_name;
+    const messages_before = root.session_name;
+
+    const report = update_service.install(opts(io, gpa, target, fx.fetch(), null), .human);
+    try std.testing.expectEqual(update_service.Kind.installed, report.kind);
+    try std.testing.expectEqualStrings(update_target.install_note, report.detail);
+    try std.testing.expect(!fx.seen_latest_download.load(.acquire));
+
+    const after = try Io.Dir.cwd().readFileAlloc(io, target, gpa, .limited(64));
+    defer gpa.free(after);
+    try std.testing.expectEqualStrings("NEW-GRAFF", after);
+    try std.testing.expect(root.approvals.?.yolo == yolo_before);
+    try std.testing.expectEqualStrings(session_before, root.session_name);
+    try std.testing.expectEqualStrings(messages_before, root.session_name);
+
+    try std.testing.expect(try update_cmd.tryHandle(&root, gpa, "/new", &aw.writer) == false);
+}
+
+test "already-installed and current versions do not reinstall" {
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    update_service.resetBusyForTest();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "graff", .data = "OLD-GRAFF" });
+    const target = try fixturePath(&tmp, io, gpa, "graff");
+    defer gpa.free(target);
+    update_service.writeInstalledVersion(io, target, "0.0.292");
+
+    const pack = try setupArchive(gpa);
+    defer gpa.free(pack.bytes);
+    defer gpa.free(pack.sums);
+    var fx: Fixture = .{ .archive = pack.bytes, .sums = pack.sums };
+    const report = update_service.install(opts(io, gpa, target, fx.fetch(), null), .human);
+    try std.testing.expectEqual(update_service.Kind.already_installed, report.kind);
+    const stayed = try Io.Dir.cwd().readFileAlloc(io, target, gpa, .limited(64));
+    defer gpa.free(stayed);
+    try std.testing.expectEqualStrings("OLD-GRAFF", stayed);
+
+    var current_fx: Fixture = .{ .archive = pack.bytes, .sums = pack.sums };
+    var current_opts = opts(io, gpa, target, current_fx.fetch(), null);
+    current_opts.running_version = "0.0.292";
+    update_service.writeInstalledVersion(io, target, "0.0.292");
+    const current = update_service.inspect(current_opts);
+    try std.testing.expectEqual(update_service.Kind.already_installed, current.kind);
+}
+
+test "offline and malformed release responses fail closed" {
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    update_service.resetBusyForTest();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "graff", .data = "OLD" });
+    const target = try fixturePath(&tmp, io, gpa, "graff");
+    defer gpa.free(target);
+    const pack = try setupArchive(gpa);
+    defer gpa.free(pack.bytes);
+    defer gpa.free(pack.sums);
+
+    var offline_fx: Fixture = .{ .archive = pack.bytes, .sums = pack.sums, .fail = .offline };
+    try std.testing.expectEqual(update_service.Kind.offline, update_service.inspect(opts(io, gpa, target, offline_fx.fetch(), null)).kind);
+
+    var bad_fx: Fixture = .{ .archive = pack.bytes, .sums = pack.sums, .fail = .malformed };
+    try std.testing.expectEqual(update_service.Kind.malformed, update_service.inspect(opts(io, gpa, target, bad_fx.fetch(), null)).kind);
+
+    const stayed = try Io.Dir.cwd().readFileAlloc(io, target, gpa, .limited(64));
+    defer gpa.free(stayed);
+    try std.testing.expectEqualStrings("OLD", stayed);
+}
+
+test "failed verification and missing sums leave the fixture untouched" {
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    update_service.resetBusyForTest();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "graff", .data = "OLD" });
+    const target = try fixturePath(&tmp, io, gpa, "graff");
+    defer gpa.free(target);
+    const pack = try setupArchive(gpa);
+    defer gpa.free(pack.bytes);
+    defer gpa.free(pack.sums);
+
+    var bad: Fixture = .{ .archive = pack.bytes, .sums = pack.sums, .fail = .bad_sums };
+    try std.testing.expectEqual(update_service.Kind.verify_failed, update_service.install(opts(io, gpa, target, bad.fetch(), null), .human).kind);
+
+    var missing: Fixture = .{ .archive = pack.bytes, .sums = pack.sums, .fail = .no_sums };
+    try std.testing.expectEqual(update_service.Kind.offline, update_service.install(opts(io, gpa, target, missing.fetch(), null), .human).kind);
+
+    const stayed = try Io.Dir.cwd().readFileAlloc(io, target, gpa, .limited(64));
+    defer gpa.free(stayed);
+    try std.testing.expectEqualStrings("OLD", stayed);
+}
+
+test "permission errors do not escalate or replace" {
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    update_service.resetBusyForTest();
+    const pack = try setupArchive(gpa);
+    defer gpa.free(pack.bytes);
+    defer gpa.free(pack.sums);
+    var fx: Fixture = .{ .archive = pack.bytes, .sums = pack.sums };
+    const report = update_service.install(opts(io, gpa, "/proc/graff-must-not-exist/graff", fx.fetch(), null), .human);
+    try std.testing.expectEqual(update_service.Kind.permission, report.kind);
+}
+
+test "cancellation before commit keeps the existing install" {
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    update_service.resetBusyForTest();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "graff", .data = "OLD" });
+    const target = try fixturePath(&tmp, io, gpa, "graff");
+    defer gpa.free(target);
+    const pack = try setupArchive(gpa);
+    defer gpa.free(pack.bytes);
+    defer gpa.free(pack.sums);
+    var cancel = std.atomic.Value(bool).init(false);
+    var fx: Fixture = .{ .archive = pack.bytes, .sums = pack.sums, .cancel_on_tarball = &cancel };
+    const report = update_service.install(opts(io, gpa, target, fx.fetch(), &cancel), .human);
+    try std.testing.expectEqual(update_service.Kind.cancelled, report.kind);
+    const stayed = try Io.Dir.cwd().readFileAlloc(io, target, gpa, .limited(64));
+    defer gpa.free(stayed);
+    try std.testing.expectEqualStrings("OLD", stayed);
+}
+
+const Race = struct {
+    o: update_service.Opts,
+    kind: update_service.Kind = .busy,
+    fn run(self: *Race) void {
+        self.kind = update_service.install(self.o, .human).kind;
+    }
+};
+
+test "simultaneous installs serialize; the loser stays busy" {
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    update_service.resetBusyForTest();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "graff", .data = "OLD" });
+    const target = try fixturePath(&tmp, io, gpa, "graff");
+    defer gpa.free(target);
+    const pack = try setupArchive(gpa);
+    defer gpa.free(pack.bytes);
+    defer gpa.free(pack.sums);
+    var hold = std.atomic.Value(bool).init(true);
+    var fx: Fixture = .{ .archive = pack.bytes, .sums = pack.sums, .hold = &hold };
+    var first: Race = .{ .o = opts(io, gpa, target, fx.fetch(), null) };
+    var thr = try std.Thread.spawn(.{}, Race.run, .{&first});
+    var spins: usize = 0;
+    while (fx.fetches.load(.monotonic) == 0) : (spins += 1) {
+        if (spins > 1_000_000) return error.InstallNeverStarted;
+        std.Thread.yield() catch {};
+    }
+    var fx2: Fixture = .{ .archive = pack.bytes, .sums = pack.sums };
+    const second = update_service.install(opts(io, gpa, target, fx2.fetch(), null), .human);
+    try std.testing.expectEqual(update_service.Kind.busy, second.kind);
+    hold.store(false, .release);
+    thr.join();
+    try std.testing.expect(first.kind == .installed or first.kind == .already_installed);
+    update_service.resetBusyForTest();
+}
+
+test "/update install without a human pending offer is refused even in yolo" {
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    update_service.resetBusyForTest();
+    update_cmd.resetPending();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "graff", .data = "OLD" });
+    const target = try fixturePath(&tmp, io, gpa, "graff");
+    defer gpa.free(target);
+    const pack = try setupArchive(gpa);
+    defer gpa.free(pack.bytes);
+    defer gpa.free(pack.sums);
+    var fx: Fixture = .{ .archive = pack.bytes, .sums = pack.sums };
+    update_cmd.setTestHooks("0.0.289", target, fx.fetch(), asset, null, false);
+    defer update_cmd.setTestHooks(null, null, null, null, null, false);
+
+    var approvals: Approvals = .{ .yolo = true };
+    var aw: Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    var root = stub(&aw.writer, true, &approvals);
+    try std.testing.expect(try update_cmd.tryHandle(&root, gpa, "/update install", &aw.writer));
+    try std.testing.expect(std.mem.indexOf(u8, aw.writer.buffered(), "do not authorize") != null);
+    const stayed = try Io.Dir.cwd().readFileAlloc(io, target, gpa, .limited(64));
+    defer gpa.free(stayed);
+    try std.testing.expectEqualStrings("OLD", stayed);
+}
+
+test "/update check then human install reports the next-launch sentence" {
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    update_service.resetBusyForTest();
+    update_cmd.resetPending();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "graff", .data = "OLD" });
+    const target = try fixturePath(&tmp, io, gpa, "graff");
+    defer gpa.free(target);
+    const pack = try setupArchive(gpa);
+    defer gpa.free(pack.bytes);
+    defer gpa.free(pack.sums);
+    var fx: Fixture = .{ .archive = pack.bytes, .sums = pack.sums };
+    update_cmd.setTestHooks("0.0.289", target, fx.fetch(), asset, null, false);
+    defer update_cmd.setTestHooks(null, null, null, null, null, false);
+
+    var approvals: Approvals = .{};
+    var aw: Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    var root = stub(&aw.writer, false, &approvals);
+    try std.testing.expect(try update_cmd.tryHandle(&root, gpa, "/update", &aw.writer));
+    try std.testing.expect(std.mem.indexOf(u8, aw.writer.buffered(), "running:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, aw.writer.buffered(), "v0.0.289") != null);
+    try std.testing.expect(std.mem.indexOf(u8, aw.writer.buffered(), "v0.0.292") != null);
+    try std.testing.expect(std.mem.indexOf(u8, aw.writer.buffered(), "/new") != null);
+    try std.testing.expect(update_cmd.hasPending());
+
+    aw.clearRetainingCapacity();
+    try std.testing.expect(try update_cmd.tryHandle(&root, gpa, "/update install", &aw.writer));
+    try std.testing.expect(std.mem.indexOf(u8, aw.writer.buffered(), update_target.install_note) != null);
+    const after = try Io.Dir.cwd().readFileAlloc(io, target, gpa, .limited(64));
+    defer gpa.free(after);
+    try std.testing.expectEqualStrings("NEW-GRAFF", after);
+}
+
+test "/new and /resume copy never claims to activate an update" {
+    const new_msg = "new session →";
+    const resume_msg = "resumed";
+    try std.testing.expect(std.mem.indexOf(u8, new_msg, "update") == null);
+    try std.testing.expect(std.mem.indexOf(u8, resume_msg, "activate") == null);
+    try std.testing.expect(std.mem.indexOf(u8, update_target.no_activate_note, "do not activate") != null);
+}

--- a/src/version_status.zig
+++ b/src/version_status.zig
@@ -1,0 +1,172 @@
+//! Running / installed / latest comparison shared by `graff update --check`,
+//! the startup update notice, and the terminal `/update` (and `/version`)
+//! surfaces. One policy so the CLI and the in-session command cannot drift.
+
+const std = @import("std");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+const Value = std.json.Value;
+
+pub const State = enum { current, older, newer, dev, unable };
+pub const Failure = enum { none, fetch, latest_tag };
+
+pub const Check = struct {
+    running: []const u8,
+    latest: ?[]const u8 = null,
+    latest_tag: ?[]const u8 = null,
+    state: State,
+    failure: Failure = .none,
+    order: ?std.math.Order = null,
+    clean_release: bool = false,
+};
+
+const Version = struct {
+    major: u32,
+    minor: u32,
+    patch: u32,
+
+    fn eql(self: Version, other: Version) bool {
+        return self.major == other.major and self.minor == other.minor and self.patch == other.patch;
+    }
+
+    fn order(self: Version, other: Version) std.math.Order {
+        if (self.major != other.major) return std.math.order(self.major, other.major);
+        if (self.minor != other.minor) return std.math.order(self.minor, other.minor);
+        return std.math.order(self.patch, other.patch);
+    }
+};
+
+pub const repo_api = "https://api.github.com/repos/justrach/codegraff/releases/latest";
+pub const repo_download_base = "https://github.com/justrach/codegraff/releases/download";
+
+pub fn stripV(s: []const u8) []const u8 {
+    return if (std.mem.startsWith(u8, s, "v")) s[1..] else s;
+}
+
+fn parseVersion(s: []const u8) ?Version {
+    var it = std.mem.splitScalar(u8, s, '.');
+    const major_s = it.next() orelse return null;
+    const minor_s = it.next() orelse return null;
+    const patch_s = it.next() orelse return null;
+    const major = std.fmt.parseInt(u32, major_s, 10) catch return null;
+    const minor = std.fmt.parseInt(u32, minor_s, 10) catch return null;
+    const patch_digits = std.mem.indexOfAny(u8, patch_s, "-+") orelse patch_s.len;
+    const patch = std.fmt.parseInt(u32, patch_s[0..patch_digits], 10) catch return null;
+    return .{ .major = major, .minor = minor, .patch = patch };
+}
+
+fn isCleanReleaseVersion(s: []const u8) bool {
+    if (s.len == 0) return false;
+    var dots: u8 = 0;
+    for (s) |c| switch (c) {
+        '0'...'9' => {},
+        '.' => dots += 1,
+        else => return false,
+    };
+    return dots == 2;
+}
+
+/// Pure comparison. `latest_tag` is the GitHub tag (with or without `v`);
+/// `running_version` is the build option baked into this process.
+pub fn compare(running_version: []const u8, latest_tag: ?[]const u8) Check {
+    const running = stripV(running_version);
+    const tag = latest_tag orelse return .{ .running = running, .state = .unable, .failure = .fetch };
+    const latest = stripV(tag);
+    const release = parseVersion(latest) orelse return .{
+        .running = running,
+        .latest_tag = tag,
+        .state = .unable,
+        .failure = .latest_tag,
+    };
+    const current = parseVersion(running);
+    const clean = current != null and isCleanReleaseVersion(running);
+    const order = if (current) |v| v.order(release) else null;
+    if (!clean) return .{
+        .running = running,
+        .latest = latest,
+        .latest_tag = tag,
+        .state = .dev,
+        .order = order,
+    };
+    return .{
+        .running = running,
+        .latest = latest,
+        .latest_tag = tag,
+        .state = switch (order.?) {
+            .lt => .older,
+            .eq => .current,
+            .gt => .newer,
+        },
+        .order = order,
+        .clean_release = true,
+    };
+}
+
+/// True when `candidate` is a clean release at or newer than `latest_tag`.
+/// Used to refuse a reinstall or implicit downgrade of an already-installed
+/// binary that is current even when this process is older.
+pub fn alreadyHasRelease(installed_version: []const u8, latest_tag: []const u8) bool {
+    const check = compare(installed_version, latest_tag);
+    return switch (check.state) {
+        .current, .newer => true,
+        .dev => check.order == .gt or check.order == .eq,
+        .older, .unable => false,
+    };
+}
+
+pub fn fetchLatestReleaseTag(io: Io, gpa: Allocator, arena: Allocator, running_version: []const u8) ?[]const u8 {
+    var client: std.http.Client = .{ .allocator = gpa, .io = io };
+    defer client.deinit();
+    var aw: Io.Writer.Allocating = .init(arena);
+    defer aw.deinit();
+    const extra = [_]std.http.Header{.{ .name = "Accept", .value = "application/vnd.github+json" }};
+    const user_agent = std.fmt.allocPrint(arena, "simple-harness/{s}", .{running_version}) catch return null;
+    const res = client.fetch(.{
+        .location = .{ .url = repo_api },
+        .method = .GET,
+        .response_writer = &aw.writer,
+        .headers = .{ .user_agent = .{ .override = user_agent } },
+        .extra_headers = &extra,
+    }) catch return null;
+    if (@intFromEnum(res.status) != 200 or aw.writer.buffered().len > 64 * 1024) return null;
+    const parsed = std.json.parseFromSliceLeaky(Value, arena, aw.writer.buffered(), .{ .allocate = .alloc_always }) catch return null;
+    if (parsed != .object) return null;
+    const tag = parsed.object.get("tag_name") orelse return null;
+    return if (tag == .string) tag.string else null;
+}
+
+pub fn checkLatest(io: Io, gpa: Allocator, arena: Allocator, running_version: []const u8) Check {
+    return compare(running_version, fetchLatestReleaseTag(io, gpa, arena, running_version));
+}
+
+/// Leak-free tag extract for tests and the update service: copies into `buf`.
+pub fn copyTagName(body: []const u8, buf: []u8) ?[]const u8 {
+    var parsed = std.json.parseFromSlice(Value, std.heap.page_allocator, body, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const tag = parsed.value.object.get("tag_name") orelse return null;
+    if (tag != .string or tag.string.len == 0 or tag.string.len > buf.len) return null;
+    @memcpy(buf[0..tag.string.len], tag.string);
+    return buf[0..tag.string.len];
+}
+
+test "comparison classifies release and dev builds with one policy" {
+    try std.testing.expectEqual(State.current, compare("0.0.292", "v0.0.292").state);
+    try std.testing.expectEqual(State.older, compare("0.0.291", "v0.0.292").state);
+    try std.testing.expectEqual(State.newer, compare("0.0.293", "v0.0.292").state);
+    const dev = compare("0.0.293-2-gabc", "v0.0.292");
+    try std.testing.expectEqual(State.dev, dev.state);
+    try std.testing.expectEqual(std.math.Order.gt, dev.order.?);
+}
+
+test "unavailable and unparseable latest checks do not guess" {
+    try std.testing.expectEqual(Failure.fetch, compare("0.0.292", null).failure);
+    try std.testing.expectEqual(Failure.latest_tag, compare("0.0.292", "latest").failure);
+}
+
+test "alreadyHasRelease refuses a reinstall when disk is current or newer" {
+    try std.testing.expect(alreadyHasRelease("0.0.292", "v0.0.292"));
+    try std.testing.expect(alreadyHasRelease("0.0.293", "v0.0.292"));
+    try std.testing.expect(!alreadyHasRelease("0.0.291", "v0.0.292"));
+    try std.testing.expect(!alreadyHasRelease("0.0.291-3-gabc", "v0.0.292"));
+}


### PR DESCRIPTION
Closes #773.

`/update` on the line REPL and TUI checks GitHub for a release and, after an explicit human confirm, installs it for future launches. This process, conversation, and permissions stay on the original binary. `/new` and `/resume` do not activate it.

After a successful install the session reports:

> Update installed for the next launch. This session is still running its original version; you can keep working.

## Safety

- Authorization is a TTY picker or `/update install` after a human `/update` check. Model output, tool calls, saved conversations, and yolo are not consent.
- In-process, nonfatal service — not `graff update` / `install.sh`, no inherited TTY, no exec or relaunch.
- Resolves the real user install (`$HOME/bin/graff` or the running exe). Package-managed and zig-out paths are explained, never overwritten, never PATH-shadowed.
- Pins the selected tag, verifies the tarball against that release's `SHA256SUMS`, installs atomically. Missing or failed verification refuses the install.
- Concurrent installs serialize. Cancel or failure before commit leaves the existing file and the live session untouched. Already-installed current-or-newer disk versions are not reinstalled or downgraded.

Running / installed / latest comparison is shared with `graff update --check` in `version_status.zig`. ADR 0083 records the next-launch boundary (same spirit as ADR 0079).

Acceptance tests use isolated fixtures only and cover success, already-installed, offline/malformed, failed verification, permission errors, cancellation, simultaneous requests, and unchanged process/conversation/permissions.