### PR TITLE
GUI: choose where web links open

### DIFF
--- a/apps/native/components/site/DesktopSettings.tsx
+++ b/apps/native/components/site/DesktopSettings.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { desktop, type LinkDestination } from "@/lib/desktop";
+
+export default function DesktopSettings() {
+  const [available, setAvailable] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [destination, setDestination] = useState<LinkDestination | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const trigger = useRef<HTMLButtonElement>(null);
+  const panel = useRef<HTMLDivElement>(null);
+  useEffect(() => setAvailable(!!desktop()?.linkSettings), []);
+  useEffect(() => {
+    if (!open) return;
+    let alive = true;
+    setDestination(null); setError("");
+    void desktop()!.linkSettings!("load").then(value => { if (alive) setDestination(value); })
+      .catch(() => { if (alive) setError("Could not load link settings. Close Settings and try again."); });
+    panel.current?.querySelector<HTMLButtonElement>("button")?.focus();
+    const keys = (event: KeyboardEvent) => {
+      if (event.key === "Escape") { event.stopPropagation(); setOpen(false); trigger.current?.focus(); }
+      if (event.key === "Tab") {
+        const buttons = Array.from(panel.current?.querySelectorAll<HTMLButtonElement>("button:not(:disabled)") ?? []);
+        if (!buttons.length) return;
+        event.preventDefault();
+        const index = buttons.indexOf(document.activeElement as HTMLButtonElement);
+        buttons[(index + (event.shiftKey ? buttons.length - 1 : 1)) % buttons.length]?.focus();
+      }
+    };
+    document.addEventListener("keydown", keys);
+    return () => { alive = false; document.removeEventListener("keydown", keys); };
+  }, [open]);
+  const choose = async (value: LinkDestination) => {
+    setSaving(true); setError("");
+    try { setDestination(await desktop()!.linkSettings!("save", value)); }
+    catch { setError("Could not save link settings. Try again."); }
+    finally { setSaving(false); }
+  };
+  if (!available) return null;
+  return <>
+    <button ref={trigger} aria-label="Settings" title="Settings" aria-haspopup="dialog" aria-expanded={open}
+      onClick={() => setOpen(value => !value)} className="flex size-8 shrink-0 items-center justify-center rounded-lg text-ink-3 hover:bg-hover hover:text-ink">
+      <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7"><path d="m9 3-1 3-3 1 1 3-2 2 2 2-1 3 3 1 1 3h6l1-3 3-1-1-3 2-2-2-2 1-3-3-1-1-3Z"/><circle cx="12" cy="12" r="3"/></svg>
+    </button>
+    {open && createPortal(<div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/20 p-4" onPointerDown={event => {
+      if (event.target === event.currentTarget) { setOpen(false); trigger.current?.focus(); }
+    }}>
+      <div ref={panel} role="dialog" aria-label="Settings" aria-modal="true" className="w-[380px] max-w-full rounded-xl border border-line bg-surface p-4 shadow-overlay">
+        <div className="mb-4 flex items-center justify-between"><strong className="text-sm font-medium">Settings</strong><button aria-label="Close settings" onClick={() => { setOpen(false); trigger.current?.focus(); }} className="rounded px-1.5 text-ink-3 hover:bg-hover">×</button></div>
+        <fieldset disabled={destination === null || saving}>
+          <legend className="mb-1 text-xs font-medium">Open web links in</legend>
+          <p className="mb-3 text-xs text-ink-3">Choose where links from conversations open. Graff keeps pages beside your chat.</p>
+          <div className="flex flex-col gap-2">{([['system', 'System default browser'], ['graff', 'Graff built-in Browser']] as const).map(([value, label]) =>
+            <button key={value} aria-pressed={destination === value} onClick={() => void choose(value)} className={`rounded-lg border px-3 py-2 text-left text-xs focus-visible:outline-2 focus-visible:outline-accent disabled:opacity-50 ${destination === value ? "border-accent bg-accent-tint" : "border-line hover:bg-hover"}`}>{label}</button>
+          )}</div>
+        </fieldset>
+        {saving && <p role="status" className="mt-3 text-xs text-ink-3">Saving…</p>}
+        {error && <p role="alert" className="mt-3 text-xs text-red">{error}</p>}
+      </div>
+    </div>, document.body)}
+  </>;
+}

