### PR TITLE
Count skipped Zig tests in the tier-1 suite ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ current is part of cutting a release.
 
 ## Unreleased
 
+- `#794`: the tier-1 suite ratchet counts skipped Zig tests with passed
+  ones. `2079 passed; 1 skipped` is a 2080-test suite, not a shrink
+  against a 2080 baseline.
 - `#768`: the Computer Use `node_repl` bridge no longer dies on
   `createElicitation is unavailable` during a read-only
   `sky.get_app_state({ disableDiff: true })`. Graff advertises MCP form

--- a/scripts/eval-tier1.sh
+++ b/scripts/eval-tier1.sh
@@ -171,11 +171,13 @@ skip_dependent() {
 
 # --- tests -------------------------------------------------------------
 suite_count() {
-  # `--summary all` prints "N/N tests passed" only when the run step actually
-  # ran. A fully cached `zig build test` on zig 0.17 prints "Build Summary: 4/4
-  # steps succeeded" and nothing else, so this comes back empty and the caller
-  # falls back to artifact_count - it does NOT mean the build is red (#439).
-  sed -n 's/.*Build Summary:.*; \([0-9][0-9]*\)\/[0-9][0-9]* tests passed.*/\1/p' <<<"$1" | tail -1
+  # `--summary all` prints "P/T tests passed (S skipped)" when the run step
+  # actually ran. T (passed + skipped) is the suite size — using P alone
+  # falsely reports a shrink whenever anything is skipped (#794). A fully
+  # cached `zig build test` on zig 0.17 prints only "Build Summary: 4/4
+  # steps succeeded", so this comes back empty and the caller falls back
+  # to a scan of the artifact (#439).
+  printf '%s\n' "$1" | python3 scripts/eval/tier1_test_binary.py summary
 }
 
 # The count off the compiled artifact instead of off the build summary: a test
@@ -192,6 +194,10 @@ if wanted tests; then
     skip_dependent tests
   else
     announce tests "zig build test, and the suite count never shrinks"
+    if ! python3 scripts/eval/test_tier1_count.py; then
+      printf '    fix: skipped tests must count toward the suite ratchet (#794)\n'
+      record_fail tests
+    else
     out=$(zig build test --summary all 2>&1)
     status=$?
     printf '%s\n' "$out" | tail -4
@@ -216,6 +222,7 @@ if wanted tests; then
           *) record_fail tests ;;
         esac
       fi
+    fi
     fi
   fi
 fi

