### PR TITLE
Hide task disclosures when no details are available

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -22,6 +22,7 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run test:desktop
       - run: bun run build
+      - run: bun run test:tasks
       - run: bun run test:projects
       - run: bun run test:stress
       - run: bun run test:agents

--- a/apps/native/app/visual-tests/tasks/fixture.tsx
+++ b/apps/native/app/visual-tests/tasks/fixture.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import TaskRows, { type TaskItem } from "@/components/primitives/TaskRows";
+
+export default function TaskRowsFixture() {
+  const [items, setItems] = useState<TaskItem[]>([]);
+  const [variant, setVariant] = useState("Capsules");
+  const [revision, setRevision] = useState(0);
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const receive = (event: Event) => {
+      const next = (event as CustomEvent<{ items: TaskItem[]; variant: string; revision: number }>).detail;
+      setItems(next.items);
+      setVariant(next.variant);
+      setRevision(next.revision);
+    };
+    window.addEventListener("fixture-tasks", receive);
+    setReady(true);
+    return () => window.removeEventListener("fixture-tasks", receive);
+  }, []);
+  return <main data-tasks-fixture data-ready={ready} data-revision={revision}
+    className="min-h-screen overflow-x-hidden bg-page px-6 py-8 text-ink">
+    <h1 className="mb-4">Task row interaction fixture</h1>
+    <button data-focus-start type="button">Before task rows</button>
+    <section data-task-rows className="my-4"><TaskRows variant={variant} items={items} /></section>
+    <button data-focus-end type="button">After task rows</button>
+  </main>;
+}

--- a/apps/native/app/visual-tests/tasks/page.tsx
+++ b/apps/native/app/visual-tests/tasks/page.tsx
@@ -1,0 +1,9 @@
+import { notFound } from "next/navigation";
+import TaskRowsFixture from "./fixture";
+
+export const dynamic = "force-dynamic";
+
+export default function TasksPage() {
+  if (process.env.GRAFF_VISUAL_TESTS !== "1") notFound();
+  return <TaskRowsFixture />;
+}