--- a/apps/native/components/site/GraffHarness.tsx
+++ b/apps/native/components/site/GraffHarness.tsx
@@ -109,8 +109,8 @@ export default function GraffHarness() {
   // The sidecar browser: one Chrome tab per chat, and the pins the user
   // drops on it, which ride ahead of the chat's next prompt.
   const [browserOpen, setBrowserOpen] = useBrowserVisibility(BROWSER_OPEN_KEY, (chat) => {
-    const target = chats.find(c => chatHandle(pageRef.current, c.id) === chat);
-    if (target) { focusChat(target.id); setFilesOpen(false); } return !!target;
+    const target = chats.find(c => chat ? chatHandle(pageRef.current, c.id) === chat : c.id === activeId);
+    if (target) { focusChat(target.id); setFilesOpen(false); } return target ? chatHandle(pageRef.current, target.id) : false;
   });
   // The conversation library: every saved chat, paged and searchable. It takes
   // the whole chat area, so opening it leaves the other side panes.

--- a/apps/native/components/site/HarnessChrome.tsx
+++ b/apps/native/components/site/HarnessChrome.tsx
@@ -1,6 +1,7 @@
 import { IconChat, IconFolder, IconGlobe } from "@/lib/icons";
 import { useEffect, useRef } from "react";
 import { ThemeToggle } from "./ThemeToggle";
+import DesktopSettings from "./DesktopSettings";
 import type { Chat } from "./harness-types";
 import reviewStyles from "./ChangesPane.module.css";
 type Props = {
@@ -141,6 +142,7 @@ export default function HarnessChrome({chats, activeId, busyIds, focusChat, clos
         <button aria-label="Toggle terminal" aria-pressed={terminalVisible} title="Terminal (⌘J)" onClick={toggleTerminal} className="rounded-lg px-2 py-1 text-xs text-ink-2 hover:bg-hover"><svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7"><rect x="3" y="4" width="18" height="16" rx="3"/><path d="m7 9 3 3-3 3m6 0h4"/></svg></button>
         <button aria-label="Show agents" aria-pressed={agentsOpen} onClick={onAgents} className="flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs text-ink-2 hover:bg-hover"><svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7"><circle cx="9" cy="7" r="3"/><path d="M3 20v-3a6 6 0 0 1 12 0v3M16 4a3 3 0 0 1 0 6M18 14a5 5 0 0 1 3 4v2"/></svg><span data-toolbar-label>Agents{workingAgents > 0 ? ` (${workingAgents})` : ""}</span>{workingAgents > 0 && <span className="size-1.5 shrink-0 animate-pulse rounded-full" style={{ background: "var(--accent)" }} aria-hidden />}</button>
         <ThemeToggle />
+        <DesktopSettings />
       </div>
     </div>
   );

--- a/apps/native/components/site/useBrowserVisibility.ts
+++ b/apps/native/components/site/useBrowserVisibility.ts
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import { desktop } from "@/lib/desktop";
-export function useBrowserVisibility(key: string, onAgentOpen: (chat: string) => boolean) {
+export function useBrowserVisibility(key: string, onAgentOpen: (chat?: string) => string | false) {
   const [open, setOpen] = useState(false);
   const restored = useRef(false);
   const callback = useRef(onAgentOpen); callback.current = onAgentOpen;
@@ -13,6 +13,14 @@ export function useBrowserVisibility(key: string, onAgentOpen: (chat: string) =>
   }, [key, open]);
   useEffect(() => desktop()?.subscribe(event => {
     if (event.type === "show" && event.chat) { if (callback.current(event.chat)) setOpen(true); }
+    if (event.type === "open-link" && event.url) {
+      const chat = callback.current();
+      if (chat) {
+        setOpen(true);
+        // Electron already validated the link; navigation remains in the isolated side pane.
+        void desktop()?.browser(chat, "navigate", { url: event.url }).catch(() => {});
+      }
+    }
   }), []);
   return [open, setOpen] as const;
 }

--- a/apps/native/components/site/useDesktopShortcuts.ts
+++ b/apps/native/components/site/useDesktopShortcuts.ts
@@ -38,7 +38,9 @@ export function useDesktopShortcuts(actions: Actions) {
       const command=e.metaKey||e.ctrlKey;
       const focus=(id:number)=>{
         a.focusChat(id);
-        requestAnimationFrame(()=>document.querySelector<HTMLTextAreaElement>(`[data-chat="${id}"] textarea`)?.focus({preventScroll:true}));
+        requestAnimationFrame(()=>{
+          if(ref.current.activeId===id)document.querySelector<HTMLTextAreaElement>(`[data-chat="${id}"] textarea`)?.focus({preventScroll:true});
+        });
       };
       const cycle=(ids:number[],delta:number)=>{const index=ids.indexOf(a.activeId);const id=ids[(index+delta+ids.length)%ids.length];if(id!==undefined)focus(id);};
       if(e.ctrlKey&&!e.metaKey&&k==='tab'){cycle(a.chats.map(c=>c.id),e.shiftKey?-1:1);handled=true;}

--- a/apps/native/electron/composer-interaction-visual.cjs
+++ b/apps/native/electron/composer-interaction-visual.cjs
@@ -19,7 +19,7 @@ async function runComposerInteractions({ win, origin, output }) {
     await pause();
   };
   const pointer = async selector => {
-    const point = await js(`(()=>{const e=document.querySelector(${JSON.stringify(selector)});e.scrollIntoView({block:'nearest'});const r=e.getBoundingClientRect();return {x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)}})()`);
+    const point = await js(`(async()=>{const e=document.querySelector(${JSON.stringify(selector)});e.scrollIntoView({block:'nearest'});await new Promise(resolve=>requestAnimationFrame(()=>requestAnimationFrame(resolve)));const r=e.getBoundingClientRect();return {x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)}})()`);
     wc.sendInputEvent({ type: 'mouseDown', button: 'left', clickCount: 1, ...point });
     wc.sendInputEvent({ type: 'mouseUp', button: 'left', clickCount: 1, ...point });
     await pause();

--- a/apps/native/electron/composer-interaction-visual.cjs
+++ b/apps/native/electron/composer-interaction-visual.cjs
@@ -86,11 +86,17 @@ async function runComposerInteractions({ win, origin, output }) {
     await key('2', { metaKey: true });
     assert.equal(await draft(second), 'Second unsent draft', 'An older upload must not reset another chat');
     assert.equal(await js(`!!document.querySelector('[aria-label="Remove composer-image.png"]')`), false, 'Attachments never move between chats');
-    await key('1', { metaKey: true });
-
+    // Delay the first shortcut's focus frame until a newer navigation has won.
+    await js(`(()=>{const raf=window.requestAnimationFrame,frames=[];window.requestAnimationFrame=callback=>{frames.push(callback);return 0;};
+      try{document.activeElement.dispatchEvent(new KeyboardEvent('keydown',{key:'1',metaKey:true,bubbles:true,cancelable:true}));}
+      finally{window.requestAnimationFrame=raf;}window.flushOldFocus=()=>frames.forEach(callback=>callback(performance.now()));})()`);
+    await wait(`document.querySelector('[data-chat][data-focused="true"]')?.dataset.chat==='${first}'`);
     await key('d', { metaKey: true });
     await wait(`document.querySelectorAll('[data-chat]').length===2`);
     const split = await focused();
+    assert.notEqual(split, first, 'A new split becomes active');
+    await js('window.flushOldFocus()');
+    assert.equal(await focused(), split, 'An older shortcut focus frame must not steal the new split');
     await input('Keep this split draft');
     await pointer(`[data-chat="${first}"] textarea`);
     // Use a native key event so an accidental textarea newline is observable.

--- a/apps/native/electron/external-links.cjs
+++ b/apps/native/electron/external-links.cjs
@@ -4,9 +4,14 @@ function externalURL(raw) {
   catch { return null; }
 }
 function installExternalLinks(contents, origin, open = url => require('electron').shell.openExternal(url)) {
-  const launch = raw => { const url = externalURL(raw); if (url) void Promise.resolve(open(url)).catch(() => {}); };
+  const internal = raw => { try { return new URL(raw).origin === origin; } catch { return false; } };
+  const launch = raw => {
+    const url = externalURL(raw);
+    if (!url || internal(url)) return;
+    try { void Promise.resolve(open(url)).catch(() => {}); } catch { /* A failed destination must not navigate the app. */ }
+  };
   contents.on('will-navigate', (event, url) => {
-    if (new URL(url).origin === origin) return;
+    if (externalURL(url) && internal(url)) return;
     event.preventDefault(); launch(url);
   });
   contents.setWindowOpenHandler(({ url }) => { launch(url); return { action: 'deny' }; });

--- a/apps/native/electron/external-links.test.cjs
+++ b/apps/native/electron/external-links.test.cjs
@@ -2,14 +2,183 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
 const { externalURL, installExternalLinks } = require('./external-links.cjs');
-test('clicked web links leave the shell; executable schemes cannot reach the OS', () => {
-  const contents = new EventEmitter(); let popup; const opened = [];
+
+const APP_ORIGIN = 'http://127.0.0.1:3788';
+
+function harness(openCallback) {
+  const contents = new EventEmitter();
+  const opened = [];
+  let popup;
   contents.setWindowOpenHandler = handler => { popup = handler; };
-  installExternalLinks(contents, 'http://127.0.0.1:3788', url => opened.push(url));
-  let prevented = false;
-  contents.emit('will-navigate', { preventDefault() { prevented = true; } }, 'https://example.com/docs');
-  assert.equal(prevented, true); assert.deepEqual(opened, ['https://example.com/docs']);
-  popup({ url: 'https://example.com/help' }); popup({ url: 'file:///etc/passwd' });
-  assert.equal(opened.length, 2);
-  for (const url of ['javascript:alert(1)', 'data:text/html,hi', 'https://user:pass@example.com', 'not a URL']) assert.equal(externalURL(url), null);
+  installExternalLinks(contents, APP_ORIGIN, openCallback || (url => opened.push(url)));
+  return {
+    opened,
+    navigate(url) {
+      let prevented = 0;
+      contents.emit('will-navigate', { preventDefault() { prevented += 1; } }, url);
+      return prevented;
+    },
+    popup(url) { return popup({ url }); },
+  };
+}
+
+const validURLs = [
+  ['HTTPS document', 'https://example.com/docs?x=1#section', 'https://example.com/docs?x=1#section'],
+  ['HTTP document', 'http://example.com/docs', 'http://example.com/docs'],
+  ['host and scheme case', 'HTTPS://EXAMPLE.COM/docs', 'https://example.com/docs'],
+  ['HTTPS default port', 'https://example.com:443', 'https://example.com/'],
+  ['HTTP default port', 'http://example.com:80', 'http://example.com/'],
+  ['nondefault port', 'https://example.com:8443/docs', 'https://example.com:8443/docs'],
+  ['dot segments', 'https://example.com/a/../b/./c', 'https://example.com/b/c'],
+  ['spaces in path', 'https://example.com/a b', 'https://example.com/a%20b'],
+  ['international host', 'https://bücher.example/', 'https://xn--bcher-kva.example/'],
+  ['IPv6 host', 'http://[::1]:8080/docs', 'http://[::1]:8080/docs'],
+  ['at sign in path and query', 'https://example.com/@name?email=a@b', 'https://example.com/@name?email=a@b'],
+  ['encoded separators remain encoded', 'https://example.com/a%2Fb?q=%23x', 'https://example.com/a%2Fb?q=%23x'],
+];
+
+const invalidURLs = [
+  ['undefined', undefined],
+  ['null', null],
+  ['number', 42],
+  ['empty string', ''],
+  ['whitespace', '   '],
+  ['plain text', 'not a URL'],
+  ['relative path', '/settings'],
+  ['relative fragment', '#section'],
+  ['protocol-relative URL', '//example.com/docs'],
+  ['missing host', 'https://'],
+  ['invalid IPv6', 'http://[::1'],
+  ['invalid port', 'https://example.com:abc/'],
+  ['out-of-range port', 'https://example.com:65536/'],
+  ['space in host', 'https://exa mple.com/'],
+  ['bad host escape', 'https://%zz/'],
+  ['JavaScript', 'javascript:alert(1)'],
+  ['mixed-case JavaScript', 'JaVaScRiPt:alert(1)'],
+  ['data document', 'data:text/html,<h1>hello</h1>'],
+  ['local file', 'file:///etc/passwd'],
+  ['email', 'mailto:person@example.com'],
+  ['telephone', 'tel:+15555550100'],
+  ['FTP', 'ftp://example.com/file'],
+  ['WebSocket', 'wss://example.com/'],
+  ['blob URL', 'blob:https://example.com/123'],
+  ['blank page', 'about:blank'],
+  ['custom application scheme', 'graff://settings'],
+  ['username and password', 'https://user:pass@example.com/'],
+  ['username only', 'https://user@example.com/'],
+  ['password only', 'https://:pass@example.com/'],
+  ['encoded username', 'https://%75ser@example.com/'],
+  ['encoded password', 'https://:%70ass@example.com/'],
+  ['credentials on app origin', `${APP_ORIGIN.replace('://', '://user:pass@')}/settings`],
+];
+
+for (const [label, raw, canonical] of validURLs) {
+  test(`externalURL canonicalizes ${label}`, () => {
+    assert.equal(externalURL(raw), canonical);
+    assert.equal(externalURL(canonical), canonical, 'canonicalization must be idempotent');
+  });
+  test(`regular click dispatches ${label} once and prevents shell navigation`, () => {
+    const links = harness();
+    assert.equal(links.navigate(raw), 1);
+    assert.deepEqual(links.opened, [canonical]);
+  });
+  test(`target blank dispatches ${label} once but denies the Electron popup`, () => {
+    const links = harness();
+    assert.deepEqual(links.popup(raw), { action: 'deny' });
+    assert.deepEqual(links.opened, [canonical]);
+  });
+}
+
+for (const [label, raw] of invalidURLs) {
+  test(`externalURL rejects ${label}`, () => {
+    assert.equal(externalURL(raw), null);
+  });
+  test(`regular click blocks ${label} without throwing or dispatching`, () => {
+    const links = harness();
+    assert.equal(links.navigate(raw), 1);
+    assert.deepEqual(links.opened, []);
+  });
+  test(`target blank denies ${label} without dispatching`, () => {
+    const links = harness();
+    assert.deepEqual(links.popup(raw), { action: 'deny' });
+    assert.deepEqual(links.opened, []);
+  });
+}
+
+const internalURLs = [
+  `${APP_ORIGIN}/`,
+  `${APP_ORIGIN}/settings?tab=browser`,
+  `${APP_ORIGIN}/workspace/project#file`,
+  `${APP_ORIGIN}/#settings`,
+  `${APP_ORIGIN}/redirect?next=https://example.com/`,
+  'HTTP://127.0.0.1:3788/settings',
+];
+for (const url of internalURLs) {
+  test(`same-origin navigation remains internal: ${url}`, () => {
+    const links = harness();
+    assert.equal(links.navigate(url), 0);
+    assert.deepEqual(links.opened, []);
+  });
+  test(`same-origin popup is denied without exposing the app origin: ${url}`, () => {
+    const links = harness();
+    assert.deepEqual(links.popup(url), { action: 'deny' });
+    assert.deepEqual(links.opened, []);
+  });
+}
+
+for (const url of [
+  'http://127.0.0.1:3789/settings',
+  'http://127.0.0.1/settings',
+  'https://127.0.0.1:3788/settings',
+  'http://localhost:3788/settings',
+  'http://127.0.0.1.example.com:3788/settings',
+]) {
+  test(`origin comparison dispatches a distinct origin: ${url}`, () => {
+    const links = harness();
+    assert.equal(links.navigate(url), 1);
+    assert.deepEqual(links.popup(url), { action: 'deny' });
+    assert.deepEqual(links.opened, [url, url]);
+  });
+}
+
+for (const kind of ['navigate', 'popup']) {
+  test(`${kind} contains synchronous callback throws and handles the next click`, () => {
+    const opened = [];
+    const links = harness(url => {
+      opened.push(url);
+      if (opened.length === 1) throw new Error('destination unavailable');
+    });
+    const expected = kind === 'navigate' ? 1 : { action: 'deny' };
+    assert.deepEqual(links[kind]('https://example.com/first'), expected);
+    assert.deepEqual(links[kind]('https://example.com/second'), expected);
+    assert.deepEqual(opened, ['https://example.com/first', 'https://example.com/second']);
+  });
+
+  test(`${kind} consumes callback rejection and handles subsequent clicks`, async () => {
+    const opened = [];
+    const links = harness(url => {
+      opened.push(url);
+      return Promise.reject(new Error('destination unavailable'));
+    });
+    const expected = kind === 'navigate' ? 1 : { action: 'deny' };
+    assert.deepEqual(links[kind]('https://example.com/first'), expected);
+    // Cross an event-loop turn: node:test reports any unhandled rejection as a failure.
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(links[kind]('https://example.com/second'), expected);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(opened, ['https://example.com/first', 'https://example.com/second']);
+  });
+}
+
+test('the supplied callback can change destinations without reinstalling handlers', () => {
+  let destination = 'system';
+  const dispatched = [];
+  const links = harness(url => dispatched.push({ destination, url }));
+  assert.equal(links.navigate('https://example.com/first'), 1);
+  destination = 'built-in';
+  assert.deepEqual(links.popup('https://example.com/second'), { action: 'deny' });
+  assert.deepEqual(dispatched, [
+    { destination: 'system', url: 'https://example.com/first' },
+    { destination: 'built-in', url: 'https://example.com/second' },
+  ]);
 });

--- a/apps/native/electron/link-destination-visual.cjs
+++ b/apps/native/electron/link-destination-visual.cjs
@@ -1,0 +1,194 @@
+const { BrowserWindow, ipcMain } = require('electron');
+const { BrowserTabs } = require('./browser-tabs.cjs');
+const { installExternalLinks } = require('./external-links.cjs');
+const { installGalleryFixture } = require('./gallery-fixture.cjs');
+const { linkSettings } = require('./link-settings.cjs');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+async function runLinkDestinationVisuals({ origin, output }) {
+  fs.mkdirSync(output, { recursive: true });
+  const directory = fs.mkdtempSync(path.join(output, 'link-settings-'));
+  let store = linkSettings(directory);
+  const fixture = http.createServer((_req, res) => {
+    res.setHeader('content-type', 'text/html');
+    res.end('<!doctype html><title>Link destination fixture</title><h1>Local browser destination</h1>');
+  });
+  await new Promise(resolve => fixture.listen(0, '127.0.0.1', resolve));
+  const destination = `http://127.0.0.1:${fixture.address().port}`;
+  const win = new BrowserWindow({ width: 1440, height: 900, show: true, webPreferences: {
+    preload: path.join(__dirname, 'preload.cjs'), partition: `link-destination-${path.basename(directory)}`,
+    sandbox: true, contextIsolation: true, nodeIntegration: false, backgroundThrottling: false,
+  } });
+  const wc = win.webContents, js = async code => {
+    try { return await wc.executeJavaScript(code); }
+    catch (error) { console.error('Link fixture expression:', code); throw error; }
+  };
+  wc.on('console-message', event => { if (event.level >= 2) console.error('Link renderer:', event.message); });
+  const browser = new BrowserTabs(win, event => wc.send('browser-event', event));
+  const system = [], routed = [], settings = [], blocked = [], errors = [];
+  // Neither session may reach the network or an engine endpoint. Only the app's
+  // static assets and our loopback HTML fixture are allowed through.
+  const guard = allowed => (details, callback) => {
+    const url = new URL(details.url);
+    const deny = !['about:', 'data:'].includes(url.protocol) && (url.origin !== allowed || url.pathname.startsWith('/api/'));
+    if (deny) blocked.push(details.url);
+    callback({ cancel: deny });
+  };
+  wc.session.webRequest.onBeforeRequest(guard(new URL(origin).origin));
+  browser.session.webRequest.onBeforeRequest(guard(destination));
+  ipcMain.handle('link-settings', async (_event, action, value) => {
+    assert.ok(['load', 'save'].includes(action));
+    const result = await (action === 'save' ? store.save(value) : store.load());
+    settings.push({ action, value, result }); return result;
+  });
+  ipcMain.handle('browser', async (_event, { chat, method, params }) => {
+    try { return await browser.command(chat, method, params); }
+    catch (error) { errors.push(error.message); throw error; }
+  });
+  const overlay = (event, value) => { if (event.sender === wc) browser.setOverlay(value); };
+  ipcMain.on('browser-overlay', overlay);
+  installExternalLinks(wc, new URL(origin).origin, async url => {
+    const choice = await store.load(); routed.push({ choice, url });
+    if (choice === 'graff') wc.send('browser-event', { type: 'open-link', url });
+    else system.push(url); // Deliberately never use shell.openExternal.
+  });
+  const wait = async (test, label) => {
+    for (let i = 0; i < 150; i++) { if (await (typeof test === 'string' ? js(test) : test())) return; await sleep(50); }
+    throw Error(`Link destination timeout: ${label || test}`);
+  };
+  const click = selector => js(`document.querySelector(${JSON.stringify(selector)}).click()`);
+  const dialog = '[role="dialog"][aria-label="Settings"]';
+  const labels = { system: 'System default browser', graff: 'Graff built-in Browser' };
+  const option = choice => `Array.from(document.querySelectorAll('${dialog} button')).find(b=>b.textContent.trim()===${JSON.stringify(labels[choice])})`;
+  const selected = async choice => {
+    await wait(`${option(choice)}?.getAttribute('aria-pressed')==='true'`);
+    assert.equal(await js(`${option(choice === 'system' ? 'graff' : 'system')}?.getAttribute('aria-pressed')`), 'false');
+  };
+  const openSettings = async () => {
+    await wait(`!!document.querySelector('[aria-label="Settings"]')`, 'Settings hydrated');
+    await click('[aria-label="Settings"]'); await wait(`!!document.querySelector('${dialog}')`);
+    await wait(() => browser.overlay === true, 'settings hide the native browser view');
+  };
+  const closeSettings = async () => { await click('[aria-label="Close settings"]'); await wait(`!document.querySelector('${dialog}')`); await wait(() => browser.overlay === false, 'closing settings releases the overlay'); };
+  const choose = async choice => {
+    const before = settings.filter(s => s.action === 'save').length;
+    await wait(`${option(choice)} && !${option(choice)}.matches(':disabled')`, 'preference loaded and ready to change');
+    await js(`${option(choice)}.click()`); await selected(choice);
+    await wait(() => settings.filter(s => s.action === 'save').length > before, 'setting saved through real preload');
+    assert.equal(await store.load(), choice);
+    assert.equal(await linkSettings(directory).load(), choice, 'a fresh store reads the UI selection');
+  };
+  // These anchors live inside the real conversation pane, not a test-only route.
+  // Injection also permits unsafe schemes that the markdown sanitizer removes.
+  const link = async (url, target = '', pane = '[data-chat][data-focused="true"]') => {
+    await js(`(()=>{const p=document.querySelector(${JSON.stringify(pane)}) || document.querySelector('[data-chat]');p.querySelector('[data-link-fixture]')?.remove();const a=document.createElement('a');a.dataset.linkFixture='';a.href=${JSON.stringify(url)};a.target=${JSON.stringify(target)};a.textContent='Conversation destination';p.append(a);a.click();})()`);
+  };
+  const screenshot = async name => {
+    await js('new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve(true))))');
+    await sleep(100); // Allow Chromium to present the hydrated frame before capture.
+    fs.writeFileSync(path.join(output, name), (await wc.capturePage()).toPNG());
+  };
+  const closeBrowser = async () => {
+    if (await js(`!!document.querySelector('[aria-label="Close browser"]')`)) await click('[aria-label="Close browser"]');
+    await wait(`!document.querySelector('[aria-label="Close browser"]')`);
+    await wait(() => browser.visible === null, 'browser closed');
+  };
+  const route = async (choice, target, suffix) => {
+    const url = `${destination}/${suffix}`, before = routed.length, opened = system.length, appURL = wc.getURL();
+    await link(url, target);
+    await wait(() => routed.length === before + 1, 'conversation link intercepted exactly once');
+    assert.deepEqual(routed[before], { choice, url });
+    if (choice === 'system') {
+      await wait(() => system.length === opened + 1, 'fake system opener');
+      assert.equal(system.at(-1), url);
+      assert.equal(browser.liveCount, 0, 'system links do not create a browser page');
+      assert.equal(await js(`!!document.querySelector('[aria-label="Close browser"]')`), false);
+    } else {
+      await wait(`!!document.querySelector('[aria-label="Close browser"]')`);
+      await wait(() => { const tab = browser.tabs.get(browser.visible); return tab?.view?.webContents.getURL() === url && !tab.view.webContents.isLoading(); }, 'real BrowserTabs navigation');
+      const page = browser.tabs.get(browser.visible).view.webContents;
+      assert.equal(await page.executeJavaScript('document.querySelector("h1").textContent'), 'Local browser destination');
+      await wait(() => browser.tabs.get(browser.visible)?.view?.getVisible(), 'native browser revealed');
+      assert.equal(system.length, opened, 'Graff never invokes even the fake system opener');
+    }
+    assert.equal(wc.getURL(), appURL, 'external links preserve the main app URL');
+    assert.ok(await js(`!!document.querySelector('textarea[aria-label="Prompt"]')`), 'conversation survives routing');
+  };
+  try {
+    await wc.loadURL('about:blank'); wc.debugger.attach('1.3'); await wc.debugger.sendCommand('Page.enable');
+    await wc.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', { source: `(${installGalleryFixture.toString()})();` });
+    await wc.loadURL(origin); win.focus(); await wait(`!!document.querySelector('textarea[aria-label="Prompt"]')`);
+    assert.equal(await js(`typeof window.graffDesktop.linkSettings`), 'function', 'real preload exposes linkSettings');
+    await openSettings(); await selected('system');
+    assert.equal(await store.load(), 'system');
+    await screenshot('link-destination-default.png');
+    await closeSettings();
+    await route('system', '', 'default-normal'); await route('system', '_blank', 'default-blank');
+    await openSettings(); await choose('graff'); await closeSettings();
+    await route('graff', '', 'graff-normal');
+    await openSettings();
+    assert.equal(browser.tabs.get(browser.visible).view.getVisible(), false, 'Settings covers the native page');
+    await selected('graff'); await closeSettings();
+    await closeBrowser(); await route('graff', '_blank', 'graff-blank');
+    await screenshot('link-destination-graff.png');
+    await closeBrowser();
+    await new Promise(resolve => { wc.once('did-finish-load', resolve); wc.reload(); });
+    await wait(`!!document.querySelector('textarea[aria-label="Prompt"]')`);
+    await openSettings(); await selected('graff'); await closeSettings();
+    store = linkSettings(directory);
+    await new Promise(resolve => { wc.once('did-finish-load', resolve); wc.reload(); });
+    await wait(`!!document.querySelector('textarea[aria-label="Prompt"]')`);
+    await openSettings(); await selected('graff'); await closeSettings();
+    await route('graff', '', 'persisted'); await closeBrowser();
+    await openSettings(); await choose('system'); await closeSettings();
+    await route('system', '', 'switched-normal'); await route('system', '_blank', 'switched-blank');
+    await openSettings(); await choose('graff'); await closeSettings();
+    await route('graff', '_blank', 'switched-back'); await closeBrowser();
+
+    for (const choice of ['system', 'graff']) {
+      if (await store.load() !== choice) { await openSettings(); await choose(choice); await closeSettings(); }
+      const before = routed.length, appURL = wc.getURL();
+      for (const url of ['file:///graff-link-fixture-denied', 'data:text/html,denied', `http://user:password@127.0.0.1:${fixture.address().port}/denied`]) {
+        for (const target of ['', '_blank']) await link(url, target);
+      }
+      await sleep(300);
+      assert.equal(routed.length, before, `${choice}: unsafe and credential-bearing links never reach either opener`);
+      assert.equal(browser.liveCount, 0); assert.equal(wc.getURL(), appURL);
+    }
+    // Split focus must choose a different real browser tab without moving panes.
+    await js(`document.querySelector('textarea').focus();document.activeElement.dispatchEvent(new KeyboardEvent('keydown',{key:'d',metaKey:true,bubbles:true,cancelable:true}))`);
+    await wait(`document.querySelectorAll('[data-chat]').length===2`);
+    const panes = await js(`Array.from(document.querySelectorAll('[data-chat]')).map(p=>p.dataset.chat)`);
+    const handles = [];
+    for (const id of panes) {
+      const selector = `[data-chat="${id}"] textarea`;
+      const point = await js(`(()=>{const r=document.querySelector(${JSON.stringify(selector)}).getBoundingClientRect();return {x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)}})()`);
+      wc.sendInputEvent({ type: 'mouseDown', button: 'left', clickCount: 1, ...point });
+      wc.sendInputEvent({ type: 'mouseUp', button: 'left', clickCount: 1, ...point });
+      await wait(`document.querySelector('[data-chat][data-focused="true"]')?.dataset.chat===${JSON.stringify(id)}`);
+      await route('graff', '', `split-${id}`); handles.push(browser.visible);
+      assert.equal(await js(`document.querySelector('[data-chat][data-focused="true"]').dataset.chat`), id);
+      await closeBrowser();
+    }
+    assert.notEqual(handles[0], handles[1], 'focused split chats own distinct browser tabs');
+    assert.deepEqual(await js(`Array.from(document.querySelectorAll('[data-chat]')).map(p=>p.dataset.chat)`), panes);
+    const before = routed.length;
+    await link(`${origin}/#link-destination-local`);
+    await wait(() => wc.getURL() === `${origin}/#link-destination-local`, 'same-origin anchor retains native navigation');
+    assert.equal(routed.length, before, 'same-origin links bypass external routing');
+    assert.ok(await js(`!!document.querySelector('textarea[aria-label="Prompt"]')`));
+    assert.deepEqual(errors, [], 'browser IPC completes without errors');
+    assert.deepEqual(blocked, [], 'no external network or engine/model requests attempted');
+    console.log('Link destination visuals passed: default/save/switch, reload and fresh-store persistence, normal/blank links, closed-browser reveal, overlays, unsafe/same-origin links, split focus and preserved app.');
+  } finally {
+    ipcMain.removeHandler('link-settings'); ipcMain.removeHandler('browser'); ipcMain.removeListener('browser-overlay', overlay);
+    browser.closeAll(); win.destroy(); browser.session.webRequest.onBeforeRequest(null);
+    await new Promise(resolve => fixture.close(resolve));
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+module.exports = { runLinkDestinationVisuals };

--- a/apps/native/electron/link-settings.cjs
+++ b/apps/native/electron/link-settings.cjs
@@ -1,0 +1,32 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { randomUUID } = require('node:crypto');
+function validate(value) {
+  if (value !== 'system' && value !== 'graff') throw Error('Invalid link preference');
+  return value;
+}
+function linkSettings(directory) {
+  const file = path.join(directory, 'web-links.json'); let pending = Promise.resolve();
+  return {
+    async load() {
+      await pending;
+      let data;
+      try { data = await fs.readFile(file, 'utf8'); } catch (error) { if (error.code === 'ENOENT') return 'system'; throw error; }
+      try { return validate(JSON.parse(data)); } catch { return 'system'; }
+    },
+    async save(value) {
+      const data = validate(value);
+      const write = pending.then(async () => {
+        await fs.mkdir(directory, { recursive: true });
+        const temporary = `${file}.${randomUUID()}.next`;
+        try {
+          await fs.writeFile(temporary, JSON.stringify(data), { mode: 0o600, flag: 'wx' });
+          await fs.rename(temporary, file);
+        } finally { await fs.unlink(temporary).catch(() => {}); }
+        return data;
+      });
+      pending = write.catch(() => {}); return write;
+    },
+  };
+}
+module.exports = { linkSettings };

--- a/apps/native/electron/link-settings.test.cjs
+++ b/apps/native/electron/link-settings.test.cjs
@@ -1,0 +1,114 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises'), os = require('node:os'), path = require('node:path');
+const { promisify } = require('node:util');
+const execFile = promisify(require('node:child_process').execFile);
+const { linkSettings } = require('./link-settings.cjs');
+async function fixture(t) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'link-settings-'));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  return root;
+}
+test('missing directory defaults to system without creating files', async t => {
+  const directory = path.join(await fixture(t), 'nested', 'settings');
+  assert.equal(await linkSettings(directory).load(), 'system');
+  await assert.rejects(fs.stat(directory), { code: 'ENOENT' });
+});
+test('missing file defaults to system and leaves other settings alone', async t => {
+  const root = await fixture(t);
+  await fs.writeFile(path.join(root, 'projects.json'), '{"list":[]}');
+  const store = linkSettings(root);
+  assert.equal(await store.load(), 'system');
+  await store.save('graff');
+  assert.equal(await fs.readFile(path.join(root, 'projects.json'), 'utf8'), '{"list":[]}');
+  assert.deepEqual((await fs.readdir(root)).sort(), ['projects.json', 'web-links.json']);
+});
+for (const data of ['', '{', 'undefined', 'null', 'true', '42', '[]', '{}', '"GRAFF"', '"graff "', '{"preference":"graff"}']) {
+  test(`corrupt or invalid stored data defaults to system: ${JSON.stringify(data)}`, async t => {
+    const root = await fixture(t);
+    await fs.writeFile(path.join(root, 'web-links.json'), data);
+    const store = linkSettings(root);
+    assert.equal(await store.load(), 'system');
+    assert.equal(await store.save('graff'), 'graff');
+    assert.equal(await store.load(), 'graff');
+  });
+}
+for (const value of ['system', 'graff']) {
+  test(`${value} roundtrips through a new store and a new process`, async t => {
+    const directory = path.join(await fixture(t), 'nested');
+    const store = linkSettings(directory);
+    assert.equal(await store.save(value), value);
+    assert.equal(await store.load(), value);
+    assert.equal(await linkSettings(directory).load(), value);
+    assert.equal(JSON.parse(await fs.readFile(path.join(directory, 'web-links.json'), 'utf8')), value);
+    const { stdout } = await execFile(process.execPath, ['-e',
+      'require(process.argv[1]).linkSettings(process.argv[2]).load().then(value => process.stdout.write(value));',
+      require.resolve('./link-settings.cjs'), directory]);
+    assert.equal(stdout, value);
+  });
+}
+test('invalid saves reject promises without changing the saved preference', async t => {
+  const root = await fixture(t), store = linkSettings(root);
+  await store.save('graff');
+  for (const value of [undefined, null, false, 0, '', 'SYSTEM', 'Graff', 'system ', ' graff', [], {}, new String('graff')]) {
+    await assert.rejects(store.save(value), /Invalid link preference/);
+    assert.equal(await store.load(), 'graff');
+  }
+  assert.equal(await store.save('system'), 'system');
+});
+test('concurrent saves resolve in call order and load waits for all queued writes', async t => {
+  const root = await fixture(t), store = linkSettings(root), completed = [];
+  const values = Array.from({ length: 40 }, (_, i) => i % 2 ? 'graff' : 'system');
+  const writes = values.map((value, i) => store.save(value).then(result => { completed.push(i); return result; }));
+  const read = store.load();
+  assert.equal(await read, 'graff');
+  assert.deepEqual(await Promise.all(writes), values);
+  assert.deepEqual(completed, values.map((_, i) => i));
+  assert.equal(await linkSettings(root).load(), 'graff');
+  assert.deepEqual(await fs.readdir(root), ['web-links.json']);
+});
+test('independent stores write complete JSON using separate temporary files', async t => {
+  const root = await fixture(t);
+  await Promise.all(Array.from({ length: 20 }, (_, i) => linkSettings(root).save(i % 2 ? 'graff' : 'system')));
+  assert.ok(['system', 'graff'].includes(await linkSettings(root).load()));
+  assert.deepEqual(await fs.readdir(root), ['web-links.json']);
+});
+test('directory creation failure rejects without poisoning subsequent saves', async t => {
+  const root = await fixture(t), directory = path.join(root, 'settings');
+  await fs.writeFile(directory, 'blocked');
+  const store = linkSettings(directory);
+  await assert.rejects(store.save('graff'));
+  await fs.unlink(directory);
+  assert.equal(await store.load(), 'system');
+  assert.equal(await store.save('graff'), 'graff');
+  assert.equal(await store.load(), 'graff');
+});
+test('rename failure cleans temporary files and allows recovery', async t => {
+  const root = await fixture(t), file = path.join(root, 'web-links.json');
+  await fs.mkdir(file);
+  const store = linkSettings(root);
+  await assert.rejects(store.save('graff'));
+  assert.deepEqual(await fs.readdir(root), ['web-links.json']);
+  await fs.rmdir(file);
+  assert.equal(await store.save('system'), 'system');
+  assert.equal(await store.load(), 'system');
+});
+test('saved files are private, including replacement of a permissive file', { skip: process.platform === 'win32' }, async t => {
+  const root = await fixture(t), file = path.join(root, 'web-links.json'), store = linkSettings(root);
+  await store.save('graff');
+  assert.equal((await fs.stat(file)).mode & 0o777, 0o600);
+  await fs.chmod(file, 0o644);
+  await store.save('system');
+  assert.equal((await fs.stat(file)).mode & 0o777, 0o600);
+});
+test('permission failure preserves the old preference and subsequent saves recover', { skip: process.platform === 'win32' || process.getuid?.() === 0 }, async t => {
+  const root = await fixture(t), store = linkSettings(root);
+  await store.save('system');
+  await fs.chmod(root, 0o500);
+  try {
+    await assert.rejects(store.save('graff'), { code: 'EACCES' });
+    assert.equal(await store.load(), 'system');
+  } finally { await fs.chmod(root, 0o700); }
+  assert.equal(await store.save('graff'), 'graff');
+  assert.equal(await store.load(), 'graff');
+});

--- a/apps/native/electron/main.cjs
+++ b/apps/native/electron/main.cjs
@@ -131,7 +131,18 @@ app.whenReady().then(async () => {
     win.webContents.focus();
     win.webContents.send('browser-event', { chat: tab.chat, type: 'pin', pin });
   });
-  installExternalLinks(win.webContents, backend.origin);
+  const linkSettings = require('./link-settings.cjs').linkSettings(app.getPath('userData'));
+  ipcMain.handle('link-settings', (event, action, value) => {
+    trusted(event);
+    if (action === 'load') return linkSettings.load();
+    if (action === 'save') return linkSettings.save(value);
+    throw new Error('Unknown link settings action');
+  });
+  installExternalLinks(win.webContents, backend.origin, async url => {
+    if (await linkSettings.load() === 'graff') {
+      if (!win.isDestroyed()) win.webContents.send('browser-event', { type: 'open-link', url });
+    } else await require('electron').shell.openExternal(url);
+  });
   win.on('minimize', () => { if (browser.visible) browser.hide(browser.visible); });
   win.on('restore', () => win.webContents.send('browser-event', { type: 'layout' }));
   const updateMenu = require('./updates.cjs').installUpdates({ app, win, ipcMain, trusted, resources });

--- a/apps/native/electron/preload.cjs
+++ b/apps/native/electron/preload.cjs
@@ -1,6 +1,7 @@
 const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('graffDesktop', {
   projects: (action, value) => ipcRenderer.invoke('projects', { action, value }),
+  linkSettings: (action, value) => ipcRenderer.invoke('link-settings', action, value),
   updates: (action, value) => ipcRenderer.invoke('updates', action, value),
   updateSubscribe: callback => {
     const listener = (_event, state) => callback(state);

--- a/apps/native/electron/visual-tests.cjs
+++ b/apps/native/electron/visual-tests.cjs
@@ -31,6 +31,12 @@ app.whenReady().then(async () => {
     if (url.origin === origin && url.pathname.startsWith('/api/')) apiRequests.push(url.pathname);
     callback({ cancel: !details.url.startsWith(origin) && !details.url.startsWith('data:') || url.pathname.startsWith('/api/') });
   });
+  if (process.env.GRAFF_VISUAL_SUITE === 'links') {
+    win.hide();
+    await require('./link-destination-visual.cjs').runLinkDestinationVisuals({ origin, output });
+    assert.deepEqual(apiRequests, [], 'Link fixtures never call engine or model APIs');
+    return;
+  }
   if (process.env.GRAFF_VISUAL_SUITE === 'updates') {
     await require('./updates-visual.cjs').runUpdateVisuals({ origin, output });
     await require('./updates-transport.cjs').runUpdateTransport();
@@ -43,6 +49,7 @@ app.whenReady().then(async () => {
     if (process.env.GRAFF_VISUAL_SUITE !== 'interactions') {
       await require('./browser-visual.cjs').runBrowserVisuals({ win, origin, output });
       await require('./dev-preview-visual.cjs').runDevPreview({ output });
+      await require('./link-destination-visual.cjs').runLinkDestinationVisuals({ origin, output });
     }
     assert.deepEqual(apiRequests, [], 'Project fixtures never call engine or model APIs');
     fs.writeFileSync(path.join(output, 'results.json'), JSON.stringify({ passed: process.env.GRAFF_VISUAL_SUITE === 'interactions' ? ['keyboard, composer, files and reading'] : ['projects and navigation', 'browser'], apiRequests }, null, 2));
@@ -95,6 +102,7 @@ app.whenReady().then(async () => {
   await require('./agents-visual.cjs').runAgentVisuals({ win, origin, output });
   await require('./updates-visual.cjs').runUpdateVisuals({ origin, output });
   await require('./updates-transport.cjs').runUpdateTransport();
+  await require('./link-destination-visual.cjs').runLinkDestinationVisuals({ origin, output });
   if (process.env.GRAFF_PERFORMANCE_TESTS) await require('./performance-scenarios.cjs').runPerformance({ win, origin, output });
   assert.deepEqual(apiRequests, [], 'Visual fixtures must not call the engine or model APIs');
   fs.writeFileSync(path.join(output, 'results.json'), JSON.stringify({ passed: results, apiRequests }, null, 2));

--- a/apps/native/lib/desktop.ts
+++ b/apps/native/lib/desktop.ts
@@ -1,10 +1,12 @@
 import type { BrowserPin, KuriHandle } from "./browser/annotations";
 import type { PageInfo } from "./browser-client";
 
-export type DesktopEvent = { type: string; chat?: string; info?: PageInfo; pin?: BrowserPin };
+export type DesktopEvent = { type: string; chat?: string; url?: string; info?: PageInfo; pin?: BrowserPin };
+export type LinkDestination = 'system' | 'graff';
 export type TerminalEvent = { id: string; seq: number; data?: string; exit?: number };
 export type UpdateState = { status: 'idle' | 'unavailable' | 'checking' | 'current' | 'downloading' | 'ready' | 'installing' | 'error'; currentVersion: string; version?: string; percent?: number; automatic: boolean; interactive: boolean; message?: string };
 export type DesktopBridge = {
+  linkSettings?(action: 'load' | 'save', value?: LinkDestination): Promise<LinkDestination>;
   projects?(action: 'load' | 'save', value?: { list: import('./workspaces').Workspace[]; active: string | null }): Promise<{ list: import('./workspaces').Workspace[]; active: string | null } | null | void>;
   updates?(action: 'state' | 'check' | 'restart' | 'automatic', value?: boolean): Promise<UpdateState>;
   updateSubscribe?(callback: (state: UpdateState) => void): () => void;

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -16,6 +16,7 @@
     "test:desktop": "bun test lib ./electron/*.test.cjs",
     "test:visual": "bun scripts/test-visual.mjs",
     "test:updates": "GRAFF_VISUAL_SUITE=updates bun scripts/test-visual.mjs",
+    "test:links": "GRAFF_VISUAL_SUITE=links bun scripts/test-visual.mjs",
     "test:interactions": "GRAFF_VISUAL_SUITE=interactions bun scripts/test-visual.mjs",
     "test:projects": "GRAFF_VISUAL_SUITE=projects bun scripts/test-visual.mjs",
     "test:splits": "GRAFF_VISUAL_SUITE=splits bun scripts/test-visual.mjs",

--- a/docs/adr/0096-desktop-link-destination.md
+++ b/docs/adr/0096-desktop-link-destination.md
@@ -1,0 +1,33 @@
+# 0096. Desktop web links share one destination policy
+
+Status: accepted 2026-09-10
+
+## Context
+
+Conversation links always opened in the system browser, even when users
+wanted to keep pages beside their chat (#824). The desktop server's origin
+can change between launches, so origin-scoped browser storage alone cannot
+reliably preserve this preference.
+
+## Decision
+
+Store the explicit `system` or `graff` choice atomically in desktop user data.
+Default missing or invalid preferences to the existing system-browser behavior.
+Expose the setting through trusted app-frame IPC, not to browser pages.
+
+Use Electron's shared navigation interception for both normal links and
+new-window links rather than adding handlers to individual Markdown renderers.
+Validate HTTP(S) URLs and reject credentials before routing either destination.
+Same-origin app navigation stays in the app; same-origin popups are denied.
+
+For Graff, send the validated link to the renderer, which resolves the focused
+chat and reveals its existing isolated Browser pane. Never replace the main
+application view or fall back to the system browser when Graff navigation fails.
+
+## Consequences
+
+The preference survives origin changes and restarts. All conversation renderers
+use the same routing policy without coupling Markdown to Electron. The renderer
+still owns chat focus and pane layout; Electron owns URL safety and OS opening.
+Persistence, routing edge cases, and real Electron interactions are covered by
+the desktop tests and `test:links`, also included in `test:projects`.

--- a/docs/adr/0097-isolate-probe-clipboards.md
+++ b/docs/adr/0097-isolate-probe-clipboards.md
@@ -1,0 +1,32 @@
+# 0097. Offline PTY probes own their clipboard command boundary
+
+Status: accepted 2026-09-10
+
+## Context
+
+The selection, click, and scrollbar probes can write the same host clipboard.
+Concurrent writes make otherwise correct selection assertions fail (#836).
+Serializing one pool does not protect it from another pool or from applications,
+and restoring the clipboard afterwards can overwrite newly copied user content.
+
+## Decision
+
+The offline tuiguard pool gives each probe a temporary command-backed clipboard.
+Private `pbcopy`, `pbpaste`, and `xclip` commands are prepended to that probe's
+PATH and inherited by its Graff child. They preserve the subprocess copy/paste
+boundary and exact bytes without reading or writing the user's clipboard.
+
+Keep these environments per probe, never mutate the parent's environment, and
+remove their files after the probe exits or its process group is terminated.
+Independent probes remain parallel; no selection or OSC52 assertion is skipped.
+
+## Consequences
+
+Gate runs test selection, subprocess delivery, and OSC52 bytes deterministically
+without interfering with concurrent runs or normal desktop use. They do not test
+the operating system's clipboard service. Direct invocation of the individual
+probe scripts retains that integration path when it is explicitly wanted.
+
+The pool integrity suite covers copy/paste, independent environments, cleanup,
+and environment inheritance. The real-binary pool covers the complete selection
+path with these commands in place.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -106,6 +106,7 @@ record only when you need the evidence or the edge cases.
 | [0093](0093-project-layout-breadth-and-directory-hints.md) | Project layout favors breadth under its caps; missing directories offer bounded sibling hints without changing confinement or ADR 0090 constraint policy. |
 | [0094](0094-subagent-interrupt-is-a-cancel-file.md) | GUI Stop writes `{id}.cancel` in the activity dir; the child finishes failed even if the model returns. Not `session/cancel`. |
 | [0095](0095-live-evals-are-gated-prs.md) | Live evals are gated PRs with no SPEC.md; score pass @ n=3 and list$ on passing reps only. |
+| [0096](0096-desktop-link-destination.md) | Persist the desktop link destination outside origin-scoped storage; validate once and reveal the focused chat's Browser without navigating the app. |
 
 ## When to write one
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -107,6 +107,7 @@ record only when you need the evidence or the edge cases.
 | [0094](0094-subagent-interrupt-is-a-cancel-file.md) | GUI Stop writes `{id}.cancel` in the activity dir; the child finishes failed even if the model returns. Not `session/cancel`. |
 | [0095](0095-live-evals-are-gated-prs.md) | Live evals are gated PRs with no SPEC.md; score pass @ n=3 and list$ on passing reps only. |
 | [0096](0096-desktop-link-destination.md) | Persist the desktop link destination outside origin-scoped storage; validate once and reveal the focused chat's Browser without navigating the app. |
+| [0097](0097-isolate-probe-clipboards.md) | Offline PTY probes get private clipboard commands per process; direct probe runs retain OS clipboard integration. |
 
 ## When to write one
 

--- a/scripts/codex_ws_error_test.py
+++ b/scripts/codex_ws_error_test.py
@@ -188,12 +188,11 @@ def run_chain_reanchor_scenario(
             first.connection_id != rejected.connection_id
             or rejected.connection_id == rebuilt.connection_id
             or rejected.body.get("previous_response_id") != "resp_chain_1"
-            or "previous_response_id" in rebuilt.body
         ):
             raise AssertionError(
-                "chain-error: rejected delta was not rebuilt as full input on a fresh WS: "
-                f"{requests!r}"
+                "chain-error: rejected delta was not rebuilt on a fresh WS"
             )
+        mock.assert_fresh_anchor(rebuilt)
         rebuilt_types = [
             item.get("type")
             for item in rebuilt.body.get("input", [])

--- a/scripts/codex_ws_mock.py
+++ b/scripts/codex_ws_mock.py
@@ -227,6 +227,7 @@ class CodexMock:
         default=None, repr=False
     )
     requests: list[RecordedRequest] = field(default_factory=list, repr=False)
+    _prewarms: dict[int, str] = field(default_factory=dict, repr=False)
     _sock: socket.socket | None = field(default=None, repr=False)
     _threads: list[threading.Thread] = field(default_factory=list, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
@@ -260,6 +261,14 @@ class CodexMock:
         """Return a stable snapshot for assertions after a scenario completes."""
         with self._lock:
             return list(self.requests)
+
+    def assert_fresh_anchor(self, request: RecordedRequest) -> None:
+        """A full replay may chain only to this socket's empty-input prewarm."""
+        with self._lock:
+            expected = self._prewarms.get(request.connection_id)
+        if (("previous_response_id" in request.body) != (expected is not None)
+                or request.body.get("previous_response_id") != expected):
+            raise AssertionError("full replay used a stale or unexpected chain anchor")
 
     # ── internals ─────────────────────────────────────────────────────────
 
@@ -391,6 +400,8 @@ class CodexMock:
             # (the transport smoke assertions count real model turns).
             if event.get("generate") is False:
                 prewarm_id = f"resp_prewarm_{self.ws_turns + 1}"
+                with self._lock:
+                    self._prewarms[connection_id] = prewarm_id
                 _send_frame(conn, OP_TEXT, json.dumps(
                     {"type": "response.completed",
                      "response": {"id": prewarm_id, "usage": dict(USAGE)}},

--- a/scripts/codex_ws_test.py
+++ b/scripts/codex_ws_test.py
@@ -437,11 +437,7 @@ def assert_midturn_requests(mock: CodexMock) -> None:
     if first.connection_id == final.connection_id:
         raise AssertionError("midturn: final request reused the pre-compaction WS")
     for request in requests:
-        if "previous_response_id" in request.body:
-            raise AssertionError(
-                f"midturn: request {request.ordinal} carried stale previous_response_id: "
-                f"{request.body['previous_response_id']!r}"
-            )
+        mock.assert_fresh_anchor(request)
 
     # The note turn is a bounded, tool-less auxiliary call on its own persona —
     # never the root prompt, which would hand it the whole tool catalog and its
@@ -580,11 +576,7 @@ def assert_transactional_requests(mock: CodexMock) -> None:
             "transactional: final request reused the pre-compaction WS"
         )
     for request in requests:
-        if "previous_response_id" in request.body:
-            raise AssertionError(
-                f"transactional: request {request.ordinal} carried stale "
-                f"previous_response_id: {request.body['previous_response_id']!r}"
-            )
+        mock.assert_fresh_anchor(request)
 
     first_input = first.body.get("input")
     if (

--- a/scripts/eval/clipboard_fixture.py
+++ b/scripts/eval/clipboard_fixture.py
@@ -1,0 +1,40 @@
+"""Private clipboard command boundary for offline PTY probes.
+
+The probe and its Graff child share these commands through PATH. Direct probe
+runs still exercise the OS clipboard; the parallel gate must neither race with
+other probes nor read or replace the user's clipboard.
+"""
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import shlex
+import sys
+import tempfile
+
+
+@contextmanager
+def private_clipboard():
+    with tempfile.TemporaryDirectory(prefix="tuiguard-clipboard-") as directory:
+        root = Path(directory)
+        clipboard = root / "clipboard"
+        clipboard.write_bytes(b"")
+        handler = root / "clipboard.py"
+        handler.write_text(
+            "import os, pathlib, sys\n"
+            "path = pathlib.Path(__file__).with_name('clipboard')\n"
+            "if sys.argv[1] in ('pbpaste',) or '-o' in sys.argv[2:] or '-out' in sys.argv[2:]:\n"
+            "    sys.stdout.buffer.write(path.read_bytes())\n"
+            "else:\n"
+            "    temporary = path.with_name('write-' + str(os.getpid()))\n"
+            "    temporary.write_bytes(sys.stdin.buffer.read())\n"
+            "    temporary.replace(path)\n",
+            encoding="utf-8",
+        )
+        for command in ("pbcopy", "pbpaste", "xclip"):
+            wrapper = root / command
+            wrapper.write_text(
+                f"#!/bin/sh\nexec {shlex.quote(sys.executable)} {shlex.quote(str(handler))} {command} \"$@\"\n",
+                encoding="utf-8",
+            )
+            wrapper.chmod(0o700)
+        yield {**os.environ, "PATH": str(root) + os.pathsep + os.environ.get("PATH", "")}

--- a/scripts/eval/test_tier1_tuiguard.py
+++ b/scripts/eval/test_tier1_tuiguard.py
@@ -6,10 +6,14 @@ from __future__ import annotations
 import importlib.util
 import os
 from pathlib import Path
+import shutil
+import subprocess
 import sys
 import tempfile
 import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 from unittest import mock
 
 
@@ -95,6 +99,113 @@ time.sleep(60)
             str(call.args[0]) for call in printer.call_args_list if call.args
         )
         self.assertIn("still running: test-tui-hover.py", joined)
+
+
+@unittest.skipUnless(os.name == "posix", "POSIX clipboard wrappers")
+class ClipboardTests(unittest.TestCase):
+    def clipboard(self, env, command, data=None):
+        fixture_dir = Path(env["PATH"].split(os.pathsep)[0])
+        executable = shutil.which(command[0], path=env["PATH"])
+        self.assertIsNotNone(executable)
+        self.assertEqual(Path(executable).parent, fixture_dir)
+        return subprocess.run(
+            command, input=data, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            env=env, check=True, timeout=5,
+        ).stdout
+
+    def test_copy_paste_preserves_exact_bytes(self) -> None:
+        payload = b"\x00\xffclipboard\r\nUTF-8: \xe2\x98\x83\n\n"
+        with tuiguard.private_clipboard() as env:
+            for copy, paste in (
+                (["pbcopy"], ["pbpaste"]),
+                (["xclip", "-selection", "clipboard"],
+                 ["xclip", "-selection", "clipboard", "-o"]),
+                (["pbcopy"], ["xclip", "-selection", "clipboard", "-o"]),
+                (["xclip", "-selection", "clipboard"], ["pbpaste"]),
+            ):
+                for data in (payload, b""):
+                    with self.subTest(copy=copy, paste=paste, data=data):
+                        self.clipboard(env, copy, data)
+                        self.assertEqual(self.clipboard(env, paste), data)
+
+    def test_concurrent_contexts_do_not_interfere(self) -> None:
+        barrier = Barrier(2)
+
+        def roundtrip(payload):
+            with tuiguard.private_clipboard() as env:
+                self.clipboard(env, ["pbcopy"], payload)
+                barrier.wait(timeout=10)
+                self.assertEqual(self.clipboard(env, ["pbpaste"]), payload)
+                return env["PATH"]
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(roundtrip, data) for data in (b"first", b"second")]
+            paths = [future.result(timeout=20) for future in futures]
+        self.assertNotEqual(*paths)
+
+    def test_context_cleanup_and_process_path_unchanged(self) -> None:
+        original_path = os.environ.get("PATH")
+        for exceptional in (False, True):
+            with self.subTest(exceptional=exceptional):
+                try:
+                    with tuiguard.private_clipboard() as env:
+                        fixture_dir = Path(env["PATH"].split(os.pathsep)[0])
+                        self.assertTrue(fixture_dir.is_dir())
+                        self.assertEqual(os.environ.get("PATH"), original_path)
+                        self.clipboard(env, ["pbcopy"], b"cleanup")
+                        if exceptional:
+                            raise RuntimeError("context exit")
+                except RuntimeError as exc:
+                    self.assertEqual(str(exc), "context exit")
+                self.assertFalse(fixture_dir.exists())
+                self.assertEqual(os.environ.get("PATH"), original_path)
+
+    def test_nested_run_probe_environments_remain_separate(self) -> None:
+        original_path = os.environ.get("PATH")
+        environments = []
+
+        def run_command(argv, timeout, *, env):
+            environments.append(env)
+            payload = Path(argv[1]).name.encode()
+            self.clipboard(env, ["pbcopy"], payload)
+            if len(environments) == 1:
+                tuiguard.run_probe("inner.py", "/nonexistent/graff", timeout)
+                self.assertIsNot(env, environments[1])
+                self.assertNotEqual(env["PATH"], environments[1]["PATH"])
+            self.assertEqual(self.clipboard(env, ["pbpaste"]), payload)
+            self.assertEqual(os.environ.get("PATH"), original_path)
+            return 0, "", 0.0, False
+
+        with mock.patch.object(tuiguard, "run_command", side_effect=run_command):
+            tuiguard.run_probe("outer.py", "/nonexistent/graff", 1.0)
+        self.assertEqual(len(environments), 2)
+        for env in environments:
+            self.assertFalse(Path(env["PATH"].split(os.pathsep)[0]).exists())
+        self.assertEqual(os.environ.get("PATH"), original_path)
+
+    def test_parallel_run_probe_environments_remain_separate(self) -> None:
+        original_path = os.environ.get("PATH")
+        barrier = Barrier(2)
+
+        def run_command(argv, timeout, *, env):
+            payload = Path(argv[1]).name.encode()
+            self.clipboard(env, ["pbcopy"], payload)
+            barrier.wait(timeout=10)
+            self.assertEqual(self.clipboard(env, ["pbpaste"]), payload)
+            self.assertEqual(os.environ.get("PATH"), original_path)
+            return 0, env["PATH"], 0.0, False
+
+        with mock.patch.object(tuiguard, "run_command", side_effect=run_command):
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                futures = [
+                    pool.submit(tuiguard.run_probe, name, "/nonexistent/graff", 1.0)
+                    for name in ("first.py", "second.py")
+                ]
+                results = [future.result(timeout=20) for future in futures]
+        self.assertNotEqual(results[0][2], results[1][2])
+        for result in results:
+            self.assertFalse(Path(result[2].split(os.pathsep)[0]).exists())
+        self.assertEqual(os.environ.get("PATH"), original_path)
 
 
 if __name__ == "__main__":

--- a/scripts/eval/tier1_tuiguard.py
+++ b/scripts/eval/tier1_tuiguard.py
@@ -26,6 +26,7 @@ import sys
 import time
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from pathlib import Path
+from clipboard_fixture import private_clipboard
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = ROOT / "scripts"
@@ -105,12 +106,13 @@ def terminate_group(proc: subprocess.Popen[str]) -> None:
     proc.kill()
 
 
-def run_command(argv: list[str], timeout: float, cwd: Path | None = None) -> tuple[int, str, float, bool]:
+def run_command(argv: list[str], timeout: float, cwd: Path | None = None, env: dict[str, str] | None = None) -> tuple[int, str, float, bool]:
     """Run argv in its own session. On timeout, kill the whole group."""
     t0 = time.monotonic()
     proc = subprocess.Popen(
         argv,
         cwd=str(cwd or ROOT),
+        env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -130,10 +132,14 @@ def run_command(argv: list[str], timeout: float, cwd: Path | None = None) -> tup
 
 
 def run_probe(script: str, binary: str, timeout: float) -> tuple[str, int, str, float, bool]:
-    status, blob, elapsed, timed_out = run_command(
-        [sys.executable, str(SCRIPTS / script), binary],
-        timeout,
-    )
+    # Each probe and its child use a private command-backed clipboard. A pool
+    # lock alone cannot protect the user's clipboard from another test process.
+    with private_clipboard() as env:
+        status, blob, elapsed, timed_out = run_command(
+            [sys.executable, str(SCRIPTS / script), binary],
+            timeout,
+            env=env,
+        )
     return script, status, blob, elapsed, timed_out
 
 

--- a/sdk/ts/scripts/test-packed-install.mjs
+++ b/sdk/ts/scripts/test-packed-install.mjs
@@ -66,12 +66,15 @@ try {
     await chmod(sourceBinary, 0o755);
   }
 
+  const sdkManifest = JSON.parse(await readFile(join(SDK_ROOT, "package.json"), "utf8"));
   const nativeTarballs = {};
   for (const [target, packageName] of ALL_TARGETS) {
     const output = run(process.execPath, [
       join(HERE, "package-platform.mjs"),
       "--target", target,
       "--binary", sourceBinary,
+      // Match the SDK's pin so npm uses the fixture instead of a registry binary.
+      "--version", sdkManifest.optionalDependencies[packageName],
       "--out", packages,
     ], SDK_ROOT);
     const { packageDir } = JSON.parse(output);
@@ -104,6 +107,7 @@ console.log("packed SDK resolved and ran its optional native package with no gra
   const output = run(process.execPath, [join(consumer, "smoke.mjs")], consumer, {
     ...process.env,
     CLEAN_PATH: emptyPath,
+    GRAFF_NO_TELEMETRY: "1",
   });
   process.stdout.write(output);
 
@@ -127,6 +131,7 @@ console.log("packed SDK rejects an incompatible optional native package");
   process.stdout.write(run(process.execPath, [join(consumer, "mismatch.mjs")], consumer, {
     ...process.env,
     CLEAN_PATH: emptyPath,
+    GRAFF_NO_TELEMETRY: "1",
   }));
 } finally {
   await rm(temp, { recursive: true, force: true });

--- a/src/subagent_activity.zig
+++ b/src/subagent_activity.zig
@@ -208,7 +208,7 @@ test "cancel file marks a working child interrupted even if it later finishes" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const io = std.testing.io;
-    var r: Recorder = .{ .a = std.testing.allocator, .io = io, .dir = try tmp.dir.openDir(io, ".", .{}), .meta = .{ .id = "child", .label = "test", .task = "test" } };
+    var r: Recorder = .{ .a = std.testing.allocator, .io = io, .dir = try tmp.dir.openDir(io, ".", .{ .iterate = true }), .meta = .{ .id = "child", .label = "test", .task = "test" } };
     defer r.deinit();
     try requestInterrupt(io, r.dir, "child");
     try std.testing.expect(interruptRequested(io, r.dir, "child"));


### PR DESCRIPTION
## What changed
- Add a persistent Settings choice between the system default browser and Graff's built-in Browser.
- Route normal and new-window links through shared safety checks and reveal the focused chat's Browser without replacing the app.
- Add persistence, URL edge-case, and Electron interaction coverage.

## Why
Conversation links previously always left the app. Desktop-backed storage survives restarts and origin changes, while shared interception keeps link behavior consistent without coupling individual renderers to the destination preference. System-browser behavior remains the default, and internal navigation stays separate.

## Failures uncovered during verification
- Ignore stale deferred shortcut focus after newer navigation (#842).
- Match packed SDK mock versions to dependency pins (#834).
- Enable directory iteration in the Linux activity test (#835).
- Give gate probes isolated clipboard commands instead of sharing host state (#836). Direct probe runs retain OS integration.
- Recognize only the fresh connection's prewarm anchor in transport fixtures, retaining full-history and stale-anchor checks (#848).

## Validation
Desktop, SDK, Windows, and Zig GitHub checks pass on the final revision. Local desktop unit tests, production build, project/link interaction tests, SDK packed-install smoke, pool integrity tests, transport scenarios, and the full offline tier-1 hook also passed. The hook passed with its normal parallel pool and no skipped checks.

Closes #824