### PR TITLE
Show active agents by default

### DIFF
--- a/apps/native/app/visual-tests/agents/fixture.tsx
+++ b/apps/native/app/visual-tests/agents/fixture.tsx
@@ -26,12 +26,12 @@ export default function Fixture() {
         ], response:working ? '' : failed ? 'Worker could not finish.' : 'The focus order is correct.'};
     }
     return { agents: scenario === 'empty' ? [] : [
-      { session: 'peer-a', title: 'Implement navigation', startId: '11', pid: 1, task: 'Refine keyboard navigation', workspace: '/demo/workspace', status: 'working', resources: { rssMiB: 20, cpuPercent: 1.2 } },
+      { session: 'peer-a', title: 'Implement navigation', startId: '11', pid: 1, task: 'Refine keyboard navigation', workspace: '/demo/workspace', status: scenario === 'idle' ? 'waiting' : 'working', resources: { rssMiB: 20, cpuPercent: 1.2 } },
       ...(params.scope === 'device' ? [{ session: 'peer-b', title: 'Review accessibility', startId: '12', pid: 2, task: 'Check focus order', workspace: '/demo/second', status: 'waiting', resources: null }] : []),
     ], messages: [{ from_session: 'peer-a', to: 'peer-b', ts_ms: 1000, text: 'The navigation update is ready for review.', kind: 'handoff' }], delivery: 'Queued' };
   }, [scenario]);
   return <main className="flex h-screen flex-col bg-page text-ink">
-    <nav className="flex gap-3 p-3">{['connected', 'empty', 'error'].map(value => <button key={value} data-agent-case={value} onClick={() => setScenario(value)}>{value}</button>)}{['light', 'dark', 'codegraff'].map(theme => <button key={theme} data-agent-theme={theme} onClick={() => applyAppearance(theme as Appearance)}>{theme}</button>)}</nav>
+    <nav className="flex gap-3 p-3">{['connected', 'idle', 'empty', 'error'].map(value => <button key={value} data-agent-case={value} onClick={() => setScenario(value)}>{value}</button>)}{['light', 'dark', 'codegraff'].map(theme => <button key={theme} data-agent-theme={theme} onClick={() => applyAppearance(theme as Appearance)}>{theme}</button>)}</nav>
     <div className="flex min-h-0 flex-1 gap-3 p-3"><div className="flex-1 min-w-0 p-5"><h1>Workspace conversation</h1><p>The agent panel keeps coordination alongside your work.</p><output data-agent-sent className="break-all">{sent}</output></div><AgentsPane root="/demo/workspace" onClose={() => {}} request={request} /></div>
   </main>;
 }