--- a/apps/native/components/primitives/TaskRows.tsx
+++ b/apps/native/components/primitives/TaskRows.tsx
@@ -188,11 +188,13 @@ export default function TaskRows({
       }`}
     >
       {rows.map((row, i) => {
-        const open = manualOpen[row.key] ?? (row.key === "index" && tick === 2);
+        const expandable = row.details.length > 0;
+        const open = expandable && (manualOpen[row.key] ?? (row.key === "index" && tick === 2));
+        const Header = expandable ? "button" : "div";
         return (
           <div
             key={row.key}
-            className={`self-stretch overflow-hidden transition-[border-radius,background-color] duration-300 hover:bg-inset ${
+            className={`self-stretch overflow-hidden transition-[border-radius,background-color] duration-300 ${expandable ? "hover:bg-inset" : ""} ${
               list ? "border-b border-line last:border-0" : "bg-surface shadow-card"
             }`}
             style={{
@@ -200,10 +202,10 @@ export default function TaskRows({
               animation: `fade-up 450ms cubic-bezier(0.23,1,0.32,1) ${i * 80}ms both`,
             }}
           >
-            <button
-              type="button"
-              aria-expanded={open}
-              onClick={() => setManualOpen((current) => ({ ...current, [row.key]: !open }))}
+            <Header
+              type={expandable ? "button" : undefined}
+              aria-expanded={expandable ? open : undefined}
+              onClick={expandable ? () => setManualOpen((current) => ({ ...current, [row.key]: !open })) : undefined}
               className="flex h-11 w-full items-center gap-2.5 px-2.5 text-left"
             >
               <span className="flex size-6 shrink-0 items-center justify-center">
@@ -214,7 +216,7 @@ export default function TaskRows({
               </span>
               <span className="text-[12.5px] text-ink-2 tabular-nums">{row.amount}</span>
               {row.pill}
-              <span
+              {expandable && <span
                 aria-hidden="true"
                 className="-ml-2 flex size-7 shrink-0 items-center justify-center rounded-full text-ink-3"
               >
@@ -225,11 +227,11 @@ export default function TaskRows({
                 >
                   <path d="M6 9l6 6 6-6" />
                 </svg>
-              </span>
-            </button>
+              </span>}
+            </Header>
 
             {/* dropdown detail — same expandable grammar as Chain of Thought */}
-            <div
+            {expandable && <div
               className="grid transition-[grid-template-rows,opacity] duration-300"
                 style={{
                   gridTemplateRows: open ? "1fr" : "0fr",
@@ -260,7 +262,7 @@ export default function TaskRows({
                     </div>
                   </div>
                 </div>
-              </div>
+              </div>}
           </div>
         );
       })}

--- a/apps/native/electron/composer-interaction-visual.cjs
+++ b/apps/native/electron/composer-interaction-visual.cjs
@@ -18,11 +18,24 @@ async function runComposerInteractions({ win, origin, output }) {
     await js(`(()=>{const e=document.querySelector(${JSON.stringify(selector)});e.focus();Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype,'value').set.call(e,${JSON.stringify(text)});e.dispatchEvent(new Event('input',{bubbles:true}));})()`);
     await pause();
   };
+  const frames = () => js('new Promise(resolve=>requestAnimationFrame(()=>requestAnimationFrame(()=>resolve(true))))');
   const pointer = async selector => {
-    const point = await js(`(()=>{const e=document.querySelector(${JSON.stringify(selector)});e.scrollIntoView({block:'nearest'});const r=e.getBoundingClientRect();return {x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)}})()`);
-    wc.sendInputEvent({ type: 'mouseDown', button: 'left', clickCount: 1, ...point });
-    wc.sendInputEvent({ type: 'mouseUp', button: 'left', clickCount: 1, ...point });
-    await pause();
+    await js(`document.querySelector(${JSON.stringify(selector)}).scrollIntoView({block:'nearest',behavior:'instant'})`);
+    for (let attempt = 0; attempt < 30; attempt++) {
+      await frames();
+      const point = await js(`(()=>{const r=document.querySelector(${JSON.stringify(selector)}).getBoundingClientRect();return {x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)}})()`);
+      // Hover can scroll the active option or reposition its portal. Settle it
+      // before pressing, then verify that the coordinates still hit this row.
+      wc.sendInputEvent({ type: 'mouseMove', ...point });
+      await frames();
+      const ready = await js(`(()=>{const e=document.querySelector(${JSON.stringify(selector)}),r=e.getBoundingClientRect();return Math.round(r.x+r.width/2)===${point.x}&&Math.round(r.y+r.height/2)===${point.y}&&e.contains(document.elementFromPoint(${point.x},${point.y}));})()`);
+      if (!ready) continue;
+      wc.sendInputEvent({ type: 'mouseDown', button: 'left', clickCount: 1, ...point });
+      wc.sendInputEvent({ type: 'mouseUp', button: 'left', clickCount: 1, ...point });
+      await pause();
+      return;
+    }
+    throw Error(`Pointer target did not settle: ${selector}`);
   };
   const draft = id => js(`document.querySelector('[data-chat="${id}"] textarea').value`);
   const focused = () => js(`Number(document.querySelector('[data-chat][data-focused="true"]').dataset.chat)`);
@@ -53,6 +66,9 @@ async function runComposerInteractions({ win, origin, output }) {
     await pointer('[data-composer-menu] [role="option"][title^="$gui-theme"]');
     assert.equal(await js('document.querySelector("textarea").value'), '$gui-theme ', 'A portaled skill selection must reach the composer');
 
+    // Do not let a stationary pointer hover newly mounted options during IME checks.
+    wc.sendInputEvent({ type: 'mouseMove', x: 1, y: 1 });
+    await frames();
     await input('/');
     await wait(`document.querySelectorAll('[data-composer-menu] [role="option"]').length>10`);
     const firstOption = await js(`document.querySelector('textarea').getAttribute('aria-activedescendant')`);

--- a/apps/native/electron/task-rows-visual.cjs
+++ b/apps/native/electron/task-rows-visual.cjs
@@ -1,0 +1,97 @@
+const assert = require('node:assert/strict');
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+// Matches the existing streaming-code/agents runner contract; no backend needed.
+async function testTaskRows({ win, origin }) {
+  const js = source => win.webContents.executeJavaScript(source);
+  const wait = async source => {
+    for (let i = 0; i < 160; i++) {
+      if (await js(source)) return;
+      await sleep(50);
+    }
+    throw Error(`Task rows check timed out: ${source}`);
+  };
+  const row = index => `document.querySelector('[data-task-rows]').firstElementChild.children[${index}]`;
+  const expanded = index => `${row(index)}.querySelector('button')?.getAttribute('aria-expanded')`;
+  const key = async keyCode => {
+    win.webContents.sendInputEvent({ type: 'keyDown', keyCode });
+    if (keyCode === 'Enter' || keyCode === 'Space') {
+      win.webContents.sendInputEvent({ type: 'char', keyCode: keyCode === 'Enter' ? '\r' : ' ' });
+    }
+    win.webContents.sendInputEvent({ type: 'keyUp', keyCode });
+    await sleep(40);
+  };
+  let revision = 0;
+  const set = async (items, variant) => {
+    await js(`window.dispatchEvent(new CustomEvent('fixture-tasks',{detail:${JSON.stringify({ items, variant, revision: ++revision })}}))`);
+    await wait(`document.querySelector('[data-tasks-fixture]').dataset.revision==='${revision}'`);
+    // Finish finite entry/expansion animations without waiting for infinite spinners.
+    await js(`Promise.all(document.getAnimations().filter(a=>a.effect?.getTiming().iterations!==Infinity).map(a=>a.finished.catch(()=>{}))).then(()=>true)`);
+  };
+  const inert = async index => {
+    const state = await js(`(()=>{const r=${row(index)},h=r.firstElementChild;return {
+      actions:r.querySelectorAll('button,[role="button"],[aria-expanded],[tabindex]').length,
+      chevrons:r.querySelectorAll('path[d="M6 9l6 6 6-6"]').length,
+      children:r.childElementCount,
+      extraHeight:r.getBoundingClientRect().height-h.getBoundingClientRect().height
+    }})()`);
+    assert.equal(state.actions, 0, 'No-details row has no action or disclosure semantics');
+    assert.equal(state.chevrons, 0, 'No-details row has no chevron');
+    assert.equal(state.children, 1, 'No-details row has no detail container');
+    assert.ok(state.extraHeight <= 2, `No detail spacing: ${JSON.stringify(state)}`);
+    await js(`${row(index)}.firstElementChild.click()`);
+    assert.equal(await js(expanded(index)), undefined, 'Clicking a static row stays inert');
+  };
+  await win.loadURL(`${origin}/visual-tests/tasks`);
+  await wait(`document.querySelector('[data-tasks-fixture]')?.dataset.ready==='true'`);
+  win.show(); win.focus();
+  await js('document.fonts.ready.then(()=>true)');
+  for (const variant of ['Capsules', 'List']) {
+    const items = [
+      { key: 'omitted', label: 'Omitted details', status: 'pending' },
+      { key: 'empty', label: 'Empty details', status: 'pending', details: [] },
+      { key: 'first', label: 'First disclosure', status: 'completed', details: [{ label: 'First detail', meta: '1' }] },
+      { key: 'second', label: 'Second disclosure', status: 'failed', details: [{ label: 'Second detail' }] },
+    ];
+    // Each variant starts with fresh row identities, while updates within it keep keys stable.
+    items.forEach(item => { item.key = `${variant}-${item.key}`; });
+    for (const status of ['pending', 'in_progress', 'completed', 'failed']) {
+      items[0].status = items[1].status = status;
+      await set(items, variant);
+      await inert(0); await inert(1);
+    }
+    await js(`document.querySelector('[data-focus-start]').focus()`);
+    await key('Tab');
+    assert.equal(await js(`document.activeElement===${row(2)}.querySelector('button')`), true, 'Tab skips both static rows');
+    await key('Enter');
+    await wait(`${expanded(2)}==='true'`);
+    assert.equal(await js(expanded(3)), 'false', 'Keyboard expansion is independent');
+    await key('Space');
+    await wait(`${expanded(2)}==='false'`);
+    await js(`${row(3)}.querySelector('button').click()`);
+    await wait(`${expanded(3)}==='true'`);
+    assert.equal(await js(expanded(2)), 'false', 'Click expansion is independent');
+    await js(`${row(2)}.querySelector('button').click()`);
+    await wait(`${expanded(2)}==='true'`);
+    await set(items, variant);
+    assert.ok(await js(`${row(2)}.getBoundingClientRect().height > ${row(2)}.firstElementChild.getBoundingClientRect().height + 5`), 'Actual details occupy visible space');
+    // Remove both shapes of details while expanded; preserve keys to test live updates.
+    delete items[2].details;
+    items[3].details = [];
+    await set(items, variant);
+    await inert(2); await inert(3);
+    assert.equal(await js(`document.querySelector('[data-task-rows]').textContent.includes('First detail')`), false);
+    await js(`document.querySelector('[data-focus-start]').focus()`);
+    await key('Tab');
+    assert.equal(await js(`document.activeElement.matches('[data-focus-end]')`), true, 'All static rows leave the tab order');
+    items[0].details = [{ label: 'New detail' }];
+    await set(items, variant);
+    assert.equal(await js(expanded(0)), 'false', 'New details provide a collapsed disclosure');
+    await js(`${row(0)}.querySelector('button').click()`);
+    await wait(`${expanded(0)}==='true'`);
+    assert.equal(await js(`${row(0)}.textContent.includes('New detail')`), true);
+    await inert(1); await inert(2); await inert(3);
+  }
+  console.log('Task rows checks passed: both variants, all statuses, static rows, keyboard/click disclosure, live detail removal/addition and independent mixed rows.');
+}
+module.exports = { testTaskRows };

--- a/apps/native/electron/visual-tests.cjs
+++ b/apps/native/electron/visual-tests.cjs
@@ -53,6 +53,11 @@ app.whenReady().then(async () => {
     assert.deepEqual(apiRequests, [], 'Stress fixtures never call engine or model APIs');
     return;
   }
+  if (process.env.GRAFF_VISUAL_SUITE === 'tasks') {
+    await require('./task-rows-visual.cjs').testTaskRows({ win, origin });
+    assert.deepEqual(apiRequests, [], 'Task fixtures never call engine or model APIs');
+    return;
+  }
   if (process.env.GRAFF_VISUAL_SUITE === 'code') {
     await require('./streaming-code-visual.cjs').runStreamingCodeVisuals({ win, origin, output });
     assert.deepEqual(apiRequests, [], 'Code fixtures never call engine or model APIs');
@@ -93,6 +98,7 @@ app.whenReady().then(async () => {
   await require('./navigation-visual.cjs').runNavigationVisuals({ win, origin, output });
   await require('./browser-visual.cjs').runBrowserVisuals({ win, origin, output });
   await require('./agents-visual.cjs').runAgentVisuals({ win, origin, output });
+  await require('./task-rows-visual.cjs').testTaskRows({ win, origin });
   await require('./updates-visual.cjs').runUpdateVisuals({ origin, output });
   await require('./updates-transport.cjs').runUpdateTransport();
   if (process.env.GRAFF_PERFORMANCE_TESTS) await require('./performance-scenarios.cjs').runPerformance({ win, origin, output });

--- a/apps/native/lib/task-rows.test.tsx
+++ b/apps/native/lib/task-rows.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import TaskRows, { type TaskItem } from "../components/primitives/TaskRows";
+
+const statuses = ["pending", "in_progress", "completed", "failed"] as const;
+const statusLabels = {
+  pending: "Pending",
+  in_progress: "In progress",
+  completed: "Completed",
+  failed: "Failed",
+};
+const chevron = 'd="M6 9l6 6 6-6"';
+const detailTransition = "transition-[grid-template-rows,opacity]";
+const detailSpacing = "mb-2.5 grid grid-cols-[24px_1fr]";
+
+function render(variant: string, items: TaskItem[]) {
+  return renderToStaticMarkup(<TaskRows variant={variant} items={items} />);
+}
+
+function expectNoDisclosure(markup: string) {
+  expect(markup).not.toContain("<button");
+  expect(markup).not.toContain('role="button"');
+  expect(markup).not.toContain("tabindex=");
+  expect(markup).not.toContain("aria-expanded=");
+  expect(markup).not.toContain(chevron);
+  expect(markup).not.toContain(detailTransition);
+  expect(markup).not.toContain(detailSpacing);
+  expect(markup).not.toContain("grid-template-rows:");
+}
+
+// Static rendering checks the disclosure control and its content together,
+// without depending on the demo timers or a browser DOM.
+describe("TaskRows disclosure (#826)", () => {
+  for (const variant of ["List", "Capsules"]) {
+    describe(variant, () => {
+      for (const status of statuses) {
+        for (const details of [undefined, []] as const) {
+          it(`${status} has no disclosure when details are ${details === undefined ? "omitted" : "empty"}`, () => {
+            const item: TaskItem = {
+              key: "index",
+              label: "Review task",
+              status,
+              amount: "3 records",
+              ...(details === undefined ? {} : { details: [] }),
+            };
+            const markup = render(variant, [item]);
+
+            expect(markup).toContain("Review task");
+            expect(markup).toContain("3 records");
+            expect(markup).toContain(statusLabels[status]);
+            expectNoDisclosure(markup);
+          });
+        }
+
+        it(`${status} preserves the collapsed disclosure and actual details`, () => {
+          const markup = render(variant, [{
+            key: "with-details",
+            label: "Review task",
+            status,
+            details: [
+              { label: "Matched records", meta: "3/3" },
+              { label: "Checked contacts" },
+            ],
+          }]);
+
+          expect(markup.match(/<button\b/g)).toHaveLength(1);
+          expect(markup).toMatch(/<button\b[^>]*type="button"[^>]*aria-expanded="false"/);
+          expect(markup).toContain(statusLabels[status]);
+          expect(markup).toContain(chevron);
+          expect(markup).toContain(detailTransition);
+          expect(markup).toContain("grid-template-rows:0fr");
+          expect(markup).toContain("Matched records");
+          expect(markup).toContain("3/3");
+          expect(markup).toContain("Checked contacts");
+        });
+      }
+
+      it("only exposes disclosure for detail-bearing rows in a mixed list", () => {
+        const markup = render(variant, [
+          { key: "missing", label: "No details supplied", status: "pending" },
+          {
+            key: "populated", label: "Expandable task", status: "in_progress",
+            details: [{ label: "Actual detail", meta: "1/2" }],
+          },
+          { key: "empty", label: "Empty details supplied", status: "completed", details: [] },
+          { key: "failed", label: "Failed without details", status: "failed" },
+        ]);
+
+        const buttons = markup.match(/<button\b[^>]*>[\s\S]*?<\/button>/g) ?? [];
+        expect(buttons).toHaveLength(1);
+        expect(buttons[0]).toContain("Expandable task");
+        expect(buttons[0]).toContain('aria-expanded="false"');
+        expect(buttons[0]).not.toContain("No details supplied");
+        expect(buttons[0]).not.toContain("Empty details supplied");
+        expect(buttons[0]).not.toContain("Failed without details");
+        expect(markup.split("aria-expanded=")).toHaveLength(2);
+        expect(markup.split(chevron)).toHaveLength(2);
+        expect(markup.split(detailTransition)).toHaveLength(2);
+        expect(markup.split(detailSpacing)).toHaveLength(2);
+        expect(markup).toContain("Actual detail");
+        for (const label of ["No details supplied", "Empty details supplied", "Failed without details"]) {
+          expect(markup).toContain(label);
+        }
+      });
+    });
+  }
+});

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -22,6 +22,7 @@
     "test:stress": "GRAFF_VISUAL_SUITE=stress bun scripts/test-visual.mjs",
     "test:code": "GRAFF_VISUAL_SUITE=code bun scripts/test-visual.mjs",
     "test:agents": "GRAFF_VISUAL_SUITE=agents bun scripts/test-visual.mjs",
+    "test:tasks": "GRAFF_VISUAL_SUITE=tasks node scripts/test-visual.mjs",
     "test:performance": "GRAFF_PERFORMANCE_TESTS=1 bun scripts/test-visual.mjs",
     "benchmark:desktop": "bun scripts/benchmark-desktop.mjs"
   },

--- a/apps/native/tsconfig.json
+++ b/apps/native/tsconfig.json
@@ -39,6 +39,7 @@
   "exclude": [
     "node_modules",
     "out",
-    "lib/*.test.ts"
+    "lib/*.test.ts",
+    "lib/*.test.tsx"
   ]
 }

--- a/scripts/codex_ws_error_test.py
+++ b/scripts/codex_ws_error_test.py
@@ -188,11 +188,15 @@ def run_chain_reanchor_scenario(
             first.connection_id != rejected.connection_id
             or rejected.connection_id == rebuilt.connection_id
             or rejected.body.get("previous_response_id") != "resp_chain_1"
-            or "previous_response_id" in rebuilt.body
+            # A fresh socket may chain only from its observed prewarm,
+            # never from the rejected inference response or another socket.
+            or not mock.has_fresh_parent(rebuilt)
         ):
             raise AssertionError(
                 "chain-error: rejected delta was not rebuilt as full input on a fresh WS: "
-                f"{requests!r}"
+                f"connections={(first.connection_id, rejected.connection_id, rebuilt.connection_id)!r}, "
+                f"rejected_parent={rejected.body.get('previous_response_id')!r}, "
+                f"rebuilt_parent={rebuilt.body.get('previous_response_id')!r}"
             )
         rebuilt_types = [
             item.get("type")

--- a/scripts/codex_ws_mock.py
+++ b/scripts/codex_ws_mock.py
@@ -227,10 +227,19 @@ class CodexMock:
         default=None, repr=False
     )
     requests: list[RecordedRequest] = field(default_factory=list, repr=False)
+    prewarm_ids: dict[int, str] = field(default_factory=dict, repr=False)
     _sock: socket.socket | None = field(default=None, repr=False)
     _threads: list[threading.Thread] = field(default_factory=list, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
     _stopping: bool = field(default=False, repr=False)
+
+    def has_fresh_parent(self, request: RecordedRequest) -> bool:
+        """Only no parent or this socket's observed prewarm is a fresh anchor."""
+        parent = request.body.get("previous_response_id")
+        if parent is None:
+            return True
+        with self._lock:
+            return request.transport == "ws" and parent == self.prewarm_ids.get(request.connection_id)
 
     def start(self) -> int:
         srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -391,6 +400,8 @@ class CodexMock:
             # (the transport smoke assertions count real model turns).
             if event.get("generate") is False:
                 prewarm_id = f"resp_prewarm_{self.ws_turns + 1}"
+                with self._lock:
+                    self.prewarm_ids[connection_id] = prewarm_id
                 _send_frame(conn, OP_TEXT, json.dumps(
                     {"type": "response.completed",
                      "response": {"id": prewarm_id, "usage": dict(USAGE)}},

--- a/scripts/codex_ws_test.py
+++ b/scripts/codex_ws_test.py
@@ -437,7 +437,7 @@ def assert_midturn_requests(mock: CodexMock) -> None:
     if first.connection_id == final.connection_id:
         raise AssertionError("midturn: final request reused the pre-compaction WS")
     for request in requests:
-        if "previous_response_id" in request.body:
+        if not mock.has_fresh_parent(request):
             raise AssertionError(
                 f"midturn: request {request.ordinal} carried stale previous_response_id: "
                 f"{request.body['previous_response_id']!r}"
@@ -580,7 +580,7 @@ def assert_transactional_requests(mock: CodexMock) -> None:
             "transactional: final request reused the pre-compaction WS"
         )
     for request in requests:
-        if "previous_response_id" in request.body:
+        if not mock.has_fresh_parent(request):
             raise AssertionError(
                 f"transactional: request {request.ordinal} carried stale "
                 f"previous_response_id: {request.body['previous_response_id']!r}"

--- a/sdk/ts/scripts/test-packed-install.mjs
+++ b/sdk/ts/scripts/test-packed-install.mjs
@@ -66,12 +66,14 @@ try {
     await chmod(sourceBinary, 0o755);
   }
 
+  const sdkManifest = JSON.parse(await readFile(join(SDK_ROOT, "package.json"), "utf8"));
   const nativeTarballs = {};
   for (const [target, packageName] of ALL_TARGETS) {
     const output = run(process.execPath, [
       join(HERE, "package-platform.mjs"),
       "--target", target,
       "--binary", sourceBinary,
+      "--version", sdkManifest.optionalDependencies[packageName],
       "--out", packages,
     ], SDK_ROOT);
     const { packageDir } = JSON.parse(output);
@@ -88,7 +90,7 @@ try {
     ),
   };
   await writeFile(join(consumer, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`);
-  npmRun(["install", "--ignore-scripts", "--no-audit", "--no-fund"], consumer);
+  npmRun(["install", "--offline", "--ignore-scripts", "--no-audit", "--no-fund"], consumer);
 
   const smoke = `
 import { Harness } from "@codegraff/sdk";

--- a/src/subagent_activity.zig
+++ b/src/subagent_activity.zig
@@ -208,7 +208,7 @@ test "cancel file marks a working child interrupted even if it later finishes" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const io = std.testing.io;
-    var r: Recorder = .{ .a = std.testing.allocator, .io = io, .dir = try tmp.dir.openDir(io, ".", .{}), .meta = .{ .id = "child", .label = "test", .task = "test" } };
+    var r: Recorder = .{ .a = std.testing.allocator, .io = io, .dir = try tmp.dir.openDir(io, ".", .{ .iterate = true }), .meta = .{ .id = "child", .label = "test", .task = "test" } };
     defer r.deinit();
     try requestInterrupt(io, r.dir, "child");
     try std.testing.expect(interruptRequested(io, r.dir, "child"));


### PR DESCRIPTION
## What changed
- Render detail-free task rows as static content, without disclosure controls or empty detail spacing; preserve expansion when details exist.
- Add rendered and interactive task-row regressions and run the browser suite in desktop CI.
- Repair the offline SDK package fixture and Linux cancellation fixture.
- Stabilize composer pointer tests by settling hover/layout and hit-testing before pressing.
- Distinguish a fresh socket's observed prewarm anchor from a stale response chain in transport tests.

## Why
Task labels and statuses do not imply details exist. Disclosure must depend on actual content, not progress or completion.

CI verification also exposed fixture defects: mismatched mock package versions could select a released executable, directory pruning required an iterable handle, pointer coordinates could become stale, and valid fresh-connection prewarming was misclassified as stale history. The fixes preserve the selection, socket-replacement, full-history, and stale-chain assertions rather than weakening them.

## Validation
- Desktop unit tests, production build, task/project/stress/agent browser suites, and updater bundle check passed.
- SDK tests, typecheck, build, and offline package smoke passed.
- Zig unit suite and transport scenarios passed.
- Full offline tier-1 pre-push checks passed.
- All seven GitHub checks passed.

Fixes #826. Fixes #837.
Related fixture repairs: #834 and #835.
