### PR TITLE
Fix missing titles on existing GUI conversations

### DIFF
--- a/apps/native/app/api/sessions/route.ts
+++ b/apps/native/app/api/sessions/route.ts
@@ -13,6 +13,7 @@ import {
   listSessionRows,
   pageSessions,
   peekHeader,
+  recoveredSessionTitle,
   type ListScope,
 } from "@/lib/session-store";
 
@@ -62,7 +63,7 @@ export async function GET(req: NextRequest) {
       const header = peekHeader(found.file, st.size);
       return Response.json({
         name,
-        title: str(parsed.title),
+        title: recoveredSessionTitle(parsed.title, parsed.messages),
         model: str(parsed.model),
         provider: str(parsed.provider),
         updatedMs: typeof parsed.updated_ms === "number" ? parsed.updated_ms : Math.round(st.mtimeMs),

--- a/apps/native/lib/session-projection.test.ts
+++ b/apps/native/lib/session-projection.test.ts
@@ -30,6 +30,35 @@ function fixture() {
   return { root, url, cleanup: () => rmSync(root, { recursive: true, force: true }) };
 }
 
+test("legacy title recovery agrees across list, search, raw and projected session views (#830)", async () => {
+  const file = fixture();
+  const messages = [
+    { role: "user", content: [{ type: "input_text", text: "[peer] wake" }] },
+    { role: "user", content: [{ type: "input_image", image_url: "data:image/png;base64,AA==" }] },
+    { role: "user", content: [{ type: "input_text", text: "Repair the sidebar label" }] },
+    { role: "assistant", content: "The fix is ready." },
+  ];
+  try {
+    for (const title of ["Untitled session", "My chosen label"]) {
+      writeFileSync(path.join(file.root, ".graff/sessions/example.session.json"), JSON.stringify({ title, model: "demo", updated_ms: 200, messages }));
+      const expected = title === "Untitled session" ? "Repair the sidebar label" : title;
+      const listUrl = new URL(file.url()); listUrl.searchParams.delete("name");
+      listUrl.searchParams.set("scope", "local"); listUrl.searchParams.set("q", expected);
+      const listing = await (await GET(new NextRequest(listUrl))).json();
+      expect(listing.sessions.find((row: { name: string }) => row.name === "example")?.title).toBe(expected);
+      for (const view of [undefined, "transcript"]) {
+        const response = await GET(new NextRequest(file.url(view)));
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.title).toBe(expected);
+        expect(body.updatedMs).toBe(200);
+        if (view) expect(body.transcript).toEqual(transcriptFromMessages(messages, "demo"));
+        else expect(body.messages).toEqual(messages);
+      }
+    }
+  } finally { file.cleanup(); }
+});
+
 test("only an explicit transcript request projects raw history; the default API stays unchanged", async () => {
   const file = fixture();
   try {

--- a/apps/native/lib/session-store.test.ts
+++ b/apps/native/lib/session-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -12,13 +12,15 @@ import {
   listSessionRows,
   pageSessions,
   sameWorkspace,
+  recoveredSessionTitle,
+  MAX_FULL_BYTES,
   SESSIONS_DIR,
 } from "./session-store.ts";
 
 function writeSession(root: string, name: string, body: Record<string, unknown>): void {
   const dir = path.join(root, SESSIONS_DIR);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(path.join(dir, `${name}.session.json`), `${JSON.stringify({ ...body, messages: [] })}\n`);
+  writeFileSync(path.join(dir, `${name}.session.json`), `${JSON.stringify({ ...body, messages: body.messages ?? [] })}\n`);
 }
 
 describe("displayWorkspace / sameWorkspace", () => {
@@ -50,6 +52,157 @@ describe("listSessionRows", () => {
     const notes = rows.find((r) => r.name === "notes");
     assert.equal(notes?.local, false);
     assert.equal(notes?.origin, "~");
+  });
+});
+
+describe("legacy placeholder titles", () => {
+  it("recovers Responses input_text from a real image-bearing file and preserves named titles", () => {
+    const cwd = mkdtempSync(path.join(tmpdir(), "graff-legacy-"));
+    const messages = [
+      { role: "user", content: "  [peer] wake" },
+      { role: "user", content: [{ type: "input_text", text: "[presence] online" }] },
+      { role: "user", content: " \n " },
+      { role: "assistant", content: "Not the title" },
+      { role: "user", content: [
+        { type: "input_text", text: "Fix the screenshot layout\n<graff-gui-skill-context>\nHidden instructions\n</graff-gui-skill-context>" },
+        { type: "input_image", image_url: `data:image/png;base64,${"A".repeat(100_000)}` },
+      ] },
+    ];
+    writeSession(cwd, "legacy", { title: "Untitled session", messages });
+    writeSession(cwd, "named", { title: "My chosen title", messages });
+    const rows = listSessionRows(cwd, cwd);
+    assert.equal(rows.find(row => row.name === "legacy")?.title, "Fix the screenshot layout");
+    assert.equal(rows.find(row => row.name === "named")?.title, "My chosen title");
+    // The GET metadata path uses this same recovery on the parsed messages.
+    assert.equal(recoveredSessionTitle("Untitled session", messages), "Fix the screenshot layout");
+    writeSession(cwd, "legacy", { title: "Untitled session", updated_ms: 2, messages: [...messages, { role: "assistant", content: "Appended reply" }] });
+    assert.equal(listSessionRows(cwd, cwd).find(row => row.name === "legacy")?.title, "Fix the screenshot layout");
+  });
+
+  it("supports string/text content, empty and injected turns, and UTF-8 boundaries", () => {
+    for (const content of ["  Real prompt  ", [{ type: "text", text: "  Real prompt  " }]]) {
+      assert.equal(recoveredSessionTitle("Untitled session", [{ role: "user", content }]), "Real prompt");
+    }
+    assert.equal(recoveredSessionTitle("Named", [{ role: "user", content: "Other" }]), "Named");
+    assert.equal(recoveredSessionTitle("Untitled session", [{ role: "user", content: "[#469 channel] wake" }]), "Untitled session");
+    assert.equal(recoveredSessionTitle("Untitled session", [{ role: "user", content: "😀".repeat(30) }]), "😀".repeat(20));
+  });
+
+  it("keeps the placeholder when a legacy file exceeds the full-read limit", () => {
+    const cwd = mkdtempSync(path.join(tmpdir(), "graff-large-"));
+    writeSession(cwd, "large", { title: "Untitled session", messages: [{ role: "user", content: "Prompt" }, { role: "assistant", content: "x".repeat(MAX_FULL_BYTES) }] });
+    assert.equal(listSessionRows(cwd, cwd)[0]?.title, "Untitled session");
+  });
+});
+
+describe("GUI legacy recovery regressions", () => {
+  function fixture(t: { after: (fn: () => void) => void }): string {
+    const root = mkdtempSync(path.join(tmpdir(), "graff-recovery-test-"));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+    return root;
+  }
+
+  function assertReadParity(root: string, name: string, expected: string): void {
+    const file = findSessionFile(root, name, root)?.file;
+    assert.ok(file);
+    const body = JSON.parse(readFileSync(file, "utf8"));
+    const row = listSessionRows(root, root).find(row => row.name === name);
+    assert.ok(row);
+    assert.equal(recoveredSessionTitle(body.title, body.messages), expected, "read metadata title");
+    assert.equal(row.title, expected, "list metadata title");
+    assert.equal(row.updatedMs, body.updated_ms);
+    assert.equal(row.model, body.model);
+    assert.equal(row.provider, body.provider);
+    assert.equal(row.workspace, body.workspace);
+    assert.equal(row.size, statSync(file).size);
+  }
+
+  it("keeps valid header metadata when the message JSON is malformed or partially saved", t => {
+    const root = fixture(t);
+    const header = { title: "Untitled session", updated_ms: 71, model: "test-model", provider: "test-provider", workspace: root };
+    for (const [name, tail] of [["partial", '[{"role":"user","content":"unfinished'], ["malformed", '[invalid]}']] as const) {
+      writeSession(root, name, header);
+      writeFileSync(path.join(root, SESSIONS_DIR, `${name}.session.json`), `${JSON.stringify(header).slice(0, -1)},"messages":${tail}`);
+      const row = listSessionRows(root, root).find(row => row.name === name);
+      assert.ok(row);
+      assert.equal(row.title, header.title);
+      assert.equal(row.updatedMs, header.updated_ms);
+      assert.equal(row.model, header.model);
+      assert.equal(row.provider, header.provider);
+      assert.equal(row.workspace, root);
+    }
+  });
+
+  it("skips empty, image-only, blank, malformed, and non-user message parts", () => {
+    const skipped = [null, 7, {}, { role: "assistant", content: "Not human" },
+      ...[null, {}, [], " \n\t ", [{ type: "input_image", image_url: "data:image/png;base64,AA==" }],
+        [null, 8, {}, { type: "text", text: 123 }, { type: "input_text", text: null }, { type: "unknown", text: "Not text" }],
+        [{ type: "text", text: " " }, { type: "input_text", text: "\n" }],
+      ].map(content => ({ role: "user", content }))];
+    assert.equal(recoveredSessionTitle("Untitled session", skipped), "Untitled session");
+    assert.equal(recoveredSessionTitle("Untitled session", [...skipped,
+      { role: "user", content: [null, { type: "input_text", text: "First human prompt" }, { type: "text", text: false }] },
+    ]), "First human prompt");
+  });
+
+  for (const prefix of ["[peer]", "[peer message", "[presence]", "[#469 presence]", "[#469 channel", "[#469 device room", "[peer channel"]) {
+    it(`skips injected ${prefix} turns in every text representation`, () => {
+      for (const content of [` \n${prefix} synthetic notice`, [{ type: "text", text: `${prefix} synthetic notice` }], [{ type: "input_text", text: `${prefix} synthetic notice` }]]) {
+        assert.equal(recoveredSessionTitle("Untitled session", [
+          { role: "user", content }, { role: "user", content: "Human question" },
+        ]), "Human question");
+      }
+    });
+  }
+
+  it("matches string, text, and input_text at mixed Unicode byte boundaries", () => {
+    for (const [prompt, expected] of [
+      ["a".repeat(77) + "😀end", "a".repeat(77)],
+      ["a".repeat(76) + "😀end", "a".repeat(76) + "😀"],
+      ["界".repeat(27), "界".repeat(26)],
+      ["é".repeat(40) + "x", "é".repeat(40)],
+    ]) {
+      for (const content of [prompt, [{ type: "text", text: prompt }], [{ type: "input_text", text: prompt }]]) {
+        assert.equal(recoveredSessionTitle("Untitled session", [{ role: "user", content }]), expected);
+      }
+    }
+  });
+
+  it("finds the first human title beyond the 64 KiB header peek", t => {
+    const root = fixture(t);
+    writeSession(root, "late", { title: "Untitled session", updated_ms: 81, model: "test-model", provider: "test-provider", workspace: root,
+      messages: [{ role: "user", content: [{ type: "input_image", image_url: "A".repeat(70_000) }] },
+        { role: "user", content: [{ type: "input_text", text: "Late human prompt" }] }] });
+    assertReadParity(root, "late", "Late human prompt");
+  });
+
+  for (const padding of [0, 70_000]) {
+    it(`invalidates a cached title when the first human prompt changes after ${padding} padding bytes`, t => {
+      const root = fixture(t);
+      const save = (prompt: string, updated_ms: number) => writeSession(root, "rewrite", {
+        title: "Untitled session", updated_ms, model: "test-model", provider: "test-provider", workspace: root,
+        messages: [{ role: "assistant", content: "x".repeat(padding) }, { role: "user", content: prompt }],
+      });
+      save("Original human prompt", 91);
+      assertReadParity(root, "rewrite", "Original human prompt");
+      const file = path.join(root, SESSIONS_DIR, "rewrite.session.json");
+      const before = readFileSync(file).subarray(0, 64 * 1024);
+      // Equal-length text and unchanged header deliberately isolate prefix-only caching.
+      save("Replaced human prompt", 91);
+      if (padding) assert.deepEqual(readFileSync(file).subarray(0, 64 * 1024), before);
+      assertReadParity(root, "rewrite", "Replaced human prompt");
+    });
+  }
+
+  it("refreshes metadata and honors a rename after caching placeholder recovery", t => {
+    const root = fixture(t);
+    const messages = [{ role: "user", content: "Recovered original" }];
+    writeSession(root, "rename", { title: "Untitled session", updated_ms: 101, model: "model-one", provider: "provider-one", workspace: root, messages });
+    assertReadParity(root, "rename", "Recovered original");
+    writeSession(root, "rename", { title: "Untitled session", updated_ms: 102, model: "model-two", provider: "provider-two", workspace: `${root}/nested`, messages });
+    assertReadParity(root, "rename", "Recovered original");
+    writeSession(root, "rename", { title: "Explicitly renamed", updated_ms: 103, model: "model-three", provider: "provider-three", workspace: root, messages });
+    assertReadParity(root, "rename", "Explicitly renamed");
   });
 });
 

--- a/apps/native/lib/session-store.ts
+++ b/apps/native/lib/session-store.ts
@@ -1,6 +1,7 @@
-import { closeSync, existsSync, openSync, readdirSync, readSync, statSync } from "node:fs";
+import { closeSync, existsSync, fstatSync, openSync, readdirSync, readSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { withoutGuiSkillContext } from "./gui-skills";
 
 /** Same layout `src/session_index.zig` owns. Header fields land before
  *  `messages`, so a list peeks the prefix instead of parsing whole files. */
@@ -86,6 +87,31 @@ export function homeDir(override?: string | null): string {
 
 type HeaderPeek = Header | null;
 
+/** Only repair the historical placeholder; explicit names are authoritative. */
+export function recoveredSessionTitle(title: unknown, messages: unknown): string | null {
+  if (title !== "Untitled session" || !Array.isArray(messages)) return str(title);
+  for (const item of messages) {
+    if (!item || typeof item !== "object" || item.role !== "user") continue;
+    const content = typeof item.content === "string" ? item.content : Array.isArray(item.content)
+      ? item.content.filter((part: any) => part && (part.type === "text" || part.type === "input_text") && typeof part.text === "string")
+        .map((part: any) => part.text).join("\n") : "";
+    const text = withoutGuiSkillContext(content.trim()).trim();
+    if (!text || ["[peer]", "[peer message", "[presence]", "[#469 presence]", "[#469 channel", "[#469 device room", "[peer channel"].some(prefix => text.startsWith(prefix))) continue;
+    // Match the engine's 80-byte, UTF-8-safe title limit.
+    let result = "";
+    for (const char of text) {
+      if (Buffer.byteLength(result + char) > 80) break;
+      result += char;
+    }
+    return result || str(title);
+  }
+  return str(title);
+}
+
+// Reuse recovery only for an unchanged file. A prompt beyond the header peek
+// can be rewritten without changing that prefix (or the file's size).
+const legacyTitles = new Map<string, { version: string; title: string }>();
+
 export function peekHeader(file: string, size: number): HeaderPeek {
   const fd = openSync(file, "r");
   try {
@@ -97,7 +123,36 @@ export function peekHeader(file: string, size: number): HeaderPeek {
     if (idx < 0) return null;
     let head = text.slice(0, idx).trimEnd();
     if (head.endsWith(",")) head = head.slice(0, -1);
-    return JSON.parse(`${head}}`) as Header;
+    const header = JSON.parse(`${head}}`) as Header;
+    if (header.title !== "Untitled session" || size > MAX_FULL_BYTES) return header;
+    const stat = fstatSync(fd, { bigint: true });
+    const version = `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}`;
+    const cached = legacyTitles.get(file);
+    if (cached?.version === version) return { ...header, title: cached.title };
+    try {
+      let body = text;
+      if (size > n) {
+        // Reuse the prefix and cap the allocation/read even if the file grows.
+        const full = Buffer.alloc(size);
+        buf.copy(full, 0, 0, n);
+        let offset = n;
+        while (offset < size) {
+          const count = readSync(fd, full, offset, size - offset, offset);
+          if (!count) break;
+          offset += count;
+        }
+        body = full.toString("utf8", 0, offset);
+      }
+      const title = recoveredSessionTitle(header.title, JSON.parse(body).messages);
+      if (title && title !== "Untitled session") {
+        if (legacyTitles.size >= 128) legacyTitles.delete(legacyTitles.keys().next().value!);
+        legacyTitles.set(file, { version, title });
+        header.title = title;
+      }
+    } catch {
+      // Partial autosaves and malformed legacy files keep their header title.
+    }
+    return header;
   } catch {
     return null;
   } finally {

--- a/src/peer_context.zig
+++ b/src/peer_context.zig
@@ -56,7 +56,7 @@ pub fn isPeerInject(m: Value) bool {
             for (arr.items) |blk| {
                 if (blk != .object) continue;
                 const t = blk.object.get("type") orelse continue;
-                if (!(t == .string and std.mem.eql(u8, t.string, "text"))) continue;
+                if (!(t == .string and (std.mem.eql(u8, t.string, "text") or std.mem.eql(u8, t.string, "input_text")))) continue;
                 if (blk.object.get("text")) |v| {
                     if (v == .string and isPeerInjectContent(v.string)) return true;
                 }

--- a/src/session.zig
+++ b/src/session.zig
@@ -105,12 +105,18 @@ pub fn sessionTitle(root: *Agent) []const u8 {
         if (m != .object) continue;
         if (!session_peer.isHumanUserTurn(m)) continue;
         if (m.object.get("content")) |c| switch (c) {
-            .string => |text| return utf8Prefix(std.mem.trim(u8, text, " \t\r\n"), 80),
+            .string => |text| {
+                const trimmed = std.mem.trim(u8, text, " \t\r\n");
+                if (trimmed.len > 0) return utf8Prefix(trimmed, 80);
+            },
             .array => |arr| for (arr.items) |part| {
                 if (part == .object) {
                     const typ = if (part.object.get("type")) |v| (if (v == .string) v.string else "") else "";
-                    if (std.mem.eql(u8, typ, "text")) {
-                        if (part.object.get("text")) |tv| if (tv == .string) return utf8Prefix(std.mem.trim(u8, tv.string, " \t\r\n"), 80);
+                    if (std.mem.eql(u8, typ, "text") or std.mem.eql(u8, typ, "input_text")) {
+                        if (part.object.get("text")) |tv| if (tv == .string) {
+                            const trimmed = std.mem.trim(u8, tv.string, " \t\r\n");
+                            if (trimmed.len > 0) return utf8Prefix(trimmed, 80);
+                        };
                     }
                 }
             },
@@ -461,7 +467,8 @@ pub fn loadSession(root: *Agent, keys: *Keys, arena: Allocator, name: []const u8
     const ultracode_mode = if (obj.get("ultracode_mode")) |v| (v == .bool and v.bool) else false;
     const goal: ?agent_mod.Goal = if (obj.get("goal")) |v| goalFromValue(v, unixMs(root.io)) else null;
     const parent = if (obj.get("parent")) |v| (if (v == .string and v.string.len > 0) v.string else null) else null;
-    const title = if (obj.get("title")) |v| (if (v == .string and v.string.len > 0) v.string else null) else null;
+    // Older builds missed Responses input_text and persisted the placeholder.
+    const title = if (obj.get("title")) |v| (if (v == .string and v.string.len > 0 and !std.mem.eql(u8, v.string, "Untitled session")) v.string else null) else null;
     // Optional for backward compatibility with sessions written before context
     // metering was persisted. JSON integers are signed; ignore negative/wrong-type
     // values instead of turning a corrupt session into an enormous unsigned count.

--- a/src/session_tests.zig
+++ b/src/session_tests.zig
@@ -88,6 +88,115 @@ test "slugifyTitle makes a filesystem-safe slug from an AI title" {
     try std.testing.expectEqualStrings("", session.slugifyTitle(a, "🎉 ✨")); // symbol-only → "" (keeps the session-<ts> name)
 }
 
+test "sessionTitle reads user text on both wires and skips empty or peer turns" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var root: Agent = undefined;
+    root.session_title = null;
+    const cases = [_][]const u8{
+        \\[{"role":"user","content":"  Fix the sidebar title  "}]
+        ,
+        \\[{"role":"user","content":[{"type":"text","text":"Fix the sidebar title"}]}]
+        ,
+        \\[{"role":"user","type":"message","content":[{"type":"input_image","image_url":"data:image/png;base64,AA=="},{"type":"input_text","text":"  "},{"type":"input_text","text":"Fix the sidebar title"}]}]
+        ,
+        \\[{"role":"user","content":[{"type":"input_text","text":"[peer] 1 unread"}]},{"role":"user","content":" \n "},{"role":"user","content":[{"type":"input_text","text":"Fix the sidebar title"}]}]
+        ,
+    };
+    for (cases) |raw| {
+        root.messages = (try std.json.parseFromSliceLeaky(Value, a, raw, .{})).array;
+        try std.testing.expectEqualStrings("Fix the sidebar title", session.sessionTitle(&root));
+    }
+    root.session_title = "Chosen title";
+    try std.testing.expectEqualStrings("Chosen title", session.sessionTitle(&root));
+    root.session_title = null;
+    root.messages = std.json.Array.init(a);
+    try std.testing.expectEqualStrings("Untitled session", session.sessionTitle(&root));
+}
+
+test "#830 title skips image-only blank malformed and nonhuman turns" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var root: Agent = undefined;
+    root.session_title = null;
+    root.messages = (try std.json.parseFromSliceLeaky(Value, a,
+        \\[null,7,{}, {"role":4,"content":"bad role"},
+        \\{"role":"assistant","content":"not human"},
+        \\{"role":"tool","content":"tool output"},
+        \\{"role":"user","content":[{"type":"input_text","text":"[peer] 1 unread"}]},
+        \\{"role":"user","content":[{"type":"input_image","image_url":"data:image/png;base64,AA=="}]},
+        \\{"role":"user","content":" \t\r\n "},
+        \\{"role":"user","content":false},
+        \\{"role":"user","content":[null,3,{}, {"type":7,"text":"wrong type"},
+        \\{"type":"input_text","text":42},{"type":"input_text"},
+        \\{"type":"input_text","text":" \n "},{"type":"output_text","text":"wrong wire"}]},
+        \\{"role":"user","content":[{"type":"input_text","text":"  Human request  "}]},
+        \\{"role":"user","content":"later request"}]
+    , .{})).array;
+    try std.testing.expectEqualStrings("Human request", session.sessionTitle(&root));
+    root.messages.items.len -= 2;
+    try std.testing.expectEqualStrings("Untitled session", session.sessionTitle(&root));
+}
+
+test "#830 title preserves UTF-8 at the 80-byte boundary" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    var root: Agent = undefined;
+    root.session_title = null;
+    const cases = .{
+        .{ "a" ** 78 ++ "é" ++ "suffix", "a" ** 78 ++ "é" },
+        .{ "a" ** 79 ++ "é" ++ "suffix", "a" ** 79 },
+        .{ "a" ** 77 ++ "界" ++ "suffix", "a" ** 77 ++ "界" },
+        .{ "a" ** 78 ++ "界" ++ "suffix", "a" ** 78 },
+        .{ "a" ** 76 ++ "🎉" ++ "suffix", "a" ** 76 ++ "🎉" },
+        .{ "a" ** 79 ++ "🎉" ++ "suffix", "a" ** 79 },
+    };
+    inline for (cases) |case| {
+        root.messages = (try std.json.parseFromSliceLeaky(Value, a, "[{\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"  " ++ case[0] ++ "  \"}]}]", .{})).array;
+        const title = session.sessionTitle(&root);
+        try std.testing.expectEqualStrings(case[1], title);
+        try std.testing.expect(std.unicode.utf8ValidateSlice(title));
+    }
+}
+
+test "#830 save serializes fallback and chosen titles without losing chat" {
+    const gpa = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    session_writer.resetForTest();
+    defer session_writer.resetForTest();
+    session_transcript.resetForTest();
+    defer session_transcript.resetForTest();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const f = try fixture(gpa, a, std.testing.io);
+    defer gpa.destroy(f);
+    f.root.session_title = null;
+    f.root.messages = (try std.json.parseFromSliceLeaky(Value, a,
+        \\[{"role":"user","content":[{"type":"input_image","image_url":"data:image/png;base64,AA=="}]},
+        \\{"role":"user","content":[{"type":"input_text","text":"  Preserve the conversation  "}]},
+        \\{"role":"assistant","content":"The complete reply"}]
+    , .{})).array;
+    for ([_]?[]const u8{ null, "Explicit chosen title" }) |chosen| {
+        f.root.session_title = chosen;
+        try session.saveSessionTo(&f.root, a, tmp.dir, "wf");
+        session.flushSaves();
+        const bytes = try readSaved(tmp.dir, gpa);
+        defer gpa.free(bytes);
+        const saved = try std.json.parseFromSliceLeaky(Value, a, bytes, .{ .allocate = .alloc_always });
+        try std.testing.expectEqualStrings(chosen orelse "Preserve the conversation", saved.object.get("title").?.string);
+        const messages = saved.object.get("messages").?.array.items;
+        try std.testing.expectEqual(@as(usize, 3), messages.len);
+        try std.testing.expectEqualStrings("input_image", messages[0].object.get("content").?.array.items[0].object.get("type").?.string);
+        try std.testing.expectEqualStrings("  Preserve the conversation  ", messages[1].object.get("content").?.array.items[0].object.get("text").?.string);
+        try std.testing.expectEqualStrings("The complete reply", messages[2].object.get("content").?.string);
+    }
+}
+
 test "hasMeaningfulState gates the blank-draft write (#184)" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();


### PR DESCRIPTION
## What changed
- Recognize both user-text content forms when saving session titles, skip empty and peer-injected content, and discard stale placeholders on resume.
- Recover legacy GUI titles consistently across listing, search, and opening a conversation. Invalidate cached recovery when the saved file changes.
- Add regression and edge-case coverage for persistence, malformed and image-only messages, Unicode boundaries, cache rewrites, and API consistency.

## Why
Existing conversations could be saved as "Untitled session" because the title fallback ignored structured user text. Correcting persistence prevents new occurrences; display-time recovery repairs existing entries without rewriting conversations or replacing named titles. Legacy reads remain bounded, and malformed or oversized files retain their saved fallback.

## Verification
Desktop unit tests and production build passed. The complete tier-1 pre-push checks passed.

Fixes #830.