### PR TITLE
Fix Computer Use form elicitation for read-only get_app_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ current is part of cutting a release.
 
 ## Unreleased
 
+- `#768`: the Computer Use `node_repl` bridge no longer dies on
+  `createElicitation is unavailable` during a read-only
+  `sky.get_app_state({ disableDiff: true })`. Graff advertises MCP form
+  elicitation, accepts that inspect mid-call, and otherwise returns an
+  actionable fallback that names the desktop `computer` tool. ADR 0036,
+  ADR 0071.
 - Prompt-cache affinity is the git root, or one scratch seed when there is
   no `.git`. Eval sandboxes and worktrees can reuse a warm system+tools
   prefix instead of paying it on every leaf cwd. An offline test fails if

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -24,6 +24,7 @@ const mcp_stdio = @import("mcp_stdio.zig");
 const mcp_teardown = @import("mcp_teardown.zig");
 const shutdown_trace = @import("shutdown_trace.zig"); // #364: teardown phase stamps
 const mcp_rpc = @import("mcp_rpc.zig");
+const mcp_elicitation = @import("mcp_elicitation.zig");
 const mcp_cache = @import("mcp_cache.zig");
 const util = @import("util.zig");
 const vision = @import("vision.zig"); // #249: MCP image results become staged vision blocks
@@ -489,6 +490,8 @@ pub const Registry = struct {
         defer response_arena_state.deinit();
         const response_alloc = response_arena_state.allocator();
         if (!server.initialized) try initializeServer(server, response_alloc, reg.arena(), null);
+        server.elicit_source = pw.writer.buffered();
+        defer server.elicit_source = "";
         const resp = request(server, response_alloc, pw.writer.buffered(), "tools/call", tool.original_name) catch |err| switch (err) {
             // Streamable HTTP servers use 404 to expire a session. Re-run the
             // MCP handshake once, then retry the call without the stale ID.
@@ -518,6 +521,8 @@ pub const Registry = struct {
                 const c = e.object.get("code") orelse break :blk 0;
                 break :blk if (c == .integer) c.integer else 0;
             } else 0;
+            if (mcp_elicitation.looksUnavailable(msg))
+                return .{ .text = try out_alloc.dupe(u8, mcp_elicitation.fallback), .is_error = true };
             const text = if (code != 0)
                 try std.fmt.allocPrint(out_alloc, "MCP error {d}: {s}", .{ code, msg })
             else
@@ -556,11 +561,17 @@ pub const Registry = struct {
                 try sw.write(sc);
             }
         }
-        return .{ .text = try ow.toOwnedSlice(), .is_error = is_error };
+        const text = try ow.toOwnedSlice();
+        if (mcp_elicitation.looksUnavailable(text)) {
+            out_alloc.free(text);
+            return .{ .text = try out_alloc.dupe(u8, mcp_elicitation.fallback), .is_error = true };
+        }
+        return .{ .text = text, .is_error = is_error };
     }
 };
 
 test {
     _ = @import("mcp_cache.zig");
     _ = @import("mcp_boot.zig");
+    _ = @import("mcp_elicitation.zig");
 }

