### PR TITLE
fix: keep chat conversations vertically scrollable

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -22,6 +22,7 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run test:desktop
       - run: bun run build
+      - run: bun run test:overflow
       - run: bun run test:projects
       - run: bun run test:stress
       - run: bun run test:agents

--- a/apps/native/app/visual-tests/overflow/overflow-fixture.tsx
+++ b/apps/native/app/visual-tests/overflow/overflow-fixture.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import ChatTranscript from "@/components/site/ChatTranscript";
+import { emptyTurn, type AssistantTurn } from "@/lib/acp";
+import type { Msg } from "@/components/site/harness-types";
+
+const noop = () => {};
+const widths = [260, 360, 720] as const;
+const cases = ["all", "url", "prose", "inline-path", "nested", "table", "fence", "stream", "error", "recap", "reasoning", "user"] as const;
+type Case = typeof cases[number];
+const token = "UnbrokenDiagnosticPayload".repeat(32);
+const path = `fixtures/${"deeply-nested-module/".repeat(18)}${"long-component-name-".repeat(12)}fixture.tsx:128-256`;
+const url = `https://example.com/artifacts/overflow-fixture/builds/${"release-candidate-".repeat(20)}report?filter=${"diagnostic%2F".repeat(35)}&view=expanded#final-result`;
+const codeLine = `const diagnostic = "${token}"; // FENCE_END`;
+const openFence = `## CASE: stream\n\nAn incomplete fence grows in explicit steps.\n\n\`\`\`typescript\nconst streamed = "`;
+const table = [
+  "## CASE: table",
+  "",
+  `| ${Array.from({ length: 8 }, (_, i) => `Header_${i}_${"WideHeader".repeat(8)}`).join(" | ")} |`,
+  `| ${Array.from({ length: 8 }, () => "---").join(" | ")} |`,
+  ...Array.from({ length: 5 }, (_, row) => `| ${Array.from({ length: 8 }, (_, col) => `Cell_${row}_${col}_${"UnbrokenCell".repeat(12)}_END`).join(" | ")} |`),
+].join("\n");
+
+function makeTurn(name: Exclude<Case, "all" | "user">, step: number): AssistantTurn {
+  const turn: AssistantTurn = { ...emptyTurn(), status: "done", thoughtMs: 0 };
+  switch (name) {
+    case "url":
+      turn.text = `## CASE: url\n\nBare URL: ${url}\n\n[${url}](${url})\n\nwww.example.com/${token}\n\nURL_END`;
+      break;
+    case "prose":
+      turn.text = `## CASE: prose\n\n${token}\n\nPROSE_END`;
+      break;
+    case "inline-path":
+      turn.text = `## CASE: inline-path\n\nOpen \`${path}\` and inspect the entire path.\n\nAlso non-path inline code: \`${token}\`.\n\nPATH_END`;
+      break;
+    case "nested":
+      turn.text = `## CASE: nested\n\n1. Outer ordered item\n   - Inner bullet ${token}\n     - Deep link [${url}](${url})\n\n> A quoted diagnostic\n>\n> - Nested quoted item \`${path}\`\n>   - ${token}\n\nNESTED_END`;
+      break;
+    case "table": turn.text = table; break;
+    case "fence":
+      turn.text = `## CASE: fence\n\n\`\`\`typescript\n${codeLine}\n${Array.from({ length: 12 }, (_, i) => `// line ${i}: ${token}`).join("\n")}\n// LAST_CODE_LINE\n\`\`\`\n\nFENCE_AFTER`;
+      break;
+    case "stream":
+      turn.status = step === 3 ? "done" : "streaming";
+      turn.text = openFence + (step >= 1 ? token.slice(0, 220) : "") + (step >= 2 ? token.slice(220) : "") + (step >= 3 ? '";\n// STREAM_CODE_END\n```\n\nSTREAM_FINISHED' : "");
+      break;
+    case "error":
+      turn.status = "error";
+      turn.text = "## CASE: error\n\nThe following alert must remain fully readable.";
+      turn.error = `ERROR_START: Unable to process ${path}: ${token} ERROR_END`;
+      break;
+    case "recap":
+      turn.text = "## CASE: recap\n\nThe recap bypasses the Markdown renderer.";
+      turn.recap = `RECAP_START ${token} ${url} RECAP_END`;
+      break;
+    case "reasoning":
+      turn.status = "thinking";
+      turn.activityKind = "agent_thought_chunk";
+      turn.reasoning = `REASONING_START Inspect ${path}\n${token}\n${url} REASONING_END`;
+      turn.text = "## CASE: reasoning\n\nExpanded reasoning must wrap rather than silently clip.";
+      break;
+  }
+  return turn;
+}
+
+function messagesFor(selected: Case, step: number): Msg[] {
+  const chosen = selected === "all" ? cases.filter(name => name !== "all") : [selected];
+  return chosen.map((name, index): Msg => name === "user"
+    ? { id: index + 1, role: "user", text: `CASE: user\n${token}\n${url}\n${path}\nUSER_END` }
+    : { id: index + 1, role: "assistant", turn: makeTurn(name as Exclude<Case, "all" | "user">, step) });
+}
+
+function Pane({ id, width, selected, step, following }: {
+  id: string; width: number; selected: Case; step: number; following: boolean;
+}) {
+  const messages = useMemo(() => messagesFor(selected, step), [selected, step]);
+  const [opened, setOpened] = useState(false);
+  const register = useCallback((element: HTMLDivElement | null) => {
+    if (element) element.dataset.overflowScroller = id;
+  }, [id]);
+  return <section data-overflow-pane={id} data-pane-width={width}
+    className="flex min-h-0 min-w-0 shrink-0 flex-col border border-line bg-surface"
+    style={{ width, height: 640 }}>
+    <header className="shrink-0 border-b border-line p-2 text-xs">{id}: {width}px</header>
+    <ChatTranscript key={selected} messages={messages} register={register} following={following}
+      onOpenPath={() => setOpened(true)} onReview={noop} />
+    <footer className="shrink-0 border-t border-line p-2">
+      <textarea data-overflow-composer={id} aria-label={`${id} composer`}
+        className="block w-full min-w-0 resize-none rounded bg-field p-2 text-xs" rows={2}
+        placeholder="Still reachable after vertical scrolling" />
+      <output data-overflow-path-opened={id} className="text-xs">{opened ? "Path clicked" : "No path clicked"}</output>
+    </footer>
+  </section>;
+}
+
+/** No fixture-level clipping or wrapping: production components must contain their own content.
+ * Use a >= 1500px viewport for two 720px panes; narrower viewports deliberately
+ * reveal the fixture board's fixed geometry, not a transcript regression.
+ * Stream updates are manual (0=open, 1=partial, 2=long, 3=closed), never timers.
+ */
+export default function OverflowFixture() {
+  const [width, setWidth] = useState<number>(360);
+  const [selected, setSelected] = useState<Case>("all");
+  const [step, setStep] = useState(0);
+  const [split, setSplit] = useState(true);
+  const [following, setFollowing] = useState(false);
+  return <main data-graff-main data-overflow-fixture data-overflow-case={selected}
+    data-stream-step={step} className="min-h-screen bg-page p-3 text-ink">
+    <nav aria-label="Overflow fixture controls" className="mb-3 flex flex-wrap gap-2">
+      {widths.map(value => <button key={value} type="button" data-overflow-width={value}
+        aria-pressed={width === value} onClick={() => setWidth(value)} className="rounded bg-field px-2 py-1">{value}px</button>)}
+      {cases.map(value => <button key={value} type="button" data-overflow-select={value}
+        aria-pressed={selected === value} onClick={() => { setSelected(value); setStep(0); }}
+        className="rounded bg-field px-2 py-1">{value}</button>)}
+      <button type="button" data-overflow-split aria-pressed={split} onClick={() => setSplit(!split)}>Two panes</button>
+      <button type="button" data-overflow-follow aria-pressed={following} onClick={() => setFollowing(!following)}>Follow tail</button>
+      {[0, 1, 2, 3].map(value => <button key={value} type="button" data-overflow-stream={value}
+        aria-pressed={step === value} onClick={() => setStep(value)}>Stream {value}</button>)}
+    </nav>
+    <div data-overflow-board className="flex items-start gap-3">
+      <Pane id="left" width={width} selected={selected} step={step} following={following} />
+      {split && <Pane id="right" width={width} selected={selected} step={step} following={following} />}
+    </div>
+  </main>;
+}

