### PR TITLE
fix(tui): expand tabs before painting prompt rows

### DIFF
--- a/TUI/issue_798_tests.zig
+++ b/TUI/issue_798_tests.zig
@@ -1,0 +1,54 @@
+//! #798: prompt history must clear the rendered composer after Down.
+const std = @import("std");
+const sim = @import("sim.zig");
+
+fn composerContains(vis: []const u8, first_row: usize, needle: []const u8) bool {
+    var row: usize = 0;
+    var lines = std.mem.splitScalar(u8, vis, '\n');
+    while (lines.next()) |line| : (row += 1) {
+        if (row >= first_row and std.mem.indexOf(u8, line, needle) != null) return true;
+    }
+    return false;
+}
+
+test "#798: Down from a wrapped prompt leaves only the fresh composer draft" {
+    const a = std.testing.allocator;
+    var term: sim.Term = undefined;
+    term.init(a, 80, 24);
+    defer term.deinit();
+
+    var prompt: std.ArrayList(u8) = .empty;
+    defer prompt.deinit(a);
+    try prompt.appendSlice(a, "issue-798-recalled-head ");
+    for (0..32) |_| try prompt.appendSlice(a, "a wrapped submitted segment ");
+    try prompt.appendSlice(a, "issue-798-recalled-tail");
+
+    // Submit through the same sim feed path as the fullscreen loop.
+    _ = term.typeText(prompt.items);
+    _ = term.enter();
+    try std.testing.expectEqualStrings("", term.model.input.getValue());
+    try std.testing.expectEqual(@as(usize, 1), term.model.prompt_hist.items.len);
+
+    // The live history cursor sits just past the newest item before Up. Keep
+    // this seam explicit: the regression starts after Up has recalled the row.
+    term.model.hist_idx = term.model.prompt_hist.items.len;
+    _ = term.feed("\x1b[A");
+    try std.testing.expectEqualStrings(prompt.items, term.model.input.getValue());
+    const recalled = try term.screen();
+    defer a.free(recalled);
+    try std.testing.expect(composerContains(recalled, term.model.prompt_origin, "issue-798-recalled-tail"));
+
+    _ = term.feed("\x1b[B");
+    try std.testing.expectEqualStrings("", term.model.input.getValue());
+    try std.testing.expectEqual(@as(?usize, null), term.model.hist_idx);
+    const fresh = try term.screen();
+    defer a.free(fresh);
+    try std.testing.expect(!composerContains(fresh, term.model.prompt_origin, "issue-798-recalled-tail"));
+
+    _ = term.typeText("ONLY-FRESH-TYPED");
+    try std.testing.expectEqualStrings("ONLY-FRESH-TYPED", term.model.input.getValue());
+    const typed = try term.screen();
+    defer a.free(typed);
+    try std.testing.expect(composerContains(typed, term.model.prompt_origin, "ONLY-FRESH-TYPED"));
+    try std.testing.expect(!composerContains(typed, term.model.prompt_origin, "issue-798-recalled-tail"));
+}

--- a/TUI/paint.zig
+++ b/TUI/paint.zig
@@ -98,9 +98,10 @@ pub fn paintRow(w: *Io.Writer, ln: []const u8, cols: usize, bg: []const u8) !voi
     try w.writeAll(bg);
     // Measure and write the same cells: a smuggled CR/BEL/BS is not a column
     // and must not reach the terminal (CR rewinds the row, BEL rings, BS