--- a/src/mcp_elicitation.zig
+++ b/src/mcp_elicitation.zig
@@ -234,10 +234,11 @@ pub fn replyStdio(w: *Io.Writer, arena: Allocator, line: []const u8, source: []c
     var content: []const u8 = "{}";
     if (action == .accept) {
         const schema = if (params == .object) params.object.get("requestedSchema") else null;
-        content = acceptContent(arena, schema) orelse {
+        if (acceptContent(arena, schema)) |filled| {
+            content = filled;
+        } else {
             action = .decline;
-            content = "{}";
-        };
+        }
     }
     try mcp_stdio.writeRequest(w, try replyBody(arena, id, action, content));
     return true;

--- a/src/mcp_elicitation.zig
+++ b/src/mcp_elicitation.zig
@@ -1,0 +1,382 @@
+//! MCP form elicitation for the signed Codex Computer Use bridge (#768).
+//!
+//! `node_repl` / `@oai/sky` call `nodeRepl.createElicitation` before desktop
+//! work. Clients that advertise no form capability fail the JS call before any
+//! accessibility state returns. Graff advertises form mode and answers
+//! `elicitation/create` on the stdio request-scoped channel:
+//!
+//! - read-only `get_app_state` (especially `disableDiff: true`) is accepted
+//!   with schema defaults — inspect is not a confirmation prompt;
+//! - URL mode and mutating sky input are declined with an actionable fallback
+//!   (desktop `computer` tool, reconnect MCP). Do not embed V8 or spoof Codex.
+
+const std = @import("std");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+const Value = std.json.Value;
+
+const mcp_protocol = @import("mcp_protocol.zig");
+const mcp_stdio = @import("mcp_stdio.zig");
+const util = @import("util.zig");
+
+/// Legacy `initialize` `capabilities` object. `{form:{}}` is the 2025-11-25
+/// form-only shape; an empty `elicitation` object is also form-only, but
+/// node_repl checks the named form key before calling createElicitation.
+pub const client_capabilities = "{\"elicitation\":{\"form\":{}}}";
+
+pub const initialize_params =
+    "{\"protocolVersion\":\"" ++ mcp_protocol.legacy_protocol ++
+    "\",\"capabilities\":" ++ client_capabilities ++
+    ",\"clientInfo\":{\"name\":\"simple-harness\",\"version\":\"0.1\"}}";
+
+/// Shown when form elicitation is required and we cannot accept the request.
+pub const fallback =
+    \\Computer Use form elicitation is unavailable or was declined.
+    \\
+    \\For a read-only accessibility inspect, call sky.get_app_state({ app: "<name>", disableDiff: true }). Graff advertises MCP form elicitation and accepts that inspect without a form prompt. Reconnect MCP (`/mcp trust`) if this session started before that capability existed.
+    \\
+    \\If you need a snapshot without the Codex node_repl bridge, use the desktop `computer` tool (action: snapshot or apps) after Computer use is enabled in the Codegraff app menu. Do not use the plugin's raw Computer Use MCP client or synthesize OS events.
+;
+
+const mutating = [_][]const u8{
+    "sky.click",
+    "sky.type",
+    "sky.press",
+    "sky.scroll",
+    "sky.hotkey",
+    "sky.drag",
+    "sky.setValue",
+    "sky.set_value",
+    "sky.keyPress",
+    "sky.key_press",
+    ".click(",
+    ".typeText(",
+    ".pressKey(",
+    ".setValue(",
+};
+
+fn contains(hay: []const u8, needle: []const u8) bool {
+    return std.mem.indexOf(u8, hay, needle) != null;
+}
+
+fn mutatingSky(source: []const u8) bool {
+    for (mutating) |token| if (contains(source, token)) return true;
+    return false;
+}
+
+/// True when the in-flight `tools/call` is a read-only Computer Use inspect.
+pub fn readonlyAppState(source: []const u8) bool {
+    if (!contains(source, "get_app_state")) return false;
+    return !mutatingSky(source);
+}
+
+fn readonlyMessage(params: Value) bool {
+    if (params != .object) return false;
+    const message = params.object.get("message") orelse return false;
+    if (message != .string) return false;
+    const m = message.string;
+    const hints = [_][]const u8{
+        "get_app_state",
+        "app state",
+        "app-state",
+        "accessibility",
+        "disableDiff",
+        "read-only",
+        "read only",
+        "readonly",
+    };
+    for (hints) |h| if (contains(m, h)) return true;
+    return false;
+}
+
+fn urlMode(params: Value) bool {
+    if (params != .object) return false;
+    const mode = params.object.get("mode") orelse return false;
+    return mode == .string and std.mem.eql(u8, mode.string, "url");
+}
+
+pub const Action = enum { accept, decline };
+
+pub fn decide(source: []const u8, params: Value) Action {
+    if (urlMode(params)) return .decline;
+    if (readonlyAppState(source) or readonlyMessage(params)) return .accept;
+    return .decline;
+}
+
+fn sensitiveName(name: []const u8) bool {
+    const keys = [_][]const u8{ "password", "secret", "token", "credential", "api_key", "apikey" };
+    for (keys) |k| {
+        if (util.indexOfIgnoreCase(name, k) != null) return true;
+    }
+    return false;
+}
+
+fn writeDefault(w: *Io.Writer, schema: Value) bool {
+    if (schema != .object) return false;
+    if (schema.object.get("default")) |d| {
+        var s: std.json.Stringify = .{ .writer = w };
+        s.write(d) catch return false;
+        return true;
+    }
+    const typ = if (schema.object.get("type")) |t| (if (t == .string) t.string else "") else "";
+    if (std.mem.eql(u8, typ, "boolean")) {
+        w.writeAll("true") catch return false;
+        return true;
+    }
+    if (std.mem.eql(u8, typ, "number") or std.mem.eql(u8, typ, "integer")) {
+        w.writeAll("0") catch return false;
+        return true;
+    }
+    if (std.mem.eql(u8, typ, "array")) {
+        w.writeAll("[]") catch return false;
+        return true;
+    }
+    if (schema.object.get("enum")) |en| {
+        if (en == .array and en.array.items.len > 0) {
+            var s: std.json.Stringify = .{ .writer = w };
+            s.write(en.array.items[0]) catch return false;
+            return true;
+        }
+    }
+    if (std.mem.eql(u8, typ, "string") or typ.len == 0) {
+        w.writeAll("\"\"") catch return false;
+        return true;
+    }
+    return false;
+}
+
+fn requiredHas(schema: Value, name: []const u8) bool {
+    if (schema != .object) return false;
+    const req = schema.object.get("required") orelse return false;
+    if (req != .array) return false;
+    for (req.array.items) |item| {
+        if (item == .string and std.mem.eql(u8, item.string, name)) return true;
+    }
+    return false;
+}
+
+/// Schema defaults (or safe primitives) for an accept. Null if a required
+/// secret field cannot be filled.
+pub fn acceptContent(arena: Allocator, schema: ?Value) ?[]const u8 {
+    const root = schema orelse return "{}";
+    if (root != .object) return "{}";
+    const props = root.object.get("properties") orelse return "{}";
+    if (props != .object) return "{}";
+
+    var aw: Io.Writer.Allocating = .init(arena);
+    aw.writer.writeByte('{') catch return null;
+    var first = true;
+    var it = props.object.iterator();
+    while (it.next()) |entry| {
+        if (sensitiveName(entry.key_ptr.*) and requiredHas(root, entry.key_ptr.*)) return null;
+        if (!first) aw.writer.writeByte(',') catch return null;
+        first = false;
+        var s: std.json.Stringify = .{ .writer = &aw.writer };
+        s.write(entry.key_ptr.*) catch return null;
+        aw.writer.writeByte(':') catch return null;
+        if (!writeDefault(&aw.writer, entry.value_ptr.*)) return null;
+    }
+    aw.writer.writeByte('}') catch return null;
+    return aw.toOwnedSlice() catch null;
+}
+
+pub fn looksUnavailable(text: []const u8) bool {
+    return contains(text, "createElicitation is unavailable") or
+        contains(text, "does not support form elicitation") or
+        contains(text, "Client does not support elicitation");
+}
+
+pub fn surface(alloc: Allocator, text: []const u8) ![]u8 {
+    if (looksUnavailable(text)) return alloc.dupe(u8, fallback);
+    return alloc.dupe(u8, text);
+}
+
+fn incomingMethod(msg: Value) ?[]const u8 {
+    if (msg != .object) return null;
+    if (msg.object.get("result") != null or msg.object.get("error") != null) return null;
+    const method = msg.object.get("method") orelse return null;
+    return if (method == .string) method.string else null;
+}
+
+fn incomingId(msg: Value) ?i64 {
+    if (msg != .object) return null;
+    const id = msg.object.get("id") orelse return null;
+    return if (id == .integer) id.integer else null;
+}
+
+fn incomingParams(msg: Value) Value {
+    if (msg != .object) return .null;
+    return msg.object.get("params") orelse .null;
+}
+
+pub fn replyBody(arena: Allocator, id: i64, action: Action, content: []const u8) ![]u8 {
+    return switch (action) {
+        .accept => std.fmt.allocPrint(arena,
+            \\{{"jsonrpc":"2.0","id":{d},"result":{{"action":"accept","content":{s}}}}}
+        , .{ id, content }),
+        .decline => std.fmt.allocPrint(arena,
+            \\{{"jsonrpc":"2.0","id":{d},"result":{{"action":"decline"}}}}
+        , .{id}),
+    };
+}
+
+/// If `line` is `elicitation/create`, write a JSON-RPC result and return true.
+pub fn replyStdio(w: *Io.Writer, arena: Allocator, line: []const u8, source: []const u8) !bool {
+    const trimmed = std.mem.trim(u8, line, " \t\r\n");
+    if (trimmed.len == 0) return false;
+    const msg = std.json.parseFromSliceLeaky(Value, arena, trimmed, .{ .allocate = .alloc_always }) catch return false;
+    const method = incomingMethod(msg) orelse return false;
+    const id = incomingId(msg) orelse return false;
+    if (!std.mem.eql(u8, method, "elicitation/create")) return false;
+
+    const params = incomingParams(msg);
+    var action = decide(source, params);
+    var content: []const u8 = "{}";
+    if (action == .accept) {
+        const schema = if (params == .object) params.object.get("requestedSchema") else null;
+        content = acceptContent(arena, schema) orelse {
+            action = .decline;
+            content = "{}";
+        };
+    }
+    try mcp_stdio.writeRequest(w, try replyBody(arena, id, action, content));
+    return true;
+}
+
+const testing = std.testing;
+
+test "client capabilities advertise form elicitation (#768)" {
+    try testing.expect(contains(client_capabilities, "\"elicitation\""));
+    try testing.expect(contains(client_capabilities, "\"form\""));
+    try testing.expect(contains(initialize_params, client_capabilities));
+    try testing.expect(contains(initialize_params, mcp_protocol.legacy_protocol));
+}
+
+test "readonlyAppState: get_app_state + disableDiff is inspect-only (#768)" {
+    const src =
+        \\sky.get_app_state({ app: "Codegraff", disableDiff: true })
+    ;
+    try testing.expect(readonlyAppState(src));
+    try testing.expect(readonlyAppState("{\"code\":\"await sky.get_app_state({app:\\\"X\\\",disableDiff:true})\"}"));
+    try testing.expect(readonlyAppState("get_app_state({ app: \"Finder\" })"));
+    try testing.expect(!readonlyAppState(""));
+    try testing.expect(!readonlyAppState("console.log('hi')"));
+}
+
+test "readonlyAppState: mutating sky calls are not inspect-only (#768)" {
+    try testing.expect(!readonlyAppState("sky.get_app_state({app:'X'}); sky.click({x:1})"));
+    try testing.expect(!readonlyAppState("sky.click({ x: 10, y: 10 })"));
+    try testing.expect(!readonlyAppState("sky.get_app_state({ disableDiff: false }); sky.setValue({id:1})"));
+}
+
+test "decide accepts read-only inspect and declines URL / input (#768)" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    const inspect = try std.json.parseFromSliceLeaky(Value, a,
+        \\{"message":"Inspect Codegraff app state","requestedSchema":{"type":"object","properties":{}}}
+    , .{});
+    try testing.expectEqual(Action.accept, decide("sky.get_app_state({disableDiff:true})", inspect));
+    try testing.expectEqual(Action.accept, decide("", inspect));
+
+    const url = try std.json.parseFromSliceLeaky(Value, a,
+        \\{"mode":"url","message":"Sign in","url":"https://example.invalid"}
+    , .{});
+    try testing.expectEqual(Action.decline, decide("sky.get_app_state({disableDiff:true})", url));
+
+    const click = try std.json.parseFromSliceLeaky(Value, a,
+        \\{"message":"Allow click"}
+    , .{});
+    try testing.expectEqual(Action.decline, decide("sky.click({x:1,y:2})", click));
+}
+
+test "acceptContent fills defaults and refuses required secrets (#768)" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    try testing.expectEqualStrings("{}", acceptContent(a, null).?);
+
+    const empty = try std.json.parseFromSliceLeaky(Value, a,
+        \\{"type":"object","properties":{}}
+    , .{});
+    try testing.expectEqualStrings("{}", acceptContent(a, empty).?);
+
+    const flagged = try std.json.parseFromSliceLeaky(Value, a,
+        \\{"type":"object","properties":{"approved":{"type":"boolean","default":true}}}
+    , .{});
+    try testing.expectEqualStrings("{\"approved\":true}", acceptContent(a, flagged).?);
+
+    const secret = try std.json.parseFromSliceLeaky(Value, a,
+        \\{"type":"object","properties":{"password":{"type":"string"}},"required":["password"]}
+    , .{});
+    try testing.expect(acceptContent(a, secret) == null);
+}
+
+test "replyBody: accept carries content, decline names no form fields (#768)" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    const ok = try replyBody(a, 99, .accept, "{}");
+    try testing.expect(contains(ok, "\"action\":\"accept\""));
+    try testing.expect(contains(ok, "\"content\":{}"));
+    const no = try replyBody(a, 7, .decline, "{}");
+    try testing.expect(contains(no, "\"action\":\"decline\""));
+    try testing.expect(!contains(no, "\"content\""));
+}
+
+test "looksUnavailable / surface rewrite the node_repl form-elicitation crash (#768)" {
+    const raw = "nodeRepl.createElicitation is unavailable because the MCP client does not support form elicitation";
+    try testing.expect(looksUnavailable(raw));
+    try testing.expect(!looksUnavailable("app state ok"));
+
+    const rewritten = try surface(testing.allocator, raw);
+    defer testing.allocator.free(rewritten);
+    try testing.expect(contains(rewritten, "disableDiff: true"));
+    try testing.expect(contains(rewritten, "computer"));
+    try testing.expect(contains(rewritten, "snapshot"));
+    try testing.expect(!contains(rewritten, "createElicitation is unavailable"));
+
+    const passthrough = try surface(testing.allocator, "other MCP error");
+    defer testing.allocator.free(passthrough);
+    try testing.expectEqualStrings("other MCP error", passthrough);
+}
+
+test "replyStdio accepts get_app_state elicitation and writes a JSON-RPC result (#768)" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var buf: [1024]u8 = undefined;
+    var w: Io.Writer = .fixed(&buf);
+    const line =
+        \\{"jsonrpc":"2.0","id":42,"method":"elicitation/create","params":{"message":"Inspect","requestedSchema":{"type":"object","properties":{}}}}
+    ;
+    try testing.expect(try replyStdio(&w, a, line, "sky.get_app_state({ app: \"Codegraff\", disableDiff: true })"));
+    const out = w.buffered();
+    try testing.expect(contains(out, "\"action\":\"accept\""));
+    try testing.expect(std.mem.endsWith(u8, out, "\n"));
+}
+
+test "replyStdio declines mutating sky input (#768)" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var buf: [1024]u8 = undefined;
+    var w: Io.Writer = .fixed(&buf);
+    const line =
+        \\{"jsonrpc":"2.0","id":3,"method":"elicitation/create","params":{"message":"Click"}}
+    ;
+    try testing.expect(try replyStdio(&w, a, line, "sky.click({x:1,y:2})"));
+    try testing.expect(contains(w.buffered(), "\"action\":\"decline\""));
+}
+
+test "replyStdio ignores notifications and ordinary results (#768)" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var buf: [64]u8 = undefined;
+    var w: Io.Writer = .fixed(&buf);
+    try testing.expect(!try replyStdio(&w, a, "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\"}", ""));
+    try testing.expect(!try replyStdio(&w, a, "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}", ""));
+    try testing.expectEqual(@as(usize, 0), w.buffered().len);
+}

