### PR TITLE
Default codedb context to --local so it is not hybrid-slow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ current is part of cutting a release.
 
 ## Unreleased
 
+- Bare `codedb context <task>` dispatches `codedb context --local` so
+  retrieval stays on-device (BM25/symbol/graph) instead of waiting on
+  hybrid embeddings rerank. `--hybrid` / `--semantic` remain available
+  and are still refused under local-only policy (ADR 0084). ADR 0086.
 - `#768`: the Computer Use `node_repl` bridge no longer dies on
   `createElicitation is unavailable` during a read-only
   `sky.get_app_state({ disableDiff: true })`. Graff advertises MCP form

--- a/docs/adr/0084-codedb-context-honors-local-only.md
+++ b/docs/adr/0084-codedb-context-honors-local-only.md
@@ -26,6 +26,7 @@ ordinary reads to codedb-pro (ADR 0040).
 - Repos that forbid transmitting working data stay on local BM25/symbol/graph.
 - Callers can enforce the boundary with `local_only` even when policy files
   are silent.
-- Hybrid remains the default where policy does not require local-only.
+- Hybrid is opt-in (`--hybrid` / `--semantic`); bare `context` is `--local`
+  (ADR 0086). Policy still refuses those remote flags before spawn.
 - Revisit only if codedb grows a stronger in-process local composer that
   graff should prefer over `--local`.