-    // walks the cursor back). Tab stays — it is legal prose. ESC stays —
-    // that is SGR. The frame builders already strip this; this is the last
-    // door so a leak cannot desync the row↔line map.
+    // walks the cursor back). Tab expands to the next stop of 8 — counting
+    // it as one cell leaves pad() short and can preserve the previous frame.
+    // ESC stays — that is SGR. The frame builders already strip this; this is
+    // the last door so a leak cannot desync the row↔line map.
     const vis = cellLen(ln);
     if (vis < cols) {
         try writeCells(w, ln);
@@ -128,10 +129,15 @@ fn pad(w: *Io.Writer, cells: usize) !void {
     while (n > 0) : (n -= 1) try w.writeByte(' ');
 }
 
-/// C0/DEL that must never be a cell. Tab is kept (legal prose); ESC is kept
-/// (SGR) and handled by the callers before they reach this.
+/// C0/DEL that must never be a cell. Tab is expanded to spaces by the callers;
+/// ESC is kept (SGR) and handled before it reaches this predicate.
 fn isRowControl(b: u8) bool {
     return (b < 0x20 and b != '\t') or b == 0x7f;
+}
+
+/// Columns a tab occupies at `col`, matching terminal stops of 8.
+fn tabPad(col: usize) usize {
+    return 8 - (col % 8);
 }
 
 fn cellLen(ln: []const u8) usize {
@@ -140,6 +146,11 @@ fn cellLen(ln: []const u8) usize {
     while (i < ln.len) {
         if (ln[i] == 0x1b) {
             i = theme_mod.skipEsc(ln, i);
+            continue;
+        }
+        if (ln[i] == '\t') {
+            n += tabPad(n);
+            i += 1;
             continue;
         }
         if (isRowControl(ln[i])) {
@@ -161,6 +172,13 @@ fn takeCells(ln: []const u8, max: usize) []const u8 {
             i = theme_mod.skipEsc(ln, i);
             continue;
         }
+        if (ln[i] == '\t') {
+            const width = tabPad(n);
+            if (n + width > max) break;
+            n += width;
+            i += 1;
+            continue;
+        }
         if (isRowControl(ln[i])) {
             i += 1;
             continue;
@@ -175,11 +193,19 @@ fn takeCells(ln: []const u8, max: usize) []const u8 {
 
 fn writeCells(w: *Io.Writer, ln: []const u8) !void {
     var i: usize = 0;
+    var col: usize = 0;
     while (i < ln.len) {
         if (ln[i] == 0x1b) {
             const e = theme_mod.skipEsc(ln, i);
             try w.writeAll(ln[i..e]);
             i = e;
+            continue;
+        }
+        if (ln[i] == '\t') {
+            const width = tabPad(col);
+            try pad(w, width);
+            col += width;
+            i += 1;
             continue;
         }
         if (isRowControl(ln[i])) {
@@ -188,8 +214,9 @@ fn writeCells(w: *Io.Writer, ln: []const u8) !void {
         }
         const start = i;
         i += 1;
-        while (i < ln.len and ln[i] != 0x1b and !isRowControl(ln[i])) : (i += 1) {}
+        while (i < ln.len and ln[i] != 0x1b and ln[i] != '\t' and !isRowControl(ln[i])) : (i += 1) {}
         try w.writeAll(ln[start..i]);
+        col += theme_mod.visibleLen(ln[start..i]);
     }
 }
 

--- a/TUI/paint_tests.zig
+++ b/TUI/paint_tests.zig
@@ -363,6 +363,42 @@ test "rows past the end of the frame are blanked, not left stale" {
     try screen.expectMatches(&want);
 }
 
+test "composer shrink clears rows exposed by a taller transcript band" {
+    const app_mod = @import("app.zig");
+    const render_mod = @import("render.zig");
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var m: app_mod.Model = undefined;
+    m.setup(a);
+    defer m.deinit();
+    for (0..80) |i| try m.pushFmt(.assistant, "transcript line {d} with enough words to wrap", .{i});
+
+    try m.input.setValue("old composer text with enough words to occupy many wrapped rows " ++
+        "before the draft gets shorter and exposes transcript cells");
+    const before = try render_mod.render(&m, a, 40, 24, 0);
+    const before_band = m.band;
+    const before_prompt = m.prompt_origin;
+
+    try m.input.setValue("new draft");
+    const after = try render_mod.render(&m, a, 40, 24, 0);
+    const after_band = m.band;
+
+    // The composer lost several wrapped rows, so the transcript both grew and
+    // moved its viewport. That geometry change must refuse scrollpaint and use
+    // the row diff, including rows that used to contain the old composer.
+    try std.testing.expect(m.prompt_origin >= before_prompt + 2);
+    try std.testing.expect(after_band.len >= before_band.len + 2);
+    try std.testing.expect(after_band.off != before_band.off);
+    try std.testing.expect(m.paint_hint == null);
+
+    var screen = try Screen.init(a, 24, 40);
+    screen.feed(try paintToBuf(a, before, 24, 40, ""));
+    screen.feed(try paintToBuf(a, after, 24, 40, before));
+    var want = try Screen.expect(a, after, 24, 40, true);
+    try screen.expectMatches(&want);
+}
+
 test "the real band's rows are exactly the rows the painter rewrites (#529)" {
     // The band is a post-pass over the composed frame, so when it CLEARS the
     // only thing that puts those rows back is the byte comparison in

--- a/TUI/paint_tests.zig
+++ b/TUI/paint_tests.zig
@@ -480,13 +480,29 @@ test "a smuggled CR or BEL in a frame row never reaches the terminal" {
     try screen.expectMatches(&want);
 }
 
-test "SGR and tab survive the cell filter; only C0 is dropped" {
+test "SGR survives the cell filter and tabs expand to terminal stops" {
     const a = std.testing.allocator;
+    // "red" is 3 cells; tab -> 5 spaces (stop 8); "a" then tab -> 7 spaces.
     const frame = "\x1b[31mred\x1b[0m\ta\tb";
     const out = try paintToBuf(a, frame, 1, 20, "");
     defer a.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b[31mred\x1b[0m") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "\ta\tb") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b[31mred\x1b[0m     a       b") != null);
+    try std.testing.expect(std.mem.indexOfScalar(u8, out, '\t') == null);
+}
+
+test "a tabbed code row shrinks without leaving the previous prompt behind (#798)" {
+    const a = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const ar = arena.allocator();
+    const cols: usize = 20;
+    const recalled = "XXXXXXXXXXXXXXXXXXXX";
+    const fresh = "ab\tcd";
+    var screen = try Screen.init(ar, 1, cols);
+    screen.feed(try paintToBuf(ar, recalled, 1, cols, ""));
+    screen.feed(try paintToBuf(ar, fresh, 1, cols, recalled));
+    var want = try Screen.expect(ar, "ab      cd", 1, cols, true);
+    try screen.expectMatches(&want);
 }
 
 test "history C0 never reaches the composed frame or the paint stream" {

--- a/TUI/root.zig
+++ b/TUI/root.zig
@@ -87,6 +87,7 @@ test {
     _ = @import("issue_537_reviewer_tests.zig");
     _ = @import("issue_524_tests.zig");
     _ = @import("issue_737_tests.zig");
+    _ = @import("issue_798_tests.zig");
     _ = @import("input.zig");
     _ = @import("keys.zig");
     _ = @import("nav.zig");


### PR DESCRIPTION
## What changed

- Expand tabs to spaces at eight-column terminal stops in the fullscreen TUI painter, using the same column accounting for measurement, clipping, and output.
- Add an end-to-end TUI simulator regression for recalling a long wrapped prompt and returning to the fresh empty draft.
- Add terminal-grid edge coverage for a shrinking composer, transcript-band geometry changes, and tabbed rows replacing older prompt content.

## Why

### Problem / failure mode

Prompt history can recall code containing tabs. The painter counted a raw tab as one cell while the terminal advances it to the next tab stop. That made the painter's padding and clipping disagree with the cells actually written, allowing content from the previously displayed prompt to remain visible even though it was no longer in the input buffer or submitted payload.

### Reason for this approach

The painter is the final boundary responsible for making the terminal grid match the composed frame. Measuring tabs from the current column and emitting equivalent spaces keeps cursor movement, row width, clipping, and cleanup consistent without changing the prompt stored in history or sent to the model.

### Constraints and trade-offs

Displayed tabs use conventional eight-column terminal stops. Prompt bytes remain unchanged. The regression tests also verify that ordinary multi-row composer shrink already clears correctly and disables the scroll fast path when geometry changes.

### Rejected alternatives

- Forcing a full-screen repaint whenever the composer shrinks would add unnecessary work and mask the width-accounting defect; the terminal-grid regression proves the normal diff path is correct once emitted cell widths agree.
- Changing prompt-history state was rejected because Down already restores the empty draft correctly.

## Verification

- `zig build`
- `zig build tui-test` — 557/557 passed
- Focused `#798`, tab-expansion, and composer-shrink tests passed
- Full generated unit-test binary — 2,071 passed, 1 skipped, 0 failed
- Tier 1: formatting, line ceiling, spec, reachability, build, TUI, all TUI guard probes, invariants, and SDK checks passed
- The remaining tier-1 test-count failure reproduces unchanged on clean `origin/main`: one workspace-switch test is skipped, so 2,071 tests run against the existing 2,072 baseline

Closes #798