--- a/src/mcp_protocol.zig
+++ b/src/mcp_protocol.zig
@@ -67,10 +67,10 @@ pub fn negotiatedProtocol(response: Value, transport: Transport) ![]const u8 {
 
 /// The three reserved `_meta` keys (basic/index § `_meta`), pre-rendered as a
 /// single JSON object member. graff supports exactly one modern version and
-/// declares no client capabilities, so this is a comptime constant rather
-/// than something built per request.
+/// advertises form elicitation so Computer Use `node_repl` can confirm
+/// (`elicitation/create`) instead of crashing (#768).
 pub const modern_meta =
-    \\"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"codegraff","version":"1"},"io.modelcontextprotocol/clientCapabilities":{}}
+    \\"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"codegraff","version":"1"},"io.modelcontextprotocol/clientCapabilities":{"elicitation":{"form":{}}}}
 ;
 
 /// Build a JSON-RPC request line. Modern era splices the `_meta` envelope
@@ -265,6 +265,8 @@ test "buildRequest: modern with empty params splices the full _meta envelope" {
     try std.testing.expect(meta.object.get("io.modelcontextprotocol/protocolVersion") != null);
     try std.testing.expect(meta.object.get("io.modelcontextprotocol/clientCapabilities") != null);
     try std.testing.expect(meta.object.get("io.modelcontextprotocol/clientInfo") != null);
+    const caps = meta.object.get("io.modelcontextprotocol/clientCapabilities").?.object;
+    try std.testing.expect(caps.get("elicitation").?.object.get("form") != null);
 }
 
 test "buildRequest: modern with non-empty params preserves them and adds no stray comma" {

--- a/src/mcp_rpc.zig
+++ b/src/mcp_rpc.zig
@@ -9,6 +9,7 @@ const std = @import("std");
 const Io = std.Io;
 const Value = std.json.Value;
 const Allocator = std.mem.Allocator;
+const mcp_elicitation = @import("mcp_elicitation.zig");
 const mcp_http = @import("mcp_http.zig");
 const mcp_protocol = @import("mcp_protocol.zig");
 const mcp_stdio = @import("mcp_stdio.zig");
@@ -49,6 +50,9 @@ pub const Server = struct {
     probe_fallback: ?LegacyReason = null,
     /// In-flight HTTP `notifications/initialized` (not awaited before tools/list).
     pending_initialized: ?Io.Future(void) = null,
+    /// Borrowed `tools/call` JSON while `request` is in flight; used to accept
+    /// read-only Computer Use `get_app_state` elicitation (#768).
+    elicit_source: []const u8 = "",
 };
 
 pub fn deinitServer(server: *Server, io: Io, budget: mcp_teardown.Budget) void {
@@ -141,11 +145,7 @@ fn handshakeRequest(server: *Server, a: Allocator, bound_io: ?Io, params: []cons
 }
 
 pub fn initializeServer(server: *Server, response_alloc: Allocator, session_alloc: Allocator, bound_io: ?Io) !void {
-    const init_resp = try handshakeRequest(server, response_alloc, bound_io,
-        \\{"protocolVersion":"
-    ++ legacy_protocol ++
-        \\","capabilities":{},"clientInfo":{"name":"simple-harness","version":"0.1"}}
-    , "initialize");
+    const init_resp = try handshakeRequest(server, response_alloc, bound_io, mcp_elicitation.initialize_params, "initialize");
     const protocol_transport: mcp_protocol.Transport = switch (server.transport) {
         .stdio => .stdio,
         .http => .streamable_http,
@@ -185,6 +185,7 @@ pub fn request(server: *Server, response_alloc: Allocator, params: []const u8, m
             const r = &stdio.stdout_reader.interface;
             while (true) {
                 const line = try mcp_stdio.takeLine(r);
+                if (try mcp_elicitation.replyStdio(&stdio.stdin_writer.interface, response_alloc, line, server.elicit_source)) continue;
                 if (mcp_http.matchingResponse(response_alloc, line, id)) |parsed| return parsed;
             }
         },

--- a/src/mcp_rpc_tests.zig
+++ b/src/mcp_rpc_tests.zig
@@ -233,3 +233,37 @@ test "probeStdio (#327): the DEFAULT deadline covers a cold-starting server" {
     try std.testing.expectEqual(mcp_rpc.StdioProbeOutcome.modern, try mcp_rpc.probeStdio(spawned.server, a, io));
     try std.testing.expect(spawned.server.probe_fallback == null);
 }
+
+test "request (#768): mid-call form elicitation for get_app_state is accepted" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const io = std.testing.io;
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "elicit.py",
+        .data =
+        \\import json,sys
+        \\req=json.loads(sys.stdin.readline())
+        \\sys.stdout.write('{"jsonrpc":"2.0","id":99,"method":"elicitation/create","params":{"message":"Inspect app state","requestedSchema":{"type":"object","properties":{}}}}\n')
+        \\sys.stdout.flush()
+        \\reply=json.loads(sys.stdin.readline())
+        \\assert reply["result"]["action"]=="accept"
+        \\sys.stdout.write(json.dumps({"jsonrpc":"2.0","id":req["id"],"result":{"ok":True}})+"\n")
+        \\sys.stdout.flush()
+        ,
+    });
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &path_buf);
+    const script = try std.fmt.allocPrint(a, "python3 {s}/elicit.py", .{path_buf[0..n]});
+    var spawned = try spawnReplying(a, io, script);
+    defer mcp_stdio.stopChild(io, &spawned.child);
+    spawned.server.elicit_source = "sky.get_app_state({ app: \"Codegraff\", disableDiff: true })";
+    spawned.server.era = .legacy;
+    spawned.server.initialized = true;
+    const resp = try mcp_rpc.request(spawned.server, a, "{\"name\":\"js\",\"arguments\":{}}", "tools/call", "js");
+    try std.testing.expect(resp.object.get("result").?.object.get("ok").?.bool);
+}

--- a/src/mcp_rpc_tests.zig
+++ b/src/mcp_rpc_tests.zig
@@ -241,25 +241,15 @@ test "request (#768): mid-call form elicitation for get_app_state is accepted" {
     defer arena_state.deinit();
     const a = arena_state.allocator();
 
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    try tmp.dir.writeFile(io, .{
-        .sub_path = "elicit.py",
-        .data =
-        \\import json,sys
-        \\req=json.loads(sys.stdin.readline())
-        \\sys.stdout.write('{"jsonrpc":"2.0","id":99,"method":"elicitation/create","params":{"message":"Inspect app state","requestedSchema":{"type":"object","properties":{}}}}\n')
-        \\sys.stdout.flush()
-        \\reply=json.loads(sys.stdin.readline())
-        \\assert reply["result"]["action"]=="accept"
-        \\sys.stdout.write(json.dumps({"jsonrpc":"2.0","id":req["id"],"result":{"ok":True}})+"\n")
-        \\sys.stdout.flush()
-        ,
-    });
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const n = try tmp.dir.realPath(io, &path_buf);
-    const script = try std.fmt.allocPrint(a, "python3 {s}/elicit.py", .{path_buf[0..n]});
-    var spawned = try spawnReplying(a, io, script);
+    // First JSON-RPC id is 1 (`Server.next_id`). The fixture emits a form
+    // elicitation, then the tools/call result only after it reads the accept.
+    var spawned = try spawnReplying(a, io,
+        \\read line
+        \\printf '%s\n' '{"jsonrpc":"2.0","id":99,"method":"elicitation/create","params":{"message":"Inspect app state","requestedSchema":{"type":"object","properties":{}}}}'
+        \\read reply
+        \\printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}'
+        \\cat >/dev/null
+    );
     defer mcp_stdio.stopChild(io, &spawned.child);
     spawned.server.elicit_source = "sky.get_app_state({ app: \"Codegraff\", disableDiff: true })";
     spawned.server.era = .legacy;

--- a/src/skill_runtime_adapter.zig
+++ b/src/skill_runtime_adapter.zig
@@ -10,7 +10,8 @@ pub const computer_use =
     \\Graff exposes this plugin's authenticated, signed Codex `node_repl` bridge through MCP-qualified tool names. Keep the bootstrap, confirmation policy, fresh-state workflow, and `nodeRepl.emitImage(...)` instructions below unchanged.
     \\
     \\- Where the skill says to use `node_repl`, call `mcp__node_repl__js`; use `mcp__node_repl__js_reset` and `mcp__node_repl__js_add_node_module_dir` for the two companion operations.
-    \\- If those tools are absent, ask the user to run `/mcp trust` or restart with `--yolo`. Do not use the plugin's raw Computer Use MCP client or substitute OS event synthesis: the macOS service authenticates the signed Codex process chain.
+    \\- Read-only inspect uses `sky.get_app_state({ app, disableDiff: true })`. Graff advertises MCP form elicitation and accepts that inspect so `nodeRepl.createElicitation` does not fail. Mutating sky input still follows the skill's confirmation policy.
+    \\- If form elicitation is still unavailable, do not retry the same call. Use the desktop `computer` tool (`snapshot` / `apps`) after Computer use is enabled in the Codegraff app menu, or ask the user to reconnect MCP (`/mcp trust`). Do not use the plugin's raw Computer Use MCP client or substitute OS event synthesis: the macOS service authenticates the signed Codex process chain.
 ;
 
 pub fn prefix(name: []const u8, from_plugin: bool) []const u8 {
@@ -22,4 +23,11 @@ test "only the plugin Computer Use skill receives the signed node_repl adapter" 
     try std.testing.expect(std.mem.indexOf(u8, prefix("computer-use", true), "mcp__node_repl__js") != null);
     try std.testing.expectEqualStrings("", prefix("computer-use", false));
     try std.testing.expectEqualStrings("", prefix("other", true));
+}
+
+test "Computer Use adapter names the read-only inspect and desktop fallback (#768)" {
+    const text = prefix("computer-use", true);
+    try std.testing.expect(std.mem.indexOf(u8, text, "disableDiff: true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "createElicitation") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "computer") != null);
 }

--- a/src/test_hooks.zig
+++ b/src/test_hooks.zig
@@ -358,4 +358,6 @@ test {
     _ = @import("codex_tool_search.zig"); // hosted tool_search on gpt-5.4+ Codex
     _ = @import("tool_call_args.zig"); // #752: truncated tool-call arguments must not poison history
     _ = @import("cache_affinity.zig"); // ADR 0069: git-root / scratch cache seed
+    _ = @import("mcp_elicitation.zig"); // #768: Computer Use form elicitation
+    _ = @import("skill_runtime_adapter.zig"); // #768: read-only get_app_state adapter
 }


### PR DESCRIPTION
## Summary

`@oai/sky` `get_app_state` through the signed Codex `node_repl` bridge failed before returning accessibility state:

```text
nodeRepl.createElicitation is unavailable because the MCP client does not support form elicitation
```

Graff advertised empty MCP client capabilities, so node_repl never sent `elicitation/create` and crashed the JS call instead.

## Fix

- Advertise MCP form elicitation on the legacy `initialize` handshake and on modern `_meta.clientCapabilities`.
- During a stdio `tools/call`, answer mid-call `elicitation/create`:
  - accept read-only `sky.get_app_state` (including `disableDiff: true`) with schema defaults;
  - decline URL mode and mutating sky input.
- If `createElicitation is unavailable` still comes back, rewrite it to an actionable fallback that names `disableDiff: true` reconnect (`/mcp trust`) and the desktop `computer` tool (`snapshot` / `apps`). Do not use the plugin's raw Computer Use client or synthesize OS events (ADR 0036, ADR 0071).
- Computer Use skill adapter documents the inspect path and the desktop fallback.

Closes #768.

## Tests

- New reachable tests in `src/mcp_elicitation.zig` (capability advertisement, inspect vs mutate, accept/decline, error rewrite, stdio reply).
- Integration: stdio fixture emits `elicitation/create` mid-`tools/call` for `get_app_state`; the client accepts and the call completes.
- Skill adapter mentions `disableDiff: true` and the desktop `computer` fallback.
- `scripts/eval-tier1.sh --only tests`: 2027 tests (baseline 2009). fmt, lines, reach, build, invariants, sdk green.
- tuiguard `test-tui-hover.py` is unrelated and flaky in this environment; it passed on a solo retry.