--- a/apps/native/app/visual-tests/overflow/page.tsx
+++ b/apps/native/app/visual-tests/overflow/page.tsx
@@ -1,0 +1,9 @@
+import { notFound } from "next/navigation";
+import OverflowFixture from "./overflow-fixture";
+
+export const dynamic = "force-dynamic";
+
+export default function OverflowPage() {
+  if (process.env.GRAFF_VISUAL_TESTS !== "1") notFound();
+  return <OverflowFixture />;
+}

--- a/apps/native/components/primitives/Markdown.tsx
+++ b/apps/native/components/primitives/Markdown.tsx
@@ -157,7 +157,7 @@ export default function Markdown({
     [onOpenPath],
   );
   return (
-    <div className="min-w-0 text-[13.5px] leading-[1.7] text-ink [&_pre]:text-[12px] [&_pre]:leading-[1.65]">
+    <div className="min-w-0 [overflow-wrap:anywhere] text-[13.5px] leading-[1.7] text-ink [&_pre]:text-[12px] [&_pre]:leading-[1.65]">
       <Streamdown
         mode={asDocument ? "static" : "streaming"}
         isAnimating={streaming}

--- a/apps/native/components/site/ChatBubbles.tsx
+++ b/apps/native/components/site/ChatBubbles.tsx
@@ -111,7 +111,7 @@ export const AssistantBody = memo(function AssistantBody({
   const lastBlock = blocks[blocks.length - 1];
 
   return (
-    <article data-turn-status={turn.status} aria-busy={live} className="min-w-0" style={{ overflowAnchor: "none", animation: "fade-in 280ms ease both" }}>
+    <article data-turn-status={turn.status} aria-busy={live} className="min-w-0 [overflow-wrap:anywhere]" style={{ overflowAnchor: "none", animation: "fade-in 280ms ease both" }}>
       {((thinking && turn.activityKind === "agent_thought_chunk") || reasoningRows.length > 0 || (turn.thoughtMs ?? 0) >= 1500) && (
         <Reasoning
           variant="Reasoning"

--- a/apps/native/components/site/ChatTranscript.tsx
+++ b/apps/native/components/site/ChatTranscript.tsx
@@ -37,7 +37,7 @@ export default memo(function ChatTranscript({ messages, register, following, onO
     return () => observer.disconnect();
   }, []);
   return <div ref={registerScroller} data-chat-transcript
-    className="min-h-0 flex-1 overflow-y-auto overscroll-contain" style={{ overflowAnchor: "none" }}>
+    className="min-h-0 min-w-0 max-w-full flex-1 overflow-x-hidden overflow-y-auto overscroll-contain" style={{ overflowAnchor: "none" }}>
     <div className="mx-auto flex w-full max-w-[720px] flex-col gap-8 px-4 py-8 sm:px-8">
       {start > 0 && <button type="button" className="self-center rounded-lg bg-field px-3 py-2 text-xs text-ink-2 hover:bg-hover" onClick={() => {
         const el = scroller.current;

--- a/apps/native/electron/chat-overflow-edge-visual.cjs
+++ b/apps/native/electron/chat-overflow-edge-visual.cjs
@@ -1,0 +1,74 @@
+const assert = require('node:assert/strict');
+
+async function runOverflowEdges({ win, origin }) {
+  const js = code => win.webContents.executeJavaScript(code);
+  const settle = () => js(`new Promise(resolve => setTimeout(resolve, 350))`);
+  win.setSize(1540, 900);
+  await win.loadURL(`${origin}/visual-tests/overflow`);
+  for (let i = 0; i < 100; i++) {
+    if (await js(`!!document.querySelector('[data-overflow-select="all"]')`)) break;
+    await settle();
+  }
+  await js(`document.fonts.ready`);
+  const click = async selector => { await js(`document.querySelector(${JSON.stringify(selector)}).click()`); await settle(); };
+  const check = async label => {
+    const panes = await js(`Array.from(document.querySelectorAll('[data-chat-transcript]'), e => {
+      const box = e.getBoundingClientRect(), failures = [];
+      const walker = document.createTreeWalker(e, NodeFilter.SHOW_TEXT);
+      let node;
+      while ((node = walker.nextNode())) {
+        if (!node.textContent.trim() || node.parentElement.closest('pre, table')) continue;
+        const range = document.createRange(); range.selectNodeContents(node);
+        for (const r of range.getClientRects()) {
+          if (r.width && (r.left < box.left - 1 || r.right > box.left + e.clientWidth + 1)) failures.push(node.textContent.slice(0, 40));
+          for (let p = node.parentElement; p && p !== e; p = p.parentElement) {
+            const s = getComputedStyle(p), b = p.getBoundingClientRect();
+            if (r.width && ['hidden', 'clip', 'auto', 'scroll'].includes(s.overflowX) &&
+                (r.left < b.left - 1 || r.right > b.right + 1)) failures.push('clipped: ' + node.textContent.slice(0, 40));
+          }
+        }
+      }
+      const before = e.scrollTop; e.scrollTop = e.scrollHeight;
+      const scrolls = e.scrollHeight <= e.clientHeight || e.scrollTop > 0;
+      e.scrollTop = before;
+      return { width: e.clientWidth, scrollWidth: e.scrollWidth, left: e.scrollLeft, scrolls, failures: failures.slice(0, 8) };
+    })`);
+    assert.equal(panes.length, 2, `${label}: two independent panes`);
+    for (const pane of panes) {
+      assert.ok(pane.scrollWidth <= pane.width, `${label}: viewport overflow ${JSON.stringify(pane)}`);
+      assert.equal(pane.left, 0, `${label}: fixed horizontal position`);
+      assert.ok(pane.scrolls, `${label}: vertical scrolling works`);
+      assert.deepEqual(pane.failures, [], `${label}: all prose glyphs readable`);
+    }
+  };
+  for (const width of [720, 360, 260, 720]) {
+    await click(`[data-overflow-width="${width}"]`);
+    for (const name of ['url', 'prose', 'inline-path', 'nested', 'table', 'fence', 'error', 'recap', 'reasoning', 'user']) {
+      await click(`[data-overflow-select="${name}"]`);
+      await check(`${width}px/${name}`);
+      if (name === 'inline-path') {
+        await js(`document.querySelector('[data-overflow-scroller="left"] code[title]').click()`);
+        assert.equal(await js(`document.querySelector('[data-overflow-path-opened="left"]').textContent`), 'Path clicked');
+      }
+      if (name === 'table' || name === 'fence') {
+        const local = await js(`Array.from(document.querySelectorAll('[data-chat-transcript]'), e => {
+          let block = e.querySelector(${JSON.stringify(name === 'table' ? 'table' : 'pre')});
+          while (block && block !== e && !(block.scrollWidth > block.clientWidth && ['auto', 'scroll'].includes(getComputedStyle(block).overflowX))) block = block.parentElement;
+          if (!block || block === e) return false;
+          block.scrollLeft = block.scrollWidth;
+          return block.scrollLeft > 0 && block.scrollLeft + block.clientWidth >= block.scrollWidth - 1 && e.scrollLeft === 0;
+        })`);
+        assert.deepEqual(local, [true, true], `${width}px/${name}: rightmost content reachable locally`);
+      }
+    }
+  }
+  await click('[data-overflow-width="260"]');
+  await click('[data-overflow-select="stream"]');
+  for (const step of [1, 2, 3]) {
+    await click(`[data-overflow-stream="${step}"]`);
+    await check(`stream step ${step}`);
+  }
+  assert.ok(await js(`document.querySelector('[data-chat-transcript]').textContent.includes('STREAM_FINISHED')`));
+  console.log('Overflow edge cases passed: nested Markdown, paths, errors, recaps, reasoning, wide blocks and streaming in two 260/360/720px panes.');
+}
+module.exports = { runOverflowEdges };

--- a/apps/native/electron/chat-overflow-visual.cjs
+++ b/apps/native/electron/chat-overflow-visual.cjs
@@ -1,0 +1,227 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+async function runChatOverflow({ win, origin, output }) {
+  const wc = win.webContents, js = code => wc.executeJavaScript(code);
+  const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+  const wait = async code => {
+    for (let i = 0; i < 120; i++) {
+      if (await js(code)) return;
+      await sleep(50);
+    }
+    throw Error(`Chat overflow timed out: ${code}`);
+  };
+  const settle = async () => {
+    await js(`document.fonts.ready.then(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve(true)))))`);
+    await sleep(150);
+  };
+  const transcript = `document.querySelector('[data-chat-transcript]')`;
+  const userWord = 'FictionalUserRibbon'.repeat(32);
+  const assistantWord = 'FictionalAssistantRibbon'.repeat(32);
+  const url = 'https://example.invalid/' + 'fictional-link-segment'.repeat(32);
+  const www = 'www.example.invalid/' + 'fictional-public-note'.repeat(32);
+  const inline = 'fictional_inline_value_'.repeat(32);
+  const user = `Please inspect these fictional overflow samples.\n\n${userWord}\n\n${url}\n\n${www}\n\n\`${inline}\`\n\n` +
+    'A readable user note stays inside the conversation pane.\n'.repeat(12);
+  const prose = `${assistantWord}\n\n${url}\n\n[${www}](https://${www})\n\n\`${inline}\`\n\n` +
+    'A readable assistant paragraph stays inside the conversation pane.\n\n'.repeat(12);
+  const fence = '```text\n' + 'fictional_code_column_'.repeat(100);
+  const headers = Array.from({ length: 12 }, (_, i) => `Fictional column ${i + 1}`);
+  const table = '\n\n| ' + headers.join(' | ') + ' |\n| ' + headers.map(() => '---').join(' | ') +
+    ' |\n| ' + headers.map((_, i) => `Sample value ${i + 1}`).join(' | ') + ' |\n\nOVERFLOW_REPLY_DONE';
+  const originalSize = win.getSize();
+
+  // Text ranges catch clipped glyphs as well as expanded boxes: overflow:hidden alone is not a fix.
+  const bounds = async label => {
+    const result = await js(`(() => {
+      const e = ${transcript}, box = e.getBoundingClientRect();
+      const failures = [], wrapped = {};
+      const tokens = ${JSON.stringify([userWord, assistantWord, url, www, inline])};
+      const walker = document.createTreeWalker(e, NodeFilter.SHOW_TEXT);
+      let node;
+      while ((node = walker.nextNode())) {
+        const parent = node.parentElement;
+        if (!node.textContent.trim() || parent.closest('pre, table, [data-streamdown="code-block"]')) continue;
+        const range = document.createRange(); range.selectNodeContents(node);
+        const rects = Array.from(range.getClientRects()).filter(r => r.width && r.height);
+        for (const r of rects) {
+          if (r.left < box.left - 1 || r.right > box.left + e.clientWidth + 1) {
+            failures.push({ text: node.textContent.slice(0, 32), left: r.left - box.left, right: r.right - box.left });
+          }
+          // Check every ancestor too, so clipping inside a bubble cannot masquerade as readable wrapping.
+          for (let p = parent; p && p !== e; p = p.parentElement) {
+            const style = getComputedStyle(p), b = p.getBoundingClientRect();
+            if (['hidden', 'clip', 'auto', 'scroll'].includes(style.overflowX) &&
+                (r.left < b.left - 1 || r.right > b.right + 1)) failures.push({ clipped: p.tagName });
+          }
+        }
+        for (const token of tokens) if (node.textContent.includes(token)) {
+          const start = node.textContent.indexOf(token);
+          range.setStart(node, start); range.setEnd(node, start + token.length);
+          const lines = new Set(Array.from(range.getClientRects()).map(r => Math.round(r.top))).size;
+          const role = parent.closest('article') ? 'assistant' : 'user';
+          wrapped[role + ':' + tokens.indexOf(token)] = lines;
+        }
+      }
+      return { width: e.clientWidth, scrollWidth: e.scrollWidth, left: e.scrollLeft,
+        documentWidth: document.documentElement.clientWidth, documentScrollWidth: document.documentElement.scrollWidth,
+        failures: failures.slice(0, 8), wrapped };
+    })()`);
+    assert.ok(result.width > 100, `${label}: usable transcript width`);
+    assert.ok(result.scrollWidth <= result.width, `${label}: transcript overflow ${JSON.stringify(result)}`);
+    assert.equal(result.left, 0, `${label}: transcript scrollLeft`);
+    assert.ok(result.documentScrollWidth <= result.documentWidth, `${label}: page overflow`);
+    assert.deepEqual(result.failures, [], `${label}: prose must remain readable`);
+    for (const key of ['user:0', 'user:2', 'user:3', 'user:4', 'assistant:1', 'assistant:2', 'assistant:3', 'assistant:4']) {
+      assert.ok(result.wrapped[key] > 1, `${label}: ${key} must exist and wrap onto multiple lines`);
+    }
+    return result.width;
+  };
+  const wheel = async (point, deltaX, deltaY) => {
+    wc.sendInputEvent({ type: 'mouseMove', ...point });
+    wc.sendInputEvent({ type: 'mouseWheel', ...point, deltaX, deltaY, canScroll: true });
+    await sleep(200);
+  };
+  const viewportWheels = async label => {
+    // The blank left gutter targets the transcript, not an intentionally scrollable code block.
+    const point = await js(`(() => {
+      const e = ${transcript}; e.scrollTop = 0; e.dispatchEvent(new Event('scroll'));
+      const r = e.getBoundingClientRect(); return { x: Math.round(r.left + 3), y: Math.round(r.top + r.height / 2) };
+    })()`);
+    await settle();
+    const top = () => js(`${transcript}.scrollTop`);
+    const before = await top();
+    for (const delta of [-240, 240]) {
+      await wheel(point, delta, 0);
+      assert.equal(await js(`${transcript}.scrollLeft`), 0, `${label}: horizontal wheel cannot pan transcript`);
+      assert.ok(Math.abs(await top() - before) < 2, `${label}: horizontal wheel cannot move vertically`);
+    }
+    await wheel(point, 0, -180);
+    assert.ok(await top() > before + 10, `${label}: vertical wheel scrolls down`);
+    const down = await top();
+    await wheel(point, -180, -180);
+    assert.ok(await top() > down + 10, `${label}: diagonal wheel retains vertical movement`);
+    assert.equal(await js(`${transcript}.scrollLeft`), 0, `${label}: diagonal wheel cannot pan transcript`);
+    const diagonal = await top();
+    await wheel(point, 180, 120);
+    assert.ok(await top() < diagonal - 10, `${label}: reverse diagonal wheel scrolls up`);
+    await bounds(label);
+  };
+  const localScroll = async (selector, label) => {
+    const point = await js(`(() => {
+      const e = ${transcript}, target = e.querySelector(${JSON.stringify(selector)});
+      if (!target) return null;
+      let local = target;
+      while (local && local !== e) {
+        if (local.scrollWidth > local.clientWidth && ['auto', 'scroll'].includes(getComputedStyle(local).overflowX)) break;
+        local = local.parentElement;
+      }
+      if (!local || local === e) return null;
+      window.overflowLocal = local;
+      local.scrollLeft = 0;
+      e.scrollTop += local.getBoundingClientRect().top - e.getBoundingClientRect().top - 60;
+      e.dispatchEvent(new Event('scroll'));
+      return true;
+    })()`);
+    assert.ok(point, `${label}: wide content needs its own horizontal scroller`);
+    await settle();
+    const geometry = await js(`(() => {
+      const e = ${transcript}, local = window.overflowLocal, r = local.getBoundingClientRect(), b = e.getBoundingClientRect();
+      return { x: Math.round(r.left + Math.min(r.width / 2, 100)), y: Math.round(Math.max(r.top, b.top) + Math.min(r.height / 2, 45)),
+        contained: r.left >= b.left - 1 && r.right <= b.left + e.clientWidth + 1, top: e.scrollTop };
+    })()`);
+    assert.ok(geometry.contained, `${label}: local scroller fits transcript`);
+    await wheel({ x: geometry.x, y: geometry.y }, -240, 0);
+    assert.ok(await js(`window.overflowLocal.scrollLeft > 10`), `${label}: horizontal wheel reveals wide content`);
+    assert.equal(await js(`${transcript}.scrollLeft`), 0, `${label}: local scrolling never pans transcript`);
+    assert.ok(Math.abs(await js(`${transcript}.scrollTop`) - geometry.top) < 2, `${label}: local horizontal wheel preserves vertical position`);
+    await js(`window.overflowLocal.scrollLeft = window.overflowLocal.scrollWidth`);
+    assert.ok(await js(`window.overflowLocal.scrollLeft + window.overflowLocal.clientWidth >= window.overflowLocal.scrollWidth - 1`), `${label}: far edge is reachable`);
+    await js(`window.overflowLocal.scrollLeft = 0`);
+  };
+  const screenshot = async name => fs.writeFileSync(path.join(output, `chat-overflow-${name}.png`), (await wc.capturePage()).toPNG());
+
+  try {
+    await wc.loadURL('about:blank');
+    wc.debugger.attach('1.3');
+    await wc.debugger.sendCommand('Page.enable');
+    await wc.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
+      source: `(${require('./gallery-fixture.cjs').installGalleryFixture.toString()})()`,
+    });
+    await wc.loadURL(origin); win.setSize(1100, 760);
+    await wait(`!!document.querySelector('textarea[aria-label="Prompt"]')`);
+    await js(`(() => {
+      const previous = window.fetch;
+      window.fetch = async (input, options) => {
+        const url = new URL(typeof input === 'string' ? input : input.url, location.href);
+        if (url.pathname.startsWith('/api/')) {
+          const request = options?.body ? JSON.parse(options.body) : {};
+          if (url.pathname === '/api/acp' && request.method === 'session/prompt') {
+            return new Response(new ReadableStream({ start(controller) {
+              const send = value => controller.enqueue(new TextEncoder().encode(JSON.stringify(value) + '\\n'));
+              window.overflowReply = text => send({ jsonrpc: '2.0', method: 'session/update', params: {
+                sessionId: 'demo', update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } }
+              } });
+              window.finishOverflowReply = () => {
+                send({ jsonrpc: '2.0', id: request.id ?? 1, result: { stopReason: 'end_turn' } }); controller.close();
+              };
+            } }), { headers: { 'content-type': 'application/x-ndjson' } });
+          }
+          // Bootstrap, title and split-pane requests still use the installed gallery mock.
+          return previous(input, options);
+        }
+        return previous(input, options);
+      };
+      const input = document.querySelector('textarea[aria-label="Prompt"]');
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set.call(input, ${JSON.stringify(user)});
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    })()`);
+    await wait(`document.querySelector('textarea[aria-label="Prompt"]').value.length > 1000`);
+    await js(`document.querySelector('textarea[aria-label="Prompt"]').dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))`);
+    await wait(`!!window.overflowReply`);
+    await js(`window.overflowReply(${JSON.stringify(prose)})`);
+    await wait(`${transcript}?.textContent.includes(${JSON.stringify(inline)}) && !!document.querySelector('article code')`);
+    await wait(`document.querySelector('article')?.textContent.includes(${JSON.stringify(inline)})`);
+    await settle();
+    await bounds('streaming prose');
+    await js(`window.overflowReply(${JSON.stringify(fence)})`);
+    await wait(`document.querySelector('[data-code-streaming]')?.textContent.includes(${JSON.stringify('fictional_code_column_'.repeat(100))})`);
+    await localScroll('[data-code-streaming] pre', 'open fence');
+    await screenshot('streaming');
+    await js(`window.overflowReply(${JSON.stringify('\n```' + table)}); window.finishOverflowReply()`);
+    await wait(`${transcript}?.textContent.includes('OVERFLOW_REPLY_DONE') && !document.querySelector('article[aria-busy="true"]') && !!document.querySelector('article table')`);
+    await settle();
+
+    const check = async label => {
+      await bounds(label);
+      await viewportWheels(label);
+      await screenshot(`${label}-prose`);
+      await localScroll('article pre', `${label} code`);
+      await screenshot(`${label}-code`);
+      await localScroll('article table', `${label} table`);
+      await screenshot(`${label}-table`);
+    };
+    await check('wide');
+    win.setSize(640, 760); await settle();
+    const narrowWidth = await bounds('narrow');
+    await check('narrow');
+    win.setSize(1100, 760); await settle();
+    assert.ok(await bounds('expanded') > narrowWidth + 100, 'Resizing expands the actual chat viewport');
+    await check('expanded');
+    await js(`document.querySelector('textarea[aria-label="Prompt"]').focus(); document.activeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'd', metaKey: true, bubbles: true, cancelable: true }))`);
+    await wait(`document.querySelectorAll('[data-chat]').length === 2`);
+    await settle();
+    assert.ok(await bounds('split') < narrowWidth, 'Split shortcut creates a narrower real chat pane');
+    await check('split');
+    win.setSize(900, 760); await settle();
+    await check('split-narrow');
+    console.log('Chat overflow passed: streamed/final text wraps, transcript wheels stay vertical, wide code/tables scroll locally, window and split resizing remain readable.');
+  } finally {
+    win.setSize(...originalSize);
+    // Navigation discards the fetch mock and unfinished streams, including on assertion failure.
+    await wc.loadURL('about:blank');
+    if (wc.debugger.isAttached()) wc.debugger.detach();
+  }
+}
+module.exports = { runChatOverflow };

--- a/apps/native/electron/composer-interaction-visual.cjs
+++ b/apps/native/electron/composer-interaction-visual.cjs
@@ -18,11 +18,24 @@ async function runComposerInteractions({ win, origin, output }) {
     await js(`(()=>{const e=document.querySelector(${JSON.stringify(selector)});e.focus();Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype,'value').set.call(e,${JSON.stringify(text)});e.dispatchEvent(new Event('input',{bubbles:true}));})()`);
     await pause();
   };
+  const frames = () => js('new Promise(resolve=>requestAnimationFrame(()=>requestAnimationFrame(()=>resolve(true))))');
   const pointer = async selector => {
-    const point = await js(`(()=>{const e=document.querySelector(${JSON.stringify(selector)});e.scrollIntoView({block:'nearest'});const r=e.getBoundingClientRect();return {x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)}})()`);
-    wc.sendInputEvent({ type: 'mouseDown', button: 'left', clickCount: 1, ...point });
-    wc.sendInputEvent({ type: 'mouseUp', button: 'left', clickCount: 1, ...point });
-    await pause();
+    await js(`document.querySelector(${JSON.stringify(selector)}).scrollIntoView({block:'nearest',behavior:'instant'})`);
+    for (let attempt = 0; attempt < 30; attempt++) {
+      await frames();
+      const point = await js(`(()=>{const r=document.querySelector(${JSON.stringify(selector)}).getBoundingClientRect();return {x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)}})()`);
+      // Hover can scroll the active option or reposition its portal. Settle it
+      // before pressing, then verify that the coordinates still hit this row.
+      wc.sendInputEvent({ type: 'mouseMove', ...point });
+      await frames();
+      const ready = await js(`(()=>{const e=document.querySelector(${JSON.stringify(selector)}),r=e.getBoundingClientRect();return Math.round(r.x+r.width/2)===${point.x}&&Math.round(r.y+r.height/2)===${point.y}&&e.contains(document.elementFromPoint(${point.x},${point.y}));})()`);
+      if (!ready) continue;
+      wc.sendInputEvent({ type: 'mouseDown', button: 'left', clickCount: 1, ...point });
+      wc.sendInputEvent({ type: 'mouseUp', button: 'left', clickCount: 1, ...point });
+      await pause();
+      return;
+    }
+    throw Error(`Pointer target did not settle: ${selector}`);
   };
   const draft = id => js(`document.querySelector('[data-chat="${id}"] textarea').value`);
   const focused = () => js(`Number(document.querySelector('[data-chat][data-focused="true"]').dataset.chat)`);
@@ -53,6 +66,9 @@ async function runComposerInteractions({ win, origin, output }) {
     await pointer('[data-composer-menu] [role="option"][title^="$gui-theme"]');
     assert.equal(await js('document.querySelector("textarea").value'), '$gui-theme ', 'A portaled skill selection must reach the composer');
 
+    // Do not let a stationary pointer hover newly mounted options during IME checks.
+    wc.sendInputEvent({ type: 'mouseMove', x: 1, y: 1 });
+    await frames();
     await input('/');
     await wait(`document.querySelectorAll('[data-composer-menu] [role="option"]').length>10`);
     const firstOption = await js(`document.querySelector('textarea').getAttribute('aria-activedescendant')`);

--- a/apps/native/electron/visual-tests.cjs
+++ b/apps/native/electron/visual-tests.cjs
@@ -31,6 +31,12 @@ app.whenReady().then(async () => {
     if (url.origin === origin && url.pathname.startsWith('/api/')) apiRequests.push(url.pathname);
     callback({ cancel: !details.url.startsWith(origin) && !details.url.startsWith('data:') || url.pathname.startsWith('/api/') });
   });
+  if (process.env.GRAFF_VISUAL_SUITE === 'overflow') {
+    await require('./chat-overflow-visual.cjs').runChatOverflow({ win, origin, output });
+    await require('./chat-overflow-edge-visual.cjs').runOverflowEdges({ win, origin });
+    assert.deepEqual(apiRequests, [], 'Overflow fixtures never call live APIs');
+    return;
+  }
   if (process.env.GRAFF_VISUAL_SUITE === 'updates') {
     await require('./updates-visual.cjs').runUpdateVisuals({ origin, output });
     await require('./updates-transport.cjs').runUpdateTransport();
@@ -89,6 +95,8 @@ app.whenReady().then(async () => {
       results.push(`${theme}/${name}`);
     }
   }
+  await require('./chat-overflow-visual.cjs').runChatOverflow({ win, origin, output });
+  await require('./chat-overflow-edge-visual.cjs').runOverflowEdges({ win, origin });
   await require('./stress-visual.cjs').runStressVisuals({ win, origin, output });
   await require('./navigation-visual.cjs').runNavigationVisuals({ win, origin, output });
   await require('./browser-visual.cjs').runBrowserVisuals({ win, origin, output });

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -21,6 +21,7 @@
     "test:splits": "GRAFF_VISUAL_SUITE=splits bun scripts/test-visual.mjs",
     "test:stress": "GRAFF_VISUAL_SUITE=stress bun scripts/test-visual.mjs",
     "test:code": "GRAFF_VISUAL_SUITE=code bun scripts/test-visual.mjs",
+    "test:overflow": "GRAFF_VISUAL_SUITE=overflow node scripts/test-visual.mjs",
     "test:agents": "GRAFF_VISUAL_SUITE=agents bun scripts/test-visual.mjs",
     "test:performance": "GRAFF_PERFORMANCE_TESTS=1 bun scripts/test-visual.mjs",
     "benchmark:desktop": "bun scripts/benchmark-desktop.mjs"

--- a/scripts/codex_ws_error_test.py
+++ b/scripts/codex_ws_error_test.py
@@ -188,11 +188,15 @@ def run_chain_reanchor_scenario(
             first.connection_id != rejected.connection_id
             or rejected.connection_id == rebuilt.connection_id
             or rejected.body.get("previous_response_id") != "resp_chain_1"
-            or "previous_response_id" in rebuilt.body
+            # A fresh socket may chain only from its observed prewarm,
+            # never from the rejected inference response or another socket.
+            or not mock.has_fresh_parent(rebuilt)
         ):
             raise AssertionError(
                 "chain-error: rejected delta was not rebuilt as full input on a fresh WS: "
-                f"{requests!r}"
+                f"connections={(first.connection_id, rejected.connection_id, rebuilt.connection_id)!r}, "
+                f"rejected_parent={rejected.body.get('previous_response_id')!r}, "
+                f"rebuilt_parent={rebuilt.body.get('previous_response_id')!r}"
             )
         rebuilt_types = [
             item.get("type")

--- a/scripts/codex_ws_mock.py
+++ b/scripts/codex_ws_mock.py
@@ -227,10 +227,19 @@ class CodexMock:
         default=None, repr=False
     )
     requests: list[RecordedRequest] = field(default_factory=list, repr=False)
+    prewarm_ids: dict[int, str] = field(default_factory=dict, repr=False)
     _sock: socket.socket | None = field(default=None, repr=False)
     _threads: list[threading.Thread] = field(default_factory=list, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
     _stopping: bool = field(default=False, repr=False)
+
+    def has_fresh_parent(self, request: RecordedRequest) -> bool:
+        """Only no parent or this socket's observed prewarm is a fresh anchor."""
+        parent = request.body.get("previous_response_id")
+        if parent is None:
+            return True
+        with self._lock:
+            return request.transport == "ws" and parent == self.prewarm_ids.get(request.connection_id)
 
     def start(self) -> int:
         srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -391,6 +400,8 @@ class CodexMock:
             # (the transport smoke assertions count real model turns).
             if event.get("generate") is False:
                 prewarm_id = f"resp_prewarm_{self.ws_turns + 1}"
+                with self._lock:
+                    self.prewarm_ids[connection_id] = prewarm_id
                 _send_frame(conn, OP_TEXT, json.dumps(
                     {"type": "response.completed",
                      "response": {"id": prewarm_id, "usage": dict(USAGE)}},

--- a/scripts/codex_ws_test.py
+++ b/scripts/codex_ws_test.py
@@ -437,7 +437,7 @@ def assert_midturn_requests(mock: CodexMock) -> None:
     if first.connection_id == final.connection_id:
         raise AssertionError("midturn: final request reused the pre-compaction WS")
     for request in requests:
-        if "previous_response_id" in request.body:
+        if not mock.has_fresh_parent(request):
             raise AssertionError(
                 f"midturn: request {request.ordinal} carried stale previous_response_id: "
                 f"{request.body['previous_response_id']!r}"
@@ -580,7 +580,7 @@ def assert_transactional_requests(mock: CodexMock) -> None:
             "transactional: final request reused the pre-compaction WS"
         )
     for request in requests:
-        if "previous_response_id" in request.body:
+        if not mock.has_fresh_parent(request):
             raise AssertionError(
                 f"transactional: request {request.ordinal} carried stale "
                 f"previous_response_id: {request.body['previous_response_id']!r}"

--- a/sdk/ts/scripts/test-packed-install.mjs
+++ b/sdk/ts/scripts/test-packed-install.mjs
@@ -66,12 +66,15 @@ try {
     await chmod(sourceBinary, 0o755);
   }
 
+  const sdkManifest = JSON.parse(await readFile(join(SDK_ROOT, "package.json"), "utf8"));
   const nativeTarballs = {};
   for (const [target, packageName] of ALL_TARGETS) {
     const output = run(process.execPath, [
       join(HERE, "package-platform.mjs"),
       "--target", target,
       "--binary", sourceBinary,
+      // The SDK and native releases can differ; match the dependency being resolved.
+      "--version", sdkManifest.optionalDependencies[packageName],
       "--out", packages,
     ], SDK_ROOT);
     const { packageDir } = JSON.parse(output);

--- a/sdk/ts/scripts/test-packed-install.mjs
+++ b/sdk/ts/scripts/test-packed-install.mjs
@@ -91,7 +91,7 @@ try {
     ),
   };
   await writeFile(join(consumer, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`);
-  npmRun(["install", "--ignore-scripts", "--no-audit", "--no-fund"], consumer);
+  npmRun(["install", "--offline", "--ignore-scripts", "--no-audit", "--no-fund"], consumer);
 
   const smoke = `
 import { Harness } from "@codegraff/sdk";

--- a/src/subagent_activity.zig
+++ b/src/subagent_activity.zig
@@ -208,7 +208,7 @@ test "cancel file marks a working child interrupted even if it later finishes" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const io = std.testing.io;
-    var r: Recorder = .{ .a = std.testing.allocator, .io = io, .dir = try tmp.dir.openDir(io, ".", .{}), .meta = .{ .id = "child", .label = "test", .task = "test" } };
+    var r: Recorder = .{ .a = std.testing.allocator, .io = io, .dir = try tmp.dir.openDir(io, ".", .{ .iterate = true }), .meta = .{ .id = "child", .label = "test", .task = "test" } };
     defer r.deinit();
     try requestInterrupt(io, r.dir, "child");
     try std.testing.expect(interruptRequested(io, r.dir, "child"));


### PR DESCRIPTION
## What changed
- Constrain the chat viewport and wrap long prose, links, and inline code.
- Preserve local horizontal scrolling for wide code blocks and tables.
- Add gesture, resizing, and narrow-pane regressions to desktop CI.
- Repair separate package, cancellation, pointer-targeting, and transport-test blockers in separate commits.

## Why
Unbroken content could widen the transcript and let conversations shift sideways. Wrapping text and containing wide blocks keeps content readable; hiding overflow alone would leave text clipped. The change preserves normal vertical scrolling without intercepting input events.

The package smoke matches fixture versions to dependency pins and installs offline. The cancellation fixture enables directory iteration. Pointer tests wait for stable hit-tested targets. Transport checks distinguish a fresh connection’s observed warm-up anchor from a stale inference chain, retaining connection-replacement and full-history assertions. These test-only repairs unblock validation without changing published versions or runtime behavior.

Closes #827.
Closes #834.
Closes #835.
Closes #837.
Closes #846.