### PR TITLE
fix(repl): keep image chips atomic and renumbered

### DIFF
--- a/scripts/codex_ws_error_test.py
+++ b/scripts/codex_ws_error_test.py
@@ -188,11 +188,15 @@ def run_chain_reanchor_scenario(
             first.connection_id != rejected.connection_id
             or rejected.connection_id == rebuilt.connection_id
             or rejected.body.get("previous_response_id") != "resp_chain_1"
-            or "previous_response_id" in rebuilt.body
+            # A fresh socket may chain only from its observed prewarm,
+            # never from the rejected inference response or another socket.
+            or not mock.has_fresh_parent(rebuilt)
         ):
             raise AssertionError(
                 "chain-error: rejected delta was not rebuilt as full input on a fresh WS: "
-                f"{requests!r}"
+                f"connections={(first.connection_id, rejected.connection_id, rebuilt.connection_id)!r}, "
+                f"rejected_parent={rejected.body.get('previous_response_id')!r}, "
+                f"rebuilt_parent={rebuilt.body.get('previous_response_id')!r}"
             )
         rebuilt_types = [
             item.get("type")

--- a/scripts/codex_ws_mock.py
+++ b/scripts/codex_ws_mock.py
@@ -227,10 +227,19 @@ class CodexMock:
         default=None, repr=False
     )
     requests: list[RecordedRequest] = field(default_factory=list, repr=False)
