### PR TITLE
fix: reflow submitted line REPL prompts

### DIFF
--- a/scripts/eval-tier1.sh
+++ b/scripts/eval-tier1.sh
@@ -241,8 +241,8 @@ if wanted tuiguard; then
   if ((!build_ok)); then
     skip_dependent tuiguard
   else
-    announce tuiguard "18 PTY probes in a 4–8 process pool (#641 / #704 / #537)"
-    # Original 17 plus #537's provider-free ESC-split regression.
+    announce tuiguard "19 PTY probes in a 4–8 process pool (#641 / #704 / #537)"
+    # Original 17 plus the ESC-split and line-REPL prompt-reflow regressions.
     # Each owns its pty/tmp/mock; the pool is the wall-time win. Deadlines
     # (#704) are checked first so a wedged probe cannot hang pre-push.
     if python3 scripts/eval/test_tier1_tuiguard.py && python3 scripts/eval/tier1_tuiguard.py zig-out/bin/graff; then :; else

--- a/scripts/eval/tier1_tuiguard.py
+++ b/scripts/eval/tier1_tuiguard.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the 18 tuiguard PTY probes as a process pool (#641 / #704 / #537).
+"""Run the 19 tuiguard PTY probes as a process pool (#641 / #704 / #537).
 
 Each probe owns its own pty/tmp/mock and is independent of the others. The
 serial loop in eval-tier1.sh was the dominant post-src wall (2–4 min). A 4–8
@@ -32,6 +32,7 @@ SCRIPTS = ROOT / "scripts"
 
 PROBES = (
     "tui-pty-guard.py",
+    "test-repl-prompt-reflow.py",
     "test-tui-escape-split.py",
     "test-tui-selection.py",
     "test-tui-typed-events.py",

--- a/scripts/test-repl-prompt-reflow.py
+++ b/scripts/test-repl-prompt-reflow.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Real-PTY guard for reflowable submitted prompts in the line REPL.
+
+The editor may use CRLF while positioning a live multi-row draft, but Enter
+must erase that block and emit the logical prompt contiguously. A terminal can
+then treat width-only wraps as soft rows and reflow them after a resize.
+"""
+
+import fcntl
+import os
+import struct
+import sys
+import tempfile
+import termios
+
+from pty_harness import PtySession
+
+
+_arg = sys.argv[1] if len(sys.argv) > 1 else "graff"
+GRAFF = os.path.abspath(_arg) if os.sep in _arg else _arg
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="graff-repl-reflow-") as tmp:
+        harness = os.path.join(tmp, ".harness")
+        os.makedirs(harness)
+        with open(os.path.join(harness, "settings.json"), "w", encoding="utf-8") as fh:
+            fh.write('{"ai_title":false,"skills":{"codedbpro":false}}')
+        empty_mcp = os.path.join(tmp, "empty-mcp.json")
+        with open(empty_mcp, "w", encoding="utf-8") as fh:
+            fh.write('{"mcpServers":{}}')
+        env = {
+            "HOME": tmp,
+            "CODEGRAFF_API_KEY": "local-pty-test",
+            "GRAFF_FLEET": "off",
+            "GRAFF_LEARN_AUTO": "off",
+            "GRAFF_MCP_CONFIG": empty_mcp,
+            "GRAFF_NO_TELEMETRY": "1",
+        }
+        with PtySession(
+            GRAFF,
+            ["--model", "deepseek-v4-pro", "--no-telemetry"],
+            cwd=tmp,
+            env=env,
+            unset_env=("CODEX_HOME", "NO_COLOR"),
+            color=True,
+            timeout=15.0,
+            rows=30,
+            cols=100,
+        ) as session:
+            session.wait_for_prompt()
+            fcntl.ioctl(
+                session.fd,
+                termios.TIOCSWINSZ,
+                struct.pack("HHHH", 30, 28, 0, 0),
+            )
+            line = (
+                "/goal submitted prompts use terminal autowrap so completed "
+                "text can reflow when the pane becomes wider"
+            )
+            cursor = len(session.raw)
+            session.send_line(line)
+            end = session.wait_for_literal("Goal set:", start=cursor)
+            window = bytes(session.raw[cursor:end])
+            if line.encode() not in window:
+                raise AssertionError(
+                    "submitted prompt was never emitted as one logical line; "
+                    "editor-width CRLF boundaries would remain hard scrollback"
+                )
+
+            fcntl.ioctl(
+                session.fd,
+                termios.TIOCSWINSZ,
+                struct.pack("HHHH", 30, 100, 0, 0),
+            )
+            session.wait_for_prompt(start=end)
+            session.send_key("ctrl-d")
+            result = session.read_until_exit(5.0)
+            if result.timed_out or result.exit_code != 0:
+                raise SystemExit(
+                    f"REPL did not exit cleanly: exit={result.exit_code} "
+                    f"timed_out={result.timed_out}"
+                )
+    print("ok    line-REPL submitted prompts keep soft wraps reflowable")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/additional_tests.zig
+++ b/src/additional_tests.zig
@@ -1,3 +1,7 @@
+const std = @import("std");
+const Io = std.Io;
+const readline_commit = @import("readline_commit.zig");
+
 test {
     _ = @import("readline_history.zig");
     _ = @import("codedbpro_paths.zig");
@@ -8,4 +12,46 @@ test {
 
 test "oneshot -p still uses the live stall-watched transport" {
     try @import("agent_tests.zig").oneshotUsesLiveTransport(@import("agent.zig").Agent);
+}
+
+test "submitted prompt uses autowrap instead of editor-width CRLF" {
+    var output: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer output.deinit();
+    const text = "a logical prompt long enough to have occupied several narrow editor rows";
+    readline_commit.commit(&output.writer, text, &.{}, null, 4, 2, 3, false);
+    const bytes = output.writer.buffered();
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, bytes, "\r\n"));
+    try std.testing.expect(std.mem.endsWith(u8, bytes, text ++ "\r\n\r\n"));
+}
+
+test "submitted prompt preserves authored newline kinds as hard breaks" {
+    var output: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer output.deinit();
+    readline_commit.commit(&output.writer, "alpha\nbeta\r\ngamma\rdelta", &.{}, null, 3, 2, 1, false);
+    try std.testing.expect(std.mem.endsWith(
+        u8,
+        output.writer.buffered(),
+        "alpha\r\nbeta\r\ngamma\r\ndelta\r\n\r\n",
+    ));
+}
+
+test "submitted prompt keeps key material masked" {
+    var output: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer output.deinit();
+    readline_commit.commit(&output.writer, "/key openai secret-value", &.{}, null, 2, 1, 3, false);
+    const bytes = output.writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, bytes, "secret-value") == null);
+    try std.testing.expect(std.mem.endsWith(u8, bytes, "/key openai ************\r\n\r\n"));
+}
+
+test "submitted prompt retains attachment chip styling" {
+    var output: Io.Writer.Allocating = .init(std.testing.allocator);
+    defer output.deinit();
+    const mark = "[Image #1]";
+    readline_commit.commit(&output.writer, mark ++ " caption", &.{mark}, null, 2, 1, 3, true);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        output.writer.buffered(),
+        "\x1b[7;38;2;5;150;105m[Image #1]\x1b[0m caption",
+    ) != null);
 }