--- a/scripts/eval/test_tier1_count.py
+++ b/scripts/eval/test_tier1_count.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""#794: the suite ratchet counts skipped Zig tests with passed ones."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+MODULE = Path(__file__).with_name("tier1_test_binary.py")
+SPEC = importlib.util.spec_from_file_location("tier1_test_binary", MODULE)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot import {MODULE}")
+binary = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(binary)
+
+
+class SuiteCountTests(unittest.TestCase):
+    def test_skipped_tests_are_in_the_suite(self) -> None:
+        text = (
+            "Build Summary: 6/6 steps succeeded; 2079/2080 tests passed (1 skipped)\n"
+            "+- run test 2079 pass, 1 skip (2080 total)\n"
+        )
+        self.assertEqual(2080, binary.suite_count_from_summary(text))
+
+    def test_passed_only_summary_uses_the_total(self) -> None:
+        text = "Build Summary: 6/6 steps succeeded; 2072/2072 tests passed\n"
+        self.assertEqual(2072, binary.suite_count_from_summary(text))
+
+    def test_artifact_mixed_line_adds_skips(self) -> None:
+        self.assertEqual(2080, binary.suite_count_from_summary("2079 passed; 1 skipped; 0 failed.\n"))
+        self.assertEqual(2072, binary.suite_count_from_summary("All 2072 tests passed.\n"))
+
+    def test_cached_steps_only_summary_is_empty(self) -> None:
+        text = "Build Summary: 4/4 steps succeeded\n"
+        self.assertIsNone(binary.suite_count_from_summary(text))
+
+    def test_passed_count_alone_is_not_the_suite(self) -> None:
+        # The old sed took 2079 from 2079/2080. That is the bug.
+        text = "Build Summary: 6/6 steps succeeded; 2079/2080 tests passed (1 skipped)\n"
+        self.assertNotEqual(2079, binary.suite_count_from_summary(text))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/eval/tier1_test_binary.py
+++ b/scripts/eval/tier1_test_binary.py
@@ -27,6 +27,8 @@ means none of them. mtime only breaks ties.
   count   [--filter TEXT]...  run that artifact and print how many tests it holds
   scan                        count named + anonymous tests from the unfiltered
                               artifact without executing it (#641)
+  summary                     read `zig build test --summary all` on stdin and
+                              print the suite size (passed + skipped, #794)
 
 Both exit non-zero with a reason on stderr rather than guess. Neither builds:
 the caller runs `zig build test` (with the same filters) first, so a compile
@@ -49,6 +51,10 @@ TEST_NAME = re.compile(r'^test "((?:[^"\\]|\\.)*)"', re.M)
 ANON_TEST = re.compile(r"(?m)^test \{")
 ALL_PASSED = re.compile(r"^All (\d+) tests passed\.$", re.M)
 MIXED = re.compile(r"^(\d+) passed; (\d+) skipped; (\d+) failed\.$", re.M)
+# zig 0.17 `--summary all`: "2079/2080 tests passed (1 skipped)". The first
+# number is passed-only; the denominator is the suite (passed + skipped).
+BUILD_SUMMARY_TOTAL = re.compile(r"Build Summary:.*; \d+/(\d+) tests passed")
+RUN_STEP_TOTAL = re.compile(r"\d+ pass(?:, \d+ skip)? \((\d+) total\)")
 
 
 class ArtifactError(Exception):
@@ -258,6 +264,31 @@ def scan_count(filters: list[str] | None = None) -> int:
     return named + anonymous_tests()
 
 
+def suite_count_from_summary(text: str) -> int | None:
+    """Suite size from `zig build test --summary all` output.
+
+    A skipped test is still in the suite. Using the passed count alone makes
+    the ratchet report a shrink whenever anything is skipped (#794). Cached
+    builds that print only `Build Summary: N/N steps succeeded` return None
+    so the caller can fall back to a scan of the artifact (#439).
+    """
+    matches = BUILD_SUMMARY_TOTAL.findall(text)
+    if matches:
+        return int(matches[-1])
+    matches = RUN_STEP_TOTAL.findall(text)
+    if matches:
+        return int(matches[-1])
+    mixed = MIXED.search(text)
+    if mixed:
+        ok, skipped, failed = (int(g) for g in mixed.groups())
+        if failed == 0:
+            return ok + skipped
+    passed = ALL_PASSED.search(text)
+    if passed:
+        return int(passed.group(1))
+    return None
+
+
 def artifact_count(path: pathlib.Path) -> tuple[int, str]:
     """Run the artifact and read its own tally. Raises if it does not pass."""
     proc = subprocess.run(
@@ -292,7 +323,15 @@ def main() -> int:
             default=[],
             help="a -Dtest-filter value the build used (repeatable; none = the full build)",
         )
+    sub.add_parser("summary", help="print suite size (passed+skipped) from a build summary on stdin")
     args = parser.parse_args()
+
+    if args.cmd == "summary":
+        n = suite_count_from_summary(sys.stdin.read())
+        if n is None:
+            return 1
+        print(n)
+        return 0
 
     try:
         chosen = select(args.filter)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When `zig build test --summary all` reports `2079/2080 tests passed (1 skipped)`, the ratchet used `2079` and treated a green suite as a shrink against a 2080 baseline. The compiled-artifact counter already used passed + skipped.

`suite_count` now reads the summary total (or `P passed; S skipped`) so skipped tests stay in the suite. Cached builds that print only `steps succeeded` still fall back to the artifact scan.

Closes #794.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

