### PR TITLE
fix: TUI follow-up spinner and isolated probe clipboard (#845, #836)

### DIFF
--- a/TUI/clipboard.zig
+++ b/TUI/clipboard.zig
@@ -2,6 +2,10 @@
 //! commands via GRAFF_CLIPBOARD_COPY / GRAFF_CLIPBOARD_PASTE so parallel
 //! children do not share the host pasteboard (#836). Direct runs leave those
 //! unset and keep the native pbcopy/xclip path.
+//!
+//! The override is bound from `environ_map` at TUI start. Spawn uses the
+//! session Io (same as `copyCb` on main) — a second Threaded Io does not
+//! drive children in this process.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -10,19 +14,39 @@ const Io = std.Io;
 pub const copy_env = "GRAFF_CLIPBOARD_COPY";
 pub const paste_env = "GRAFF_CLIPBOARD_PASTE";
 
+/// Process-lifetime path from `bind`. The slice is owned by environ_map.
+var bound_copy: ?[]const u8 = null;
+var bound_io: ?Io = null;
+
+pub fn bind(io: Io, environ_map: *const std.process.Environ.Map) void {
+    bound_io = io;
+    const v = environ_map.get(copy_env) orelse {
+        bound_copy = null;
+        return;
+    };
+    bound_copy = if (v.len == 0) null else v;
+}
+
+pub fn unbind() void {
+    bound_copy = null;
+    bound_io = null;
+}
+
 pub fn envCopy() ?[]const u8 {
-    const z = std.c.getenv("GRAFF_CLIPBOARD_COPY") orelse return null;
-    const v = std.mem.span(z);
+    const v = bound_copy orelse return null;
     return if (v.len == 0) null else v;
 }
 
 /// Fill `buf` with the copy argv. An explicit override (the env value, or a
 /// test-supplied path) wins; otherwise the platform native tool.
+/// Overrides run as `/bin/sh <path>` so a probe script needs neither +x nor
+/// a shebang, and spawn never PATH-searches the inherited path.
 pub fn fillCopyArgv(buf: *[4][]const u8, override: ?[]const u8) ?[]const []const u8 {
     if (override) |p| {
         if (p.len > 0) {
-            buf[0] = p;
-            return buf[0..1];
+            buf[0] = "/bin/sh";
+            buf[1] = p;
+            return buf[0..2];
         }
     }
     switch (builtin.os.tag) {
@@ -44,12 +68,7 @@ pub fn copyArgv(buf: *[4][]const u8) ?[]const []const u8 {
     return fillCopyArgv(buf, envCopy());
 }
 
-/// Write `text` to the resolved copy command's stdin. True on exit 0.
-pub fn writeText(text: []const u8) bool {
-    if (text.len == 0) return false;
-    var store: [4][]const u8 = undefined;
-    const argv = copyArgv(&store) orelse return false;
-    const io = Io.Threaded.global_single_threaded.io();
+fn runCopy(io: Io, argv: []const []const u8, text: []const u8) bool {
     var child = std.process.spawn(io, .{
         .argv = argv,
         .stdin = .pipe,
@@ -68,11 +87,26 @@ pub fn writeText(text: []const u8) bool {
     return term == .exited and term.exited == 0;
 }
 
-test "an override copy command is a single inherited argv (#836)" {
+/// Write `text` on `io` to the resolved copy command's stdin. True on exit 0.
+pub fn writeTextIo(io: Io, text: []const u8) bool {
+    if (text.len == 0) return false;
+    var store: [4][]const u8 = undefined;
+    const argv = copyArgv(&store) orelse return false;
+    return runCopy(io, argv, text);
+}
+
+/// Session copy: bound Io when the TUI has started, else `io` is required
+/// via `writeTextIo`. False when nothing is bound and there is no fallback.
+pub fn writeText(text: []const u8) bool {
+    return writeTextIo(bound_io orelse return false, text);
+}
+
+test "an override copy command is inherited as /bin/sh plus the path (#836)" {
     var buf: [4][]const u8 = undefined;
     const got = fillCopyArgv(&buf, "/tmp/probe-copy") orelse return error.NoArgv;
-    try std.testing.expectEqual(@as(usize, 1), got.len);
-    try std.testing.expectEqualStrings("/tmp/probe-copy", got[0]);
+    try std.testing.expectEqual(@as(usize, 2), got.len);
+    try std.testing.expectEqualStrings("/bin/sh", got[0]);
+    try std.testing.expectEqualStrings("/tmp/probe-copy", got[1]);
 }
 
 test "an empty override falls through to the native clipboard tool (#836)" {
@@ -98,4 +132,46 @@ test "null override is the native tool, never an empty argv (#836)" {
         try std.testing.expect(got.len > 0);
         try std.testing.expect(got[0].len > 0);
     }
+}
+
+test "bind reads GRAFF_CLIPBOARD_COPY from environ_map (#836)" {
+    const gpa = std.testing.allocator;
+    var env = std.process.Environ.Map.init(gpa);
+    defer env.deinit();
+    try env.put(copy_env, "/tmp/probe-copy");
+    bind(std.testing.io, &env);
+    defer unbind();
+    try std.testing.expectEqualStrings("/tmp/probe-copy", envCopy() orelse return error.Unbound);
+    var buf: [4][]const u8 = undefined;
+    const got = copyArgv(&buf) orelse return error.NoArgv;
+    try std.testing.expectEqualStrings("/tmp/probe-copy", got[1]);
+}
+
+test "writeText runs the bound copy command (#836)" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return error.SkipZigTest;
+    const io = std.testing.io;
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "clipboard", .data = "SENTINEL" });
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &path_buf);
+    const clip = try std.fmt.allocPrint(gpa, "{s}/clipboard", .{path_buf[0..n]});
+    defer gpa.free(clip);
+    const script = try std.fmt.allocPrint(gpa, "cat > '{s}'\n", .{clip});
+    defer gpa.free(script);
+    try tmp.dir.writeFile(io, .{ .sub_path = "copy", .data = script });
+    const copy_path = try std.fmt.allocPrint(gpa, "{s}/copy", .{path_buf[0..n]});
+    defer gpa.free(copy_path);
+
+    var env = std.process.Environ.Map.init(gpa);
+    defer env.deinit();
+    try env.put(copy_env, copy_path);
+    bind(io, &env);
+    defer unbind();
+
+    try std.testing.expect(writeText("isolate-me"));
+    const got = try tmp.dir.readFileAlloc(io, "clipboard", gpa, .limited(64));
+    defer gpa.free(got);
+    try std.testing.expectEqualStrings("isolate-me", got);
 }

--- a/TUI/clipboard.zig
+++ b/TUI/clipboard.zig
@@ -1,0 +1,100 @@
+//! Clipboard tool argv. Offline tuiguard probes inherit private copy/paste
+//! commands via GRAFF_CLIPBOARD_COPY / GRAFF_CLIPBOARD_PASTE so parallel
+//! children do not share the host pasteboard (#836). Direct runs leave those
+//! unset and keep the native pbcopy/xclip path.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Io = std.Io;
+
+pub const copy_env = "GRAFF_CLIPBOARD_COPY";
+pub const paste_env = "GRAFF_CLIPBOARD_PASTE";
+
+pub fn envCopy() ?[]const u8 {
+    const v = std.posix.getenv(copy_env) orelse return null;
+    return if (v.len == 0) null else v;
+}
+
+/// Fill `buf` with the copy argv. An explicit override (the env value, or a
+/// test-supplied path) wins; otherwise the platform native tool.
+pub fn fillCopyArgv(buf: *[4][]const u8, override: ?[]const u8) ?[]const []const u8 {
+    if (override) |p| {
+        if (p.len > 0) {
+            buf[0] = p;
+            return buf[0..1];
+        }
+    }
+    switch (builtin.os.tag) {
+        .macos => {
+            buf[0] = "pbcopy";
+            return buf[0..1];
+        },
+        .linux => {
+            buf[0] = "xclip";
+            buf[1] = "-selection";
+            buf[2] = "clipboard";
+            return buf[0..3];
+        },
+        else => return null,
+    }
+}
+
+pub fn copyArgv(buf: *[4][]const u8) ?[]const []const u8 {
+    return fillCopyArgv(buf, envCopy());
+}
+
+/// Write `text` to the resolved copy command's stdin. True on exit 0.
+pub fn writeText(text: []const u8) bool {
+    if (text.len == 0) return false;
+    var store: [4][]const u8 = undefined;
+    const argv = copyArgv(&store) orelse return false;
+    const io = Io.Threaded.global_single_threaded.io();
+    var child = std.process.spawn(io, .{
+        .argv = argv,
+        .stdin = .pipe,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    }) catch return false;
+    if (child.stdin) |*s| {
+        var wbuf: [4096]u8 = undefined;
+        var w = s.writerStreaming(io, &wbuf);
+        w.interface.writeAll(text) catch {};
+        w.interface.flush() catch {};
+        s.close(io);
+        child.stdin = null;
+    }
+    const term = child.wait(io) catch return false;
+    return term == .exited and term.exited == 0;
+}
+
+test "an override copy command is a single inherited argv (#836)" {
+    var buf: [4][]const u8 = undefined;
+    const got = fillCopyArgv(&buf, "/tmp/probe-copy") orelse return error.NoArgv;
+    try std.testing.expectEqual(@as(usize, 1), got.len);
+    try std.testing.expectEqualStrings("/tmp/probe-copy", got[0]);
+}
+
+test "an empty override falls through to the native clipboard tool (#836)" {
+    var over_buf: [4][]const u8 = undefined;
+    var native_buf: [4][]const u8 = undefined;
+    const got = fillCopyArgv(&over_buf, "") orelse return error.NoNative;
+    const native = fillCopyArgv(&native_buf, null) orelse return error.NoNative;
+    try std.testing.expectEqual(native.len, got.len);
+    try std.testing.expectEqualStrings(native[0], got[0]);
+    switch (builtin.os.tag) {
+        .macos => try std.testing.expectEqualStrings("pbcopy", native[0]),
+        .linux => {
+            try std.testing.expectEqualStrings("xclip", native[0]);
+            try std.testing.expectEqualStrings("clipboard", native[2]);
+        },
+        else => {},
+    }
+}
+
+test "null override is the native tool, never an empty argv (#836)" {
+    var buf: [4][]const u8 = undefined;
+    if (fillCopyArgv(&buf, null)) |got| {
+        try std.testing.expect(got.len > 0);
+        try std.testing.expect(got[0].len > 0);
+    }
+}

--- a/TUI/clipboard.zig
+++ b/TUI/clipboard.zig
@@ -11,7 +11,8 @@ pub const copy_env = "GRAFF_CLIPBOARD_COPY";
 pub const paste_env = "GRAFF_CLIPBOARD_PASTE";
 
 pub fn envCopy() ?[]const u8 {
-    const v = std.posix.getenv(copy_env) orelse return null;
+    const z = std.c.getenv("GRAFF_CLIPBOARD_COPY") orelse return null;
+    const v = std.mem.span(z);
     return if (v.len == 0) null else v;
 }
 

--- a/TUI/issue_845_tests.zig
+++ b/TUI/issue_845_tests.zig
@@ -1,0 +1,86 @@
+//! #845: composing or queuing a follow-up must not freeze the thinking
+//! indicator or interrupt the live turn. Driven through Term (AGENTS.md).
+
+const std = @import("std");
+
+const engine = @import("engine.zig");
+const glyphs = @import("glyphs.zig");
+const Term = @import("sim.zig").Term;
+
+fn attachThinking(term: *Term, alloc: std.mem.Allocator) !*engine.Job {
+    try term.model.push(.user, "think about this");
+    try term.model.push(.pending, "");
+    const job = try alloc.create(engine.Job);
+    job.* = .{
+        .gpa = alloc,
+        .history = &.{},
+        .params = .{},
+        .stream = .{},
+        .raw = .{},
+        .threaded = false,
+    };
+    job.events.attach(alloc);
+    term.model.pending = job;
+    return job;
+}
+
+test "queuing a follow-up keeps the thinking indicator live (#845)" {
+    const alloc = std.testing.allocator;
+    var term: Term = undefined;
+    term.init(alloc, 80, 24);
+    defer term.deinit();
+    const job = try attachThinking(&term, alloc);
+    _ = job;
+
+    term.now_ms = 0;
+    const idle = try term.screen();
+    defer alloc.free(idle);
+    try std.testing.expect(std.mem.indexOf(u8, idle, "Thinking") != null);
+    try std.testing.expect(std.mem.indexOf(u8, idle, glyphs.thinking[0]) != null);
+
+    _ = term.typeText("queued follow-up");
+    try std.testing.expectEqualStrings("queued follow-up", term.model.input.getValue());
+    try std.testing.expect(term.model.pending != null);
+    try std.testing.expect(!term.model.cancel_requested);
+
+    term.now_ms = 500;
+    const composing = try term.screen();
+    defer alloc.free(composing);
+    try std.testing.expect(std.mem.indexOf(u8, composing, "Thinking") != null);
+    try std.testing.expect(std.mem.indexOf(u8, composing, "queued follow-up") != null);
+    try std.testing.expect(std.mem.indexOf(u8, composing, glyphs.thinking[1]) != null);
+    try std.testing.expect(std.mem.indexOf(u8, composing, glyphs.thinking[0]) == null);
+
+    _ = term.enter();
+    try std.testing.expectEqual(@as(usize, 1), term.model.steer_queue.items.len);
+    try std.testing.expectEqualStrings("queued follow-up", term.model.steer_queue.items[0]);
+    try std.testing.expectEqualStrings("", term.model.input.getValue());
+    try std.testing.expect(term.model.pending != null);
+    try std.testing.expect(!term.model.cancel_requested);
+    try std.testing.expect(term.model.pending.? == job);
+
+    term.now_ms = 1000;
+    const queued = try term.screen();
+    defer alloc.free(queued);
+    try std.testing.expect(std.mem.indexOf(u8, queued, "Thinking") != null);
+    try std.testing.expect(std.mem.indexOf(u8, queued, "queued") != null);
+    try std.testing.expect(std.mem.indexOf(u8, queued, glyphs.thinking[0]) != null);
+    try std.testing.expect(std.mem.indexOf(u8, queued, glyphs.thinking[1]) == null);
+}
+
+test "empty Enter with a queued follow-up is the interrupt; typing is not (#845)" {
+    const alloc = std.testing.allocator;
+    var term: Term = undefined;
+    term.init(alloc, 80, 24);
+    defer term.deinit();
+    _ = try attachThinking(&term, alloc);
+
+    _ = term.typeText("next");
+    _ = term.enter();
+    try std.testing.expectEqual(@as(usize, 1), term.model.steer_queue.items.len);
+    try std.testing.expect(!term.model.cancel_requested);
+
+    _ = term.enter();
+    try std.testing.expect(term.model.cancel_requested);
+    try std.testing.expect(term.model.pending != null);
+}

--- a/TUI/issue_845_tests.zig
+++ b/TUI/issue_845_tests.zig
@@ -30,7 +30,6 @@ test "queuing a follow-up keeps the thinking indicator live (#845)" {
     term.init(alloc, 80, 24);
     defer term.deinit();
     const job = try attachThinking(&term, alloc);
-    _ = job;
 
     term.now_ms = 0;
     const idle = try term.screen();

--- a/TUI/root.zig
+++ b/TUI/root.zig
@@ -65,6 +65,7 @@ pub const theme = @import("theme.zig");
 pub const catalog = @import("catalog.zig");
 pub const dump = @import("dump.zig");
 pub const sim = @import("sim.zig");
+pub const clipboard = @import("clipboard.zig");
 
 test {
     _ = engine;
@@ -112,6 +113,8 @@ test {
     _ = @import("layout_cache.zig");
     _ = @import("selection.zig");
     _ = @import("selection_tests.zig");
+    _ = clipboard;
+    _ = @import("issue_845_tests.zig");
     _ = @import("theme_tint.zig");
     _ = @import("hover.zig");
     _ = @import("hover_tests.zig");

--- a/TUI/run.zig
+++ b/TUI/run.zig
@@ -6,6 +6,7 @@ const Io = std.Io;
 
 const app = @import("app.zig");
 const bgop = @import("bgop.zig");
+const clipboard = @import("clipboard.zig");
 const engine = @import("engine.zig");
 const key_mod = @import("key.zig");
 const keys = @import("keys.zig");
@@ -45,6 +46,8 @@ pub fn run(
     // the pty storm test needs a way to count frames from outside the process.
     pacing.stats_on = environ_map.get("GRAFF_TUI_PAINT_STATS") != null;
     pacing.resetStats();
+    // #836: private copy command from the probe env; spawn on this Io.
+    clipboard.bind(io, environ_map);
     engine.g_turn_ctx = opts.turn_ctx;
     engine.g_turn_fn = opts.turn_fn;
     engine.g_model_fn = opts.model_fn;

--- a/TUI/run_tests.zig
+++ b/TUI/run_tests.zig
@@ -113,3 +113,8 @@ test "the loop self-heals: a resize EVENT and a periodic sweep force a repaint" 
     // canvas — /theme and the startup OSC-11 flip both force a full paint.
     try std.testing.expect(std.mem.indexOf(u8, src, "m.theme_id != prev_theme") != null);
 }
+
+test "the TUI binds the inherited clipboard override at start (#836)" {
+    const src = @embedFile("run.zig");
+    try std.testing.expect(std.mem.indexOf(u8, src, "clipboard.bind(io, environ_map)") != null);
+}

--- a/TUI/selection.zig
+++ b/TUI/selection.zig
@@ -18,9 +18,9 @@
 //! fork engine behaviour, and nothing here reaches a provider.
 
 const std = @import("std");
-const builtin = @import("builtin");
 
 const app = @import("app.zig");
+const clipboard = @import("clipboard.zig");
 const engine = @import("engine.zig");
 const key_mod = @import("key.zig");
 const osc52 = @import("osc52.zig");
@@ -352,28 +352,7 @@ fn cpAt(s: []const u8, i: usize) Cp {
 pub fn copyText(text: []const u8) bool {
     if (text.len == 0) return false;
     if (engine.g_copy_fn) |f| return f(engine.g_turn_ctx, text);
-    const argv: []const []const u8 = switch (builtin.os.tag) {
-        .macos => &.{"pbcopy"},
-        .linux => &.{ "xclip", "-selection", "clipboard" },
-        else => return false,
-    };
-    const io = std.Io.Threaded.global_single_threaded.io();
-    var child = std.process.spawn(io, .{
-        .argv = argv,
-        .stdin = .pipe,
-        .stdout = .ignore,
-        .stderr = .ignore,
-    }) catch return false;
-    if (child.stdin) |*s| {
-        var wbuf: [4096]u8 = undefined;
-        var w = s.writerStreaming(io, &wbuf);
-        w.interface.writeAll(text) catch {};
-        w.interface.flush() catch {};
-        s.close(io);
-        child.stdin = null;
-    }
-    const term = child.wait(io) catch return false;
-    return term == .exited and term.exited == 0;
+    return clipboard.writeText(text);
 }
 
 // ---------------------------------------------------------------- tests

--- a/scripts/clipboard_isolate.py
+++ b/scripts/clipboard_isolate.py
@@ -1,0 +1,49 @@
+"""Private clipboard commands for tuiguard probes (#836).
+
+Each offline-gate probe gets its own copy/paste scripts and a file they
+read/write. The Graff child inherits GRAFF_CLIPBOARD_COPY / PASTE, so
+parallel probes never share the host pasteboard. Direct probe runs leave
+those unset and keep native pbcopy/pbpaste (or skip).
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import stat
+import sys
+from pathlib import Path
+
+COPY_ENV = "GRAFF_CLIPBOARD_COPY"
+PASTE_ENV = "GRAFF_CLIPBOARD_PASTE"
+
+
+def install_private(scratch: Path) -> dict[str, str]:
+    """Write copy/paste wrappers under `scratch` and return the env to inherit."""
+    scratch.mkdir(parents=True, exist_ok=True)
+    clip = scratch / "clipboard"
+    copy = scratch / "copy"
+    paste = scratch / "paste"
+    clip.write_bytes(b"")
+    path = shlex.quote(str(clip))
+    copy.write_text(f"#!/bin/sh\ncat > {path}\n", encoding="utf-8")
+    paste.write_text(f"#!/bin/sh\ncat {path}\n", encoding="utf-8")
+    mode = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+    copy.chmod(mode)
+    paste.chmod(mode)
+    return {COPY_ENV: str(copy), PASTE_ENV: str(paste)}
+
+
+def tools() -> tuple[list[str] | None, list[str] | None]:
+    """(copy_argv, paste_argv). None, None when no native or private tool."""
+    copy = os.environ.get(COPY_ENV, "").strip()
+    paste = os.environ.get(PASTE_ENV, "").strip()
+    if copy and paste:
+        return [copy], [paste]
+    if sys.platform == "darwin":
+        return ["pbcopy"], ["pbpaste"]
+    return None, None
+
+
+def isolated() -> bool:
+    return bool(os.environ.get(COPY_ENV, "").strip() and os.environ.get(PASTE_ENV, "").strip())

--- a/scripts/eval/test_tier1_tuiguard.py
+++ b/scripts/eval/test_tier1_tuiguard.py
@@ -124,10 +124,11 @@ time.sleep(60)
         self.assertEqual(script, "test-tui-selection.py")
         self.assertEqual(status, 0)
         self.assertFalse(timed_out)
-        self.assertTrue(captured.get(tuiguard.clipboard_isolate.COPY_ENV))
-        self.assertTrue(captured.get(tuiguard.clipboard_isolate.PASTE_ENV))
-        self.assertTrue(os.path.isfile(captured[tuiguard.clipboard_isolate.COPY_ENV]))
-        self.assertTrue(os.path.isfile(captured[tuiguard.clipboard_isolate.PASTE_ENV]))
+        copy = captured.get(tuiguard.clipboard_isolate.COPY_ENV, "")
+        paste = captured.get(tuiguard.clipboard_isolate.PASTE_ENV, "")
+        self.assertTrue(copy.endswith("/copy"), copy)
+        self.assertTrue(paste.endswith("/paste"), paste)
+        self.assertNotEqual(copy, paste)
 
     def test_run_pool_names_still_running_on_parent_deadline(self) -> None:
         def hang(script: str, binary: str, timeout: float):

--- a/scripts/eval/test_tier1_tuiguard.py
+++ b/scripts/eval/test_tier1_tuiguard.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.util
 import os
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
 import time
@@ -76,6 +77,57 @@ time.sleep(60)
         for pid in pids:
             with self.assertRaises(OSError):
                 os.kill(pid, 0)
+
+    def test_private_clipboards_do_not_share(self) -> None:
+        a = tempfile.TemporaryDirectory(prefix="clip-a-")
+        b = tempfile.TemporaryDirectory(prefix="clip-b-")
+        self.addCleanup(a.cleanup)
+        self.addCleanup(b.cleanup)
+        env_a = tuiguard.clipboard_isolate.install_private(Path(a.name))
+        env_b = tuiguard.clipboard_isolate.install_private(Path(b.name))
+        self.assertNotEqual(env_a[tuiguard.clipboard_isolate.COPY_ENV], env_b[tuiguard.clipboard_isolate.COPY_ENV])
+        subprocess.run(
+            [env_a[tuiguard.clipboard_isolate.COPY_ENV]],
+            input=b"alpha-only",
+            check=True,
+        )
+        subprocess.run(
+            [env_b[tuiguard.clipboard_isolate.COPY_ENV]],
+            input=b"beta-only",
+            check=True,
+        )
+        got_a = subprocess.run(
+            [env_a[tuiguard.clipboard_isolate.PASTE_ENV]],
+            capture_output=True,
+            check=True,
+        ).stdout
+        got_b = subprocess.run(
+            [env_b[tuiguard.clipboard_isolate.PASTE_ENV]],
+            capture_output=True,
+            check=True,
+        ).stdout
+        self.assertEqual(got_a, b"alpha-only")
+        self.assertEqual(got_b, b"beta-only")
+
+    def test_run_probe_inherits_private_clipboard_env(self) -> None:
+        captured: dict[str, str] = {}
+
+        def grab(argv, timeout, cwd=None, env=None):
+            _ = argv, timeout, cwd
+            captured.update(env or {})
+            return 0, "", 0.01, False
+
+        with mock.patch.object(tuiguard, "run_command", side_effect=grab):
+            script, status, _, _, timed_out = tuiguard.run_probe(
+                "test-tui-selection.py", "/nonexistent/graff", 1.0
+            )
+        self.assertEqual(script, "test-tui-selection.py")
+        self.assertEqual(status, 0)
+        self.assertFalse(timed_out)
+        self.assertTrue(captured.get(tuiguard.clipboard_isolate.COPY_ENV))
+        self.assertTrue(captured.get(tuiguard.clipboard_isolate.PASTE_ENV))
+        self.assertTrue(os.path.isfile(captured[tuiguard.clipboard_isolate.COPY_ENV]))
+        self.assertTrue(os.path.isfile(captured[tuiguard.clipboard_isolate.PASTE_ENV]))
 
     def test_run_pool_names_still_running_on_parent_deadline(self) -> None:
         def hang(script: str, binary: str, timeout: float):

--- a/scripts/eval/tier1_tuiguard.py
+++ b/scripts/eval/tier1_tuiguard.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Run the 19 tuiguard PTY probes as a process pool (#641 / #704 / #537).
 
-Each probe owns its own pty/tmp/mock and is independent of the others. The
+Each probe owns its own pty/tmp/mock and a private clipboard command pair
+(#836) inherited by its Graff child. The
 serial loop in eval-tier1.sh was the dominant post-src wall (2–4 min). A 4–8
 worker pool brings that to roughly one long probe (fold-headers / hover).
 
@@ -26,9 +27,12 @@ import sys
 import time
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from pathlib import Path
+import tempfile
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+import clipboard_isolate  # noqa: E402
 
 PROBES = (
     "tui-pty-guard.py",
@@ -105,12 +109,18 @@ def terminate_group(proc: subprocess.Popen[str]) -> None:
     proc.kill()
 
 
-def run_command(argv: list[str], timeout: float, cwd: Path | None = None) -> tuple[int, str, float, bool]:
+def run_command(
+    argv: list[str],
+    timeout: float,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> tuple[int, str, float, bool]:
     """Run argv in its own session. On timeout, kill the whole group."""
     t0 = time.monotonic()
     proc = subprocess.Popen(
         argv,
         cwd=str(cwd or ROOT),
+        env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -130,11 +140,18 @@ def run_command(argv: list[str], timeout: float, cwd: Path | None = None) -> tup
 
 
 def run_probe(script: str, binary: str, timeout: float) -> tuple[str, int, str, float, bool]:
-    status, blob, elapsed, timed_out = run_command(
-        [sys.executable, str(SCRIPTS / script), binary],
-        timeout,
-    )
-    return script, status, blob, elapsed, timed_out
+    scratch = tempfile.TemporaryDirectory(prefix=f"tuiguard-clip-{script}-")
+    try:
+        env = os.environ.copy()
+        env.update(clipboard_isolate.install_private(Path(scratch.name)))
+        status, blob, elapsed, timed_out = run_command(
+            [sys.executable, str(SCRIPTS / script), binary],
+            timeout,
+            env=env,
+        )
+        return script, status, blob, elapsed, timed_out
+    finally:
+        scratch.cleanup()
 
 
 def run_pool(

--- a/scripts/test-tui-scrollbar-osc52.py
+++ b/scripts/test-tui-scrollbar-osc52.py
@@ -32,6 +32,7 @@ import tempfile
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import clipboard_isolate  # noqa: E402
 
 BIN = os.path.abspath(sys.argv[1] if len(sys.argv) > 1 else "zig-out/bin/graff")
 COLS, ROWS = 100, 30
@@ -260,11 +261,14 @@ def main():
         return 0
     import ptyharness
 
-    # The local half of the copy writes the real clipboard; put it back.
+    # The local half of a direct run writes the host clipboard; put it back.
+    # Isolated probes (#836) own a private file and must not touch pbcopy.
     saved = None
-    if sys.platform == "darwin":
+    copy_argv, paste_argv = clipboard_isolate.tools()
+    restore_host = paste_argv is not None and not clipboard_isolate.isolated()
+    if restore_host:
         try:
-            saved = subprocess.run(["pbpaste"], capture_output=True, check=True).stdout
+            saved = subprocess.run(paste_argv, capture_output=True, check=True).stdout
         except Exception:  # noqa: BLE001
             saved = None
     try:
@@ -278,9 +282,9 @@ def main():
             print(f"tui-scrollbar-osc52: pty unavailable ({e}) — skipping")
             return 0
     finally:
-        if saved is not None:
+        if restore_host and saved is not None and copy_argv is not None:
             try:
-                subprocess.run(["pbcopy"], input=saved, check=False)
+                subprocess.run(copy_argv, input=saved, check=False)
             except Exception:  # noqa: BLE001
                 pass
     if err:

--- a/scripts/test-tui-selection.py
+++ b/scripts/test-tui-selection.py
@@ -18,6 +18,8 @@ own), the probe:
 
 Usage: python3 scripts/test-tui-selection.py [path/to/graff]  (default zig-out/bin/graff)
 Exit 0 = pass. Skips (exit 0, notice) with no pty or no clipboard tool.
+Tuiguard injects private copy/paste commands (#836); a direct run keeps
+native pbcopy/pbpaste and stays macOS-only.
 """
 import os
 import re
@@ -25,6 +27,10 @@ import subprocess
 import sys
 import tempfile
 import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import clipboard_isolate  # noqa: E402
 
 # Absolutized BEFORE the fork: the child chdirs into its scratch workspace.
 BIN = os.path.abspath(sys.argv[1] if len(sys.argv) > 1 else "zig-out/bin/graff")
@@ -111,11 +117,17 @@ def reap(pid, fd):
 
 
 def clipboard_set(text):
-    subprocess.run(["pbcopy"], input=text.encode(), check=True)
+    copy, _ = clipboard_isolate.tools()
+    if copy is None:
+        raise RuntimeError("no clipboard copy command")
+    subprocess.run(copy, input=text.encode(), check=True)
 
 
 def clipboard_get():
-    return subprocess.run(["pbpaste"], capture_output=True, check=True).stdout.decode()
+    _, paste = clipboard_isolate.tools()
+    if paste is None:
+        raise RuntimeError("no clipboard paste command")
+    return subprocess.run(paste, capture_output=True, check=True).stdout.decode()
 
 
 def clipboard_after_copy(prev, tries=10):
@@ -289,19 +301,20 @@ def main():
     except ImportError:
         print("tui-selection: no pty support here — skipping")
         return 0
-    if sys.platform != "darwin":
+    if clipboard_isolate.tools()[0] is None:
         print("tui-selection: clipboard probe is macOS-only (pbcopy/pbpaste) — skipping")
         return 0
     saved = None
+    restore_host = not clipboard_isolate.isolated()
     try:
-        saved = clipboard_get()
+        saved = clipboard_get() if restore_host else None
     except Exception:
         print("tui-selection: no clipboard access — skipping")
         return 0
     try:
         err = run()
     finally:
-        if saved is not None:
+        if restore_host and saved is not None:
             try:
                 clipboard_set(saved)
             except Exception:

--- a/src/agent_interrupt.zig
+++ b/src/agent_interrupt.zig
@@ -186,14 +186,18 @@ pub fn escPressed(echo: bool) bool {
         if (echo) {
             if (!main_mod.g_steer_echoed) {
                 main_mod.g_steer_visible.store(true, .release);
-                repl_glue.steerEcho("\n");
-                repl_glue.steerEcho(style.accent);
-                repl_glue.steerEcho("↳ steer ›");
-                repl_glue.steerEcho(style.reset);
-                repl_glue.steerEcho(" ");
+                repl_glue.steerLock();
+                repl_glue.steerEchoUnlocked("\n");
+                repl_glue.steerEchoUnlocked(style.accent);
+                repl_glue.steerEchoUnlocked("↳ steer ›");
+                repl_glue.steerEchoUnlocked(style.reset);
+                repl_glue.steerEchoUnlocked(" ");
                 main_mod.g_steer_echoed = true;
+                repl_glue.steerEchoUnlocked(buf[i .. i + 1]);
+                repl_glue.steerUnlock();
+            } else {
+                repl_glue.steerEcho(buf[i .. i + 1]);
             }
-            repl_glue.steerEcho(buf[i .. i + 1]);
         }
     }
     return esc_found;

--- a/src/agent_stream_render.zig
+++ b/src/agent_stream_render.zig
@@ -32,36 +32,61 @@ test {
     _ = @import("compact_status.zig");
 }
 
+/// CSI around one spinner frame. When the steer row is live, hop up one
+/// line (DECSC/DECRC) so the frame never wipes the queued follow-up (#845).
+pub fn spinnerFramePrefix(steer_visible: bool) []const u8 {
+    return if (steer_visible)
+        "\x1b7\x1b[1A\r\x1b[2K\x1b[?7l"
+    else
+        "\r\x1b[2K\x1b[?7l";
+}
+
+pub fn spinnerFrameSuffix(steer_visible: bool) []const u8 {
+    return if (steer_visible) "\x1b[?7h\x1b8" else "\x1b[?7h";
+}
+
+pub fn spinnerStopSeq(steer_visible: bool) []const u8 {
+    return if (steer_visible)
+        "\x1b[?7h\x1b7\x1b[1A\r\x1b[2K\x1b8"
+    else
+        "\x1b[?7h\r\x1b[2K";
+}
+
 pub fn spinnerTask(io: Io) void {
     var i: usize = 0;
     var buf: [512]u8 = undefined;
     var w = Io.File.stdout().writer(io, &buf);
+    const glue = @import("repl_glue.zig");
     while (!Agent.g_spin_stop.load(.acquire)) {
-        if (main_mod.g_steer_visible.load(.acquire)) {
-            io.sleep(.fromMilliseconds(20), .awake) catch break;
-            continue;
-        }
-        // Clear-then-draw each frame: animations may vary in width.
-        w.interface.writeAll("\r\x1b[2K\x1b[?7l") catch return; // ?7l: autowrap off so a wide spinner truncates instead of wrapping in a narrow window (the "goes on and on" bug)
-        if (@import("compact_status.zig").isActive()) {
-            w.interface.writeAll(@import("compact_status.zig").label) catch return;
-        } else {
-            anim.anims[anim.g_anim_current].frame(&w.interface, i) catch return;
-        }
-        w.interface.writeAll("\x1b[?7h") catch return; // restore autowrap
-        w.interface.flush() catch return;
+        const steer = main_mod.g_steer_visible.load(.acquire);
+        glue.steerLock();
+        // Clear-then-draw each frame: animations may vary in width. ?7l:
+        // autowrap off so a wide spinner truncates instead of wrapping.
+        const drew = blk: {
+            w.interface.writeAll(spinnerFramePrefix(steer)) catch break :blk false;
+            if (@import("compact_status.zig").isActive()) {
+                w.interface.writeAll(@import("compact_status.zig").label) catch break :blk false;
+            } else {
+                anim.anims[anim.g_anim_current].frame(&w.interface, i) catch break :blk false;
+            }
+            w.interface.writeAll(spinnerFrameSuffix(steer)) catch break :blk false;
+            w.interface.flush() catch break :blk false;
+            break :blk true;
+        };
+        glue.steerUnlock();
+        if (!drew) return;
         i += 1;
         const frame_ticks = @max(@as(usize, 1), @as(usize, anim.anims[anim.g_anim_current].frame_ms) / 20);
         var t: usize = 0;
         while (t < frame_ticks and !Agent.g_spin_stop.load(.acquire)) : (t += 1) {
-            if (main_mod.g_steer_visible.load(.acquire)) break;
             io.sleep(.fromMilliseconds(20), .awake) catch break;
         }
     }
-    if (!main_mod.g_steer_visible.load(.acquire)) {
-        w.interface.writeAll("\x1b[?7h\r\x1b[2K") catch return; // restore autowrap + clear
-        w.interface.flush() catch {};
-    }
+    const steer = main_mod.g_steer_visible.load(.acquire);
+    glue.steerLock();
+    w.interface.writeAll(spinnerStopSeq(steer)) catch {};
+    w.interface.flush() catch {};
+    glue.steerUnlock();
 }
 
 pub fn spinnerStart(self: *Agent) void {
@@ -155,4 +180,19 @@ pub fn toggleThinkingFold(self: *Agent) void {
         advanceThinkingRows(&self.thinking_rows, &self.thinking_col, termCols(), self.thinking_text.items);
     }
     w.flush() catch return;
+}
+
+test "a live steer row hops the spinner up one line instead of freezing (#845)" {
+    const hop = spinnerFramePrefix(true);
+    try std.testing.expect(std.mem.indexOf(u8, hop, "\x1b7") != null);
+    try std.testing.expect(std.mem.indexOf(u8, hop, "\x1b[1A") != null);
+    try std.testing.expect(std.mem.startsWith(u8, hop, "\x1b7"));
+    try std.testing.expectEqualStrings("\x1b[?7h\x1b8", spinnerFrameSuffix(true));
+    try std.testing.expect(std.mem.indexOf(u8, spinnerStopSeq(true), "\x1b[1A") != null);
+}
+
+test "without a steer row the spinner still redraws in place (#845)" {
+    try std.testing.expectEqualStrings("\r\x1b[2K\x1b[?7l", spinnerFramePrefix(false));
+    try std.testing.expectEqualStrings("\x1b[?7h", spinnerFrameSuffix(false));
+    try std.testing.expectEqualStrings("\x1b[?7h\r\x1b[2K", spinnerStopSeq(false));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -200,12 +200,12 @@ pub var g_codedbpro_licensed: bool = false; // pub: codedbpro_report's native-to
 const anim = @import("anim.zig");
 // Steering (Codex-style): bytes typed while a turn streams are captured (not discarded), echoed live in dim emerald, and queued to run next on Enter —
 // follow-ups queue without waiting for the turn to finish. TTY-only (raw-stdin esc-watch is off in --json/GUI mode); watchdog/select arms may
-// drain/echo stdin while the stream reader is blocked, so g_steer_visible pauses spinner redraws to keep the live row intact.
+// drain/echo stdin while the stream reader is blocked. g_steer_visible: spinner hops up one line (#845).
 pub var g_steer_buf: std.ArrayList(u8) = .empty; // in-progress line (page-alloc)
 const SteerEntry = repl_glue.SteerEntry; // struct { text: []const u8, force: bool }
 pub var g_steer_queue: std.ArrayList(SteerEntry) = .empty; // completed lines
 pub var g_steer_echoed = false; // "↳ steer ›" prefix shown for the current line
-pub var g_steer_visible: std.atomic.Value(bool) = .init(false); // visible live steering row; pauses spinner redraws
+pub var g_steer_visible: std.atomic.Value(bool) = .init(false); // visible live steering row; spinner draws on the line above
 pub var g_steer_lock: std.atomic.Value(bool) = .init(false); // spin-guards g_steer_queue/g_steer_buf mutations across concurrent drainers (main reader + pool esc-watch/watchdog arms) so one submit never flushes as N entries (#129); acquire via repl_glue.steerLock
 pub var g_out: ?*Io.Writer = null; // stdout writer for steer echo (set in main)
 pub var g_gui_mu: Io.Mutex = .init; // serializes --json stdout across pool-thread subagent emits (guiEmit + printDelta)

--- a/src/repl_glue.zig
+++ b/src/repl_glue.zig
@@ -371,11 +371,12 @@ pub fn replCancelCb(ctx_ptr: ?*anyopaque) void {
 
 pub const SteerEntry = struct { text: []const u8, force: bool };
 
-/// Spin-lock guarding g_steer_buf/g_steer_queue mutations. The concurrent steer
-/// drainers (the main reader + pool esc-watch/watchdog arms, #129) hold it only
-/// for the tiny queue/buffer critical sections — never across a stdin read/poll
-/// — so it stays uncontended and needs no Io handle (unlike the Io.Mutex used
-/// elsewhere, which the io-less escPressed cannot reach).
+/// Spin-lock guarding g_steer_buf/g_steer_queue mutations and the stdout
+/// bytes that share a line with the thinking spinner (#845). The concurrent
+/// steer drainers (the main reader + pool esc-watch/watchdog arms, #129) hold
+/// it only for the tiny queue/buffer critical sections — never across a stdin
+/// read/poll — so it stays uncontended and needs no Io handle (unlike the
+/// Io.Mutex used elsewhere, which the io-less escPressed cannot reach).
 pub fn steerLock() void {
     while (main_mod.g_steer_lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) std.atomic.spinLoopHint();
 }
@@ -427,7 +428,14 @@ pub fn resetSteerPartial() void {
 /// Writes steering echo to the stdout writer (the same buffered writer the
 /// streaming text uses, already flushed before escPressed runs, so ordering
 /// stays correct) and flushes so the user sees queued keystrokes live.
+/// Serialized with spinner frames so a hop-up redraw cannot land mid-echo (#845).
 pub fn steerEcho(bytes: []const u8) void {
+    steerLock();
+    defer steerUnlock();
+    steerEchoUnlocked(bytes);
+}
+
+pub fn steerEchoUnlocked(bytes: []const u8) void {
     if (main_mod.g_out) |w| {
         w.writeAll(bytes) catch {};
         w.flush() catch {};

--- a/src/subagent_activity.zig
+++ b/src/subagent_activity.zig
@@ -208,7 +208,7 @@ test "cancel file marks a working child interrupted even if it later finishes" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const io = std.testing.io;
-    var r: Recorder = .{ .a = std.testing.allocator, .io = io, .dir = try tmp.dir.openDir(io, ".", .{}), .meta = .{ .id = "child", .label = "test", .task = "test" } };
+    var r: Recorder = .{ .a = std.testing.allocator, .io = io, .dir = try tmp.dir.openDir(io, ".", .{ .iterate = true }), .meta = .{ .id = "child", .label = "test", .task = "test" } };
     defer r.deinit();
     try requestInterrupt(io, r.dir, "child");
     try std.testing.expect(interruptRequested(io, r.dir, "child"));

--- a/src/tui_launch.zig
+++ b/src/tui_launch.zig
@@ -375,8 +375,9 @@ fn filesCb(ctx: ?*anyopaque, gpa: Allocator) ?[]const u8 {
     return run_res.stdout;
 }
 
-fn copyCb(_: ?*anyopaque, text: []const u8) bool {
-    return tui.clipboard.writeText(text);
+fn copyCb(ctx: ?*anyopaque, text: []const u8) bool {
+    const c: *repl_glue.ReplCtx = @ptrCast(@alignCast(ctx orelse return false));
+    return tui.clipboard.writeTextIo(c.io, text);
 }
 
 fn writeDoctor(w: *Io.Writer) void {

--- a/src/tui_launch.zig
+++ b/src/tui_launch.zig
@@ -375,27 +375,8 @@ fn filesCb(ctx: ?*anyopaque, gpa: Allocator) ?[]const u8 {
     return run_res.stdout;
 }
 
-fn copyCb(ctx: ?*anyopaque, text: []const u8) bool {
-    const c: *repl_glue.ReplCtx = @ptrCast(@alignCast(ctx orelse return false));
-    const argv: []const []const u8 = switch (builtin.os.tag) {
-        .macos => &.{"pbcopy"},
-        .linux => &.{ "xclip", "-selection", "clipboard" },
-        else => return false,
-    };
-    var child = std.process.spawn(c.io, .{
-        .argv = argv,
-        .stdin = .pipe,
-        .stdout = .ignore,
-        .stderr = .ignore,
-    }) catch return false;
-    var wbuf: [4096]u8 = undefined;
-    var fw = child.stdin.?.writerStreaming(c.io, &wbuf);
-    fw.interface.writeAll(text) catch {};
-    fw.interface.flush() catch {};
-    child.stdin.?.close(c.io);
-    child.stdin = null;
-    const term = child.wait(c.io) catch return false;
-    return term == .exited and term.exited == 0;
+fn copyCb(_: ?*anyopaque, text: []const u8) bool {
+    return tui.clipboard.writeText(text);
 }
 
 fn writeDoctor(w: *Io.Writer) void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #845 and #836.

- Queuing a TUI follow-up no longer freezes the thinking indicator: `spinnerTask` keeps frames while the steer row is visible, hopping one line with DECSC/DECRC so the input is not wiped.
- Tuiguard probes get private copy/paste via `GRAFF_CLIPBOARD_COPY` / `PASTE` so parallel clipboard tests do not collide.

Also unblocks Linux `zig build test`: the cancel-file unit test now iterates its tmpDir (same flag as the retention test).

Branch is off latest `main`. Tier 1 green, including 19 tuiguard PTY probes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d64-4949-703b-8c44-a9bb932f4ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d64-4949-703b-8c44-a9bb932f4ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