--- a/docs/adr/0086-codedb-context-is-local-first.md
+++ b/docs/adr/0086-codedb-context-is-local-first.md
@@ -1,0 +1,26 @@
+# 0086. Native codedb context is local-first
+
+Status: accepted 2026-09-07
+
+## Context
+
+codedb's composer defaults to hybrid advisory rerank: local BM25/symbol
+hits plus a hosted embeddings lane. That network hop is why a bare
+`codedb context <task>` often sits for seconds (and can ride the 60s
+tool deadline) even when the index is warm. ADR 0084 made `--local`
+mandatory under repository policy; everywhere else graff still spawned
+the hybrid default.
+
+## Decision
+
+Bare `codedb context <task>` dispatches `codedb context --local`. Remote
+rerank is opt-in via `--hybrid` or `--semantic`, and those flags are
+still refused before spawn when policy or `local_only` requires
+on-device retrieval (ADR 0084).
+
+## Consequences
+
+- Typical context calls stay on-device (BM25/symbol/graph) and return
+  without waiting on embeddings.
+- A caller that wants the hosted rerank must say so.
+- codedb's own default is unchanged; graff injects `--local` at spawn.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -95,6 +95,7 @@ record only when you need the evidence or the edge cases.
 | [0083](0083-meta-tool-choice-is-auto-only.md) | Meta / Muse Spark `tool_choice` is `auto` at the source; `max` effort folds to `xhigh` (#751). |
 | [0084](0084-codedb-context-honors-local-only.md) | Native `codedb context` is `--local` (or refused before spawn) when repository policy or `local_only` forbids transmitting working data; no-retention hybrid is not no egress. |
 | [0085](0085-in-session-update-is-next-launch.md) | `/update` installs a verified release for the next launch; this session keeps its original binary. |
+| [0086](0086-codedb-context-is-local-first.md) | Bare `codedb context` is `--local`; `--hybrid` / `--semantic` are opt-in remote rerank (and still refused under ADR 0084 policy). |
 
 ## When to write one
 

--- a/src/codedb_local.zig
+++ b/src/codedb_local.zig
@@ -4,9 +4,11 @@
 //! hosted embeddings lane for advisory rerank. "No remote retention" is not no
 //! egress. When repository policy or the per-call `local_only` argument
 //! requires on-device retrieval, graff injects `context --local` before spawn
-//! and never dispatches hybrid/semantic rerank. If that boundary cannot be
-//! guaranteed, dispatch is refused. Ordinary reads stay native codedb
-//! (ADR 0040) — this is not a codedb-pro redirect.
+//! and never dispatches hybrid/semantic rerank. Bare `context <task>` is also
+//! `--local` (ADR 0086): hybrid is the slow remote-rerank path and is opt-in.
+//! If a local-only boundary cannot be guaranteed, dispatch is refused.
+//! Ordinary reads stay native codedb (ADR 0040) — this is not a codedb-pro
+//! redirect.
 
 const std = @import("std");
 const Io = std.Io;
@@ -130,19 +132,22 @@ pub fn restHasFlag(rest: []const u8, check: *const fn ([]const u8) bool) bool {
     return false;
 }
 
-/// Default `context` is hybrid (remote advisory rerank) unless `--local`.
-pub fn defaultWouldRemoteRerank(rest: []const u8) bool {
-    return !restHasFlag(rest, tokenIsLocalFlag);
+/// Explicit `--hybrid` / `--semantic` opt into remote advisory rerank.
+/// Bare `context <task>` is on-device (ADR 0086).
+pub fn restAsksRemoteRerank(rest: []const u8) bool {
+    return restHasFlag(rest, tokenIsRemoteFlag);
 }
 
 pub fn planContext(required_local: bool, rest: []const u8) Plan {
-    if (!required_local) {
-        if (restHasFlag(rest, tokenIsLocalFlag)) return .{ .kind = .local, .inject_local = false };
+    if (restAsksRemoteRerank(rest)) {
+        if (required_local) {
+            return .{ .kind = .refuse, .inject_local = false, .refuse_reason = refuse_remote };
+        }
         return .{ .kind = .remote, .inject_local = false };
     }
-    if (restHasFlag(rest, tokenIsRemoteFlag)) {
-        return .{ .kind = .refuse, .inject_local = false, .refuse_reason = refuse_remote };
-    }
+    // Default and explicit `--local`/`--no-semantic`: on-device. Inject
+    // `--local` unless the caller already passed a local flag, so codedb
+    // does not fall through to its hybrid composer (seconds of network).
     return .{ .kind = .local, .inject_local = !restHasFlag(rest, tokenIsLocalFlag) };
 }
 
@@ -218,7 +223,7 @@ test "local-only context never selects remote rerank" {
     try std.testing.expectEqual(Kind.local, plan.kind);
     try std.testing.expect(plan.inject_local);
     try std.testing.expect(!wouldInvokeRemoteRerank(plan));
-    try std.testing.expect(defaultWouldRemoteRerank(task));
+    try std.testing.expect(!restAsksRemoteRerank(task));
 
     const argv = try contextArgv(gpa, plan, task);
     defer gpa.free(argv);
@@ -273,11 +278,21 @@ test "per-call local_only and existing --local stay on-device" {
     try std.testing.expectEqual(@as(usize, 1), locals);
 }
 
-test "without local-only policy default context still allows remote rerank" {
+test "default context is local; hybrid is opt-in (ADR 0086)" {
+    const gpa = std.testing.allocator;
     const plan = planContext(false, "find auth");
-    try std.testing.expectEqual(Kind.remote, plan.kind);
-    try std.testing.expect(wouldInvokeRemoteRerank(plan));
-    try std.testing.expect(defaultWouldRemoteRerank("find auth"));
-    try std.testing.expect(!defaultWouldRemoteRerank("--local find auth"));
-    try std.testing.expect(!defaultWouldRemoteRerank("--no-semantic find auth"));
+    try std.testing.expectEqual(Kind.local, plan.kind);
+    try std.testing.expect(plan.inject_local);
+    try std.testing.expect(!wouldInvokeRemoteRerank(plan));
+    try std.testing.expect(!restAsksRemoteRerank("find auth"));
+    try std.testing.expect(!restAsksRemoteRerank("--local find auth"));
+    try std.testing.expect(!restAsksRemoteRerank("--no-semantic find auth"));
+    try std.testing.expect(restAsksRemoteRerank("--hybrid find auth"));
+    const argv = try contextArgv(gpa, plan, "find auth");
+    defer gpa.free(argv);
+    try std.testing.expectEqualStrings("--local", argv[2]);
+
+    const hybrid = planContext(false, "--hybrid find auth");
+    try std.testing.expectEqual(Kind.remote, hybrid.kind);
+    try std.testing.expect(wouldInvokeRemoteRerank(hybrid));
 }

--- a/src/no_local_tools.zig
+++ b/src/no_local_tools.zig
@@ -128,7 +128,7 @@ pub const lean_subagent_desc = "Spawn a sidecar for a self-contained task. Child
 pub const lean_bash_desc = "Run /bin/sh -c in cwd. Returns stdout, stderr, exit. Foreground still running after 15s (or timeout ms) backgrounds — bash_output(wait_ms>0) waits; do not poll.";
 pub const lean_read_file_desc = "Read a UTF-8 file. Call before editing. contains=exact-key numbered lines; start_line/end_line for a window.";
 pub const lean_edit_file_desc = "Replace exact text. Prefer one batched edits[] over many calls. Prefer over write_file for an existing file.";
-pub const lean_codedb_desc = "Indexed nav: context <task> · around <name> · callpath A B · list_dir <path> · status. Prefer over bash grep/find/ls.";
+pub const lean_codedb_desc = "Indexed nav: context <task> (local) · around <name> · callpath A B · list_dir <path> · status. Prefer over bash grep/find/ls.";
 pub const lean_attempt_completion_desc = "Task is done. Put the final answer in result.";
 
 fn leanCompactDesc(name: []const u8) ?[]const u8 {

--- a/src/schema.zig
+++ b/src/schema.zig
@@ -105,9 +105,9 @@ pub const base_specs = [_]ToolSpec{
     .{ .name = skill_docs.tool_name, .desc = skill_docs.tool_desc, .schema = skill_docs.tool_schema },
     .{
         .name = "codedb",
-        .desc = "Indexed code nav (github.com/justrach/codedb). ONE command — not a hop chain: context <task> · around <name> · callpath A B · list_dir <path> · status. Prefer over bash grep/find/ls. list_dir is in-process (gitignore, PathConfine; no binary). status reports codedb.snapshot. Paths stay in the cwd. context is local-only when local_only is set or repository policy forbids transmitting working data (no remote rerank).",
+        .desc = "Indexed code nav (github.com/justrach/codedb). ONE command — not a hop chain: context <task> · around <name> · callpath A B · list_dir <path> · status. Prefer over bash grep/find/ls. list_dir is in-process (gitignore, PathConfine; no binary). status reports codedb.snapshot. Paths stay in the cwd. context is on-device (`--local`) by default; pass --hybrid/--semantic only for remote advisory rerank. local_only or repository policy refuse those remote flags before spawn.",
         .schema =
-        \\{"type": "object", "properties": {"command": {"type": "string", "description": "One of: \"context how does auth work\", \"around codedbGuard\", \"callpath exec codedbGuard\", \"list_dir src\", \"status\"."}, "local_only": {"type": "boolean", "description": "Force on-device retrieval: dispatch `codedb context --local` with no remote rerank. Also applied automatically when repository policy requires local-only retrieval. If local-only cannot be guaranteed, the call is refused before spawn."}}, "required": ["command"]}
+        \\{"type": "object", "properties": {"command": {"type": "string", "description": "One of: \"context how does auth work\", \"around codedbGuard\", \"callpath exec codedbGuard\", \"list_dir src\", \"status\". Bare context is local (on-device); add --hybrid only if you want remote rerank."}, "local_only": {"type": "boolean", "description": "Refuse remote rerank: dispatch `codedb context --local`. Also applied automatically when repository policy requires local-only retrieval. Explicit --hybrid/--semantic under that policy is refused before spawn."}}, "required": ["command"]}
         ,
     },
     .{ .name = result_read.tool_name, .desc = result_read.tool_desc, .schema = result_read.tool_schema },

--- a/src/tool_schema_tests.zig
+++ b/src/tool_schema_tests.zig
@@ -455,7 +455,8 @@ test "codedb schema exposes per-call local_only (#765)" {
     for (schema.root_specs) |t| if (std.mem.eql(u8, t.name, "codedb")) {
         found = true;
         try std.testing.expect(std.mem.indexOf(u8, t.schema, "\"local_only\"") != null);
-        try std.testing.expect(std.mem.indexOf(u8, t.schema, "no remote rerank") != null);
+        try std.testing.expect(std.mem.indexOf(u8, t.schema, "remote rerank") != null);
+        try std.testing.expect(std.mem.indexOf(u8, t.desc, "on-device") != null);
         try std.testing.expect(std.mem.indexOf(u8, t.desc, "local_only") != null);
     };
     try std.testing.expect(found);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bare `codedb context <task>` was spawning codedb’s **hybrid** composer: local BM25 plus a hosted embeddings rerank. That network hop is why a context call often sat for seconds (and could ride the 60s tool deadline) even with a warm index.

#765 / ADR 0084 already forced `--local` under repository policy. Everywhere else graff still used the slow default.

**This PR:** inject `codedb context --local` unless the caller asked for `--hybrid` or `--semantic`. Those remote flags stay available and are still refused before spawn when policy or `local_only` requires on-device retrieval.

ADR 0086.

**Checked**
- `zig build test -Dtest-filter=codedb`: 101/101
- `scripts/eval-tier1.sh` via pre-push: green
- Suite count still 2063
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

