### PR TITLE
Fix folder-picker desktop visual crash on 292

### DIFF
--- a/apps/native/components/site/WorkspaceDialog.tsx
+++ b/apps/native/components/site/WorkspaceDialog.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { createPortal } from "react-dom";
 import { Switch } from "@/components/atoms/Switch";
 import type { PromptModel } from "@/components/primitives/PromptBar";
-import { displayDirPath, rankFolderEntries, sameDir, splitFolderQuery } from "@/lib/folder-picker";
+import { displayDirPath, rankFolderEntries, sameBrowse, sameDir, splitFolderQuery } from "@/lib/folder-picker";
 import { browseFolders, fsReveal, type FolderListing } from "@/lib/fs-client";
 import { IconCrossSmall, IconFolder } from "@/lib/icons";
 import { basename, type Workspace } from "@/lib/workspaces";
@@ -133,11 +133,12 @@ function FolderPicker({ startPath, onPick, onClose }: { startPath?: string; onPi
 
   const parsed = splitFolderQuery(typed, listing?.path);
   const listingPath = listing?.path ?? null;
+  const listingHome = listing?.home ?? null;
   useEffect(() => {
     if (!listingPath || !parsed.browse) return;
-    if (sameDir(parsed.browse, listingPath)) return;
+    if (sameBrowse(parsed.browse, listingPath, listingHome)) return;
     void go(parsed.browse, { refresh: true });
-  }, [go, listingPath, parsed.browse]);
+  }, [go, listingHome, listingPath, parsed.browse]);
   const shown = useMemo(
     () => (listing ? rankFolderEntries(listing.entries, parsed.needle) : []),
     [listing, parsed.needle],

--- a/apps/native/electron/project-recovery-visual.cjs
+++ b/apps/native/electron/project-recovery-visual.cjs
@@ -3,13 +3,23 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 async function runProjectRecovery({ win, origin, output }) {
-  const wc = win.webContents, js = code => wc.executeJavaScript(code);
+  const wc = win.webContents;
+  const js = async code => {
+    let last;
+    for (let i = 0; i < 8; i++) {
+      try { return await wc.executeJavaScript(code); } catch (error) {
+        last = error;
+        await new Promise(r => setTimeout(r, 50));
+      }
+    }
+    throw last;
+  };
   const wait = async code => { for (let i = 0; i < 120; i++) { if (await js(code)) return; await new Promise(r => setTimeout(r, 50)); } throw Error(`Recovery check timed out: ${code}`); };
   const click = (selector, text) => js(`Array.from(document.querySelectorAll(${JSON.stringify(selector)})).find(e=>e.textContent.trim()===${JSON.stringify(text)}).click()`);
   const input = (label, value) => js(`(()=>{const e=document.querySelector('[aria-label="${label}"]');e.focus();Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value').set.call(e,${JSON.stringify(value)});e.dispatchEvent(new Event('input',{bubbles:true}));})()`);
   const library = '[data-conversation-library]';
   await wc.loadURL(origin);
-  await wait(`!!document.querySelector('[data-project-context]')`);
+  await wait(`document.readyState==='complete'&&!!document.querySelector('[data-project-context]')`);
   await js(`(() => {
     const previous = window.fetch;
     const json = (value, status=200) => new Response(JSON.stringify(value), {status,headers:{'content-type':'application/json'}});

--- a/apps/native/electron/projects-visual.cjs
+++ b/apps/native/electron/projects-visual.cjs
@@ -63,6 +63,10 @@ async function runProjectVisuals({ win, origin, output }) {
   assert.equal(await js(`document.querySelector('button[aria-label="Changes"]')?.getAttribute('aria-current')`), null);
   await js(`document.querySelector('button[aria-label="Open folder…"]').click()`);
   await wait(`!!document.querySelector('[role="dialog"]')`);
+  // Unmount the picker before navigating: an in-flight listing + loadURL
+  // left the renderer unable to run the next suite's scripts.
+  await js(`document.querySelector('[role="dialog"] button[aria-label="Close"]').click()`);
+  await wait(`!document.querySelector('[role="dialog"]')`);
   await wc.loadURL(origin);
   await wait(`!!document.querySelector('textarea[aria-label="Prompt"]')`);
   win.setSize(900, 680);

--- a/apps/native/lib/folder-picker.test.ts
+++ b/apps/native/lib/folder-picker.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { displayDirPath, joinDir, rankFolderEntries, sameDir, splitFolderQuery } from "./folder-picker.ts";
+import { displayDirPath, joinDir, rankFolderEntries, sameBrowse, sameDir, splitFolderQuery } from "./folder-picker.ts";
 
 describe("displayDirPath", () => {
   it("adds a single trailing separator and leaves root alone", () => {
@@ -23,6 +23,12 @@ describe("joinDir / sameDir", () => {
     assert.equal(sameDir("/", "/"), true);
     assert.equal(sameDir("/a", "/b"), false);
     assert.equal(sameDir("/a", null), false);
+  });
+  it("treats ~ as the listing home so the picker does not refetch", () => {
+    assert.equal(sameBrowse("~", "/Users/example", "/Users/example"), true);
+    assert.equal(sameBrowse("~/", "/Users/example/", "/Users/example"), true);
+    assert.equal(sameBrowse("~", "/demo", "/Users/example"), false);
+    assert.equal(sameBrowse("/Users/example/", "/Users/example", "/Users/example"), true);
   });
 });
 

--- a/apps/native/lib/folder-picker.ts
+++ b/apps/native/lib/folder-picker.ts
@@ -19,6 +19,18 @@ export function sameDir(a: string | null | undefined, b: string | null | undefin
   return normalizeDir(a) === normalizeDir(b);
 }
 
+/** True when `browse` is the listing already on screen.
+ * `~` / `~/` is the listing's home, so typing it must not refetch. */
+export function sameBrowse(
+  browse: string | null | undefined,
+  listingPath: string | null | undefined,
+  home?: string | null,
+): boolean {
+  if (sameDir(browse, listingPath)) return true;
+  if (!browse || !home) return false;
+  return normalizeDir(browse) === "~" && sameDir(listingPath, home);
+}
+
 export function normalizeDir(p: string): string {
   const n = p.replace(/\\/g, "/").replace(/\/+$/, "");
   return n.length > 0 ? n : "/";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The #776 folder picker folded into `release/v0.0.292` via #784, but desktop CI on #779 was red: `test:projects` printed "Projects passed" and then died with `Script failed to execute` as project-recovery started.

The Open folder dialog was still mounted (and still fetching) when the suite navigated away. This:

- closes the picker before `loadURL`
- treats `~` / `~/` as the listing home so the picker does not refetch
- retries renderer scripts after load and waits for `document.readyState === 'complete'`

Same commit is on #779 (`df55f57`) so main gets the fix when that PR lands.

**Checked**
- `node --experimental-strip-types --test` on `folder-picker.test.ts` / `fuzzy.test.ts` (10/10)
- Forced `zig build test` / `tui-test` filters for `/update`, `/version`, #748, #751, #761, #765, #768
- Full suite on this base: **2063** tests, matching `test_count_baseline`
- `scripts/eval-tier1.sh` via pre-push: green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