+    prewarm_ids: dict[int, str] = field(default_factory=dict, repr=False)
     _sock: socket.socket | None = field(default=None, repr=False)
     _threads: list[threading.Thread] = field(default_factory=list, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
     _stopping: bool = field(default=False, repr=False)
+
+    def has_fresh_parent(self, request: RecordedRequest) -> bool:
+        """Only no parent or this socket's observed prewarm is a fresh anchor."""
+        parent = request.body.get("previous_response_id")
+        if parent is None:
+            return True
+        with self._lock:
+            return request.transport == "ws" and parent == self.prewarm_ids.get(request.connection_id)
 
     def start(self) -> int:
         srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -391,6 +400,8 @@ class CodexMock:
             # (the transport smoke assertions count real model turns).
             if event.get("generate") is False:
                 prewarm_id = f"resp_prewarm_{self.ws_turns + 1}"
+                with self._lock:
+                    self.prewarm_ids[connection_id] = prewarm_id
                 _send_frame(conn, OP_TEXT, json.dumps(
                     {"type": "response.completed",
                      "response": {"id": prewarm_id, "usage": dict(USAGE)}},

--- a/scripts/codex_ws_test.py
+++ b/scripts/codex_ws_test.py
@@ -437,7 +437,7 @@ def assert_midturn_requests(mock: CodexMock) -> None:
     if first.connection_id == final.connection_id:
         raise AssertionError("midturn: final request reused the pre-compaction WS")
     for request in requests:
-        if "previous_response_id" in request.body:
+        if not mock.has_fresh_parent(request):
             raise AssertionError(
                 f"midturn: request {request.ordinal} carried stale previous_response_id: "
                 f"{request.body['previous_response_id']!r}"
@@ -580,7 +580,7 @@ def assert_transactional_requests(mock: CodexMock) -> None:
             "transactional: final request reused the pre-compaction WS"
         )
     for request in requests:
-        if "previous_response_id" in request.body:
+        if not mock.has_fresh_parent(request):
             raise AssertionError(
                 f"transactional: request {request.ordinal} carried stale "
                 f"previous_response_id: {request.body['previous_response_id']!r}"

--- a/sdk/ts/scripts/test-packed-install.mjs
+++ b/sdk/ts/scripts/test-packed-install.mjs
@@ -66,12 +66,14 @@ try {
     await chmod(sourceBinary, 0o755);
   }
 
+  const sdkManifest = JSON.parse(await readFile(join(SDK_ROOT, "package.json"), "utf8"));
   const nativeTarballs = {};
   for (const [target, packageName] of ALL_TARGETS) {
     const output = run(process.execPath, [
       join(HERE, "package-platform.mjs"),
       "--target", target,
       "--binary", sourceBinary,
+      "--version", sdkManifest.optionalDependencies[packageName],
       "--out", packages,
     ], SDK_ROOT);
     const { packageDir } = JSON.parse(output);
@@ -88,7 +90,7 @@ try {
     ),
   };
   await writeFile(join(consumer, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`);
-  npmRun(["install", "--ignore-scripts", "--no-audit", "--no-fund"], consumer);
+  npmRun(["install", "--offline", "--ignore-scripts", "--no-audit", "--no-fund"], consumer);
 
   const smoke = `
 import { Harness } from "@codegraff/sdk";

--- a/src/readline.zig
+++ b/src/readline.zig
@@ -244,7 +244,7 @@ pub fn readLine(
                 redraw(out, buf.items, cur, marks.items, &pastes, &rstate, prompt_col);
             },
             0x17, 0x1f => { // Ctrl-W / Ctrl-_ → delete previous word
-                const s = pastes.prevWord(buf.items, cur);
+                const s = rl_image.prevWord(buf.items, cur, &pastes);
                 if (s < cur) {
                     rl_image.deleteAtom(root, gpa, buf, &cur, &pastes, s, cur);
                     cur = s;
@@ -337,7 +337,7 @@ pub fn readLine(
                 }
                 const b1 = editByte(in) orelse break; // #396: guarded
                 if (b1 == 0x7f or b1 == 0x08) { // Option/Alt+Delete → delete previous word
-                    const s = pastes.prevWord(buf.items, cur);
+                    const s = rl_image.prevWord(buf.items, cur, &pastes);
                     if (s < cur) {
                         rl_image.deleteAtom(root, gpa, buf, &cur, &pastes, s, cur);
                         cur = s;
@@ -346,17 +346,17 @@ pub fn readLine(
                     continue;
                 }
                 if (b1 == 'b') { // Alt-b → word left
-                    cur = pastes.prevWord(buf.items, cur);
+                    cur = rl_image.prevWord(buf.items, cur, &pastes);
                     redraw(out, buf.items, cur, marks.items, &pastes, &rstate, prompt_col);
                     continue;
                 }
                 if (b1 == 'f') { // Alt-f → word right
-                    cur = pastes.nextWord(buf.items, cur);
+                    cur = rl_image.nextWord(buf.items, cur, &pastes);
                     redraw(out, buf.items, cur, marks.items, &pastes, &rstate, prompt_col);
                     continue;
                 }
                 if (b1 == 'd') { // Alt-d → delete next word
-                    const e = pastes.nextWord(buf.items, cur);
+                    const e = rl_image.nextWord(buf.items, cur, &pastes);
                     if (e > cur) {
                         rl_image.deleteAtom(root, gpa, buf, &cur, &pastes, cur, e);
                         redraw(out, buf.items, cur, marks.items, &pastes, &rstate, prompt_col);
@@ -391,11 +391,11 @@ pub fn readLine(
                         redraw(out, buf.items, cur, marks.items, &pastes, &rstate, prompt_col);
                     },
                     'C' => { // right (word-right with a modifier)
-                        cur = if (word_mod) pastes.nextWord(buf.items, cur) else (rl_image.right(buf.items, cur) orelse pastes.right(cur, buf.items.len));
+                        cur = if (word_mod) rl_image.nextWord(buf.items, cur, &pastes) else (rl_image.right(buf.items, cur) orelse pastes.right(cur, buf.items.len));
                         redraw(out, buf.items, cur, marks.items, &pastes, &rstate, prompt_col);
                     },
                     'D' => { // left (word-left with a modifier)
-                        cur = if (word_mod) pastes.prevWord(buf.items, cur) else (rl_image.left(buf.items, cur) orelse pastes.left(cur));
+                        cur = if (word_mod) rl_image.prevWord(buf.items, cur, &pastes) else (rl_image.left(buf.items, cur) orelse pastes.left(cur));
                         redraw(out, buf.items, cur, marks.items, &pastes, &rstate, prompt_col);
                     },
                     'H' => {

--- a/src/readline_image.zig
+++ b/src/readline_image.zig
@@ -60,10 +60,24 @@ pub fn right(text: []const u8, cur: usize) ?usize {
     return null;
 }
 
+/// Word motion/deletion must not enter an image chip. Modified Backspace used
+/// the generic word boundary and turned `[Image #2] ` into literal `[Image`.
+pub fn prevWord(text: []const u8, cur: usize, pastes: *const PasteStore) usize {
+    return left(text, cur) orelse pastes.prevWord(text, cur);
+}
+
+pub fn nextWord(text: []const u8, cur: usize, pastes: *const PasteStore) usize {
+    return right(text, cur) orelse pastes.nextWord(text, cur);
+}
+
 /// Drop composer slots the buffer no longer names and rewrite remaining `#N`s.
 pub fn afterEdit(root: *Agent, gpa: Allocator, buf: *std.ArrayList(u8), cur: *usize) void {
+    var composer_slots: u16 = 0;
+    for (root.pending_images[0..root.pending_image_len], 0..) |img, i| {
+        if (img.from_composer) composer_slots |= @as(u16, 1) << @intCast(i);
+    }
     const remap = vision_queue.retainReferenced(root, buf.items);
-    rewriteChips(gpa, buf, cur, remap);
+    rewriteChips(gpa, buf, cur, remap, composer_slots);
 }
 
 pub fn deleteAtom(root: *Agent, gpa: Allocator, buf: *std.ArrayList(u8), cur: *usize, pastes: *PasteStore, from: usize, to: usize) void {
@@ -80,7 +94,7 @@ pub fn clearLine(root: *Agent, gpa: Allocator, buf: *std.ArrayList(u8), cur: *us
 }
 
 /// Rewrite `[Image #old]` to the compacted chip numbers. Identity is a no-op.
-pub fn rewriteChips(gpa: Allocator, buf: *std.ArrayList(u8), cur: *usize, remap: vision_queue.Remap) void {
+pub fn rewriteChips(gpa: Allocator, buf: *std.ArrayList(u8), cur: *usize, remap: vision_queue.Remap, composer_slots: u16) void {
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(gpa);
     var i: usize = 0;
@@ -89,6 +103,20 @@ pub fn rewriteChips(gpa: Allocator, buf: *std.ArrayList(u8), cur: *usize, remap:
     while (i < buf.items.len) {
         if (imageChipAt(buf.items, i)) |chip| {
             const new_n: u8 = if (chip.n >= 1 and chip.n <= vision_queue.cap) remap[chip.n - 1] else 0;
+            const was_composer = chip.n >= 1 and chip.n <= vision_queue.cap and
+                (composer_slots & (@as(u16, 1) << @intCast(chip.n - 1))) != 0;
+            if (new_n == 0 and was_composer) {
+                changed = true;
+                var end = chip.end;
+                if (end < buf.items.len and buf.items[end] == ' ') end += 1;
+                if (cur.* >= end) {
+                    new_cur -= end - chip.start;
+                } else if (cur.* > chip.start) {
+                    new_cur = out.items.len;
+                }
+                i = end;
+                continue;
+            }
             var tmp: [20]u8 = undefined;
             const repl = if (new_n == 0 or new_n == chip.n)
                 buf.items[chip.start..chip.end]
@@ -147,6 +175,15 @@ test "left/right treat an image chip as one atom (#702)" {
     try std.testing.expect(right(text, 14) == null);
 }
 
+test "word deletion keeps repeated image chips atomic" {
+    const gpa = std.testing.allocator;
+    var pastes: PasteStore = .{};
+    defer pastes.deinit(gpa);
+    const text = "[Image #1] [Image #2] ";
+    try std.testing.expectEqual(@as(usize, 11), prevWord(text, text.len, &pastes));
+    try std.testing.expectEqual(@as(usize, text.len), nextWord(text, 11, &pastes));
+}
+
 test "afterEdit drops an abandoned chip and remaps the rest (#702)" {
     const gpa = std.testing.allocator;
     var root: Agent = .{
@@ -173,6 +210,42 @@ test "afterEdit drops an abandoned chip and remaps the rest (#702)" {
     try std.testing.expectEqual(@as(u8, 2), vision_queue.nextChipNumber(&root));
 }
 
+test "duplicate composer payload drops its stale chip before #2 is reused" {
+    const gpa = std.testing.allocator;
+    var root: Agent = .{
+        .gpa = gpa,
+        .arena = gpa,
+        .io = undefined,
+        .client = undefined,
+        .provider = .{ .id = "xai", .kind = .responses, .auth = .bearer, .url = "", .api_key = "", .model = "grok-4", .context = 100_000 },
+        .messages = undefined,
+        .sub = false,
+        .label = "test",
+        .out = null,
+    };
+    vision_queue.stage(&root, .{ .media_type = "image/png", .b64 = "AAA", .label = "same.png", .from_composer = true });
+    vision_queue.stage(&root, .{ .media_type = "image/png", .b64 = "AAA", .label = "same.png", .from_composer = true });
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(gpa);
+    try buf.appendSlice(gpa, "[Image #1] [Image #2] ");
+    var cur: usize = buf.items.len;
+    afterEdit(&root, gpa, &buf, &cur);
+    try std.testing.expectEqualStrings("[Image #1] ", buf.items);
+    try std.testing.expectEqual(@as(usize, buf.items.len), cur);
+    try std.testing.expectEqual(@as(u8, 1), root.pending_image_len);
+
+    vision_queue.stage(&root, .{ .media_type = "image/png", .b64 = "AAA", .label = "same.png" });
+    var marks: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (marks.items) |mark| gpa.free(mark);
+        marks.deinit(gpa);
+    }
+    var pastes: PasteStore = .{};
+    defer pastes.deinit(gpa);
+    insertComposerChip(&root, gpa, &buf, &cur, &marks, &pastes);
+    try std.testing.expectEqualStrings("[Image #1] [Image #2] ", buf.items);
+}
+
 test "rewriteChips remaps #2 to #1 after the first slot is dropped (#702)" {
     const gpa = std.testing.allocator;
     var buf: std.ArrayList(u8) = .empty;
@@ -181,7 +254,7 @@ test "rewriteChips remaps #2 to #1 after the first slot is dropped (#702)" {
     var cur: usize = buf.items.len;
     var remap: vision_queue.Remap = @splat(0);
     remap[1] = 1;
-    rewriteChips(gpa, &buf, &cur, remap);
+    rewriteChips(gpa, &buf, &cur, remap, @as(u16, 1) << 1);
     try std.testing.expectEqualStrings("[Image #1] look", buf.items);
     try std.testing.expectEqual(@as(usize, buf.items.len), cur);
 }

--- a/src/subagent_activity.zig
+++ b/src/subagent_activity.zig
@@ -208,7 +208,7 @@ test "cancel file marks a working child interrupted even if it later finishes" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const io = std.testing.io;
-    var r: Recorder = .{ .a = std.testing.allocator, .io = io, .dir = try tmp.dir.openDir(io, ".", .{}), .meta = .{ .id = "child", .label = "test", .task = "test" } };
+    var r: Recorder = .{ .a = std.testing.allocator, .io = io, .dir = try tmp.dir.openDir(io, ".", .{ .iterate = true }), .meta = .{ .id = "child", .label = "test", .task = "test" } };
     defer r.deinit();
     try requestInterrupt(io, r.dir, "child");
     try std.testing.expect(interruptRequested(io, r.dir, "child"));


### PR DESCRIPTION
Fixes #820
Fixes #834
Fixes #835

## What changed

- Route modified word motion and deletion through image-chip boundaries.
- Remove stale composer-backed chips when payload deduplication drops their queue slot.
- Generate packed-SDK native fixtures at the optional-dependency versions they represent and require the consumer install to stay offline.
- Open the subagent cancellation test directory with iteration enabled.
- Teach WebSocket recovery assertions to accept only the replacement socket's observed prewarm anchor.
- Add regressions for atomic word deletion and reused live ordinals.

## Why

Image chips are attachment controls, not ordinary words. Generic word boundaries could split a chip into literal text. Separately, payload deduplication could remove an attachment slot without removing its chip, allowing repeated `[Image #2]` labels to accumulate.

The Linux CI fixture also reached directory pruning through a handle that was not opened for iteration, causing `BADF`. The SDK package smoke built native fixtures at the SDK version rather than the versions declared by its optional dependencies, which allowed package resolution to select a released binary instead of the isolated fake executable.

WebSocket recovery can legitimately prewarm a replacement connection before replaying full history. The previous assertion rejected every parent anchor, misclassifying that fresh connection-local prewarm as a stale inference chain.

## Constraints and trade-offs

- Zero-remapped chips are removed only when they were backed by composer attachments, so literal typed `[Image #N]` text remains unchanged.
- Existing image-payload deduplication behavior is preserved.
- SDK and native package releases may differ; the test follows the declared dependency pins instead of changing published versions.
- Offline fixture installation makes accidental registry fallback fail directly rather than requesting credentials.
- WebSocket assertions still reject inference parents and anchors from other connections, and still require recovery to use a new socket with full input history.