--- a/apps/native/components/site/AgentsPane.tsx
+++ b/apps/native/components/site/AgentsPane.tsx
@@ -6,6 +6,7 @@ import SubagentActivity from './SubagentActivity';
 
 export default function AgentsPane({ root, onClose, request = agentRequest }: { root?: string; onClose(): void; request?: typeof agentRequest }) {
   const [scope, setScope] = useState('workspace');
+  const [showIdle, setShowIdle] = useState(false);
   const [snapshot, setSnapshot] = useState<AgentSnapshot | null>(null);
   const [error, setError] = useState('');
   const [recipient, setRecipient] = useState<LocalAgent | null>(null);
@@ -34,9 +35,10 @@ export default function AgentsPane({ root, onClose, request = agentRequest }: { 
     void poll();
     return () => { disposed = true; controller.abort(); clearTimeout(timer); };
   }, [root, scope, refresh, request]);
-  const agents = snapshot?.agents ?? [];
+  const connected = snapshot?.agents ?? [];
+  const agents = connected.filter(agent => showIdle || agent.status === 'working');
   const selected = agents.find(a => recipient && agentKey(a) === agentKey(recipient));
-  const name = (session: string) => agents.find(a => a.session === session)?.title || session || 'Workspace';
+  const name = (session: string) => connected.find(a => a.session === session)?.title || session || 'Workspace';
   const choose = (agent: LocalAgent) => { setRecipient(agent); setNotice(''); setComposing(false); content.current?.scrollTo({top:0}); };
   const submit = async () => {
     if (!selected || !text.trim() || sending) return;
@@ -53,10 +55,11 @@ export default function AgentsPane({ root, onClose, request = agentRequest }: { 
       <div className="flex gap-1 border-b border-line p-3" role="group" aria-label="Agent scope">
         {['workspace', 'device'].map(value => <button key={value} aria-pressed={scope === value} onClick={() => { setScope(value); setRecipient(null); }} className={`rounded-lg px-3 py-2 text-xs ${scope === value ? 'bg-hover-2 text-ink' : 'text-ink-2 hover:bg-hover'}`}>{value === 'workspace' ? 'This workspace' : 'All local Graffs'}</button>)}
       </div>
+      <label className="flex items-center gap-2 border-b border-line px-3 py-2 text-xs text-ink-3"><input type="checkbox" checked={showIdle} onChange={e => setShowIdle(e.target.checked)} />Show idle agents</label>
       <div ref={content} className="min-h-0 flex-1 overflow-y-auto p-3 space-y-4">
         {error && <p role="alert" className="text-sm text-ink-2">{error} <button className="underline" onClick={() => setRefresh(n => n + 1)}>Retry</button></p>}
         {!snapshot && !error && <p role="status" className="text-sm text-ink-3">Finding local Graffs…</p>}
-        {snapshot && !agents.length && <p className="text-sm text-ink-3">No connected Graffs {scope === 'workspace' ? 'in this workspace' : 'on this laptop'}. Start a Graff session to coordinate.</p>}
+        {snapshot && !agents.length && <p className="text-sm text-ink-3">No {showIdle ? 'connected' : 'active'} Graffs {scope === 'workspace' ? 'in this workspace' : 'on this laptop'}.{!showIdle && connected.length > 0 ? ' Show idle agents to see connected sessions waiting for input.' : ' Start a Graff session to coordinate.'}</p>}
         {!selected && <ul className="space-y-2">{agents.map(agent => <li key={agentKey(agent)}><button onClick={() => choose(agent)} aria-pressed={false} className="w-full rounded-xl border border-line p-3 text-left hover:bg-hover">
           <span className="flex items-center gap-2"><span className="min-w-0 flex-1 truncate text-sm font-medium">{agentName(agent)}</span><span className="text-xs text-ink-3">{agent.status === 'working' ? 'Working' : agent.status === 'waiting' ? 'Waiting' : 'Connected'}</span></span>
           <span className="mt-1 block text-xs text-ink-2 break-words">{agent.task || 'No task published'}</span>
@@ -64,15 +67,15 @@ export default function AgentsPane({ root, onClose, request = agentRequest }: { 
           <span title="Graff process only; shared workers and GPU are not attributed" className="mt-2 block text-[11px] text-ink-3 tabular-nums">{agent.resources ? `${agent.resources.rssMiB.toFixed(1)} MiB · ${agent.resources.cpuPercent === null ? 'CPU sampling…' : `${agent.resources.cpuPercent.toFixed(1)}% CPU`}` : 'Resource measurements unavailable'}</span>
         </button></li>)}</ul>}
         {selected && <><div className="flex min-w-0 items-center gap-3 text-xs"><button aria-label="Back to all agents" className="shrink-0 rounded-lg px-2 py-1 hover:bg-hover" onClick={() => setRecipient(null)}>← Agents</button><strong className="truncate">{agentName(selected)}</strong></div><SubagentActivity key={agentKey(selected)} root={root} parent={selected} scope={scope} request={request} /></>}
-        {!selected && !!snapshot?.messages.length && <section aria-label="Peer messages" className="space-y-3"><h3 className="text-xs font-medium text-ink-3">Recent coordination</h3>{snapshot.messages.map((message, i) => <article key={`${message.ts_ms}:${i}`} className="rounded-xl border border-line p-3">
+        {!selected && !!snapshot?.messages.length && <details aria-label="Peer messages" className="space-y-3"><summary className="cursor-pointer text-xs font-medium text-ink-3">Coordination history</summary>{snapshot.messages.map((message, i) => <article key={`${message.ts_ms}:${i}`} className="rounded-xl border border-line p-3">
           <div className="flex items-center gap-2 text-[11px] text-ink-3"><span className="min-w-0 flex-1 truncate">{message.from_user ? 'You' : name(message.from_session)} → {name(message.to)}</span><time>{new Date(message.ts_ms).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</time></div>
           {message.kind === 'handoff' && <span className="text-xs text-accent">Handoff request</span>}<p className="mt-2 whitespace-pre-wrap break-words text-sm">{message.text}</p>
-        </article>)}</section>}
+        </article>)}</details>}
       </div>
       {selected && <button className="shrink-0 border-t border-line px-4 py-3 text-left text-xs hover:bg-hover" aria-expanded={composing} onClick={() => setComposing(value => !value)}>{composing ? 'Hide message composer' : 'Message this Graff…'}</button>}
       {(!selected || composing) && <form className="space-y-2 border-t border-line p-3" onSubmit={e => { e.preventDefault(); void submit(); }}>
         <label className="block text-xs text-ink-2">To<select aria-label="Message recipient" value={selected ? agentKey(selected) : ''} onChange={e => { setRecipient(agents.find(a => agentKey(a) === e.target.value) ?? null); setNotice(''); }} className="ml-2 max-w-[85%] rounded-lg bg-hover px-2 py-1 text-ink"><option value="">Select a Graff</option>{agents.map(a => <option key={agentKey(a)} value={agentKey(a)}>{agentName(a)}</option>)}</select></label>
-        {recipient && !selected && <p className="text-xs text-ink-3">Recipient is unavailable in this view. Select a connected Graff.</p>}
+        {recipient && !selected && <p className="text-xs text-ink-3">Recipient is unavailable in this view. Select another Graff or show idle agents.</p>}
         <textarea ref={input} aria-label="Message to Graff" value={text} onChange={e => setText(e.target.value)} maxLength={8192} rows={2} placeholder="Ask a peer, share context, or request a handoff…" className="w-full resize-y rounded-xl border border-line bg-surface p-3 text-sm outline-none focus:border-accent" />
         <div className="flex items-center gap-2"><select aria-label="Coordination type" value={kind} onChange={e => setKind(e.target.value)} className="rounded-lg bg-hover p-2 text-xs"><option value="message">Message</option><option value="handoff">Handoff request</option></select><button type="submit" disabled={!selected || !text.trim() || sending || !!error} className="ml-auto rounded-lg bg-hover-2 px-3 py-2 text-sm disabled:opacity-40">{sending ? 'Queuing…' : 'Send to Graff'}</button></div>
         {notice && <p role="status" className="text-xs text-ink-2">{notice}</p>}

--- a/apps/native/components/site/SubagentActivity.tsx
+++ b/apps/native/components/site/SubagentActivity.tsx
@@ -6,6 +6,7 @@ import { AssistantBody } from './ChatBubbles';
 
 export default function SubagentActivity({root, parent, scope, request}: {root?: string; parent: LocalAgent; scope: string; request: typeof agentRequest}) {
   const [children, setChildren] = useState<ChildAgent[]>([]);
+  const [showFinished, setShowFinished] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [activity, setActivity] = useState<ChildActivity | null>(null);
   const [error, setError] = useState('');
@@ -62,13 +63,16 @@ export default function SubagentActivity({root, parent, scope, request}: {root?:
     // Snapshot replay time is not the child's execution time.
     return {...value, tools:value.tools.map(tool => ({...tool, startedAt:undefined, elapsedMs:undefined}))};
   }, [activity, selected]);
+  const visibleChildren = children.filter(child => showFinished || child.status === 'working');
   return <section aria-label="Sub-agents" className="space-y-3 rounded-xl border border-line p-3">
     <h3 className="text-sm font-medium">Sub-agents</h3>
+    <label className="flex items-center gap-2 text-xs text-ink-3"><input type="checkbox" checked={showFinished} onChange={e => setShowFinished(e.target.checked)} />Show finished sub-agents</label>
+    {loaded && children.length > 0 && !visibleChildren.length && <p className="text-xs text-ink-3">No active sub-agents.</p>}
     {error ? <p role="alert" className="text-xs text-ink-2">{error} <button className="underline" onClick={() => setRefresh(n => n + 1)}>Retry</button></p>
       : !loaded ? <p role="status" className="text-xs text-ink-3">Finding sub-agents…</p>
       : !children.length ? <p className="text-xs text-ink-3">No sub-agent activity published by this session yet. Older Graff binaries do not publish this feed.</p> : null}
-    {selected ? <select aria-label="Select sub-agent" className="w-full min-w-0 rounded-lg bg-hover p-2 text-xs text-ink" value={selected} onChange={e => setSelected(e.target.value)}>{!children.some(child => child.id === selected) && <option value={selected}>Selected sub-agent</option>}{children.map(child => <option key={child.id} value={child.id}>{child.label || 'Sub-agent'} · {child.status}</option>)}</select>
-    : <div className="max-h-48 space-y-1 overflow-y-auto">{children.map(child => <button key={child.id} data-child-agent={child.id} onClick={() => setSelected(child.id)} className="w-full rounded-lg p-2 text-left text-xs hover:bg-hover">
+    {selected ? <select aria-label="Select sub-agent" className="w-full min-w-0 rounded-lg bg-hover p-2 text-xs text-ink" value={selected} onChange={e => setSelected(e.target.value)}>{!visibleChildren.some(child => child.id === selected) && <option value={selected}>{children.find(child => child.id === selected)?.label || 'Selected sub-agent'}</option>}{visibleChildren.map(child => <option key={child.id} value={child.id}>{child.label || 'Sub-agent'} · {child.status}</option>)}</select>
+    : <div className="max-h-48 space-y-1 overflow-y-auto">{visibleChildren.map(child => <button key={child.id} data-child-agent={child.id} onClick={() => setSelected(child.id)} className="w-full rounded-lg p-2 text-left text-xs hover:bg-hover">
       <span className="flex items-center gap-2"><span className="min-w-0 flex-1 truncate font-medium">{child.label || 'Sub-agent'}</span><span className="text-ink-3">{child.status === 'working' ? 'Working' : child.status === 'completed' ? 'Completed' : 'Failed'}</span></span>
       <span className="mt-1 block truncate text-ink-3" title={child.task}>{child.task}</span>
     </button>)}</div>}

--- a/apps/native/electron/agents-visual.cjs
+++ b/apps/native/electron/agents-visual.cjs
@@ -17,11 +17,23 @@ async function runAgentVisuals({ win, origin, output }) {
     assert.ok(bounds.right <= bounds.width && bounds.bottom < bounds.height, JSON.stringify(bounds));
     fs.writeFileSync(path.join(output, `agents-${theme}.png`), (await win.webContents.capturePage()).toPNG());
   }
+  await js(`document.querySelector('[data-agent-case="idle"]').click()`);
+  await wait(`document.body.textContent.includes('No active Graffs')`);
+  assert.equal(await js(`document.querySelectorAll('li button').length`), 0, 'A peer disappears when it stops working');
+  await js(`document.querySelector('[data-agent-case="connected"]').click()`);
+  await wait(`document.querySelectorAll('li button').length === 1`);
   await js(`document.querySelectorAll('[aria-label="Agent scope"] button')[1].click()`);
-  await wait(`document.body.textContent.includes('Review accessibility')`);
+  await wait(`document.querySelectorAll('li button').length === 1`);
+  assert.equal(await js(`document.querySelector('[aria-label="Message recipient"]').textContent.includes('Review accessibility')`), false, 'Idle peers are excluded from active recipients');
+  assert.equal(await js(`document.querySelector('[aria-label="Peer messages"]').open`), false, 'Old coordination stays collapsed');
+  await js(`Array.from(document.querySelectorAll('label')).find(l => l.textContent.includes('Show idle agents')).querySelector('input').click()`);
+  await wait(`document.querySelectorAll('li button').length === 2`);
   await js(`document.querySelectorAll('li button')[1].click()`);
   await wait(`document.querySelector('[data-child-agent="child-working"]')`);
   assert.notEqual(await js(`document.activeElement.getAttribute('aria-label')`), 'Message to Graff', 'Inspection should not move focus into the send form');
+  assert.equal(await js(`document.querySelector('[data-child-agent="child-completed"]')`), null, 'Completed children are hidden by default');
+  assert.equal(await js(`document.querySelector('[data-child-agent="child-failed"]')`), null, 'Failed children are hidden by default');
+  await js(`Array.from(document.querySelectorAll('label')).find(l => l.textContent.includes('Show finished sub-agents')).querySelector('input').click()`);
   await selectChild('child-working');
   await wait(`document.querySelector('[aria-label="Sub-agent activity"]')?.textContent.includes('Live')`);
   assert.equal(await js(`document.querySelector('[data-tool-summary]')?.getAttribute('aria-expanded')`), 'false');

--- a/docs/adr/0076-local-agent-panel.md
+++ b/docs/adr/0076-local-agent-panel.md
@@ -8,7 +8,10 @@ The GUI defaults to peers in the current worktree, with an explicit device-wide
 view. The `graff/agents` ACP extension exposes verified live peers, bounded recent
 room history, and explicit addressed human messages. Discovery compares process
 start identities, not PID alone. Old peers without a verifiable identity are
-excluded. Legacy activity is shown as connected, never inferred from CPU usage.
+excluded. The panel defaults to currently working peers; “Show idle agents”
+reveals other verified connected sessions, including waiting and legacy peers.
+The count and recipient picker follow this filter as presence refreshes.
+Coordination history is collapsed by default. Legacy activity is shown as connected, never inferred from CPU usage.
 
 A lightweight observer entry point bypasses provider, MCP and session startup.
 It serves the same extension independently of a busy model turn. It creates no

--- a/docs/adr/0082-subagent-activity-through-acp.md
+++ b/docs/adr/0082-subagent-activity-through-acp.md
@@ -26,7 +26,9 @@ child identifier. Inspection neither consumes inboxes nor sends instructions.
 The GUI opens a focused child selector after selecting a parent Graff. It reuses
 the existing transcript and collapsed tool disclosures. Late responses from a
 previous selection are discarded. Polling pauses when the window is hidden and
-stops for completed children. Messaging remains an explicit separate action.
+stops for completed children. The list defaults to working children, with an
+explicit “Show finished sub-agents” option for completed and failed results.
+An already-open activity remains readable when that child finishes. Messaging remains an explicit separate action.
 
 ## Consequences
 

--- a/docs/releases/v0.0.293.md
+++ b/docs/releases/v0.0.293.md
@@ -1,0 +1,1 @@
+The Agents panel now shows working agents by default. Idle sessions and finished sub-agents remain available through explicit toggles, and coordination history starts collapsed.

--- a/scripts/eval/tier1-manifest.json
+++ b/scripts/eval/tier1-manifest.json
@@ -15,7 +15,7 @@
     "src/repl.zig",
     "TUI/root.zig"
   ],
-  "test_count_baseline": 2063,
+  "test_count_baseline": 2072,
   "test_count_slack": 25,
   "required_invariants": [
     {


### PR DESCRIPTION
The Agents panel now shows working agents by default. Idle sessions and finished sub-agents remain available through explicit toggles, and coordination history starts collapsed.