--- a/src/readline.zig
+++ b/src/readline.zig
@@ -41,6 +41,7 @@ const isImagePath = input_util.isImagePath;
 const redraw = input_util.redraw;
 const editByte = input_util.editByte; // #396: job-control-aware continuation reads
 const addMark = input_util.addMark;
+const readline_commit = @import("readline_commit.zig");
 const rl_image = @import("readline_image.zig");
 const util = @import("util.zig");
 
@@ -218,14 +219,10 @@ pub fn readLine(
                 redraw(out, buf.items, cur, marks.items, &pastes, &rstate, prompt_col);
             },
             '\r', '\n' => {
-                // The cursor may be mid-block; step past the last input row so
-                // the submitted line and whatever prints next start cleanly.
-                // The second newline leaves a blank-line gutter between the
-                // submitted prompt and the model output, so it is easy to see
-                // where the response starts.
-                if (rstate.rows - 1 > rstate.crow) out.print("\x1b[{d}B", .{rstate.rows - 1 - rstate.crow}) catch {};
-                out.writeAll("\r\n\r\n") catch {};
-                out.flush() catch {};
+                // Replace the manually wrapped editor block with one logical
+                // terminal line. Soft wraps can then reflow after a resize;
+                // authored newlines remain hard and the blank gutter remains.
+                readline_commit.commit(out, buf.items, marks.items, &pastes, rstate.rows, rstate.crow, prompt_col, main_mod.use_color);
                 // Expand live semantic paste spans; typed lookalikes stay text.
                 try pastes.expand(gpa, buf);
                 break;

--- a/src/readline_commit.zig
+++ b/src/readline_commit.zig
@@ -1,0 +1,64 @@
+//! Submission boundary for the raw line editor.
+//!
+//! Editing uses explicit CRLF moves so cursor placement is deterministic. On
+//! Enter those visual wraps must be erased and the logical input written again
+//! with terminal autowrap, or the editor's old width becomes hard scrollback.
+
+const std = @import("std");
+const Io = std.Io;
+const PasteStore = @import("readline_paste.zig").Store;
+const util = @import("util.zig");
+
+pub fn commit(out: *Io.Writer, items: []const u8, marks: []const []const u8, pastes: ?*const PasteStore, rows: usize, cursor_row: usize, prompt_col: usize, use_color: bool) void {
+    const prompt_len = if (prompt_col > 0) prompt_col - 1 else 0;
+    const bottom = if (rows > 0) rows - 1 else 0;
+
+    // Remove every manually wrapped editor row, preserving the prompt prefix
+    // on row zero. Relative moves remain correct if drawing previously scrolled.
+    out.writeAll("\x1b[0m") catch {};
+    if (bottom > cursor_row) out.print("\x1b[{d}B", .{bottom - cursor_row}) catch {};
+    var row = bottom;
+    while (row > 0) : (row -= 1) out.writeAll("\r\x1b[K\x1b[A") catch {};
+    out.writeAll("\r") catch {};
+    if (prompt_len > 0) out.print("\x1b[{d}C", .{prompt_len}) catch {};
+    out.writeAll("\x1b[K") catch {};
+
+    // Do not insert breaks for visual wrapping: the terminal's autowrap flag
+    // records those rows as soft and can reflow them after a resize. Authored
+    // newlines remain explicit hard breaks, and credentials stay masked.
+    const secret_start = util.sensitiveInputStart(items);
+    var mark_end: usize = 0;
+    var mark_open = false;
+    var i: usize = 0;
+    while (i < items.len) : (i += 1) {
+        const masked = if (secret_start) |start| i >= start else false;
+        if (!mark_open) {
+            var best_end = i;
+            for (marks) |mark| {
+                if (mark.len == 0 or i + mark.len > items.len) continue;
+                if (std.mem.eql(u8, items[i .. i + mark.len], mark)) best_end = @max(best_end, i + mark.len);
+            }
+            if (pastes) |store| {
+                if (store.highlightEndAt(items, i)) |end| best_end = @max(best_end, end);
+            }
+            if (best_end > i) {
+                out.writeAll(if (use_color) "\x1b[7;38;2;5;150;105m" else "\x1b[7m") catch {};
+                mark_end = best_end;
+                mark_open = true;
+            }
+        }
+        if (items[i] == '\r' or items[i] == '\n') {
+            if (items[i] == '\r' and i + 1 < items.len and items[i + 1] == '\n') i += 1;
+            out.writeAll("\r\n") catch {};
+        } else {
+            out.writeByte(if (masked) '*' else items[i]) catch {};
+        }
+        if (mark_open and i + 1 == mark_end) {
+            out.writeAll("\x1b[0m") catch {};
+            mark_open = false;
+        }
+    }
+    if (mark_open) out.writeAll("\x1b[0m") catch {};
+    out.writeAll("\r\n\r\n") catch {};
+    out.flush() catch {};
+}


### PR DESCRIPTION
## What changed

- On line REPL submission, erase the manually wrapped editor block and re-emit the logical prompt through terminal autowrap.
- Preserve authored CR/LF breaks, `/key` masking, attachment/paste chip styling, and the existing blank gutter before output.
- Add unit coverage plus a real-PTY narrow-to-wide regression and register it in tier 1.

## Why

The line REPL uses explicit CRLF sequences while editing so cursor movement across live wrapped rows is deterministic. Enter previously committed those painted rows directly, turning width-only wraps into hard terminal scrollback boundaries. A later pane resize could reflow streamed response text, but the completed prompt remained wrapped at its old width.

Repainting only at the submission boundary fixes the presentation artifact without changing the logical prompt stored in history or transcripts. Explicitly authored newlines remain hard breaks.

The fullscreen TUI and persistence paths were not changed: the stored prompt already contains no synthetic newlines, and the reported failure occurred in the line REPL. Changing stored text or the fullscreen renderer would address the wrong layer.

Closes #797
